### PR TITLE
feat(parquet)!: use Azure identity auth extension

### DIFF
--- a/rust/otap-dataflow/.chloggen/parquet-exporter-azure-identity-auth.yaml
+++ b/rust/otap-dataflow/.chloggen/parquet-exporter-azure-identity-auth.yaml
@@ -1,0 +1,8 @@
+# Use this changelog template to create an entry for release notes.
+
+change_type: breaking
+component: pipeline
+note: "Parquet Azure storage now authenticates through a bound bearer_token_provider extension."
+issues: [3356]
+subtext: |
+  Migration: Remove auth and storage_scope from Parquet Azure storage config. Bind an azure_identity_auth extension configured with the Azure Storage scope.

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -308,7 +308,13 @@ jemalloc = [
     "otap-df-controller/jemalloc-pprof",
 ]
 mimalloc = ["dep:mimalloc"]
-azure = ["otap-df-otap/azure"]
+# Azure Blob Storage for the Parquet exporter. Azure storage authenticates through
+# a bound bearer token provider, so enabling it pulls in that extension.
+azure = [
+    "otap-df-otap/azure",
+    "otap-df-core-nodes/azure",
+    "azure-identity-auth-extension",
+]
 aws = ["otap-df-otap/aws", "otap-df-contrib-nodes/aws"]
 unsafe-optimizations = ["unchecked-index", "unchecked-arithmetic"]
 unchecked-index = []

--- a/rust/otap-dataflow/configs/trafficgen-parquet-azure.yaml
+++ b/rust/otap-dataflow/configs/trafficgen-parquet-azure.yaml
@@ -4,6 +4,13 @@ groups:
   default:
     pipelines:
       main:
+        extensions:
+          azure_identity:
+            type: urn:microsoft:extension:azure_identity_auth
+            config:
+              method: development
+              scope: https://storage.azure.com/.default
+
         policies:
           channel_capacity:
             control:
@@ -22,12 +29,12 @@ groups:
               registry_path: https://github.com/open-telemetry/semantic-conventions.git[model]
           exporter:
             type: exporter:parquet
+            capabilities:
+              bearer_token_provider: azure_identity
             config:
               storage:
                 azure:
                   base_uri: https://mystorageaccount.blob.core.windows.net/mycontainer/telemetry
-                  auth:
-                    type: azure_cli
               partitioning_strategies:
                 - schema_metadata: ["_part_id"]
               writer_options:

--- a/rust/otap-dataflow/crates/core-nodes/Cargo.toml
+++ b/rust/otap-dataflow/crates/core-nodes/Cargo.toml
@@ -82,6 +82,8 @@ dev-tools = [
     "dep:weaver_resolver",
     "dep:weaver_semconv",
 ]
+# Azure Blob Storage backend for the Parquet exporter.
+azure = ["otap-df-otap/azure"]
 bench = []
 
 [dev-dependencies]

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/README.md
@@ -58,6 +58,29 @@ and
 [`configs/trafficgen-parquet-s3.yaml`](../../../../../configs/trafficgen-parquet-s3.yaml)
 for backend-specific configuration examples.
 
+Azure storage authentication is supplied by a bound `bearer_token_provider`
+capability. Configure the Azure identity extension with the storage scope; do
+not place identity credentials in the exporter config:
+
+```yaml
+extensions:
+  azure_identity:
+    type: urn:microsoft:extension:azure_identity_auth
+    config:
+      method: managed_identity
+      scope: https://storage.azure.com/.default
+
+nodes:
+  parquet:
+    type: exporter:parquet
+    capabilities:
+      bearer_token_provider: azure_identity
+    config:
+      storage:
+        azure:
+          base_uri: https://account.blob.core.windows.net/container/prefix
+```
+
 ## Examples
 
 Partition by schema metadata:

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/README.md
@@ -59,8 +59,9 @@ and
 for backend-specific configuration examples.
 
 Azure storage authentication is supplied by a bound `bearer_token_provider`
