### PR TITLE
feat(engine): Define SecretProvider capability

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/capability/mod.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/mod.rs
@@ -47,6 +47,7 @@ pub mod auth;
 pub(crate) mod error;
 pub(crate) mod factory;
 pub mod registry;
+pub mod secret_provider;
 pub mod vendor_bundle;
 
 pub use error::{CapabilityError, CapabilityErrorSource};

--- a/rust/otap-dataflow/crates/engine/src/capability/secret_provider.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/secret_provider.rs
@@ -1,0 +1,66 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! The `Secret` capability.
+
+use std::{pin::Pin, sync::Arc, time::Instant};
+
+use futures::Stream;
+use otap_df_engine_macros::capability;
+use secrecy::{ExposeSecret, SecretString};
+
+use crate::capability::CapabilityError;
+
+/// A per-consumer subscription to secret refreshes.
+pub type SecretStream = Pin<Box<dyn Stream<Item = Secret> + 'static>>;
+
+/// Hands out secrets to data-path nodes.
+#[capability(
+    name = "secret_provider",
+    description = "Provides secrets, refreshed in the background"
+)]
+pub trait SecretProvider {
+    /// Returns a secret for the provider's configured scope(s).
+    async fn get_secret(&self, name: &str) -> Result<Secret, CapabilityError>;
+
+    /// Subscribes to the stream of secret refreshes.
+    fn secret_stream(&self, name: &str) -> SecretStream;
+}
+
+/// A secret.
+pub struct Secret {
+    secret: Arc<SecretString>,
+    expires_on: Option<Instant>,
+}
+
+impl Secret {
+    /// Creates a secret with **no known expiry**.
+    #[must_use]
+    pub fn without_expiry(secret: impl Into<SecretString>) -> Self {
+        Self {
+            secret: Arc::new(secret.into()),
+            expires_on: None,
+        }
+    }
+
+    /// Creates a secret with an explicit optional monotonic expiry.
+    #[must_use]
+    pub fn with_expiry(secret: impl Into<SecretString>, expires_on: Option<Instant>) -> Self {
+        Self {
+            secret: Arc::new(secret.into()),
+            expires_on,
+        }
+    }
+
+    /// Exposes the secret.
+    #[must_use]
+    pub fn expose_secret(&self) -> &str {
+        self.secret.expose_secret()
+    }
+
+    /// The monotonic instant at which this secret expires, if known.
+    #[must_use]
+    pub const fn expires_on(&self) -> Option<Instant> {
+        self.expires_on
+    }
+}

--- a/rust/otap-dataflow/crates/engine/src/local/capability.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/capability.rs
@@ -28,6 +28,11 @@ pub mod auth {
     }
 }
 
+/// Local (!Send) trait variant of the secrets capability.
+pub mod secrets {
+    pub use crate::capability::secret_provider::local::SecretProvider;
+}
+
 /// Local (!Send) trait variant of the vendor-bundle capability.
 pub mod vendor_bundle {
     pub use crate::capability::vendor_bundle::local::VendorBundle;


### PR DESCRIPTION
# Changes

* Introduce `SecretProvider` capability

# Details

What I'm trying to do is add support for basic authentication in OTLP exporter. Basic auth needs a username and password and is sent as `Authorization: Basic <base64(username:password)>`. The password could come from many different places. Initially I want to support files. But users will likely have a need for other mechanisms (key vaults, etc.).

The idea here is to introduce a `SecretProvider` capability to abstract\separate the concerns of retrieving\managing secrets from the concerns of using them to do interesting things (like authenticate).

Thinking something along the lines of this for config:

```yaml
groups:
  default:
    pipelines:
      main:
        extensions:
          otlp-auth-secrets:
            type: "urn:otel:extension:file_secret"
            config:
              secrets:
                - name: otlp-basic-auth-password
                  path: "<secret file path>",
                  watch: true

        nodes:
          otlp-http-exporter:
            type: "urn:otel:exporter:otlp_http"
            capabilities:
              secret_provider: otlp-auth-secrets
            config:
              endpoint: "https://my-endpoint:4318"
              client_pool_size: 1
              http:
                auth:
                  type: basic
                  username: "<username>"
                  password_secret: "otlp-basic-auth-password"
```

Config could also be something like this:

```yaml
groups:
  default:
    pipelines:
      main:
        extensions:
          otlp-auth-secrets:
            type: "urn:otel:extension:file_secret"
            config:
              secrets:
                - name: otlp-basic-auth-password
                  path: "<secret file path>",
                  watch: true
          otlp-basic-auth:
            type: "urn:otel:extension:basic_auth"
            capabilities: // Not currently supported, could be tricky to do so
              secret_provider: otlp-auth-secrets
            config:
              username: "<username>"
              password_secret: "otlp-basic-auth-password"

        nodes:
          otlp-http-exporter:
            type: "urn:otel:exporter:otlp_http"
            capabilities:
              basic_auth_provider: otlp-basic-auth
            config:
              endpoint: "https://my-endpoint:4318"
              client_pool_size: 1
```

But then we have circular dependency with capabilities needing other capabilities. Could be tricky to get working. Open to trying.

/cc @c-valdebenito