### PR TITLE
chore(repo): Split build/test chains and avoid full CI repeat after merge

### DIFF
--- a/.github/workflows/dataflow-engine-binary-size.yml
+++ b/.github/workflows/dataflow-engine-binary-size.yml
@@ -117,10 +117,13 @@ jobs:
         with:
           toolchain: stable
 
+      # Manual runs can target non-main refs. Restore their shared cache, but
+      # only let main and its scheduled runs update the repository cache.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: ./rust/otap-dataflow
           cache-bin: false
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/dataflow-engine-binary-size.yml
+++ b/.github/workflows/dataflow-engine-binary-size.yml
@@ -117,13 +117,13 @@ jobs:
         with:
           toolchain: stable
 
-      # Manual runs can target non-main refs. Restore their shared cache, but
-      # only let main and its scheduled runs update the repository cache.
+      # Keep specialized analysis caches restore-only so they do not compete
+      # with the required build caches published by Post-Merge Actions.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: ./rust/otap-dataflow
           cache-bin: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: false
 
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/df-engine-internal-observability.yml
+++ b/.github/workflows/df-engine-internal-observability.yml
@@ -49,13 +49,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
-      # Restore shared caches on every event, but avoid saving large caches
-      # under ephemeral PR and merge-group refs.
+      # Keep specialized validation caches restore-only so they do not compete
+      # with the required build caches published by Post-Merge Actions.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: ./rust/otap-dataflow
           cache-bin: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: false
       - name: Setup Weaver
         uses: open-telemetry/weaver/.github/actions/setup-weaver@26c685ff52b925056ff1d53476c6022638c01220 # v0.25.1
         with:

--- a/.github/workflows/df-engine-internal-observability.yml
+++ b/.github/workflows/df-engine-internal-observability.yml
@@ -49,10 +49,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
+      # Restore shared caches on every event, but avoid saving large caches
+      # under ephemeral PR and merge-group refs.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: ./rust/otap-dataflow
           cache-bin: false
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Setup Weaver
         uses: open-telemetry/weaver/.github/actions/setup-weaver@26c685ff52b925056ff1d53476c6022638c01220 # v0.25.1
         with:

--- a/.github/workflows/post-merge-actions.yml
+++ b/.github/workflows/post-merge-actions.yml
@@ -34,6 +34,7 @@ jobs:
           shared-key: build_required
           workspaces: ./rust/otap-dataflow
           cache-bin: false
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Free disk space
         run: |
           sudo rm -rf /usr/lib/jvm /usr/share/dotnet /usr/share/swift /usr/local/.ghcup
@@ -64,6 +65,7 @@ jobs:
           shared-key: build_required
           workspaces: ./rust/otap-dataflow
           cache-bin: false
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Free disk space
         shell: pwsh
         run: |