-capability. Configure the Azure identity extension with the storage scope; do
-not place identity credentials in the exporter config:
+capability. The top-level `azure` feature enables the Azure identity extension
+for you; you still need to declare it and bind it on the node. Configure it with
+the storage scope, and do not place identity credentials in the exporter config:
 
 ```yaml
 extensions:

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
@@ -1458,6 +1458,121 @@ mod test {
             });
     }
 
+    /// Scenario: The factory builds an exporter whose storage needs no bearer token capability.
+    /// Guarantees: File-backed pipelines start without any capability binding declared on the node.
+    #[test]
+    fn factory_creates_file_storage_exporter_without_a_bound_capability() {
+        use otap_df_engine::context::ControllerContext;
+        use otap_df_engine::testing::test_node;
+        use serde_json::json;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let base_dir: String = temp_dir.path().to_str().unwrap().into();
+
+        let metrics_system = otap_df_telemetry::InternalTelemetrySystem::default();
+        let controller_ctx = ControllerContext::new(metrics_system.registry());
+        let pipeline_ctx = controller_ctx
+            .pipeline_context_with("grp".into(), "pipe".into(), 0, 1, 0)
+            .with_node_context(
+                "parquet_exporter".into(),
+                PARQUET_EXPORTER_URN.into(),
+                otap_df_config::node::NodeKind::Exporter,
+                std::collections::HashMap::new(),
+            );
+
+        let mut node_config = NodeUserConfig::new_exporter_config(PARQUET_EXPORTER_URN);
+        node_config.config = json!({ "storage": { "file": { "base_uri": base_dir } } });
+
+        let created = (PARQUET_EXPORTER.create)(
+            pipeline_ctx,
+            test_node("parquet_exporter"),
+            Arc::new(node_config),
+            &ExporterConfig::new("parquet_exporter"),
+            &otap_df_engine::capability::registry::Capabilities::empty(),
+        );
+
+        assert!(
+            created.is_ok(),
+            "file storage must not require a capability binding"
+        );
+    }
+
+    /// Scenario: The factory is given a config it cannot deserialize.
+    /// Guarantees: The node fails at wiring time rather than starting with an unusable storage config.
+    #[test]
+    fn factory_rejects_an_invalid_storage_config() {
+        use otap_df_engine::context::ControllerContext;
+        use otap_df_engine::testing::test_node;
+        use serde_json::json;
+
+        let metrics_system = otap_df_telemetry::InternalTelemetrySystem::default();
+        let controller_ctx = ControllerContext::new(metrics_system.registry());
+        let pipeline_ctx = controller_ctx
+            .pipeline_context_with("grp".into(), "pipe".into(), 0, 1, 0)
+            .with_node_context(
+                "parquet_exporter".into(),
+                PARQUET_EXPORTER_URN.into(),
+                otap_df_config::node::NodeKind::Exporter,
+                std::collections::HashMap::new(),
+            );
+
+        let mut node_config = NodeUserConfig::new_exporter_config(PARQUET_EXPORTER_URN);
+        node_config.config = json!({ "storage": { "file": { "unexpected_key": "x" } } });
+
+        let created = (PARQUET_EXPORTER.create)(
+            pipeline_ctx,
+            test_node("parquet_exporter"),
+            Arc::new(node_config),
+            &ExporterConfig::new("parquet_exporter"),
+            &otap_df_engine::capability::registry::Capabilities::empty(),
+        );
+
+        assert!(created.is_err(), "invalid storage config must be rejected");
+    }
+
+    /// Scenario: The factory builds an Azure-backed exporter with no capability bound to the node.
+    /// Guarantees: Wiring fails up front instead of starting an exporter that cannot authenticate.
+    #[test]
+    #[cfg(feature = "azure")]
+    fn factory_rejects_azure_storage_without_a_bound_capability() {
+        use otap_df_engine::context::ControllerContext;
+        use otap_df_engine::testing::test_node;
+        use serde_json::json;
+
+        let metrics_system = otap_df_telemetry::InternalTelemetrySystem::default();
+        let controller_ctx = ControllerContext::new(metrics_system.registry());
+        let pipeline_ctx = controller_ctx
+            .pipeline_context_with("grp".into(), "pipe".into(), 0, 1, 0)
+            .with_node_context(
+                "parquet_exporter".into(),
+                PARQUET_EXPORTER_URN.into(),
+                otap_df_config::node::NodeKind::Exporter,
+                std::collections::HashMap::new(),
+            );
+
+        let mut node_config = NodeUserConfig::new_exporter_config(PARQUET_EXPORTER_URN);
+        node_config.config = json!({
+            "storage": {
+                "azure": {
+                    "base_uri": "https://mystorageaccount.blob.core.windows.net/container"
+                }
+            }
+        });
+
+        let created = (PARQUET_EXPORTER.create)(
+            pipeline_ctx,
+            test_node("parquet_exporter"),
+            Arc::new(node_config),
+            &ExporterConfig::new("parquet_exporter"),
+            &otap_df_engine::capability::registry::Capabilities::empty(),
+        );
+
+        assert!(
+            created.is_err(),
+            "azure storage must require a bound bearer_token_provider"
+        );
+    }
+
     /// Scenario: The Parquet exporter successfully writes a PData message.
     /// Guarantees: The shared terminal export metric set is reported.
     #[test]

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
@@ -47,6 +47,7 @@ use futures_timer::Delay;
 use linkme::distributed_slice;
 use otap_df_config::node::NodeUserConfig;
 use otap_df_engine::ExporterFactory;
+use otap_df_engine::capability::auth::bearer_token_provider::BearerTokenProvider;
 use otap_df_engine::config::ExporterConfig;
 use otap_df_engine::context::PipelineContext;
 use otap_df_engine::control::NodeControlMsg;
@@ -73,6 +74,9 @@ const PARQUET_EXPORTER_URN: &str = "urn:otel:exporter:parquet";
 /// Parquet exporter for OTAP Data
 pub struct ParquetExporter {
     config: config::Config,
+    token_provider: Option<
+        Box<dyn otap_df_engine::shared::capability::auth::bearer_token_provider::BearerTokenProvider>,
+    >,
     pdata_metrics: Option<MeasurementMetricSet<ExporterExportMetrics>>,
     io_metrics: Option<MetricSet<metrics::ParquetExporterMetrics>>,
 }
@@ -90,9 +94,19 @@ pub static PARQUET_EXPORTER: ExporterFactory<OtapPdata> = ExporterFactory {
              node: NodeId,
              node_config: Arc<NodeUserConfig>,
              exporter_config: &ExporterConfig,
-             _capabilities: &otap_df_engine::capability::registry::Capabilities| {
+             capabilities: &otap_df_engine::capability::registry::Capabilities| {
+        let mut exporter = ParquetExporter::from_config(pipeline, &node_config.config)?;
+        if exporter.config.storage.requires_bearer_token_provider() {
+            exporter.token_provider = Some(
+                capabilities
+                    .require_shared::<BearerTokenProvider>()
+                    .map_err(|e| otap_df_config::error::Error::InvalidUserConfig {
+                        error: e.to_string(),
+                    })?,
+            );
+        }
         Ok(ExporterWrapper::local(
-            ParquetExporter::from_config(pipeline, &node_config.config)?,
+            exporter,
             node,
             node_config,
             exporter_config,
@@ -110,6 +124,7 @@ impl ParquetExporter {
         // Prefer using from_config in the factory path so metrics are properly wired.
         Self {
             config,
+            token_provider: None,
             pdata_metrics: None,
             io_metrics: None,
         }
@@ -131,6 +146,7 @@ impl ParquetExporter {
 
         Ok(ParquetExporter {
             config,
+            token_provider: None,
             pdata_metrics: Some(pdata_metrics),
             io_metrics: Some(io_metrics),
         })
@@ -176,19 +192,21 @@ impl Exporter<OtapPdata> for ParquetExporter {
                 message = "parquet exporter retry settings are not applied to local file storage (invalid values will still be rejected)"
             );
         }
-        let object_store = otap_df_otap::object_store::from_storage_type_with_retry(
-            &self.config.storage,
-            self.config.retry.as_ref(),
-        )
-        .map_err(|e| {
-            let source_detail = format_error_sources(&e);
-            Error::ExporterError {
-                exporter: exporter_id.clone(),
-                kind: ExporterErrorKind::Configuration,
-                error: format!("error initializing object store {e}"),
-                source_detail,
-            }
-        })?;
+        let object_store =
+            otap_df_otap::object_store::from_storage_type_with_retry_and_token_provider(
+                &self.config.storage,
+                self.config.retry.as_ref(),
+                self.token_provider.take(),
+            )
+            .map_err(|e| {
+                let source_detail = format_error_sources(&e);
+                Error::ExporterError {
+                    exporter: exporter_id.clone(),
+                    kind: ExporterErrorKind::Configuration,
+                    error: format!("error initializing object store {e}"),
+                    source_detail,
+                }
+            })?;
 
         let writer_options = self.config.writer_options.unwrap_or_default();
 

--- a/rust/otap-dataflow/crates/otap/src/object_store.rs
+++ b/rust/otap-dataflow/crates/otap/src/object_store.rs
@@ -8,8 +8,10 @@ use object_store::ObjectStore;
 use object_store::local::LocalFileSystem;
 use serde::{Deserialize, Serialize};
 
-#[cfg(any(feature = "azure", feature = "aws"))]
+#[cfg(feature = "aws")]
 use crate::cloud_auth;
+
+use otap_df_engine::shared::capability::auth::bearer_token_provider::BearerTokenProvider;
 
 #[cfg(any(feature = "azure", feature = "aws"))]
 use object_store::path::Path;
@@ -159,7 +161,7 @@ impl RetryOptions {
 
 /// Supported object storage types
 #[derive(Clone, Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub enum StorageType {
     /// File storage
     File {
@@ -176,14 +178,6 @@ pub enum StorageType {
         /// - Fabric: `https://<account>.dfs.fabric.microsoft.com`
         /// - More: See [object_store::azure::MicrosoftAzureBuilder::with_url]
         base_uri: String,
