### PR TITLE
fix(metrics): Preserve receiver item-count metrics through processors that rebuild PData context

### DIFF
--- a/rust/otap-dataflow/.chloggen/preserve-metrics-context-through-processors.yaml
+++ b/rust/otap-dataflow/.chloggen/preserve-metrics-context-through-processors.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: pipeline
+note: "Preserve receiver item-count metrics through processors that batch, split, partition, or aggregate telemetry."
+issues: [3803]
+subtext:

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -258,11 +258,11 @@ pub struct Config {
     #[serde(with = "humantime_serde", default = "default_max_batch_duration")]
     pub max_batch_duration: Duration,
 
-    /// Limits the number of pending requests for ack/nack tracking.
+    /// Limits the number of pending requests for completion tracking.
     #[serde(default = "default_inbound_request_limit")]
     pub inbound_request_limit: NonZeroUsize,
 
-    /// Limits the number of outbound requests for ack/nack tracking.
+    /// Limits the number of outbound requests for completion tracking.
     #[serde(default = "default_outbound_request_limit")]
     pub outbound_request_limit: NonZeroUsize,
 
@@ -962,8 +962,8 @@ where
         // when none of them subscribed to ack/nack.
         let peer_addr = ctx.peer_addr();
 
-        // If there are subscribers, calculate an inbound slot key.
-        let inkey = if ctx.has_subscribers() {
+        // Retain contexts needed for Ack/Nack routing or metrics unwinding.
+        let inkey = if ctx.needs_completion_tracking() {
             let slot = self
                 .buffer
                 .inbound
@@ -1186,8 +1186,8 @@ where
             let weight = ownership;
             let mut pdata = OtapPdata::new(Context::default(), records.into());
 
-            // If any inputs in this batch require notification, get an
-            // outbound slot and subscribe.
+            // If any inputs require completion tracking, get an outbound slot
+            // and subscribe so their contexts can unwind after this output.
             let (routed_ctxs, merged_peer) = self.buffer.drain_context(weight, &mut input_context);
             // Forward the receiver-observed peer address only when every
             // input merged into this output batch came from the same peer

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -2097,7 +2097,7 @@ mod tests {
                             looped += 1;
 
                             // Apply ack/nack policy
-                            if new_output.has_subscribers() {
+                            if new_output.has_ack_or_nack_interests() {
                                 let policy = nack_policy
                                     .as_ref()
                                     .map(|p| p(total_outputs - 1, &new_output))
@@ -3647,7 +3647,7 @@ mod tests {
                 let last = outputs.len() - 1;
                 for (i, out) in outputs.into_iter().enumerate() {
                     assert!(
-                        out.has_subscribers(),
+                        out.has_ack_or_nack_interests(),
                         "every fragment must be subscribed for ack/nack"
                     );
                     if i == last {

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
@@ -325,8 +325,8 @@ impl local::Processor<OtapPdata> for TemporalReaggregationProcessor {
         // We may need up to one inbound slot and three outbound slots.
         //
         // The inbound slot is used to track the inbound request context and is
-        // needed if either there are ack/nack interests on the context OR if some of
-        // the data is aggregable meaning we won't just pass the whole batch
+        // needed if the context requires completion tracking OR if some of the
+        // data is aggregable, meaning we won't just pass the whole batch
         // through untouched.
         //
         // One outbound slot may be needed to flush the existing batch if we
@@ -652,10 +652,10 @@ impl TemporalReaggregationProcessor {
                     // the in-progress builder; remember its peer_addr so the
                     // next flush can compute the merged output peer_addr.
                     self.aggregated_peer.push(pdata.peer_addr());
-                    // Pass data through if there are no subscribers -- but we
-                    // still need a wakeup to flush the aggregated portion.
+                    // Pass data through directly if no completion routing or
+                    // metrics unwinding depends on the inbound context.
                     let (inbound_ctx, _) = pdata.into_parts();
-                    if !inbound_ctx.has_subscribers() {
+                    if !inbound_ctx.needs_completion_tracking() {
                         self.ensure_wakeup_scheduled(effect_handler)?;
                         let pt_pdata =
                             OtapPdata::new(inbound_ctx, OtapPayload::OtapArrowRecords(records));
@@ -710,11 +710,10 @@ impl TemporalReaggregationProcessor {
                     // The full input was folded into the in-progress builder;
                     // remember its peer_addr for the next flush.
                     self.aggregated_peer.push(pdata.peer_addr());
-                    // Nothing to passthrough and no subscribers so we don't
-                    // care about ack/nack -- but we still need a wakeup to
-                    // flush the aggregated data.
+                    // If no completion routing or metrics unwinding depends on
+                    // the inbound context, only schedule the aggregate flush.
                     let (inbound_ctx, _) = pdata.into_parts();
-                    if !inbound_ctx.has_subscribers() {
+                    if !inbound_ctx.needs_completion_tracking() {
                         self.ensure_wakeup_scheduled(effect_handler)?;
                         return Ok(());
                     }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/testing.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/testing.rs
@@ -169,7 +169,7 @@ pub(super) fn run_test(config: serde_json::Value, actions: Vec<Action>) {
                             match pdata_action {
                                 PdataAction::AssertSubscribers(expected) => {
                                     assert_eq!(
-                                        output.has_subscribers(),
+                                        output.has_ack_or_nack_interests(),
                                         expected,
                                         "has_subscribers mismatch"
                                     );

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/testing.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/testing.rs
@@ -171,7 +171,7 @@ pub(super) fn run_test(config: serde_json::Value, actions: Vec<Action>) {
                                     assert_eq!(
                                         output.has_ack_or_nack_interests(),
                                         expected,
-                                        "has_subscribers mismatch"
+                                        "has_ack_or_nack_interests mismatch"
                                     );
                                 }
                                 PdataAction::Nack(reason) => {

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -1992,7 +1992,7 @@ mod test {
                 assert_eq!(outbound_context.source_node(), Some(0));
                 inbound_context.set_source_node(0);
                 assert_eq!(inbound_context, outbound_context);
-                assert!(outbound_context.has_subscribers());
+                assert!(outbound_context.has_ack_or_nack_subscribers());
             })
             .validate(|_ctx| async move {})
     }
@@ -2072,7 +2072,7 @@ mod test {
                 // The processor at node 5 should have tagged the outbound source.
                 assert_eq!(outbound_pdata.get_source_node(), Some(5));
                 // The original ACK subscriber should still be present.
-                assert!(outbound_pdata.has_subscribers());
+                assert!(outbound_pdata.has_ack_or_nack_interests());
 
                 // Behavior check: ACK unwinds back to the original subscriber.
                 let (node_id, ack) = next_ack(AckMsg::new(outbound_pdata))

--- a/rust/otap-dataflow/crates/otap/src/accessory/context/split_contexts.rs
+++ b/rust/otap-dataflow/crates/otap/src/accessory/context/split_contexts.rs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//! utilities for managing context of inbound and outbound requests
+//! Utilities for managing context of inbound and outbound requests
 //! produced by processors that may split the incoming batch into
 //! multiple outbound batches
 
@@ -23,9 +23,10 @@ struct Outbound {
     inbound_key: Key,
 }
 
-/// Contexts manages the context of inbound and outbound batches. The intent here is to keep enough state
-/// that if any batches are split by the pipeline, we can Ack/Nack the inbound batch and when all outbound batches
-/// are completed.
+/// Manages inbound contexts until every outbound split has completed.
+///
+/// This preserves both Ack/Nack routing and pipeline metric frames until the
+/// inbound batch can be completed.
 ///
 /// It contains two slot maps:
 /// - Inbound: manages how many outbound batches are associated with an inbound batch, as well as
@@ -48,8 +49,8 @@ impl Contexts {
 
     /// Insert an inbound batch into the context.
     ///
-    /// If the inbound batch does not need to be managed (no subscribers), it is not inserted into the context
-    /// and a null key is returned.
+    /// If the inbound batch does not need completion tracking, it is not inserted
+    /// into the context and a null key is returned.
     ///
     /// Returns `None` if the inbound slot map is full.
     ///
@@ -62,8 +63,8 @@ impl Contexts {
         context: Context,
         error_reason: Option<String>,
     ) -> Option<Key> {
-        if !context.has_subscribers() {
-            // no point in managing the inbound/outbound the context if there are no subscribers
+        if !context.needs_completion_tracking() {
+            // No completion routing or metrics unwinding depends on this context.
             return Some(Key::null());
         }
 
@@ -79,10 +80,10 @@ impl Contexts {
     /// Inserts an outbound batch into the context. This will update any necessary state related
     /// to the inbound batch (increment count of outbound batches).
     ///
-    /// Returns the key of the outbound batch. IF the inbound batch doesn't exist it will return
-    /// a null key. Note: even after calling insert_inbound, the inbound batch may not exist
-    /// because we determined from the context it doesn't need to be tracked (e.g. it has no
-    /// subscribers).
+    /// Returns the key of the outbound batch. If the inbound batch doesn't exist,
+    /// it returns a null key. Even after calling `insert_inbound`, the inbound
+    /// batch may not exist because its context did not require completion
+    /// tracking.
     ///
     /// Returns `None` if the outbound slot map is full.
     pub fn insert_outbound(&mut self, inbound_key: Key) -> Option<Key> {
@@ -129,8 +130,8 @@ impl Contexts {
     /// Clears the outbound slot and returns the context and error reason if the inbound slot is now empty.
     ///
     /// Returns `Some((context, error_reason))` if the inbound slot is now empty. This would mean that
-    /// all outbound batches for this inbound slot have been processed and the inbound batch could be
-    /// Ack/NAck'd
+    /// all outbound batches for this inbound slot have been processed and the
+    /// inbound batch can be completed.
     pub fn clear_outbound(&mut self, outbound_key: Key) -> Option<(Context, Option<String>)> {
         let inbound_key = {
             let outbound = self.outbound.take(outbound_key)?;
@@ -176,7 +177,7 @@ mod test {
         ctx
     }
 
-    // Helper to create a test context without subscribers
+    // Helper to create a test context without completion interests.
     fn create_context_without_subscribers() -> Context {
         Context::default()
     }
@@ -355,6 +356,29 @@ mod test {
             error_msg1,
             "First error should be preserved"
         );
+    }
+
+    /// Scenario: A split input has pipeline metric interests but no Ack/Nack subscriber.
+    /// Guarantees: The original context is retained until every split output completes.
+    #[test]
+    fn test_with_metrics_only_context() {
+        let mut contexts = new_contexts();
+        let pdata = create_test_pdata().test_subscribe_to(
+            otap_df_engine::Interests::PRODUCER_METRICS,
+            smallvec::smallvec![],
+            1,
+        );
+        let (original_context, _) = pdata.into_parts();
+
+        let inbound_key = contexts
+            .insert_inbound(original_context.clone(), None)
+            .unwrap();
+        assert!(!inbound_key.is_null());
+
+        let outbound_key = contexts.insert_outbound(inbound_key).unwrap();
+        let (completed_context, error) = contexts.clear_outbound(outbound_key).unwrap();
+        assert_eq!(completed_context, original_context);
+        assert!(error.is_none());
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -170,6 +170,19 @@ impl Context {
             .any(|f| f.interests.intersects(Interests::ACKS_OR_NACKS))
     }
 
+    /// Returns true when this context must be retained until processing completes.
+    ///
+    /// Ack/Nack subscribers require completion routing, while pipeline metric
+    /// frames require completion unwinding so their measurements are recorded.
+    #[must_use]
+    pub fn needs_completion_tracking(&self) -> bool {
+        self.stack.iter().any(|frame| {
+            frame
+                .interests
+                .intersects(Interests::ACKS_OR_NACKS | Interests::PIPELINE_METRICS)
+        })
+    }
+
     /// Returns true if the context stack has any frames at all.
     /// Used to decide whether an ack/nack should be sent to the controller.
     ///
@@ -2233,6 +2246,25 @@ mod test {
             frames[0].route.entry_time_ns, 0,
             "CONSUMER_METRICS alone should not stamp time"
         );
+    }
+
+    /// Scenario: Contexts contain no frames, source-tagging only, pipeline metrics, or Ack interests.
+    /// Guarantees: Completion tracking is required only for pipeline metrics and Ack/Nack routing.
+    #[test]
+    fn needs_completion_tracking_matches_completion_interests() {
+        let mut empty = Context::default();
+        assert!(!empty.needs_completion_tracking());
+
+        empty.set_source_node(1);
+        assert!(!empty.needs_completion_tracking());
+
+        let mut metrics = Context::default();
+        metrics.push_entry_frame(1, Interests::CONSUMER_METRICS);
+        assert!(metrics.needs_completion_tracking());
+
+        let mut subscriber = Context::default();
+        subscriber.subscribe_to(Interests::ACKS, CallData::new(), 1);
+        assert!(subscriber.needs_completion_tracking());
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -159,17 +159,6 @@ impl Context {
         self.stack.last().map(|f| f.route.clone())
     }
 
-    /// Are there any subscribers with actual interests (ACKS or
-    /// NACKS)?
-    ///
-    /// TODO: This could be O(1) by propagating a new interest bit.
-    #[must_use]
-    pub fn has_subscribers(&self) -> bool {
-        self.stack
-            .iter()
-            .any(|f| f.interests.intersects(Interests::ACKS_OR_NACKS))
-    }
-
     /// Returns true when this context must be retained until processing completes.
     ///
     /// Ack/Nack subscribers require completion routing, while pipeline metric
@@ -706,13 +695,6 @@ impl OtapPdata {
     ) -> Self {
         self.context.subscribe_to(interests, calldata, node_id);
         self
-    }
-
-    /// Returns Context::has_subscribers()
-    #[cfg(any(test, feature = "test-utils"))]
-    #[must_use]
-    pub fn has_subscribers(&self) -> bool {
-        self.context.has_subscribers()
     }
 
     /// Stamp the top context frame with a receive timestamp.
@@ -2044,7 +2026,7 @@ mod test {
         assert_eq!(ctx.source_node(), Some(42));
         assert_eq!(ctx.stack.len(), 1);
         // Source-node-only frames have empty interests -- not subscribers.
-        assert!(!ctx.has_subscribers());
+        assert!(!ctx.has_ack_or_nack_subscribers());
 
         // Same node_id is a no-op (dedup).
         ctx.set_source_node(42);
@@ -2054,7 +2036,7 @@ mod test {
         ctx.set_source_node(99);
         assert_eq!(ctx.source_node(), Some(99));
         assert_eq!(ctx.stack.len(), 2);
-        assert!(!ctx.has_subscribers());
+        assert!(!ctx.has_ack_or_nack_subscribers());
     }
 
     #[test]
@@ -2068,7 +2050,7 @@ mod test {
             100,
         );
         let pdata = pdata.add_source_node(200);
-        assert!(pdata.has_subscribers());
+        assert!(pdata.has_ack_or_nack_interests());
 
         // next_ack skips the empty-interests frame and finds node 100.
         let ack = AckMsg::new(pdata);
@@ -2148,11 +2130,11 @@ mod test {
                 101,
             )
             .add_source_node(202);
-        assert!(pdata.has_subscribers());
+        assert!(pdata.has_ack_or_nack_interests());
         assert_eq!(pdata.get_source_node(), Some(202));
 
         let cloned = pdata.clone_without_context();
-        assert!(!cloned.has_subscribers());
+        assert!(!cloned.has_ack_or_nack_interests());
         assert_eq!(cloned.get_source_node(), None);
 
         let ack = AckMsg::new(cloned.clone());
@@ -2187,14 +2169,17 @@ mod test {
 
         let (mut context, _payload) = pdata.into_parts();
         context.capture_signal(SignalType::Logs);
-        assert!(context.has_subscribers(), "precondition: has subscribers");
+        assert!(
+            context.has_ack_or_nack_subscribers(),
+            "precondition: has subscribers"
+        );
 
         let detached = context.clone_detached();
 
         assert_eq!(detached.transport_headers(), Some(&headers));
         assert_eq!(detached.peer_addr(), Some(addr));
         assert!(
-            !detached.has_subscribers(),
+            !detached.has_ack_or_nack_subscribers(),
             "detached context must not inherit the inbound subscribers"
         );
         assert_eq!(detached.source_node(), None);
@@ -2206,7 +2191,7 @@ mod test {
 
         // The source context is untouched: it stays parked in the split
         // processor's slot map and Acks upstream once its outbounds settle.
-        assert!(context.has_subscribers());
+        assert!(context.has_ack_or_nack_subscribers());
         assert_eq!(context.signal(), Some(SignalType::Logs));
     }
 


### PR DESCRIPTION
# Change summary

Preserve metrics-only PData contexts through processors that batch, split, partition, or aggregate telemetry.

Receiver item counts are stored on PData context frames and recorded during completion unwinding.

```text
receiver stamps item count
          |
processor checks has_subscribers()
          |
          X metrics-only context discarded
```

`Context::has_subscribers()` only detects explicit Ack/Nack subscribers. Processors using it to decide whether to retain context therefore dropped frames containing only pipeline metrics.

To fix, replaced `has_subscribers()` with `needs_completion_tracking()`. It returns true when a context contains:

- an Ack/Nack subscriber
- a producer or consumer pipeline metric frame

Use the new predicate in:

- batch
- temporal reaggregation
- the split-context helper used by transform and partition

This is a focused fix for the existing processors. Further work could be needed to produce stronger APIs to prevent another accidental disposal.

## Related issue

<!--We highly recommend correlation of every PR to an issue-->

* Closes #3803

## Validation

Re-running the repro config shows that all receiver metrics are produced in ITS metrics debug:

```text
Received 1 resource metrics
Received 5 metrics
Received 5 data points
ResourceMetric #0, Schema:[], Attributes: service.name=df_engine service.version=0.51.0 service.instance.id=01a015b3-4349-7770-9418-8b01f4e7eeeb
   ScopeMetric #0, Name: node.producer, Version: @, Schema: [], Attributes: channel.id=hyperedge:3043a89ee8d62c30 node.port=default channel.kind=pdata channel.mode=local channel.type=mpsc channel.impl=internal node.id=receiver node.urn=urn:otel:receiver:traffic_generator node.type=receiver pipeline.id=batch pipeline.group.id=repro deployment.generation=0 core.id=0 numa.node.id=0
      receive_items signal=logs outcome=success 380
   ScopeMetric #1, Name: node.producer, Version: @, Schema: [], Attributes: channel.id=hyperedge:3043a89ee8d62c30 node.port=default channel.kind=pdata channel.mode=local channel.type=mpsc channel.impl=internal node.id=receiver node.urn=urn:otel:receiver:traffic_generator node.type=receiver pipeline.id=log_sampling_control pipeline.group.id=repro deployment.generation=0 core.id=1 numa.node.id=0
      receive_items signal=logs outcome=success 400
   ScopeMetric #2, Name: node.producer, Version: @, Schema: [], Attributes: channel.id=hyperedge:3043a89ee8d62c30 node.port=default channel.kind=pdata channel.mode=local channel.type=mpsc channel.impl=internal node.id=receiver node.urn=urn:otel:receiver:traffic_generator node.type=receiver pipeline.id=partition_split pipeline.group.id=repro deployment.generation=0 core.id=2 numa.node.id=0
      receive_items signal=logs outcome=success 400
   ScopeMetric #3, Name: node.producer, Version: @, Schema: [], Attributes: channel.id=hyperedge:742f4642696ccf84 node.port=default channel.kind=pdata channel.mode=local channel.type=mpsc channel.impl=internal node.id=receiver node.urn=urn:otel:receiver:traffic_generator node.type=receiver pipeline.id=temporal_reaggregation pipeline.group.id=repro deployment.generation=0 core.id=3 numa.node.id=0
      receive_items signal=metrics outcome=success 360
   ScopeMetric #4, Name: node.producer, Version: @, Schema: [], Attributes: channel.id=hyperedge:3043a89ee8d62c30 node.port=default channel.kind=pdata channel.mode=local channel.type=mpsc channel.impl=internal node.id=receiver node.urn=urn:otel:receiver:traffic_generator node.type=receiver pipeline.id=transform_split pipeline.group.id=repro deployment.generation=0 core.id=4 numa.node.id=0
      receive_items signal=logs outcome=success 400
```

## User-facing changes

<!--
Describe the impact, or write `None`.
User-facing changes require a `.chloggen/*.yaml` entry. If no entry is needed,
include `chore` in the PR title. Documentation-only changes are exempt.
-->