--- a/.github/workflows/post-merge-actions.yml
+++ b/.github/workflows/post-merge-actions.yml
@@ -1,0 +1,79 @@
+name: Post-Merge Actions
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Populate only the two caches used by required test builds. Warming every
+# Rust configuration would approach the cost of full CI and exceed the value
+# of the repository's shared 10 GB Actions cache budget.
+jobs:
+  warm-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          prefix-key: v1-rust
+          shared-key: build_required
+          workspaces: ./rust/otap-dataflow
+          cache-bin: false
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/lib/jvm /usr/share/dotnet /usr/share/swift /usr/local/.ghcup
+          sudo rm -rf /usr/local/julia* /usr/local/lib/android /usr/local/share/chromium
+          sudo rm -rf /opt/microsoft /opt/google /opt/az /usr/local/share/powershell
+      - name: install nextest
+        uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
+        with:
+          tool: cargo-nextest
+      - name: Warm required build cache
+        run: cargo nextest archive --locked --all-features --workspace --archive-file nextest-archive.tar.zst
+        working-directory: ./rust/otap-dataflow
+
+  warm-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: stable
+      - name: Install SymCrypt
+        uses: ./.github/actions/install-symcrypt
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          prefix-key: v1-rust
+          shared-key: build_required
+          workspaces: ./rust/otap-dataflow
+          cache-bin: false
+      - name: Free disk space
+        shell: pwsh
+        run: |
+          if (Test-Path "C:\Android") { Remove-Item -Recurse -Force "C:\Android" }
+          if (Test-Path "C:\SeleniumWebDrivers") { Remove-Item -Recurse -Force "C:\SeleniumWebDrivers" }
+          if (Test-Path "C:\imagemagick") { Remove-Item -Recurse -Force "C:\imagemagick" }
+      - name: install nextest
+        uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
+        with:
+          tool: cargo-nextest
+      - name: Warm required build cache
+        run: cargo nextest archive --locked --no-default-features --features=crypto-symcrypt,mimalloc,azure,aws,azure-monitor-exporter,geneva-exporter,contrib-processors,unsafe-optimizations --workspace --archive-file nextest-archive.tar.zst
+        working-directory: ./rust/otap-dataflow

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -3,9 +3,6 @@ permissions:
   contents: read
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -13,6 +10,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+
+# GitHub limits Actions caches to 10 GB per repository. PR and merge-group
+# caches are scoped to ephemeral refs and cannot benefit other PRs, so this
+# workflow restores caches but leaves cache writes to trusted main workflows.
 
 # Cancel in-progress runs on new commits to same PR
 concurrency:
@@ -112,6 +113,7 @@ jobs:
           prefix-key: v1-rust
           workspaces: ./rust/${{ matrix.folder }}
           cache-bin: false