-
-        /// Optional storage scope to request tokens for, mostly useful for
-        /// operating in azure clouds other than public. Defaults to
-        /// [azure::DEFAULT_STORAGE_SCOPE] if not provided.
-        storage_scope: Option<String>,
-
-        /// The auth settings, see [cloud_auth::azure::AuthMethod]
-        auth: cloud_auth::azure::AuthMethod,
     },
 
     /// AWS S3 storage
@@ -210,6 +204,19 @@ pub enum StorageType {
         /// The auth settings, see [cloud_auth::aws::AuthMethod]
         auth: cloud_auth::aws::AuthMethod,
     },
+}
+
+impl StorageType {
+    /// Whether this storage backend obtains credentials from a bearer token capability.
+    #[must_use]
+    pub const fn requires_bearer_token_provider(&self) -> bool {
+        #[cfg(feature = "azure")]
+        if matches!(self, Self::Azure { .. }) {
+            return true;
+        }
+
+        false
+    }
 }
 
 /// Extract the path prefix from a cloud storage URI that builders discard.
@@ -297,6 +304,18 @@ pub fn from_storage_type_with_retry(
     storage: &StorageType,
     retry: Option<&RetryOptions>,
 ) -> Result<Arc<dyn ObjectStore>, object_store::Error> {
+    from_storage_type_with_retry_and_token_provider(storage, retry, None)
+}
+
+/// Fetch an object store and use the supplied bearer token provider for Azure storage.
+pub fn from_storage_type_with_retry_and_token_provider(
+    storage: &StorageType,
+    retry: Option<&RetryOptions>,
+    token_provider: Option<Box<dyn BearerTokenProvider>>,
+) -> Result<Arc<dyn ObjectStore>, object_store::Error> {
+    #[cfg(not(feature = "azure"))]
+    let _ = token_provider;
+
     if let Some(retry) = retry {
         retry.validate()?;
     }
@@ -315,24 +334,14 @@ pub fn from_storage_type_with_retry(
         }
 
         #[cfg(feature = "azure")]
-        StorageType::Azure {
-            base_uri,
-            storage_scope,
-            auth,
-        } => {
-            use azure_core::credentials::TokenCredential;
+        StorageType::Azure { base_uri } => {
             use object_store::azure::MicrosoftAzureBuilder;
 
-            let token_credential: Arc<dyn TokenCredential> =
-                cloud_auth::azure::from_auth_method(auth.clone()).map_err(|e| {
-                    object_store::Error::Generic {
-                        store: "Azure",
-                        source: Box::new(e),
-                    }
-                })?;
-
-            let credential_provider =
-                azure::AzureTokenCredentialProvider::new(token_credential, storage_scope.clone());
+            let token_provider = token_provider.ok_or_else(|| object_store::Error::Generic {
+                store: "Azure",
+                source: "Azure storage requires a bound bearer_token_provider capability".into(),
+            })?;
+            let credential_provider = azure::AzureTokenCredentialProvider::new(token_provider);
 
             let mut builder = MicrosoftAzureBuilder::new()
                 .with_url(base_uri)
@@ -686,35 +695,29 @@ mod test {
         assert!(from_storage_type(&storage).is_ok());
     }
 
+    /// Scenario: Azure storage is constructed without a bearer token capability.
+    /// Guarantees: Construction fails before any unauthenticated storage client is returned.
     #[test]
     #[cfg(feature = "azure")]
-    fn test_get_azure_storage() {
+    fn test_get_azure_storage_requires_token_provider() {
         crate::crypto::ensure_crypto_provider();
         let storage = StorageType::Azure {
             base_uri: "https://mystorageaccount.blob.core.windows.net/container".to_string(),
-            storage_scope: None,
-            auth: cloud_auth::azure::AuthMethod::AzureCli {
-                subscription: None,
-                tenant_id: None,
-            },
         };
-        assert!(from_storage_type(&storage).is_ok());
+        assert!(from_storage_type(&storage).is_err());
     }
 
+    /// Scenario: Azure storage with retry settings lacks a bearer token capability.
+    /// Guarantees: Retry configuration does not bypass the required auth capability.
     #[test]
     #[cfg(feature = "azure")]
     fn test_get_azure_storage_with_retry() {
         crate::crypto::ensure_crypto_provider();
         let storage = StorageType::Azure {
             base_uri: "https://mystorageaccount.blob.core.windows.net/container".to_string(),
-            storage_scope: None,
-            auth: cloud_auth::azure::AuthMethod::AzureCli {
-                subscription: None,
-                tenant_id: None,
-            },
         };
         let retry = valid_retry_options();
-        assert!(from_storage_type_with_retry(&storage, Some(&retry)).is_ok());
+        assert!(from_storage_type_with_retry(&storage, Some(&retry)).is_err());
     }
 
     #[test]
@@ -771,85 +774,40 @@ mod test {
         test_deserialize(&json, expected);
     }
 
+    /// Scenario: Azure storage config contains only its blob storage URI.
+    /// Guarantees: Identity configuration is not required inside the exporter storage block.
     #[test]
     #[cfg(feature = "azure")]
-    fn test_azure_config_with_azure_cli() {
+    fn test_azure_config() {
         let json = json!({
             "azure": {
-                "base_uri": "https://mystorageaccount.blob.core.windows.net/container",
-                "auth": {
-                    "type": "azure_cli"
-                }
+                "base_uri": "https://mystorageaccount.blob.core.windows.net/container"
             }
         })
         .to_string();
 
         let expected = StorageType::Azure {
             base_uri: "https://mystorageaccount.blob.core.windows.net/container".to_string(),
-            storage_scope: None,
-            auth: cloud_auth::azure::AuthMethod::AzureCli {
-                subscription: None,
-                tenant_id: None,
-            },
         };
         test_deserialize(&json, expected);
     }
 
+    /// Scenario: Azure storage config uses the removed inline auth block.
+    /// Guarantees: Legacy credentials are rejected instead of being silently ignored.
     #[test]
     #[cfg(feature = "azure")]
-    fn test_azure_config_with_managed_identity() {
+    fn test_azure_config_rejects_inline_auth() {
         let json = json!({
             "azure": {
                 "base_uri": "https://mystorageaccount.blob.core.windows.net/container",
-                "storage_scope": "https://storage.azure.com/.default",
                 "auth": {
-                    "type": "managed_identity",
-                    "user_assigned_id": {
-                        "client_id": "test-client-id"
-                    }
+                    "type": "managed_identity"
                 }
             }
         })
         .to_string();
 
-        let expected = StorageType::Azure {
-            base_uri: "https://mystorageaccount.blob.core.windows.net/container".to_string(),
-            storage_scope: Some("https://storage.azure.com/.default".to_string()),
-            auth: cloud_auth::azure::AuthMethod::ManagedIdentity {
-                user_assigned_id: Some(cloud_auth::azure::UserAssignedId::ClientId(
-                    "test-client-id".to_string(),
-                )),
-            },
-        };
-        test_deserialize(&json, expected);
-    }
-
-    #[test]
-    #[cfg(feature = "azure")]
-    fn test_azure_config_with_workload_identity() {
-        let json = json!({
-            "azure": {
-                "base_uri": "https://mystorageaccount.blob.core.windows.net/container",
-                "auth": {
-                    "type": "workload_identity",
-                    "client_id": "test-client-id",
-                    "tenant_id": "test-tenant-id",
-                    "token_file_path": "/var/run/secrets/token"
-                }
-            }
-        })
-        .to_string();
-
-        let expected = StorageType::Azure {
-            base_uri: "https://mystorageaccount.blob.core.windows.net/container".to_string(),
-            storage_scope: None,
-            auth: cloud_auth::azure::AuthMethod::WorkloadIdentity {
-                client_id: Some("test-client-id".to_string()),
-                tenant_id: Some("test-tenant-id".to_string()),
-                token_file_path: Some("/var/run/secrets/token".into()),
-            },
-        };
-        test_deserialize(&json, expected);
+        assert!(serde_json::from_str::<StorageType>(&json).is_err());
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/otap/src/object_store.rs
+++ b/rust/otap-dataflow/crates/otap/src/object_store.rs
@@ -695,6 +695,37 @@ mod test {
         assert!(from_storage_type(&storage).is_ok());
     }
 
+    /// Scenario: Each supported storage backend is asked whether it needs a bearer token capability.
+    /// Guarantees: Only Azure demands the binding, so file and S3 pipelines start without one.
+    #[test]
+    fn only_azure_requires_a_bearer_token_provider() {
+        let file = StorageType::File {
+            base_uri: "/tmp/otap".to_string(),
+        };
+        assert!(!file.requires_bearer_token_provider());
+
+        #[cfg(feature = "azure")]
+        {
+            let azure = StorageType::Azure {
+                base_uri: "https://mystorageaccount.blob.core.windows.net/container".to_string(),
+            };
+            assert!(azure.requires_bearer_token_provider());
+        }
+
+        #[cfg(feature = "aws")]
+        {
+            let s3 = StorageType::S3 {
+                base_uri: "s3://my-bucket/telemetry".to_string(),
+                region: None,
+                endpoint: None,
+                allow_http: None,
+                virtual_hosted_style_request: None,
+                auth: cloud_auth::aws::AuthMethod::Default,
+            };
+            assert!(!s3.requires_bearer_token_provider());
+        }
+    }
+
     /// Scenario: Azure storage is constructed without a bearer token capability.
     /// Guarantees: Construction fails before any unauthenticated storage client is returned.
     #[test]

--- a/rust/otap-dataflow/crates/otap/src/object_store/azure.rs
+++ b/rust/otap-dataflow/crates/otap/src/object_store/azure.rs
@@ -75,9 +75,86 @@ impl CredentialProvider for AzureTokenCredentialProvider {
 #[cfg(test)]
 mod test {
     use super::*;
-    use otap_df_engine::capability::CapabilityError;
     use otap_df_engine::capability::auth::BearerToken;
     use otap_df_engine::capability::auth::bearer_token_provider::TokenStream;
+    use otap_df_engine::capability::{CapabilityError, CapabilityErrorSource};
+
+    /// Scenario: The bound capability cannot produce a token.
+    /// Guarantees: The failure is reported to object_store instead of surfacing an unauthenticated request.
+    #[tokio::test]
+    async fn get_credential_reports_a_provider_failure() {
+        let provider = setup_provider(vec![]);
+
+        let error = provider
+            .get_credential()
+            .await
+            .expect_err("a provider failure must fail credential acquisition");
+
+        assert!(matches!(
+            error,
+            object_store::Error::Generic { store: "Azure", .. }
+        ));
+    }
+
+    /// Scenario: The capability fails after a credential was already cached.
+    /// Guarantees: The stale cached credential is not replayed once the provider stops issuing tokens.
+    #[tokio::test]
+    async fn cached_credential_is_not_replayed_after_a_provider_failure() {
+        let provider = setup_provider(vec!["token1".to_string()]);
+        let _ = provider
+            .get_credential()
+            .await
+            .expect("first acquisition succeeds");
+
+        assert!(provider.get_credential().await.is_err());
+    }
+
+    /// Scenario: The credential provider is rendered in diagnostics output.
+    /// Guarantees: Rendering never discloses the bearer token it holds.
+    #[test]
+    fn debug_rendering_withholds_token_material() {
+        let provider = setup_provider(vec!["super-secret-token".to_string()]);
+
+        let rendered = format!("{provider:?}");
+
+        assert!(rendered.contains("AzureTokenCredentialProvider"));
+        assert!(!rendered.contains("super-secret-token"));
+    }
+
+    /// Scenario: Azure storage is built with a bound bearer token capability, with and without retry.
+    /// Guarantees: The capability-backed credential path constructs a usable store in both cases.
+    #[test]
+    fn azure_storage_builds_when_a_token_provider_is_supplied() {
+        crate::crypto::ensure_crypto_provider();
+        let storage = crate::object_store::StorageType::Azure {
+            base_uri: "https://mystorageaccount.blob.core.windows.net/container/telemetry"
+                .to_string(),
+        };
+
+        let store = crate::object_store::from_storage_type_with_retry_and_token_provider(
+            &storage,
+            None,
+            Some(Box::new(TestTokenProvider::new(vec!["token1".to_string()]))),
+        );
+        assert!(store.is_ok(), "expected a store, got {store:?}");
+
+        let retry = crate::object_store::RetryOptions {
+            max_retries: 3,
+            init_backoff: std::time::Duration::from_millis(100),
+            max_backoff: std::time::Duration::from_secs(5),
+            backoff_base: 2.0,
+            retry_timeout: std::time::Duration::from_secs(30),
+        };
+        let store_with_retry = crate::object_store::from_storage_type_with_retry_and_token_provider(
+            &storage,
+            Some(&retry),
+            Some(Box::new(TestTokenProvider::new(vec!["token1".to_string()]))),
+        );
+        assert!(
+            store_with_retry.is_ok(),
+            "expected a store, got {store_with_retry:?}"
+        );
+    }
 
     /// Scenario: The capability returns repeated and refreshed token values.
     /// Guarantees: The bridge reuses credentials for equal tokens and replaces them on refresh.
@@ -147,8 +224,13 @@ mod test {
     #[async_trait::async_trait]
     impl BearerTokenProvider for TestTokenProvider {
         async fn get_token(&self) -> Result<BearerToken, CapabilityError> {
-            let token = self.tokens.lock().await.pop().unwrap();
-            Ok(BearerToken::without_expiry(token))
+            match self.tokens.lock().await.pop() {
+                Some(token) => Ok(BearerToken::without_expiry(token)),
+                None => Err(CapabilityErrorSource::<
+                    otap_df_engine::capability::auth::bearer_token_provider::BearerTokenProvider,
+                >::new("test_extension".into())
+                .error("no token available")),
+            }
         }
 
         fn token_stream(&self) -> TokenStream {

--- a/rust/otap-dataflow/crates/otap/src/object_store/azure.rs
+++ b/rust/otap-dataflow/crates/otap/src/object_store/azure.rs
@@ -3,49 +3,36 @@
 
 use std::sync::Arc;
 
-use azure_core::credentials::{AccessToken, TokenCredential};
 use object_store::{CredentialProvider, azure::AzureCredential};
-use std::sync::Mutex;
+use otap_df_engine::shared::capability::auth::bearer_token_provider::BearerTokenProvider;
+use tokio::sync::Mutex;
 
-/// The default resource storage scope to request tokens for. This is
-/// used in public cloud, but may need to be overridden for other clouds
-/// such as Azure China or Azure Government.
-///
-/// See: <https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory#microsoft-authentication-library-msal>
-pub const DEFAULT_STORAGE_SCOPE: &str = "https://storage.azure.com/.default";
-
-/// [CredentialProvider] implementation that works with a [TokenCredential]
-/// from the azure SDK.
-///
-/// object_store provides their own implementations of many credentials like
-/// ManagedIdentityCredential or WorkloadIdentityCredential, however those
-/// implementations are limited in functionality and do not support all options
-/// like overriding storage scope. See [DEFAULT_STORAGE_SCOPE].
-#[derive(Debug)]
+/// Bridges the engine's bearer token capability to object_store Azure credentials.
 pub struct AzureTokenCredentialProvider {
-    token_cred: Arc<dyn TokenCredential>,
-    storage_scope: String,
+    token_provider: Mutex<Box<dyn BearerTokenProvider>>,
     state: Mutex<Option<TokenProviderState>>,
 }
 
 #[derive(Debug)]
 struct TokenProviderState {
-    /// The last obtained token from [Self::token_cred]
-    current_access_token: AccessToken,
-    /// The object store representation of [Self::current_access_token]
+    current_token: String,
     current_object_store_cred: Arc<AzureCredential>,
 }
 
+impl std::fmt::Debug for AzureTokenCredentialProvider {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AzureTokenCredentialProvider")
+            .finish_non_exhaustive()
+    }
+}
+
 impl AzureTokenCredentialProvider {
-    /// Create a new provider based on the given [TokenCredential].
-    /// If you are operating in an azure cloud other than public
-    /// (the normal one), you may want to provide a different scope.
-    ///
-    /// See [DEFAULT_STORAGE_SCOPE].
-    pub fn new(cred: Arc<dyn TokenCredential>, scope: Option<String>) -> Self {
+    /// Create a provider backed by a resolved bearer token capability.
+    #[must_use]
+    pub fn new(token_provider: Box<dyn BearerTokenProvider>) -> Self {
         Self {
-            token_cred: cred,
-            storage_scope: scope.unwrap_or(DEFAULT_STORAGE_SCOPE.to_string()),
+            token_provider: Mutex::new(token_provider),
             state: Mutex::new(None),
         }
     }
@@ -55,76 +42,45 @@ impl AzureTokenCredentialProvider {
 impl CredentialProvider for AzureTokenCredentialProvider {
     type Credential = AzureCredential;
 
-    /// Get an [AzureCredential] based on the  underlying [TokenCredential].
-    ///
-    /// This has a bunch of machinery because [AzureCredential] and
-    /// [TokenCredential] have different underlying representations.
-    ///
-    /// [TokenCredentials] typically have the responsibility of caching and
-    /// refreshing tokens themselves and are based on `Cow<str>`, so they're
-    /// cheapyly clonable.
-    ///
-    /// [AzureCredential::BearerToken] on the other hand is just a String and
-    /// needs to be wrapped in Arc (hence the trait signature).
-    ///
-    /// The goal here is to delegate caching to the underlying [TokenCredential]
-    /// while avoiding allocating a String on every call to this function by
-    /// caching the [AzureCredential] representation of the current token and
-    /// updating it as needed.
+    /// Get an [AzureCredential] from the extension-managed token cache.
     async fn get_credential(&self) -> object_store::Result<Arc<AzureCredential>> {
-        // First, get a token from the underlying credential, this is "free" if
-        // there's a valid cached token.
-        let maybe_new_token = self
-            .token_cred
-            .get_token(&[&self.storage_scope], None)
+        let token = self
+            .token_provider
+            .lock()
+            .await
+            .get_token()
             .await
             .map_err(|e| object_store::Error::Generic {
                 store: "Azure",
                 source: Box::new(e),
             })?;
+        let token = token.expose_token();
 
-        // If state is not initialized, then this is the first time we're called.
-        // Initialize the state and return early.
-        let mut state = self.state.lock().expect("Lock is not poisoned.");
-        if state.is_none() {
-            let object_store_cred = Arc::new(AzureCredential::BearerToken(
-                maybe_new_token.token.secret().to_owned(),
-            ));
-
-            *state = Some(TokenProviderState {
-                current_access_token: maybe_new_token,
-                current_object_store_cred: object_store_cred.clone(),
-            });
-
-            return Ok(object_store_cred);
+        let mut state = self.state.lock().await;
+        if let Some(state) = state.as_ref()
+            && state.current_token == token
+        {
+            return Ok(state.current_object_store_cred.clone());
         }
 
-        // If the secret from the currently cached token matches the new one,
-        // then we can reuse the cached [AzureCredential]. Otherwise we update.
-        let state = state.as_mut().expect("State is initialized.");
-        let current_token = &state.current_access_token;
-        let cred = if current_token.token.secret() == maybe_new_token.token.secret() {
-            state.current_object_store_cred.clone()
-        } else {
-            let object_store_cred = Arc::new(AzureCredential::BearerToken(
-                maybe_new_token.token.secret().to_owned(),
-            ));
-            state.current_access_token = maybe_new_token;
-            state.current_object_store_cred = object_store_cred.clone();
-            object_store_cred
-        };
-
-        Ok(cred)
+        let credential = Arc::new(AzureCredential::BearerToken(token.to_owned()));
+        *state = Some(TokenProviderState {
+            current_token: token.to_owned(),
+            current_object_store_cred: credential.clone(),
+        });
+        Ok(credential)
     }
 }
 
 #[cfg(test)]
 mod test {
-    use std::time::Duration;
-    use time::OffsetDateTime;
-
     use super::*;
+    use otap_df_engine::capability::CapabilityError;
+    use otap_df_engine::capability::auth::BearerToken;
+    use otap_df_engine::capability::auth::bearer_token_provider::TokenStream;
 
+    /// Scenario: The capability returns repeated and refreshed token values.
+    /// Guarantees: The bridge reuses credentials for equal tokens and replaces them on refresh.
     #[tokio::test]
     async fn test_same_different_same() {
         let provider = setup_provider(vec![
@@ -144,6 +100,8 @@ mod test {
         assert!(Arc::ptr_eq(&cred3, &cred4));
     }
 
+    /// Scenario: A token value returns after a different token was observed.
+    /// Guarantees: Credential identity follows refresh events rather than token text history.
     #[tokio::test]
     async fn test_same_text_diff_token() {
         let provider = setup_provider(vec![
@@ -157,6 +115,8 @@ mod test {
         assert!(!Arc::ptr_eq(&cred1, &cred3));
     }
 
+    /// Scenario: Consecutive capability reads return the same token.
+    /// Guarantees: The bridge avoids reallocating the object-store credential.
     #[tokio::test]
     async fn test_same_token() {
         let provider = setup_provider(vec!["token1".to_string(), "token1".to_string()]);
@@ -166,16 +126,15 @@ mod test {
     }
 
     fn setup_provider(tokens: Vec<String>) -> AzureTokenCredentialProvider {
-        let cred = Arc::new(TestTokenCredential::new(tokens));
-        AzureTokenCredentialProvider::new(cred, None)
+        AzureTokenCredentialProvider::new(Box::new(TestTokenProvider::new(tokens)))
     }
 
     #[derive(Debug)]
-    struct TestTokenCredential {
+    struct TestTokenProvider {
         tokens: Mutex<Vec<String>>,
     }
 
-    impl TestTokenCredential {
+    impl TestTokenProvider {
         fn new(mut tokens: Vec<String>) -> Self {
             // Reverse so popping from the end gives the correct order.
             tokens.reverse();
@@ -186,17 +145,14 @@ mod test {
     }
 
     #[async_trait::async_trait]
-    impl TokenCredential for TestTokenCredential {
-        async fn get_token(
-            &self,
-            _scopes: &[&str],
-            _options: Option<azure_core::credentials::TokenRequestOptions<'_>>,
-        ) -> azure_core::Result<AccessToken> {
-            let token = self.tokens.lock().unwrap().pop().unwrap();
-            Ok(AccessToken::new(
-                token,
-                OffsetDateTime::now_utc() + Duration::from_secs(3600),
-            ))
+    impl BearerTokenProvider for TestTokenProvider {
+        async fn get_token(&self) -> Result<BearerToken, CapabilityError> {
+            let token = self.tokens.lock().await.pop().unwrap();
+            Ok(BearerToken::without_expiry(token))
+        }
+
+        fn token_stream(&self) -> TokenStream {
+            Box::pin(futures::stream::empty())
         }
     }
 }


### PR DESCRIPTION
# Change summary

Removes Azure credential construction from the Parquet exporter and sources blob-storage tokens from a bound `bearer_token_provider` extension instead.

The exporter previously built its own `TokenCredential` from inline `auth` config. 
It now resolves the capability at factory time and passes it into object-store construction,  so `AzureTokenCredentialProvider` bridges extension-managed tokens into object_store's `AzureCredential`. 
Token acquisition and refresh move out of the exporter and into the extension, matching how the  Azure Monitor and OTLP exporters already consume the capability.

The capability is required only when Azure storage is selected; file and S3 backends are unaffected.

## Related issue

* Closes #3356

## Validation

- Unit tests
- Local integration testing

## User-facing changes

Breaking. Parquet Azure storage config no longer accepts `auth` or storage_scope; configs that set them now fail validation.

Migration: remove those keys and bind an azure_identity_auth extension configured with the Azure
