### PR TITLE
chore(deps): update rust crate h2 to 0.4.16 [security]

### DIFF
--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -4978,9 +4978,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
`cargo deny` fails on every PR and on `main` since RUSTSEC-2026-0258 was published: `h2` accepted and queued empty DATA frames without limit, which can lead to unbounded memory usage or a panic on length overflow when streams are not drained. Patched in h2 0.4.16.

This bumps only the `h2` entry in `rust/otap-dataflow/Cargo.lock` (2 lines). Running `cargo update -p h2` locally also re-resolved a number of unrelated `windows-sys` edges, so the lock entry was updated directly to keep the diff minimal.

Verified locally: `cargo deny check advisories` reports `advisories ok`, and `cargo check --workspace --locked` succeeds.

### Changelog

* [ ] Added a `.chloggen/*.yaml` entry
* [x] This PR is a `chore` (indicated in title)
* [ ] This is a documentation-only PR.