+          save-if: false
       - name: Free disk space (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -207,6 +209,7 @@ jobs:
         with:
           workspaces: ./rust/otap-dataflow
           cache-bin: false
+          save-if: false
       - name: Run user_events Linux smoke test when supported
         env:
           OTAP_DF_RUN_USEREVENTS_E2E: "1"
@@ -228,6 +231,7 @@ jobs:
         with:
           workspaces: ./rust/otap-dataflow
           cache-bin: false
+          save-if: false
       - name: Run ETW Windows smoke test
         run: cargo test --locked -p otap-df-contrib-nodes etw_receiver_decodes_tracelogging_events_end_to_end --features etw-receiver -- --ignored
         working-directory: ./rust/otap-dataflow
@@ -343,6 +347,7 @@ jobs:
           prefix-key: v1-rust
           workspaces: ./rust/${{ matrix.folder }}
           cache-bin: false
+          save-if: false
       - name: cargo clippy ${{ matrix.folder }}
         run: |
           cargo clippy --all-targets --all-features --workspace -- -D warnings
@@ -479,15 +484,10 @@ jobs:
         run: cargo test --locked -p otap-df-otap --tests --no-run
         working-directory: ./rust/${{ matrix.folder }}
 
-  # Required builds for otap-dataflow: compile once per OS, create nextest archive.
-  # Test binaries are uploaded as artifacts so test partitions don't re-compile.
-  build_required:
-    strategy:
-      fail-fast: false
-      matrix:
-        folder: [otap-dataflow]
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+  # Required Linux build: compile once and create a nextest archive.
+  # Linux test partitions depend only on this job, not the Windows build.
+  build_required_linux:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -495,22 +495,57 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
-      - name: Install SymCrypt (Windows)
-        if: runner.os == 'Windows'
-        uses: ./.github/actions/install-symcrypt
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           prefix-key: v1-rust
-          workspaces: ./rust/${{ matrix.folder }}
+          # Keep one stable required-build namespace; platform and Rust hashes
+          # still separate incompatible Linux and Windows artifacts.
+          shared-key: build_required
+          workspaces: ./rust/otap-dataflow
           cache-bin: false
-      - name: Free disk space (Linux)
-        if: runner.os == 'Linux'
+          save-if: false
+      - name: Free disk space
         run: |
           sudo rm -rf /usr/lib/jvm /usr/share/dotnet /usr/share/swift /usr/local/.ghcup
           sudo rm -rf /usr/local/julia* /usr/local/lib/android /usr/local/share/chromium
           sudo rm -rf /opt/microsoft /opt/google /opt/az /usr/local/share/powershell
-      - name: Free disk space (Windows)
-        if: runner.os == 'Windows'
+      - name: install nextest
+        uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
+        with:
+          tool: cargo-nextest
+      - name: Build and archive tests
+        run: cargo nextest archive --locked --all-features --workspace --archive-file nextest-archive.tar.zst
+        working-directory: ./rust/otap-dataflow
+      - name: Upload nextest archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nextest-archive-ubuntu-latest
+          path: ./rust/otap-dataflow/nextest-archive.tar.zst
+          retention-days: 1
+
+  # Required Windows build: compile once and create a nextest archive.
+  # Windows test partitions depend only on this job, not the Linux build.
+  build_required_windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: stable
+      - name: Install SymCrypt
+        uses: ./.github/actions/install-symcrypt
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          prefix-key: v1-rust
+          # Keep one stable required-build namespace; platform and Rust hashes
+          # still separate incompatible Linux and Windows artifacts.
+          shared-key: build_required
+          workspaces: ./rust/otap-dataflow
+          cache-bin: false
+          save-if: false
+      - name: Free disk space
         shell: pwsh
         run: |
           if (Test-Path "C:\Android") { Remove-Item -Recurse -Force "C:\Android" }
@@ -520,31 +555,24 @@ jobs:
         uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: cargo-nextest
-      - name: Build and archive tests (Incomplete)
-        if: runner.os == 'Windows'
+      - name: Build and archive tests
         run: cargo nextest archive --locked --no-default-features --features=crypto-symcrypt,mimalloc,azure,aws,azure-monitor-exporter,geneva-exporter,contrib-processors,unsafe-optimizations --workspace --archive-file nextest-archive.tar.zst
-        working-directory: ./rust/${{ matrix.folder }}
-      - name: Build and archive tests (Complete)
-        if: runner.os != 'Windows'
-        run: cargo nextest archive --locked --all-features --workspace --archive-file nextest-archive.tar.zst
-        working-directory: ./rust/${{ matrix.folder }}
+        working-directory: ./rust/otap-dataflow
       - name: Upload nextest archive
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: nextest-archive-${{ matrix.os }}
-          path: ./rust/${{ matrix.folder }}/nextest-archive.tar.zst
+          name: nextest-archive-windows-latest
+          path: ./rust/otap-dataflow/nextest-archive.tar.zst
           retention-days: 1
 
-  # Required test partitions: download pre-built archive and run 1/3 of tests each.
-  test_required:
-    needs: build_required
+  # Required Linux test partitions: run immediately after the Linux build.
+  test_required_linux:
+    needs: build_required_linux
     strategy:
       fail-fast: false
       matrix:
-        folder: [otap-dataflow]
-        os: [ubuntu-latest, windows-latest]
         partition: [1, 2, 3]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -552,47 +580,87 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
-      - name: Install SymCrypt (Windows)
-        if: runner.os == 'Windows'
-        uses: ./.github/actions/install-symcrypt
       - name: install nextest
         uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: cargo-nextest
-      - name: Free disk space (Linux)
-        if: runner.os == 'Linux'
+      - name: Free disk space
         run: |
           sudo rm -rf /usr/lib/jvm /usr/share/dotnet /usr/share/swift /usr/local/.ghcup
           sudo rm -rf /usr/local/julia* /usr/local/lib/android /usr/local/share/chromium
           sudo rm -rf /opt/microsoft /opt/google /opt/az /usr/local/share/powershell
       - name: Build the test collector
-        if: runner.os == 'Linux'
         run: make otelarrowcol
-      - name: Install wasm32-wasip2 target (Linux)
-        if: runner.os == 'Linux'
+      - name: Install wasm32-wasip2 target
         run: rustup target add wasm32-wasip2
       - name: Download nextest archive
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: nextest-archive-${{ matrix.os }}
-          path: ./rust/${{ matrix.folder }}
+          name: nextest-archive-ubuntu-latest
+          path: ./rust/otap-dataflow
       - name: Run tests (partition ${{ matrix.partition }}/3)
         run: cargo nextest run --profile ci --config-file .config/nextest.toml --archive-file nextest-archive.tar.zst --partition count:${{ matrix.partition }}/3
-        working-directory: ./rust/${{ matrix.folder }}
+        working-directory: ./rust/otap-dataflow
       - name: Write JUnit artifact metadata
         if: always()
         shell: bash
         run: |
-          echo '{"job": "${{ github.job }}", "os": "${{ matrix.os }}", "partition": "${{ matrix.partition }}", "folder": "${{ matrix.folder }}"}' \
-            > ./rust/${{ matrix.folder }}/target/nextest/ci/metadata.json
+          echo '{"job": "${{ github.job }}", "os": "ubuntu-latest", "partition": "${{ matrix.partition }}", "folder": "otap-dataflow"}' \
+            > ./rust/otap-dataflow/target/nextest/ci/metadata.json
       - name: Upload JUnit XML results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: junit-xml-required-${{ matrix.os }}-${{ matrix.partition }}
+          name: junit-xml-required-ubuntu-latest-${{ matrix.partition }}
           path: |
-            ./rust/${{ matrix.folder }}/target/nextest/ci/junit.xml
-            ./rust/${{ matrix.folder }}/target/nextest/ci/metadata.json
+            ./rust/otap-dataflow/target/nextest/ci/junit.xml
+            ./rust/otap-dataflow/target/nextest/ci/metadata.json
+          retention-days: 30
+          if-no-files-found: ignore
+
+  # Required Windows test partitions: run immediately after the Windows build.
+  test_required_windows:
+    needs: build_required_windows
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2, 3]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: stable
+      - name: Install SymCrypt
+        uses: ./.github/actions/install-symcrypt
+      - name: install nextest
+        uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
+        with:
+          tool: cargo-nextest
+      - name: Download nextest archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nextest-archive-windows-latest
+          path: ./rust/otap-dataflow
+      - name: Run tests (partition ${{ matrix.partition }}/3)
+        run: cargo nextest run --profile ci --config-file .config/nextest.toml --archive-file nextest-archive.tar.zst --partition count:${{ matrix.partition }}/3
+        working-directory: ./rust/otap-dataflow
+      - name: Write JUnit artifact metadata
+        if: always()
+        shell: bash
+        run: |
+          echo '{"job": "${{ github.job }}", "os": "windows-latest", "partition": "${{ matrix.partition }}", "folder": "otap-dataflow"}' \
+            > ./rust/otap-dataflow/target/nextest/ci/metadata.json
+      - name: Upload JUnit XML results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: junit-xml-required-windows-latest-${{ matrix.partition }}
+          path: |
+            ./rust/otap-dataflow/target/nextest/ci/junit.xml
+            ./rust/otap-dataflow/target/nextest/ci/metadata.json
           retention-days: 30
           if-no-files-found: ignore
 
