### PR TITLE
chore(azure-monitor-exporter): Refactor Azure Monitor exporter to use bearer-auth adapter

### DIFF
--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs
@@ -37,9 +37,6 @@ pub struct LogsIngestionClient {
     http_client: Client,
     endpoint: String,
 
-    // Pre-formatted authorization header provider
-    auth_header: HeaderValue,
-
     /// Optional ARM resource ID header for Azure Monitor source tracking.
     resource_id_header: Option<HeaderValue>,
 
@@ -113,15 +110,14 @@ impl LogsIngestionClientPool {
 impl LogsIngestionClient {
     /// Creates a new Azure Monitor logs ingestion client instance from provided components.
     ///
-    /// Primarily used for testing. The auth header is initialized with a placeholder
-    /// and should be updated via `update_auth()` before making requests.
+    /// Primarily used for testing.
     ///
     /// # Arguments
     /// * `http_client` - The HTTP client to use for requests
     /// * `endpoint` - The full endpoint URL for the Azure Monitor ingestion API
     ///
     /// # Returns
-    /// A configured client instance with a placeholder auth header
+    /// A configured client instance
     #[must_use]
     pub fn from_parts(
         http_client: Client,
@@ -131,16 +127,12 @@ impl LogsIngestionClient {
         Self {
             http_client,
             endpoint,
-            auth_header: HeaderValue::from_static("Bearer "), // placeholder, will be updated on first use
             resource_id_header: None,
             metrics,
         }
     }
 
     /// Creates a new Azure Monitor logs ingestion client instance from the configuration.
-    ///
-    /// The auth header is initialized with a placeholder and should be updated
-    /// via `update_auth()` before making requests.
     ///
     /// # Arguments
     /// * `config` - The API configuration containing endpoint, DCR, and stream info
@@ -170,32 +162,34 @@ impl LogsIngestionClient {
         Ok(Self {
             http_client,
             endpoint,
-            auth_header: HeaderValue::from_static("Bearer "), // placeholder, will be updated on first use
             resource_id_header,
             metrics,
         })
-    }
-
-    /// Update the authorization header with a new access token.
-    pub fn update_auth(&mut self, header: HeaderValue) {
-        self.auth_header = header;
     }
 
     /// Export compressed data to Log Analytics ingestion API with automatic retry.
     ///
     /// Retries on:
     /// - Network errors
-    /// - 401 (after token refresh)
     /// - 429 (rate limiting) - uses Retry-After header if present
     /// - 5xx (server errors)
     ///
+    /// A 401 is not retried here: every attempt would replay `auth_header`, so
+    /// recovery belongs to the caller, which invalidates the rejected token and
+    /// re-dispatches once a fresh one is cached.
+    ///
     /// # Arguments
     /// * `body` - The gzip-compressed JSON data to send
+    /// * `auth_header` - The authorization header for this request
     ///
     /// # Returns
     /// * `Ok(Duration)` - Total time spent (including retries) if successful
     /// * `Err(String)` - Error message if all retries exhausted or non-retryable error
-    pub async fn export(&mut self, body: Bytes) -> Result<Duration, Error> {
+    pub async fn export(
+        &mut self,
+        body: Bytes,
+        auth_header: &HeaderValue,
+    ) -> Result<Duration, Error> {
         let mut attempt = 0u32;
         let mut rng = SmallRng::seed_from_u64(
             std::time::SystemTime::now()
@@ -206,7 +200,7 @@ impl LogsIngestionClient {
         );
 
         loop {
-            match self.try_export(body.clone()).await {
+            match self.try_export(body.clone(), auth_header).await {
                 Ok(duration) => return Ok(duration),
                 Err(e) if !e.is_retryable() => {
                     return Err(Error::ExportFailed {
@@ -249,7 +243,11 @@ impl LogsIngestionClient {
     }
 
     /// Single export attempt without retry logic.
-    async fn try_export(&mut self, body: Bytes) -> Result<Duration, Error> {
+    async fn try_export(
+        &mut self,
+        body: Bytes,
+        auth_header: &HeaderValue,
+    ) -> Result<Duration, Error> {
         let start = Instant::now();
 
         let mut request = self
@@ -257,7 +255,7 @@ impl LogsIngestionClient {
             .post(&self.endpoint)
             .header(CONTENT_TYPE, "application/json")
             .header(CONTENT_ENCODING, "gzip")
-            .header(AUTHORIZATION, &self.auth_header);
+            .header(AUTHORIZATION, auth_header);
 
         if let Some(ref resource_id) = self.resource_id_header {
             request = request.header(AZURE_MONITOR_SOURCE_RESOURCEID_HEADER, resource_id);
@@ -438,67 +436,6 @@ mod tests {
         );
 
         assert_eq!(client.endpoint, "https://example.com/endpoint");
-        // auth_header is placeholder
-        assert_eq!(client.auth_header, HeaderValue::from_static("Bearer "));
-    }
-
-    #[test]
-    fn test_new_initial_state() {
-        let http_client = create_test_http_client();
-        let api_config = create_test_api_config();
-
-        let client =
-            LogsIngestionClient::new(&api_config, http_client, create_test_metrics()).unwrap();
-
-        // Auth header is placeholder
-        assert_eq!(client.auth_header, HeaderValue::from_static("Bearer "));
-    }
-
-    // ==================== Auth Header Update Tests ====================
-
-    #[test]
-    fn test_update_auth_changes_header() {
-        let mut client = LogsIngestionClient::from_parts(
-            create_test_http_client(),
-            "https://example.com".to_string(),
-            create_test_metrics(),
-        );
-
-        assert_eq!(client.auth_header, HeaderValue::from_static("Bearer "));
-
-        client.update_auth(HeaderValue::from_static("Bearer new_token"));
-
-        assert_eq!(
-            client.auth_header,
-            HeaderValue::from_static("Bearer new_token")
-        );
-    }
-
-    #[test]
-    fn test_update_auth_multiple_times() {
-        let mut client = LogsIngestionClient::from_parts(
-            create_test_http_client(),
-            "https://example.com".to_string(),
-            create_test_metrics(),
-        );
-
-        client.update_auth(HeaderValue::from_static("Bearer token1"));
-        assert_eq!(
-            client.auth_header,
-            HeaderValue::from_static("Bearer token1")
-        );
-
-        client.update_auth(HeaderValue::from_static("Bearer token2"));
-        assert_eq!(
-            client.auth_header,
-            HeaderValue::from_static("Bearer token2")
-        );
-
-        client.update_auth(HeaderValue::from_static("Bearer token3"));
-        assert_eq!(
-            client.auth_header,
-            HeaderValue::from_static("Bearer token3")
-        );
     }
 
     // ==================== LogsIngestionClientPool Tests ====================
@@ -604,45 +541,6 @@ mod tests {
         let client2 = client1.clone();
 
         assert_eq!(client1.endpoint, client2.endpoint);
-    }
-
-    #[test]
-    fn test_client_clone_has_same_auth_header() {
-        let mut client1 = LogsIngestionClient::from_parts(
-            create_test_http_client(),
-            "https://example.com".to_string(),
-            create_test_metrics(),
-        );
-
-        client1.update_auth(HeaderValue::from_static("Bearer test_token"));
-        let client2 = client1.clone();
-
-        assert_eq!(client1.auth_header, client2.auth_header);
-    }
-
-    #[test]
-    fn test_client_clone_has_independent_header() {
-        let mut client1 = LogsIngestionClient::from_parts(
-            create_test_http_client(),
-            "https://example.com".to_string(),
-            create_test_metrics(),
-        );
-
-        client1.update_auth(HeaderValue::from_static("Bearer token1"));
-        let mut client2 = client1.clone();
-
-        // Modify client2's header
-        client2.update_auth(HeaderValue::from_static("Bearer token2"));
-
-        // client1's header should be unchanged
-        assert_eq!(
-            client1.auth_header,
-            HeaderValue::from_static("Bearer token1")
-        );
-        assert_eq!(
-            client2.auth_header,
-            HeaderValue::from_static("Bearer token2")
-        );
     }
 
     // ==================== Edge Cases ====================

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs
@@ -184,7 +184,7 @@ impl LogsIngestionClient {
     ///
     /// # Returns
     /// * `Ok(Duration)` - Total time spent (including retries) if successful
-    /// * `Err(String)` - Error message if all retries exhausted or non-retryable error
+    /// * `Err(Error)` - Error if all retries are exhausted or a non-retryable error is returned
     pub async fn export(
         &mut self,
         body: Bytes,

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs
@@ -339,6 +339,8 @@ mod tests {
     use reqwest::header::HeaderValue;
     use std::cell::RefCell;
     use std::rc::Rc;
+    use wiremock::matchers::{header, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     // ==================== Test Helpers ====================
 
@@ -436,6 +438,170 @@ mod tests {
         );
 
         assert_eq!(client.endpoint, "https://example.com/endpoint");
+    }
+
+    // ==================== Export Tests ====================
+
+    /// Scenario: an export is dispatched with a caller-supplied bearer header.
+    /// Guarantees: that exact header reaches the ingestion endpoint, so the
+    /// credential a request carries is the one its caller stamped on it.
+    #[tokio::test]
+    async fn export_sends_the_supplied_authorization_header() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(header("authorization", "Bearer supplied-token"))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut client = LogsIngestionClient::from_parts(
+            create_test_http_client(),
+            mock_server.uri(),
+            create_test_metrics(),
+        );
+
+        let result = client
+            .export(
+                Bytes::from_static(b"payload"),
+                &HeaderValue::from_static("Bearer supplied-token"),
+            )
+            .await;
+
+        assert!(result.is_ok(), "expected success, got {result:?}");
+    }
+
+    /// Scenario: one pooled client dispatches two exports carrying different
+    /// bearer headers.
+    /// Guarantees: each request sends its own header, so a client cannot leak a
+    /// credential from an earlier export into a later one.
+    #[tokio::test]
+    async fn export_uses_the_header_supplied_for_each_request() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(header("authorization", "Bearer first"))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(header("authorization", "Bearer second"))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut client = LogsIngestionClient::from_parts(
+            create_test_http_client(),
+            mock_server.uri(),
+            create_test_metrics(),
+        );
+
+        for token in ["Bearer first", "Bearer second"] {
+            let _ = client
+                .export(
+                    Bytes::from_static(b"payload"),
+                    &HeaderValue::from_str(token).unwrap(),
+                )
+                .await
+                .expect("export should succeed");
+        }
+    }
+
+    /// Scenario: the ingestion endpoint rejects an export with HTTP 401.
+    /// Guarantees: the client fails after a single attempt instead of replaying
+    /// the same rejected token, and reports the failure as an auth rejection so
+    /// the caller can invalidate that token.
+    #[tokio::test]
+    async fn unauthorized_export_is_not_retried() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("expired"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut client = LogsIngestionClient::from_parts(
+            create_test_http_client(),
+            mock_server.uri(),
+            create_test_metrics(),
+        );
+
+        let error = client
+            .export(
+                Bytes::from_static(b"payload"),
+                &HeaderValue::from_static("Bearer stale"),
+            )
+            .await
+            .expect_err("401 should fail the export");
+
+        assert!(error.is_unauthorized());
+        assert!(matches!(error, Error::ExportFailed { attempts: 1, .. }));
+        assert_eq!(mock_server.received_requests().await.unwrap().len(), 1);
+    }
+
+    /// Scenario: the ingestion endpoint rejects an export with HTTP 403.
+    /// Guarantees: the client fails after a single attempt and does not report a
+    /// permission problem as an auth rejection, since refreshing the token
+    /// cannot resolve it.
+    #[tokio::test]
+    async fn forbidden_export_is_not_retried() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("denied"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut client = LogsIngestionClient::from_parts(
+            create_test_http_client(),
+            mock_server.uri(),
+            create_test_metrics(),
+        );
+
+        let error = client
+            .export(
+                Bytes::from_static(b"payload"),
+                &HeaderValue::from_static("Bearer scoped-out"),
+            )
+            .await
+            .expect_err("403 should fail the export");
+
+        assert!(!error.is_unauthorized());
+        assert_eq!(mock_server.received_requests().await.unwrap().len(), 1);
+    }
+
+    /// Scenario: a client configured with an Azure Monitor source resource ID
+    /// exports a batch.
+    /// Guarantees: the resource ID header accompanies the request alongside the
+    /// per-request bearer header.
+    #[tokio::test]
+    async fn export_sends_the_configured_resource_id_header() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(header(AZURE_MONITOR_SOURCE_RESOURCEID_HEADER, "sub%2Frg"))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut api_config = create_test_api_config();
+        api_config.dcr_endpoint = mock_server.uri();
+        api_config.azure_monitor_source_resourceid = Some("sub/rg".to_string());
+        let mut client = LogsIngestionClient::new(
+            &api_config,
+            create_test_http_client(),
+            create_test_metrics(),
+        )
+        .unwrap();
+
+        let _ = client
+            .export(
+                Bytes::from_static(b"payload"),
+                &HeaderValue::from_static("Bearer token"),
+            )
+            .await
+            .expect("export should succeed");
     }
 
     // ==================== LogsIngestionClientPool Tests ====================

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs
@@ -99,12 +99,6 @@ impl LogsIngestionClientPool {
         Ok(())
     }
 
-    pub fn update_auth(&mut self, header: HeaderValue) {
-        for client in &mut self.clients {
-            client.update_auth(header.clone());
-        }
-    }
-
     #[inline(always)]
     pub fn take(&mut self) -> LogsIngestionClient {
         self.clients.pop().expect("client pool is empty")

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/error.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/error.rs
@@ -423,6 +423,27 @@ mod tests {
         assert!(error.is_unauthorized());
     }
 
+    /// Scenario: failures that are not an HTTP 401, including an export that
+    /// exhausted its retries on a server error.
+    /// Guarantees: they do not invalidate the cached bearer token, so a healthy
+    /// credential survives unrelated export failures.
+    #[test]
+    fn non_401_errors_are_not_reported_as_unauthorized() {
+        assert!(!Error::forbidden("denied".to_string()).is_unauthorized());
+        assert!(!Error::PayloadTooLarge.is_unauthorized());
+        assert!(
+            !Error::ExportFailed {
+                attempts: 5,
+                last_error: Box::new(Error::ServerError {
+                    status: StatusCode::INTERNAL_SERVER_ERROR,
+                    body: String::new(),
+                    retry_after: None,
+                }),
+            }
+            .is_unauthorized()
+        );
+    }
+
     // ==================== Display Tests ====================
 
     #[test]

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/error.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/error.rs
@@ -29,6 +29,13 @@ pub enum Error {
         body: Option<String>,
     },
 
+    /// A batch was ready to export but no usable bearer token was cached.
+    #[error("No usable bearer token: {reason}")]
+    NoBearerToken {
+        /// Why the bearer-auth adapter reports no usable token.
+        reason: &'static str,
+    },
+
     // ==================== HTTP/Network Errors ====================
     /// Failed to create HTTP client.
     #[error("Failed to create HTTP client")]

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/error.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/error.rs
@@ -184,14 +184,21 @@ impl Error {
     pub fn is_retryable(&self) -> bool {
         matches!(
             self,
-            Error::Network { .. }
-                | Error::Auth {
-                    kind: AuthErrorKind::Unauthorized,
-                    ..
-                }
-                | Error::RateLimited { .. }
-                | Error::ServerError { .. }
+            Error::Network { .. } | Error::RateLimited { .. } | Error::ServerError { .. }
         )
+    }
+
+    /// Returns true if this error was caused by an HTTP 401 response.
+    #[must_use]
+    pub fn is_unauthorized(&self) -> bool {
+        match self {
+            Error::Auth {
+                kind: AuthErrorKind::Unauthorized,
+                ..
+            } => true,
+            Error::ExportFailed { last_error, .. } => last_error.is_unauthorized(),
+            _ => false,
+        }
     }
 
     /// Returns the retry-after duration if specified by the server.
@@ -374,7 +381,6 @@ mod tests {
     #[test]
     fn test_is_retryable() {
         // Retryable
-        assert!(Error::unauthorized(String::new()).is_retryable());
         assert!(
             Error::RateLimited {
                 body: String::new(),
@@ -392,6 +398,7 @@ mod tests {
         );
 
         // Not retryable
+        assert!(!Error::unauthorized(String::new()).is_retryable());
         assert!(!Error::forbidden(String::new()).is_retryable());
         assert!(!Error::PayloadTooLarge.is_retryable());
         assert!(
@@ -401,6 +408,19 @@ mod tests {
             }
             .is_retryable()
         );
+    }
+
+    /// Scenario: an export wraps the HTTP 401 that terminated its retry loop.
+    /// Guarantees: completion handling can still identify the auth rejection and
+    /// invalidate the bearer-token generation used by the request.
+    #[test]
+    fn wrapped_unauthorized_error_is_identified() {
+        let error = Error::ExportFailed {
+            attempts: 1,
+            last_error: Box::new(Error::unauthorized("rejected".to_string())),
+        };
+
+        assert!(error.is_unauthorized());
     }
 
     // ==================== Display Tests ====================

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
@@ -262,25 +262,38 @@ impl AzureMonitorExporter {
             .borrow_mut()
             .add_batch_size(pending_batch.compressed_data.len() as f64);
 
-        let client = self.client_pool.take();
-        let (auth_header, token_generation) = auth
-            .header()
-            .expect("queueing is gated on a usable bearer token");
-        if let Some(completed_export) = self
-            .in_flight_exports
-            .push_export(
-                client,
-                pending_batch.batch_id,
-                pending_batch.row_count,
-                pending_batch.compressed_data,
-                auth_header,
-                token_generation,
-            )
-            .await
-        {
+        // Settle the completion that frees the slot before reading the token: a
+        // 401 completion invalidates the cached header, and stamping this batch
+        // first would send it with a credential already known to be rejected.
+        if let Some(completed_export) = self.in_flight_exports.reap_if_at_capacity().await {
             self.finalize_export(effect_handler, auth, completed_export)
                 .await?;
         }
+
+        let Some((auth_header, token_generation)) = auth.header() else {
+            let error = Error::NoBearerToken {
+                reason: auth.not_ready_reason(),
+            };
+            return self
+                .handle_export_failure(
+                    effect_handler,
+                    pending_batch.batch_id,
+                    pending_batch.row_count,
+                    pending_batch.compressed_data.len() as u64,
+                    error,
+                )
+                .await;
+        };
+
+        let client = self.client_pool.take();
+        self.in_flight_exports.push_export(
+            client,
+            pending_batch.batch_id,
+            pending_batch.row_count,
+            pending_batch.compressed_data,
+            auth_header,
+            token_generation,
+        );
 
         self.last_batch_queued_at = tokio::time::Instant::now();
 
@@ -933,6 +946,75 @@ mod tests {
             .unwrap();
 
         assert!(!auth.is_ready());
+    }
+
+    /// Queue a one-entry batch so the next `queue_pending_batch` has work to do.
+    fn prime_pending_batch(exporter: &mut AzureMonitorExporter) {
+        let _ = exporter
+            .gzip_batcher
+            .push(Bytes::from_static(br#"{"Message":"x"}"#))
+            .unwrap();
+        let _ = exporter.gzip_batcher.finalize().unwrap();
+    }
+
+    /// Scenario: the in-flight set is full and the export that frees the slot
+    /// comes back 401, while the message being processed still has batches to
+    /// queue.
+    /// Guarantees: the rejected token is settled before the next batch is
+    /// stamped, and that batch is failed rather than dispatched with the dead
+    /// credential or aborting the node.
+    #[tokio::test]
+    async fn a_401_freeing_a_slot_fails_the_next_batch_instead_of_stamping_it() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("token expired"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut exporter = exporter_targeting(mock_server.uri()).await;
+        exporter.in_flight_exports = InFlightExports::new(1);
+        let mut auth = auth_with_cached_token().await;
+        let effect_handler = test_effect_handler();
+
+        // Fill the single slot. The token is still good, so this batch is stamped
+        // and dispatched.
+        prime_pending_batch(&mut exporter);
+        exporter
+            .queue_pending_batch(&effect_handler, &mut auth)
+            .await
+            .unwrap();
+        assert!(auth.is_ready());
+        assert_eq!(exporter.in_flight_exports.len(), 1);
+
+        // At capacity: the reaped 401 invalidates the cached token, so the batch
+        // that was waiting on the slot must not be dispatched.
+        prime_pending_batch(&mut exporter);
+        exporter.state.add_batch_msg_relationship(2, 100);
+        exporter
+            .queue_pending_batch(&effect_handler, &mut auth)
+            .await
+            .unwrap();
+
+        assert!(!auth.is_ready(), "the 401 must invalidate the used token");
+        assert_eq!(
+            exporter.in_flight_exports.len(),
+            0,
+            "no export may be stamped with the rejected token"
+        );
+        assert!(
+            exporter.state.batch_to_msg.is_empty(),
+            "the undispatchable batch must be failed, not stranded"
+        );
+        assert_eq!(
+            exporter
+                .metrics
+                .borrow()
+                .export_for(Outcome::Failure)
+                .batches
+                .get(),
+            2
+        );
     }
 
     /// Scenario: pdata arrives before the bearer token provider has published a

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
@@ -661,6 +661,7 @@ mod tests {
     use bytes::Bytes;
     use futures::StreamExt;
     use http::StatusCode;
+    use http::header::HeaderValue;
     use otap_df_channel::mpsc;
     use otap_df_engine::Interests;
     use otap_df_engine::capability::CapabilityError;
@@ -674,8 +675,11 @@ mod tests {
     use otap_df_otap::pdata::Context;
     use otap_df_telemetry::registry::TelemetryRegistryHandle;
     use otap_df_telemetry::reporter::MetricsReporter;
+    use rand::{RngExt, SeedableRng, rngs::SmallRng};
     use std::collections::HashMap;
     use std::time::{Duration, Instant};
+    use wiremock::matchers::{header, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     /// Test double for the `BearerTokenProvider` capability. Yields a single
     /// non-expiring token and then ends the stream.
@@ -746,6 +750,45 @@ mod tests {
         let pipeline_ctx = create_test_pipeline_ctx();
         let _ =
             AzureMonitorExporter::new(pipeline_ctx, config, Box::new(MockTokenProvider)).unwrap();
+    }
+
+    fn test_effect_handler() -> EffectHandler<OtapPdata> {
+        let (_, reporter) = MetricsReporter::create_new_and_receiver(10);
+        EffectHandler::new(
+            NodeId {
+                index: 0,
+                name: "test_exporter".to_string().into(),
+            },
+            reporter,
+        )
+    }
+
+    /// Build an exporter whose client pool targets `endpoint`, as `start` would.
+    async fn exporter_targeting(endpoint: String) -> AzureMonitorExporter {
+        let mut config = create_test_config();
+        config.api.dcr_endpoint = endpoint;
+        let mut exporter = AzureMonitorExporter::new(
+            create_test_pipeline_ctx(),
+            config,
+            Box::new(MockTokenProvider),
+        )
+        .unwrap();
+        exporter
+            .client_pool
+            .initialize(&exporter.config.api)
+            .await
+            .unwrap();
+        exporter
+    }
+
+    async fn auth_with_cached_token() -> BearerAuth {
+        let mut auth = BearerAuth::new(
+            Box::new(MockTokenProvider),
+            AZURE_MONITOR_BEARER_AUTH_EVENTS,
+        );
+        auth.poll_refresh().await;
+        assert!(auth.is_ready());
+        auth
     }
 
     /// Scenario: A completed export succeeds with a known compressed request-body size.
@@ -890,6 +933,205 @@ mod tests {
             .unwrap();
 
         assert!(!auth.is_ready());
+    }
+
+    /// Scenario: pdata arrives before the bearer token provider has published a
+    /// usable token.
+    /// Guarantees: the message is refused instead of buffered, so the exporter
+    /// never batches records it cannot authenticate.
+    #[tokio::test]
+    async fn pdata_is_refused_while_no_bearer_token_is_cached() {
+        let mut exporter = exporter_targeting("http://localhost".to_string()).await;
+        let mut auth = BearerAuth::new(
+            Box::new(MockTokenProvider),
+            AZURE_MONITOR_BEARER_AUTH_EVENTS,
+        );
+        assert!(!auth.is_ready(), "no token has been polled yet");
+        assert!(!auth.not_ready_reason().is_empty());
+
+        let mut msg_id = 0;
+        exporter
+            .handle_message(
+                &test_effect_handler(),
+                Ok(Message::PData(OtapPdata::new(
+                    Context::default(),
+                    OtapPayload::OtlpBytes(OtlpProtoBytes::ExportLogsRequest(Bytes::new())),
+                ))),
+                &mut msg_id,
+                &mut auth,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(msg_id, 0, "refused pdata must not consume a message id");
+        assert!(exporter.state.msg_to_data.is_empty());
+    }
+
+    /// Scenario: a logs message arrives once a bearer token is cached, carrying
+    /// no convertible log records.
+    /// Guarantees: it is admitted for processing rather than refused for auth
+    /// reasons, and is then released instead of being retained by the exporter.
+    #[tokio::test]
+    async fn logs_are_admitted_once_a_bearer_token_is_cached() {
+        let mut exporter = exporter_targeting("http://localhost".to_string()).await;
+        let mut auth = auth_with_cached_token().await;
+
+        let mut msg_id = 0;
+        exporter
+            .handle_message(
+                &test_effect_handler(),
+                Ok(Message::PData(OtapPdata::new(
+                    Context::default(),
+                    OtapPayload::OtlpBytes(OtlpProtoBytes::ExportLogsRequest(Bytes::new())),
+                ))),
+                &mut msg_id,
+                &mut auth,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(msg_id, 1, "admitted pdata consumes a message id");
+        assert!(exporter.state.msg_to_data.is_empty());
+    }
+
+    /// Scenario: buffered log entries are flushed by shutdown while a bearer
+    /// token is cached.
+    /// Guarantees: the batch reaches the ingestion endpoint carrying that token,
+    /// and the drained export is accounted as a success.
+    #[tokio::test]
+    async fn shutdown_exports_buffered_logs_with_the_cached_token() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(header("authorization", "Bearer test-token"))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut exporter = exporter_targeting(mock_server.uri()).await;
+        let mut auth = auth_with_cached_token().await;
+        let effect_handler = test_effect_handler();
+
+        exporter
+            .handle_logs(
+                &effect_handler,
+                Context::default(),
+                OtapPayload::empty(SignalType::Logs),
+                vec![Bytes::from_static(br#"{"Message":"hello"}"#)],
+                1,
+                &mut auth,
+            )
+            .await
+            .unwrap();
+        assert_eq!(exporter.state.msg_to_data.len(), 1);
+
+        exporter
+            .handle_shutdown(&effect_handler, &mut auth)
+            .await
+            .unwrap();
+
+        assert_eq!(exporter.in_flight_exports.len(), 0);
+        assert!(exporter.state.msg_to_data.is_empty());
+        let m = exporter.metrics.borrow();
+        assert_eq!(m.export_for(Outcome::Success).batches.get(), 1);
+        assert_eq!(m.export_for(Outcome::Failure).batches.get(), 0);
+    }
+
+    /// Scenario: a single logs message carries enough records to fill a batch.
+    /// Guarantees: the full batch is dispatched as soon as it is ready, rather
+    /// than waiting for shutdown or the periodic flush.
+    #[tokio::test]
+    async fn a_full_batch_is_dispatched_as_soon_as_it_is_ready() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(header("authorization", "Bearer test-token"))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut exporter = exporter_targeting(mock_server.uri()).await;
+        let mut auth = auth_with_cached_token().await;
+        let effect_handler = test_effect_handler();
+
+        // Entries must be distinct: identical ones compress too well to reach
+        // the compressed batch limit.
+        let mut rng = SmallRng::seed_from_u64(7);
+        let entries: Vec<Bytes> = (0..2_500)
+            .map(|_| {
+                let msg: String = (0..1_024)
+                    .map(|_| rng.random_range(b'a'..=b'z') as char)
+                    .collect();
+                Bytes::from(format!(r#"{{"Message":"{msg}"}}"#))
+            })
+            .collect();
+
+        exporter
+            .handle_logs(
+                &effect_handler,
+                Context::default(),
+                OtapPayload::empty(SignalType::Logs),
+                entries,
+                1,
+                &mut auth,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            exporter.in_flight_exports.len(),
+            1,
+            "a ready batch is dispatched without waiting for shutdown"
+        );
+
+        exporter
+            .drain_in_flight_exports(&effect_handler, &mut auth)
+            .await
+            .unwrap();
+        assert_eq!(
+            exporter
+                .metrics
+                .borrow()
+                .export_for(Outcome::Success)
+                .batches
+                .get(),
+            1
+        );
+    }
+
+    /// Scenario: shutdown arrives while no bearer token is cached.
+    /// Guarantees: the exporter skips the flush it cannot authenticate and still
+    /// releases every buffered message rather than dropping it silently.
+    #[tokio::test]
+    async fn shutdown_without_a_token_releases_buffered_messages() {
+        let mut exporter = exporter_targeting("http://localhost".to_string()).await;
+        let mut auth = BearerAuth::new(
+            Box::new(MockTokenProvider),
+            AZURE_MONITOR_BEARER_AUTH_EVENTS,
+        );
+        assert!(!auth.is_ready(), "no token has been polled yet");
+
+        exporter
+            .state
+            .add_msg_to_data(7, Context::default(), OtapPayload::empty(SignalType::Logs));
+
+        exporter
+            .handle_shutdown(&test_effect_handler(), &mut auth)
+            .await
+            .unwrap();
+
+        assert!(exporter.state.msg_to_data.is_empty());
+    }
+
+    /// Scenario: the bearer-auth adapter reports an unusable token and a closed
+    /// token stream.
+    /// Guarantees: both hooks are wired to Azure Monitor's event namespace and
+    /// can be raised without panicking.
+    #[test]
+    fn bearer_auth_events_are_reportable() {
+        let invalid = HeaderValue::from_str("\n").expect_err("control chars are invalid");
+        (AZURE_MONITOR_BEARER_AUTH_EVENTS.invalid_token)(&invalid);
+        (AZURE_MONITOR_BEARER_AUTH_EVENTS.token_stream_closed)();
     }
 
     // Azure Monitor can temporarily stop accepting new pdata while it is at

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
@@ -5,7 +5,6 @@ use async_trait::async_trait;
 use otap_df_channel::error::RecvError;
 use otap_df_config::SignalType;
 use otap_df_engine::ConsumerEffectHandlerExtension;
-use otap_df_engine::capability::auth::BearerToken;
 use otap_df_engine::context::PipelineContext;
 use otap_df_engine::control::{AckMsg, NackMsg, NodeControlMsg};
 use otap_df_engine::error::Error as EngineError;
@@ -28,9 +27,8 @@ use super::in_flight_exports::{CompletedExport, InFlightExports};
 use super::metrics::AzureMonitorExporterMetricsRc;
 use super::state::AzureMonitorExporterState;
 use super::transformer::Transformer;
-use futures::StreamExt;
+use otap_df_otap::bearer_auth::{BearerAuth, BearerAuthEvents};
 use otap_df_otap::pdata::{Context, OtapPdata};
-use reqwest::header::HeaderValue;
 
 use otap_df_telemetry::common_attributes::{HttpResponse, Outcome};
 
@@ -42,56 +40,19 @@ use std::rc::Rc;
 const MAX_IN_FLIGHT_EXPORTS: usize = 16;
 const PERIODIC_EXPORT_INTERVAL: u64 = 3;
 
-/// Safety margin before actual token expiry within which the exporter stops
-/// accepting new pdata. Kept small and aligned with the extension's own
-/// usability margin (`TOKEN_USABLE_MARGIN_SECS`): the bound
-/// `BearerTokenProvider` extension refreshes the token well ahead of expiry, so
-/// under healthy operation this margin is never reached. It only gates data
-/// acceptance in the degraded case where a refresh is failing and the cached
-/// token is genuinely about to expire; until then a still-valid token keeps
-/// being served, matching the provider's "serve valid tokens near expiry"
-/// behavior.
-const TOKEN_USABLE_MARGIN_SECS: u64 = 30;
-
-/// The exporter's view of the current bearer token's remaining lifetime.
-///
-/// Models the three states explicitly instead of encoding them in a single
-/// `Instant` with a sentinel: no token yet, a non-expiring token, or a token
-/// with a known expiry.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum TokenExpiry {
-    /// No usable token yet (before the first token arrives).
-    None,
-    /// A token with no known expiry; valid until replaced.
-    NeverExpires,
-    /// A token that expires at the given monotonic instant.
-    At(tokio::time::Instant),
-}
-
-impl TokenExpiry {
-    /// Derives the expiry state from a provider token. A token without a known
-    /// `expires_on` is treated as non-expiring ("valid until replaced").
-    #[inline]
-    fn from_token(token: &BearerToken) -> Self {
-        match token.expires_on() {
-            Some(expires_on) => Self::At(tokio::time::Instant::from_std(expires_on)),
-            None => Self::NeverExpires,
-        }
-    }
-
-    /// Returns whether the token is still usable at `now`. An expiring token is
-    /// usable only while more than `margin` remains before expiry, so a request
-    /// started now still completes against a valid token; otherwise the exporter
-    /// stops accepting pdata and back-pressures.
-    #[inline]
-    fn is_usable(self, now: tokio::time::Instant, margin: std::time::Duration) -> bool {
-        match self {
-            Self::None => false,
-            Self::NeverExpires => true,
-            Self::At(expiry) => expiry > now + margin,
-        }
-    }
-}
+/// Raises shared bearer-auth warnings under the Azure Monitor event namespace.
+const AZURE_MONITOR_BEARER_AUTH_EVENTS: BearerAuthEvents = BearerAuthEvents {
+    invalid_token: |error| {
+        otel_warn!("azure_monitor_exporter.auth.invalid_bearer_token", error = %error);
+    },
+    token_stream_closed: || {
+        otel_warn!(
+            "azure_monitor_exporter.auth.token_stream_closed",
+            message =
+                "bearer token provider closed its stream; no further token refreshes will arrive"
+        );
+    },
+};
 
 /// Azure Monitor exporter.
 pub struct AzureMonitorExporter {
@@ -104,7 +65,7 @@ pub struct AzureMonitorExporter {
     in_flight_exports: InFlightExports,
     last_batch_queued_at: tokio::time::Instant,
     heartbeat: Option<Heartbeat>,
-    token_provider: Box<dyn BearerTokenProvider>,
+    token_provider: Option<Box<dyn BearerTokenProvider>>,
 }
 
 impl AzureMonitorExporter {
@@ -152,7 +113,7 @@ impl AzureMonitorExporter {
             in_flight_exports: InFlightExports::new(MAX_IN_FLIGHT_EXPORTS),
             last_batch_queued_at: tokio::time::Instant::now(),
             heartbeat,
-            token_provider,
+            token_provider: Some(token_provider),
         })
     }
 
@@ -179,6 +140,7 @@ impl AzureMonitorExporter {
     async fn finalize_export(
         &mut self,
         effect_handler: &EffectHandler<OtapPdata>,
+        auth: &mut BearerAuth,
         completed_export: CompletedExport,
     ) -> Result<(), EngineError> {
         let CompletedExport {
@@ -187,10 +149,15 @@ impl AzureMonitorExporter {
             result,
             row_count,
             body_size_bytes,
+            token_generation,
         } = completed_export;
 
         // Return the client to the pool
         self.client_pool.release(client);
+
+        if result.as_ref().is_err_and(Error::is_unauthorized) {
+            auth.invalidate(token_generation);
+        }
 
         match result {
             Ok(duration) => {
@@ -281,6 +248,7 @@ impl AzureMonitorExporter {
     async fn queue_pending_batch(
         &mut self,
         effect_handler: &EffectHandler<OtapPdata>,
+        auth: &mut BearerAuth,
     ) -> Result<(), EngineError> {
         let pending_batch = match self.gzip_batcher.take_pending_batch() {
             Some(batch) => batch,
@@ -295,6 +263,9 @@ impl AzureMonitorExporter {
             .add_batch_size(pending_batch.compressed_data.len() as f64);
 
         let client = self.client_pool.take();
+        let (auth_header, token_generation) = auth
+            .header()
+            .expect("queueing is gated on a usable bearer token");
         if let Some(completed_export) = self
             .in_flight_exports
             .push_export(
@@ -302,10 +273,12 @@ impl AzureMonitorExporter {
                 pending_batch.batch_id,
                 pending_batch.row_count,
                 pending_batch.compressed_data,
+                auth_header,
+                token_generation,
             )
             .await
         {
-            self.finalize_export(effect_handler, completed_export)
+            self.finalize_export(effect_handler, auth, completed_export)
                 .await?;
         }
 
@@ -321,6 +294,7 @@ impl AzureMonitorExporter {
         payload: OtapPayload,
         log_entries: Vec<Bytes>,
         msg_id: u64,
+        auth: &mut BearerAuth,
     ) -> Result<(), EngineError> {
         if context.may_return_payload() {
             self.state.add_msg_to_data(msg_id, context, payload);
@@ -339,7 +313,7 @@ impl AzureMonitorExporter {
                 Ok(gzip_batcher::PushResult::BatchReady(new_batch_id)) => {
                     // new batch id is being associated with the current message
                     self.state.add_batch_msg_relationship(new_batch_id, msg_id);
-                    self.queue_pending_batch(effect_handler).await?;
+                    self.queue_pending_batch(effect_handler, auth).await?;
                 }
                 Ok(gzip_batcher::PushResult::TooLarge) => {
                     let error = Error::LogEntryTooLarge;
@@ -397,10 +371,11 @@ impl AzureMonitorExporter {
     async fn drain_in_flight_exports(
         &mut self,
         effect_handler: &EffectHandler<OtapPdata>,
+        auth: &mut BearerAuth,
     ) -> Result<(), EngineError> {
         let completed_exports = self.in_flight_exports.drain().await;
         for completed_export in completed_exports {
-            self.finalize_export(effect_handler, completed_export)
+            self.finalize_export(effect_handler, auth, completed_export)
                 .await?;
         }
         Ok(())
@@ -409,10 +384,11 @@ impl AzureMonitorExporter {
     async fn queue_current_batch(
         &mut self,
         effect_handler: &EffectHandler<OtapPdata>,
+        auth: &mut BearerAuth,
     ) -> Result<(), EngineError> {
         match self.gzip_batcher.finalize() {
             Ok(FinalizeResult::Ok) => {
-                return self.queue_pending_batch(effect_handler).await;
+                return self.queue_pending_batch(effect_handler, auth).await;
             }
             Ok(FinalizeResult::Empty) => Ok(()),
             Err(error) => Err(EngineError::InternalError {
@@ -424,9 +400,12 @@ impl AzureMonitorExporter {
     async fn handle_shutdown(
         &mut self,
         effect_handler: &EffectHandler<OtapPdata>,
+        auth: &mut BearerAuth,
     ) -> Result<(), EngineError> {
-        self.queue_current_batch(effect_handler).await?;
-        self.drain_in_flight_exports(effect_handler).await?;
+        if auth.is_ready() {
+            self.queue_current_batch(effect_handler, auth).await?;
+        }
+        self.drain_in_flight_exports(effect_handler, auth).await?;
 
         for (msg_id, context, payload) in self.state.drain_all() {
             otel_warn!(
@@ -451,9 +430,16 @@ impl AzureMonitorExporter {
         effect_handler: &EffectHandler<OtapPdata>,
         msg: Result<Message<OtapPdata>, RecvError>,
         msg_id: &mut u64,
+        auth: &mut BearerAuth,
     ) -> Result<(), EngineError> {
         match msg {
             Ok(Message::PData(pdata)) => {
+                if !auth.is_ready() {
+                    effect_handler
+                        .notify_nack(NackMsg::new(auth.not_ready_reason(), pdata))
+                        .await?;
+                    return Ok(());
+                }
                 *msg_id += 1;
                 let (context, payload) = pdata.into_parts();
 
@@ -495,7 +481,7 @@ impl AzureMonitorExporter {
                 };
 
                 if let Some(log_entries) = log_entries {
-                    self.handle_logs(effect_handler, context, payload, log_entries, *msg_id)
+                    self.handle_logs(effect_handler, context, payload, log_entries, *msg_id, auth)
                         .await?;
                 }
             }
@@ -530,12 +516,12 @@ impl Exporter<OtapPdata> for AzureMonitorExporter {
 
         let mut msg_id = 0;
 
-        // Subscribe to bearer tokens from the bound provider capability. The
-        // stream yields the current token immediately and then a new value each
-        // time the provider refreshes it. Credential acquisition and refresh
-        // scheduling are owned by the provider extension.
-        let mut token_stream = self.token_provider.token_stream();
-        let mut token_stream_active = true;
+        let mut auth = BearerAuth::new(
+            self.token_provider
+                .take()
+                .expect("bearer token provider is present before startup"),
+            AZURE_MONITOR_BEARER_AUTH_EVENTS,
+        );
 
         self.client_pool
             .initialize(&self.config.api)
@@ -551,61 +537,52 @@ impl Exporter<OtapPdata> for AzureMonitorExporter {
             + tokio::time::Duration::from_secs(PERIODIC_EXPORT_INTERVAL);
         let mut next_heartbeat_send = tokio::time::Instant::now();
 
-        // pdata is not accepted until a usable token arrives. Starts as `None`
-        // so `has_token` is false until the first token is published.
-        let mut token_expiry = TokenExpiry::None;
+        let margin_sleep = tokio::time::sleep_until(tokio::time::Instant::now());
+        tokio::pin!(margin_sleep);
+        let mut armed_margin_deadline: Option<std::time::Instant> = None;
 
         loop {
-            // We have a valid token as long as it won't expire within the
-            // usability safety margin.
-            let has_token = token_expiry.is_usable(
-                tokio::time::Instant::now(),
-                tokio::time::Duration::from_secs(TOKEN_USABLE_MARGIN_SECS),
-            );
+            let has_token = auth.is_ready();
             let at_capacity = self.in_flight_exports.len() >= MAX_IN_FLIGHT_EXPORTS;
             let accepting_pdata = has_token && !at_capacity;
+
+            let token_margin_deadline = auth.refresh_deadline();
+            if token_margin_deadline != armed_margin_deadline {
+                if let Some(deadline) = token_margin_deadline {
+                    margin_sleep
+                        .as_mut()
+                        .reset(tokio::time::Instant::from_std(deadline));
+                }
+                armed_margin_deadline = token_margin_deadline;
+            }
 
             tokio::select! {
                 biased;
 
-                // Receive bearer tokens (initial + refreshes) from the provider.
-                maybe_token = token_stream.next(), if token_stream_active => {
-                    match maybe_token {
-                        Some(token) => {
-                            match HeaderValue::from_str(&format!("Bearer {}", token.expose_token())) {
-                                Ok(header) => {
-                                    self.client_pool.update_auth(header.clone());
-                                    if let Some(ref mut hb) = self.heartbeat {
-                                        hb.update_auth(header.clone());
-                                    }
+                () = &mut margin_sleep, if token_margin_deadline.is_some() => {
+                    continue;
+                }
 
-                                    token_expiry = TokenExpiry::from_token(&token);
-
-                                    otel_info!("azure_monitor_exporter.auth.token_acquired");
-                                }
-                                Err(e) => {
-                                    otel_error!("azure_monitor_exporter.auth.header_creation_failed", error = ?e);
-                                }
-                            }
-                        }
-                        None => {
-                            // Provider closed the token stream; no further refreshes
-                            // will arrive. Stop polling it.
-                            token_stream_active = false;
-                            otel_warn!("azure_monitor_exporter.auth.token_stream_ended");
-                        }
-                    }
+                () = auth.poll_refresh(), if auth.is_active() => {
+                    continue;
                 }
 
                 _ = tokio::time::sleep_until(next_heartbeat_send), if has_token && self.heartbeat.is_some() => {
                     next_heartbeat_send = tokio::time::Instant::now() + self.config.heartbeat.frequency;
                     if let Some(ref mut hb) = self.heartbeat {
+                        let (header, generation) = auth
+                            .header()
+                            .expect("heartbeat is gated on a usable bearer token");
+                        hb.update_auth(header);
                         match hb.send().await {
                             Ok(_) => {
                                 self.metrics.borrow_mut().record_heartbeat(Outcome::Success);
                                 otel_debug!("azure_monitor_exporter.heartbeat.sent");
                             }
                             Err(e) => {
+                                if e.is_unauthorized() {
+                                    auth.invalidate(generation);
+                                }
                                 self.metrics.borrow_mut().record_heartbeat(Outcome::Failure);
                                 otel_warn!("azure_monitor_exporter.heartbeat.send_failed", error = %e);
                             }
@@ -615,7 +592,7 @@ impl Exporter<OtapPdata> for AzureMonitorExporter {
 
                 completed = self.in_flight_exports.next_completion() => {
                     if let Some(completed_export) = completed {
-                        self.finalize_export(&effect_handler, completed_export).await?;
+                        self.finalize_export(&effect_handler, &mut auth, completed_export).await?;
                     }
                 }
 
@@ -624,7 +601,7 @@ impl Exporter<OtapPdata> for AzureMonitorExporter {
 
                     if self.last_batch_queued_at.elapsed() >= std::time::Duration::from_secs(PERIODIC_EXPORT_INTERVAL) && self.gzip_batcher.has_pending_data() {
                         otel_debug!("azure_monitor_exporter.export.periodic_flush");
-                        self.queue_current_batch(&effect_handler).await?;
+                        self.queue_current_batch(&effect_handler, &mut auth).await?;
                     }
                 }
 
@@ -660,7 +637,7 @@ impl Exporter<OtapPdata> for AzureMonitorExporter {
                             let _ = self.metrics.borrow_mut().report(&mut metrics_reporter);
                         }
                         Ok(Message::Control(NodeControlMsg::Shutdown { deadline, .. })) => {
-                            self.handle_shutdown(&effect_handler).await?;
+                            self.handle_shutdown(&effect_handler, &mut auth).await?;
                             let snapshots = self.metrics.borrow_mut().terminal_snapshots();
                             return Ok(TerminalState::new(
                                 deadline,
@@ -668,7 +645,7 @@ impl Exporter<OtapPdata> for AzureMonitorExporter {
                             ));
                         }
                         other => {
-                            self.handle_message(&effect_handler, other, &mut msg_id).await?;
+                            self.handle_message(&effect_handler, other, &mut msg_id, &mut auth).await?;
                         }
                     }
                 }
@@ -868,6 +845,53 @@ mod tests {
         assert!(exporter.state.msg_to_data.is_empty());
     }
 
+    /// Scenario: Azure Monitor returns HTTP 401 for an export stamped with the
+    /// currently cached bearer-token generation.
+    /// Guarantees: completion handling invalidates that generation so the exporter
+    /// stops accepting pdata until the provider publishes a replacement token.
+    #[tokio::test]
+    async fn unauthorized_completion_invalidates_the_used_token() {
+        let config = create_test_config();
+        let pipeline_ctx = create_test_pipeline_ctx();
+        let mut exporter =
+            AzureMonitorExporter::new(pipeline_ctx, config, Box::new(MockTokenProvider)).unwrap();
+        let mut auth = BearerAuth::new(
+            Box::new(MockTokenProvider),
+            AZURE_MONITOR_BEARER_AUTH_EVENTS,
+        );
+        auth.poll_refresh().await;
+        let (_, token_generation) = auth.header().expect("mock provider publishes a token");
+
+        let (_, reporter) = MetricsReporter::create_new_and_receiver(10);
+        let effect_handler = EffectHandler::new(
+            NodeId {
+                index: 0,
+                name: "test_exporter".to_string().into(),
+            },
+            reporter,
+        );
+        let client = super::super::client::LogsIngestionClient::from_parts(
+            reqwest::Client::new(),
+            "http://localhost".to_string(),
+            exporter.metrics.clone(),
+        );
+        let completed = CompletedExport {
+            batch_id: 1,
+            client,
+            result: Err(Error::unauthorized("rejected".to_string())),
+            row_count: 1,
+            body_size_bytes: 1,
+            token_generation,
+        };
+
+        exporter
+            .finalize_export(&effect_handler, &mut auth, completed)
+            .await
+            .unwrap();
+
+        assert!(!auth.is_ready());
+    }
+
     // Azure Monitor can temporarily stop accepting new pdata while it is at
     // capacity. Once shutdown is latched, the exporter channel must still drain
     // already buffered pdata before delivering the final Shutdown message.
@@ -913,79 +937,5 @@ mod tests {
             msg,
             Message::Control(NodeControlMsg::Shutdown { .. })
         ));
-    }
-
-    // ==================== Token usability logic ====================
-
-    #[test]
-    fn token_usable_when_expiry_beyond_margin() {
-        let now = tokio::time::Instant::now();
-        let margin = Duration::from_secs(TOKEN_USABLE_MARGIN_SECS);
-        let expiry = TokenExpiry::At(now + Duration::from_secs(TOKEN_USABLE_MARGIN_SECS + 60));
-        assert!(expiry.is_usable(now, margin));
-    }
-
-    #[test]
-    fn token_unusable_within_margin() {
-        // A token that expires inside the margin must stop pdata acceptance so
-        // an in-flight request can't outlive the token.
-        let now = tokio::time::Instant::now();
-        let margin = Duration::from_secs(TOKEN_USABLE_MARGIN_SECS);
-        let expiry = TokenExpiry::At(now + Duration::from_secs(TOKEN_USABLE_MARGIN_SECS - 5));
-        assert!(!expiry.is_usable(now, margin));
-    }
-
-    #[test]
-    fn token_unusable_at_exact_margin_boundary() {
-        // `expiry == now + margin`: the strictly-greater check treats the exact
-        // boundary as not usable.
-        let now = tokio::time::Instant::now();
-        let margin = Duration::from_secs(TOKEN_USABLE_MARGIN_SECS);
-        assert!(!TokenExpiry::At(now + margin).is_usable(now, margin));
-    }
-
-    #[test]
-    fn token_unusable_when_already_expired() {
-        let now = tokio::time::Instant::now();
-        let margin = Duration::from_secs(TOKEN_USABLE_MARGIN_SECS);
-        let expiry = TokenExpiry::At(now - Duration::from_secs(1));
-        assert!(!expiry.is_usable(now, margin));
-    }
-
-    #[test]
-    fn startup_state_gates_pdata() {
-        // The loop initializes `token_expiry = TokenExpiry::None`, which must
-        // read as "no usable token" so pdata is gated until the first token
-        // arrives.
-        let now = tokio::time::Instant::now();
-        let margin = Duration::from_secs(TOKEN_USABLE_MARGIN_SECS);
-        assert!(!TokenExpiry::None.is_usable(now, margin));
-    }
-
-    /// Scenario: derive a `TokenExpiry` from a token that carries an explicit
-    /// expiry instant.
-    /// Guarantees: the expiry is mapped to `TokenExpiry::At` at the token's
-    /// exact instant.
-    #[test]
-    fn expiry_uses_token_expiry_when_present() {
-        let expires_on = Instant::now() + Duration::from_secs(3600);
-        let token = BearerToken::with_expiry("secret".to_owned(), Some(expires_on));
-        assert_eq!(
-            TokenExpiry::from_token(&token),
-            TokenExpiry::At(tokio::time::Instant::from_std(expires_on))
-        );
-    }
-
-    /// Scenario: derive a `TokenExpiry` from a token with no expiry set.
-    /// Guarantees: it maps to `TokenExpiry::NeverExpires` and always reads as
-    /// usable, so a non-expiring token is never treated as stale.
-    #[test]
-    fn non_expiring_token_never_expires_and_stays_usable() {
-        let now = tokio::time::Instant::now();
-        let margin = Duration::from_secs(TOKEN_USABLE_MARGIN_SECS);
-        let token = BearerToken::without_expiry("secret".to_owned());
-        let expiry = TokenExpiry::from_token(&token);
-        assert_eq!(expiry, TokenExpiry::NeverExpires);
-        assert!(expiry.is_usable(now, margin));
     }
 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/in_flight_exports.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/in_flight_exports.rs
@@ -152,6 +152,8 @@ mod tests {
     use std::cell::RefCell;
     use std::rc::Rc;
     use std::time::Duration as StdDuration;
+    use wiremock::matchers::{header, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     // ==================== Test Helpers ====================
 
@@ -408,6 +410,56 @@ mod tests {
         assert!(completed.is_some());
         assert_eq!(completed.unwrap().row_count, 10);
         assert_eq!(exports.queued_rows(), 25);
+    }
+
+    /// Scenario: an export is enqueued with a bearer header and the generation
+    /// of the token that header was built from.
+    /// Guarantees: the dispatched request carries that header, and the completion
+    /// reports the same generation, so a rejection invalidates exactly the token
+    /// the request used.
+    #[tokio::test]
+    async fn push_export_sends_the_stamped_header_and_reports_its_generation() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(header("authorization", "Bearer gen-7"))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        otap_df_otap::crypto::ensure_crypto_provider();
+        let client = LogsIngestionClient::from_parts(
+            Client::new(),
+            mock_server.uri(),
+            create_test_metrics(),
+        );
+
+        let mut exports = InFlightExports::new(5);
+        let backpressured = exports
+            .push_export(
+                client,
+                7,
+                3,
+                Bytes::from_static(b"payload"),
+                HeaderValue::from_static("Bearer gen-7"),
+                42,
+            )
+            .await;
+        assert!(backpressured.is_none());
+        assert_eq!(exports.queued_rows(), 3);
+
+        let completed = exports.next_completion().await.expect("export completes");
+
+        assert_eq!(completed.batch_id, 7);
+        assert_eq!(completed.token_generation, 42);
+        assert_eq!(completed.row_count, 3);
+        assert_eq!(completed.body_size_bytes, 7);
+        assert!(
+            completed.result.is_ok(),
+            "expected success, got {:?}",
+            completed.result
+        );
+        assert_eq!(exports.queued_rows(), 0);
     }
 
     // ==================== drain Tests ====================

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/in_flight_exports.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/in_flight_exports.rs
@@ -5,6 +5,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use futures::future::LocalBoxFuture;
 use futures::stream::FuturesUnordered;
+use http::HeaderValue;
 use tokio::time::Duration;
 
 use super::client::LogsIngestionClient;
@@ -16,6 +17,7 @@ pub struct CompletedExport {
     pub result: Result<Duration, Error>,
     pub row_count: u64,
     pub body_size_bytes: u64,
+    pub token_generation: u64,
 }
 
 pub struct InFlightExports {
@@ -89,8 +91,17 @@ impl InFlightExports {
         batch_id: u64,
         row_count: u64,
         body: Bytes,
+        auth_header: HeaderValue,
+        token_generation: u64,
     ) -> Option<CompletedExport> {
-        let fut = Self::make_export_future(client, batch_id, row_count, body);
+        let fut = Self::make_export_future(
+            client,
+            batch_id,
+            row_count,
+            body,
+            auth_header,
+            token_generation,
+        );
         self.queued_rows = self.queued_rows.saturating_add(row_count);
         self.push(fut).await
     }
@@ -101,9 +112,12 @@ impl InFlightExports {
         batch_id: u64,
         row_count: u64,
         body: Bytes,
+        auth_header: HeaderValue,
+        token_generation: u64,
     ) -> LocalBoxFuture<'static, CompletedExport> {
         Box::pin(async move {
             let body_size_bytes = body.len() as u64;
+            client.update_auth(auth_header);
             let result = client.export(body).await;
             CompletedExport {
                 batch_id,
@@ -111,6 +125,7 @@ impl InFlightExports {
                 result,
                 row_count,
                 body_size_bytes,
+                token_generation,
             }
         })
     }
@@ -186,8 +201,13 @@ mod tests {
                 result,
                 row_count,
                 body_size_bytes: 0,
+                token_generation: 1,
             }
         })
+    }
+
+    fn test_auth() -> (HeaderValue, u64) {
+        (HeaderValue::from_static("Bearer test-token"), 1)
     }
 
     // ==================== Construction Tests ====================
@@ -277,8 +297,16 @@ mod tests {
         let client = create_test_client();
 
         // This should not block because we are under the limit
+        let (auth_header, token_generation) = test_auth();
         let result = exports
-            .push_export(client, 1, 10, Bytes::from("data"))
+            .push_export(
+                client,
+                1,
+                10,
+                Bytes::from("data"),
+                auth_header,
+                token_generation,
+            )
             .await;
 
         assert!(result.is_none());
@@ -300,8 +328,16 @@ mod tests {
         // 2. Now call push_export. Since we are at limit (1), it must wait for a completion.
         // It should receive the completion from our dummy future immediately.
         let client = create_test_client();
+        let (auth_header, token_generation) = test_auth();
         let result = exports
-            .push_export(client, 2, 20, Bytes::from("data"))
+            .push_export(
+                client,
+                2,
+                20,
+                Bytes::from("data"),
+                auth_header,
+                token_generation,
+            )
             .await;
 
         // Should get the completed dummy export
@@ -320,13 +356,29 @@ mod tests {
         // Under the limit, push_export does not block and increments the
         // in-flight record tally by the enqueued row count. The real export
         // future stays pending.
+        let (auth_header, token_generation) = test_auth();
         let _ = exports
-            .push_export(create_test_client(), 1, 100, Bytes::from("data"))
+            .push_export(
+                create_test_client(),
+                1,
+                100,
+                Bytes::from("data"),
+                auth_header,
+                token_generation,
+            )
             .await;
         assert_eq!(exports.queued_rows(), 100);
 
+        let (auth_header, token_generation) = test_auth();
         let _ = exports
-            .push_export(create_test_client(), 2, 50, Bytes::from("data"))
+            .push_export(
+                create_test_client(),
+                2,
+                50,
+                Bytes::from("data"),
+                auth_header,
+                token_generation,
+            )
             .await;
         assert_eq!(exports.queued_rows(), 150);
     }
@@ -343,8 +395,16 @@ mod tests {
 
         // At capacity, push_export(+25) pops the completed future (-10) before
         // adding the new one: 10 + 25 - 10 = 25.
+        let (auth_header, token_generation) = test_auth();
         let completed = exports
-            .push_export(create_test_client(), 2, 25, Bytes::from("data"))
+            .push_export(
+                create_test_client(),
+                2,
+                25,
+                Bytes::from("data"),
+                auth_header,
+                token_generation,
+            )
             .await;
         assert!(completed.is_some());
         assert_eq!(completed.unwrap().row_count, 10);

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/in_flight_exports.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/in_flight_exports.rs
@@ -27,8 +27,8 @@ pub struct InFlightExports {
     ///
     /// Maintained by [`InFlightExports::push_export`] (which increments by the
     /// enqueued `row_count`) and the completion paths ([`next_completion`],
-    /// [`push`], and [`drain`], which decrement by the completed export's
-    /// `row_count`).
+    /// [`reap_if_at_capacity`], and [`drain`], which decrement by the completed
+    /// export's `row_count`).
     queued_rows: u64,
 }
 
@@ -66,26 +66,26 @@ impl InFlightExports {
         }
     }
 
-    /// Push a future. If at capacity, waits for one completion and returns it.
-    #[inline]
-    async fn push(
-        &mut self,
-        fut: LocalBoxFuture<'static, CompletedExport>,
-    ) -> Option<CompletedExport> {
-        let completed = if self.futures.len() >= self.limit {
-            self.futures.next().await
-        } else {
-            None
-        };
+    /// Free a slot when the set is full, returning the export that completed.
+    ///
+    /// Callers must reap before [`push_export`](Self::push_export) and settle the
+    /// completion first: it may reject the token the next export would otherwise
+    /// already have been stamped with.
+    pub async fn reap_if_at_capacity(&mut self) -> Option<CompletedExport> {
+        if self.futures.len() < self.limit {
+            return None;
+        }
+        let completed = self.futures.next().await;
         if let Some(ref c) = completed {
             self.queued_rows = self.queued_rows.saturating_sub(c.row_count);
         }
-        self.futures.push(fut);
         completed
     }
 
-    /// Create and push an export. Returns any completed export due to backpressure.
-    pub async fn push_export(
+    /// Stamp a batch with `auth_header` and add it to the in-flight set.
+    ///
+    /// Does not enforce the limit; call [`reap_if_at_capacity`](Self::reap_if_at_capacity) first.
+    pub fn push_export(
         &mut self,
         client: LogsIngestionClient,
         batch_id: u64,
@@ -93,7 +93,7 @@ impl InFlightExports {
         body: Bytes,
         auth_header: HeaderValue,
         token_generation: u64,
-    ) -> Option<CompletedExport> {
+    ) {
         let fut = Self::make_export_future(
             client,
             batch_id,
@@ -103,7 +103,12 @@ impl InFlightExports {
             token_generation,
         );
         self.queued_rows = self.queued_rows.saturating_add(row_count);
-        self.push(fut).await
+        self.push(fut);
+    }
+
+    #[inline]
+    fn push(&mut self, fut: LocalBoxFuture<'static, CompletedExport>) {
+        self.futures.push(fut);
     }
 
     /// Create a boxed export future.
@@ -245,7 +250,7 @@ mod tests {
         let pending_future: LocalBoxFuture<'static, CompletedExport> =
             Box::pin(std::future::pending());
 
-        let _ = exports.push(pending_future).await;
+        exports.push(pending_future);
 
         assert_eq!(exports.len(), 1);
     }
@@ -257,7 +262,7 @@ mod tests {
         for _ in 0..5 {
             let pending_future: LocalBoxFuture<'static, CompletedExport> =
                 Box::pin(std::future::pending());
-            let _ = exports.push(pending_future).await;
+            exports.push(pending_future);
         }
 
         assert_eq!(exports.len(), 5);
@@ -266,28 +271,55 @@ mod tests {
     // ==================== push Tests ====================
 
     #[tokio::test]
-    async fn test_push_under_limit_returns_none() {
-        let mut exports = InFlightExports::new(5);
-
-        let pending_future: LocalBoxFuture<'static, CompletedExport> =
-            Box::pin(std::future::pending());
-
-        let result = exports.push(pending_future).await;
-
-        assert!(result.is_none());
-        assert_eq!(exports.len(), 1);
-    }
-
-    #[tokio::test]
     async fn test_push_increments_len() {
         let mut exports = InFlightExports::new(10);
 
         for i in 0..5 {
             let pending_future: LocalBoxFuture<'static, CompletedExport> =
                 Box::pin(std::future::pending());
-            let _ = exports.push(pending_future).await;
+            exports.push(pending_future);
             assert_eq!(exports.len(), i + 1);
         }
+    }
+
+    // ==================== reap_if_at_capacity Tests ====================
+
+    /// Scenario: a caller asks to free a slot while the in-flight set is below
+    /// its limit.
+    /// Guarantees: reaping returns nothing without awaiting, so queueing a batch
+    /// never stalls while slots remain.
+    #[tokio::test]
+    async fn reap_under_the_limit_returns_none_without_waiting() {
+        let mut exports = InFlightExports::new(5);
+        exports.push(Box::pin(std::future::pending()));
+
+        let reaped =
+            tokio::time::timeout(StdDuration::from_millis(50), exports.reap_if_at_capacity())
+                .await
+                .expect("reaping below the limit must not wait");
+
+        assert!(reaped.is_none());
+        assert_eq!(exports.len(), 1);
+    }
+
+    /// Scenario: a caller asks to free a slot while the in-flight set is full.
+    /// Guarantees: exactly one export is awaited and handed back, freeing a slot
+    /// and decrementing the in-flight record tally, so the caller can settle that
+    /// completion before stamping the next export.
+    #[tokio::test]
+    async fn reap_at_capacity_returns_the_completed_export_and_frees_a_slot() {
+        let mut exports = InFlightExports::new(1);
+        exports.queued_rows = 10;
+        exports.push(mock_completed_export_future(100, 10, true));
+
+        let reaped = exports
+            .reap_if_at_capacity()
+            .await
+            .expect("at capacity, one export must be reaped");
+
+        assert_eq!(reaped.batch_id, 100);
+        assert_eq!(exports.len(), 0);
+        assert_eq!(exports.queued_rows(), 0);
     }
 
     // ==================== push_export Tests ====================
@@ -297,56 +329,16 @@ mod tests {
         let mut exports = InFlightExports::new(5);
         let client = create_test_client();
 
-        // This should not block because we are under the limit
         let (auth_header, token_generation) = test_auth();
-        let result = exports
-            .push_export(
-                client,
-                1,
-                10,
-                Bytes::from("data"),
-                auth_header,
-                token_generation,
-            )
-            .await;
+        exports.push_export(
+            client,
+            1,
+            10,
+            Bytes::from("data"),
+            auth_header,
+            token_generation,
+        );
 
-        assert!(result.is_none());
-        assert_eq!(exports.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn test_push_export_respects_limit() {
-        let mut exports = InFlightExports::new(1);
-
-        // 1. Fill the capacity with a dummy future that completes immediately
-        // We use a dummy future because if we used push_export, it would create a real
-        // export future that might retry and take a long time to fail/complete.
-        let _ = exports
-            .push(mock_completed_export_future(100, 1, true))
-            .await;
-        assert_eq!(exports.len(), 1);
-
-        // 2. Now call push_export. Since we are at limit (1), it must wait for a completion.
-        // It should receive the completion from our dummy future immediately.
-        let client = create_test_client();
-        let (auth_header, token_generation) = test_auth();
-        let result = exports
-            .push_export(
-                client,
-                2,
-                20,
-                Bytes::from("data"),
-                auth_header,
-                token_generation,
-            )
-            .await;
-
-        // Should get the completed dummy export
-        assert!(result.is_some());
-        let completed = result.unwrap();
-        assert_eq!(completed.batch_id, 100);
-
-        // The new export should be in the queue
         assert_eq!(exports.len(), 1);
     }
 
@@ -354,61 +346,54 @@ mod tests {
     async fn test_push_export_increments_queued_rows() {
         let mut exports = InFlightExports::new(5);
 
-        // Under the limit, push_export does not block and increments the
-        // in-flight record tally by the enqueued row count. The real export
-        // future stays pending.
+        // push_export increments the in-flight record tally by the enqueued row
+        // count. The real export future stays pending.
         let (auth_header, token_generation) = test_auth();
-        let _ = exports
-            .push_export(
-                create_test_client(),
-                1,
-                100,
-                Bytes::from("data"),
-                auth_header,
-                token_generation,
-            )
-            .await;
+        exports.push_export(
+            create_test_client(),
+            1,
+            100,
+            Bytes::from("data"),
+            auth_header,
+            token_generation,
+        );
         assert_eq!(exports.queued_rows(), 100);
 
         let (auth_header, token_generation) = test_auth();
-        let _ = exports
-            .push_export(
-                create_test_client(),
-                2,
-                50,
-                Bytes::from("data"),
-                auth_header,
-                token_generation,
-            )
-            .await;
+        exports.push_export(
+            create_test_client(),
+            2,
+            50,
+            Bytes::from("data"),
+            auth_header,
+            token_generation,
+        );
         assert_eq!(exports.queued_rows(), 150);
     }
 
     #[tokio::test]
-    async fn test_push_export_backpressure_decrements_queued_rows() {
+    async fn test_backpressure_decrements_queued_rows() {
         let mut exports = InFlightExports::new(1);
         exports.queued_rows = 10;
         // Fill capacity with a completing future worth 10 records.
-        let _ = exports
-            .push(mock_completed_export_future(1, 10, true))
-            .await;
+        exports.push(mock_completed_export_future(1, 10, true));
         assert_eq!(exports.len(), 1);
 
-        // At capacity, push_export(+25) pops the completed future (-10) before
-        // adding the new one: 10 + 25 - 10 = 25.
-        let (auth_header, token_generation) = test_auth();
-        let completed = exports
-            .push_export(
-                create_test_client(),
-                2,
-                25,
-                Bytes::from("data"),
-                auth_header,
-                token_generation,
-            )
-            .await;
+        // Reaping pops the completed future (-10), then push_export adds the new
+        // one (+25): 10 - 10 + 25 = 25.
+        let completed = exports.reap_if_at_capacity().await;
         assert!(completed.is_some());
         assert_eq!(completed.unwrap().row_count, 10);
+
+        let (auth_header, token_generation) = test_auth();
+        exports.push_export(
+            create_test_client(),
+            2,
+            25,
+            Bytes::from("data"),
+            auth_header,
+            token_generation,
+        );
         assert_eq!(exports.queued_rows(), 25);
     }
 
@@ -435,17 +420,14 @@ mod tests {
         );
 
         let mut exports = InFlightExports::new(5);
-        let backpressured = exports
-            .push_export(
-                client,
-                7,
-                3,
-                Bytes::from_static(b"payload"),
-                HeaderValue::from_static("Bearer gen-7"),
-                42,
-            )
-            .await;
-        assert!(backpressured.is_none());
+        exports.push_export(
+            client,
+            7,
+            3,
+            Bytes::from_static(b"payload"),
+            HeaderValue::from_static("Bearer gen-7"),
+            42,
+        );
         assert_eq!(exports.queued_rows(), 3);
 
         let completed = exports.next_completion().await.expect("export completes");
@@ -479,9 +461,9 @@ mod tests {
         let mut exports = InFlightExports::new(5);
 
         // Push 3 dummy completed futures
-        let _ = exports.push(mock_completed_export_future(1, 1, true)).await;
-        let _ = exports.push(mock_completed_export_future(2, 1, true)).await;
-        let _ = exports.push(mock_completed_export_future(3, 1, true)).await;
+        exports.push(mock_completed_export_future(1, 1, true));
+        exports.push(mock_completed_export_future(2, 1, true));
+        exports.push(mock_completed_export_future(3, 1, true));
 
         assert_eq!(exports.len(), 3);
 
@@ -500,12 +482,8 @@ mod tests {
     async fn test_drain_resets_queued_rows_to_zero() {
         let mut exports = InFlightExports::new(5);
         exports.queued_rows = 60;
-        let _ = exports
-            .push(mock_completed_export_future(1, 20, true))
-            .await;
-        let _ = exports
-            .push(mock_completed_export_future(2, 40, false))
-            .await;
+        exports.push(mock_completed_export_future(1, 20, true));
+        exports.push(mock_completed_export_future(2, 40, false));
 
         let drained = exports.drain().await;
         assert_eq!(drained.len(), 2);
@@ -531,9 +509,7 @@ mod tests {
     async fn test_next_completion_returns_completed() {
         let mut exports = InFlightExports::new(5);
 
-        let _ = exports
-            .push(mock_completed_export_future(42, 1, true))
-            .await;
+        exports.push(mock_completed_export_future(42, 1, true));
 
         let result = exports.next_completion().await;
 
@@ -547,9 +523,7 @@ mod tests {
         let mut exports = InFlightExports::new(5);
         // Simulate in-flight exports totaling 100 records.
         exports.queued_rows = 100;
-        let _ = exports
-            .push(mock_completed_export_future(1, 30, true))
-            .await;
+        exports.push(mock_completed_export_future(1, 30, true));
 
         let completed = exports.next_completion().await.unwrap();
         assert_eq!(completed.row_count, 30);
@@ -560,9 +534,7 @@ mod tests {
     async fn test_next_completion_failure_decrements_queued_rows() {
         let mut exports = InFlightExports::new(5);
         exports.queued_rows = 40;
-        let _ = exports
-            .push(mock_completed_export_future(1, 40, false))
-            .await;
+        exports.push(mock_completed_export_future(1, 40, false));
 
         let completed = exports.next_completion().await.unwrap();
         assert!(completed.result.is_err());
@@ -574,7 +546,7 @@ mod tests {
         let mut exports = InFlightExports::new(5);
         // queued_rows is 0 but a completion reports 5 records; saturating_sub
         // must keep it at 0 rather than wrapping around.
-        let _ = exports.push(mock_completed_export_future(1, 5, true)).await;
+        exports.push(mock_completed_export_future(1, 5, true));
         let _ = exports.next_completion().await.unwrap();
         assert_eq!(exports.queued_rows(), 0);
     }
@@ -589,8 +561,8 @@ mod tests {
         let pending1: LocalBoxFuture<'static, CompletedExport> = Box::pin(std::future::pending());
         let pending2: LocalBoxFuture<'static, CompletedExport> = Box::pin(std::future::pending());
 
-        let _ = exports.push(pending1).await;
-        let _ = exports.push(pending2).await;
+        exports.push(pending1);
+        exports.push(pending2);
 
         assert_eq!(exports.len(), 2);
 
@@ -609,8 +581,7 @@ mod tests {
         for _ in 0..limit {
             let pending: LocalBoxFuture<'static, CompletedExport> =
                 Box::pin(std::future::pending());
-            let result = exports.push(pending).await;
-            assert!(result.is_none(), "Should not return completion under limit");
+            exports.push(pending);
         }
 
         assert_eq!(exports.len(), limit);

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/in_flight_exports.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/in_flight_exports.rs
@@ -117,8 +117,7 @@ impl InFlightExports {
     ) -> LocalBoxFuture<'static, CompletedExport> {
         Box::pin(async move {
             let body_size_bytes = body.len() as u64;
-            client.update_auth(auth_header);
-            let result = client.export(body).await;
+            let result = client.export(body, &auth_header).await;
             CompletedExport {
                 batch_id,
                 client,


### PR DESCRIPTION
# Change Summary

chore(azure-monitor-exporter): Refactor Azure Monitor exporter to use bearer-auth adapter

## What issue does this PR close?

* Related to #3356

## How are these changes tested?

- Unit tests
- Local integration test

## Are there any user-facing changes?

No

### Changelog

* [ ] Added a `.chloggen/*.yaml` entry
* [x] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