@@ -612,6 +680,7 @@ jobs:
           prefix-key: v1-rust
           workspaces: ./rust/otap-dataflow
           cache-bin: false
+          save-if: false
       - name: Free disk space
         run: |
           sudo rm -rf /usr/lib/jvm /usr/share/dotnet /usr/share/swift /usr/local/.ghcup
@@ -679,6 +748,7 @@ jobs:
           prefix-key: v1-rust
           workspaces: ./rust/${{ matrix.folder }}
           cache-bin: false
+          save-if: false
       - name: Install OpenSSL (Windows)
         if: runner.os == 'Windows'
         # Required for the crypto-openssl feature (rustls-openssl -> openssl-sys).
@@ -712,6 +782,7 @@ jobs:
         with:
           workspaces: ./rust/otap-dataflow
           cache-bin: false
+          save-if: false
       - name: Run host metrics semconv drift check
         env:
           OTAP_HOST_METRICS_SEMCONV_REGISTRY: ${{ github.workspace }}/semantic-conventions/model
@@ -753,6 +824,7 @@ jobs:
         with:
           workspaces: ./rust/otap-dataflow
           cache-bin: false
+          save-if: false
       - name: Setup Weaver
         uses: open-telemetry/weaver/.github/actions/setup-weaver@26c685ff52b925056ff1d53476c6022638c01220 # v0.25.1
         with:
@@ -1042,7 +1114,8 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
-      - test_required
+      - test_required_linux
+      - test_required_windows
       - test_nonrequired
     permissions:
       checks: write
@@ -1111,7 +1184,8 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
-      - test_required
+      - test_required_linux
+      - test_required_windows
       - fmt_required
       - clippy_required
       - deny_required
@@ -1128,8 +1202,12 @@ jobs:
     steps:
       - name: Check if all required jobs succeeded
         run: |
-          if [[ "${{ needs.test_required.result }}" != "success" ]]; then
-            echo "test_required failed or was cancelled"
+          if [[ "${{ needs.test_required_linux.result }}" != "success" ]]; then
+            echo "test_required_linux failed or was cancelled"
+            exit 1
+          fi
+          if [[ "${{ needs.test_required_windows.result }}" != "success" ]]; then
+            echo "test_required_windows failed or was cancelled"
             exit 1
           fi
           if [[ "${{ needs.fmt_required.result }}" != "success" ]]; then


### PR DESCRIPTION
# Chore Summary

- Split the required Linux and Windows Rust build/test chains so each test matrix starts as soon as its matching build completes
- Make Rust-CI caches restore-only to prevent ephemeral pull-request and merge-queue refs from consuming the repository cache budget
- Replace the full Rust-CI run on `main` with a `Post-Merge Actions` workflow that warms the required Linux and Windows build caches

## Expected impact

| Area | Before | After | Potential gain |
| --- | --- | --- | --- |
| Required test chain | Linux tests wait for the slower Windows build | Linux and Windows tests start after their matching builds | Approximately 7-9 minutes removed from the Linux test path |
| End-to-end required status | The delayed Linux test path can determine workflow completion | Other required jobs may become the critical path | Approximately 2 minutes in a sampled PR run and 8-9 minutes in a sampled merge-queue run |
| Rust-CI cache writes | Large job-specific caches are saved under ephemeral PR and merge-queue refs | Rust-CI restores caches but never saves them | Reduces churn within GitHub's 10 GB repository cache limit |
| Post-merge Rust-CI | Approximately 6.4 runner-hours across 57 jobs | Approximately 0.8 runner-hours across two cache-warming jobs | Approximately 85% less compute |
| Shared cache priority | The full suite competes to publish many job-specific caches | `main` publishes the required Linux and Windows build caches | Prioritizes the merge-critical build configurations |

## Tradeoff

The post-merge workflow intentionally does not warm Rust-CI's coverage, clippy, smoke-test, ARM, or macOS caches. Those configurations can still restore an existing compatible cache, but only the required Linux and Windows build caches are guaranteed to be refreshed after each merge.

The current cache inventory supports prioritizing these builds:

| Observation | Current state |
| --- | --- |
| Repository cache limit | 10 GB |
| Recent Rust cache size | Commonly 1-2 GB per entry |
| Dominant cache refs | `refs/pull/*/merge` entries from recent PR runs |
| Shared `main` Rust caches | None were present in the inspected cache inventory |

This means a small number of ephemeral PR entries can consume the repository budget and evict caches that would otherwise be reusable by every PR and merge-queue run. The restore-only Rust-CI policy stops adding those ephemeral entries, while the post-merge workflow repopulates the two critical shared caches.