### PR TITLE
chore(engine): add attributed retained-work scope

### DIFF
--- a/rust/otap-dataflow/crates/engine/src/retained_work.rs
+++ b/rust/otap-dataflow/crates/engine/src/retained_work.rs
@@ -3,13 +3,178 @@
 
 //! Runtime-local retained-work accounting primitives.
 //!
-//! This module owns accounting state only. Runtime installation, attribution,
-//! telemetry export, and production charge sites are layered on separately.
+//! This module owns accounting state and immutable bounded attribution. Runtime
+//! installation, telemetry export, and production charge sites are layered on
+//! separately.
 
+use otap_df_config::{NodeId, PipelineKey};
 use std::cell::Cell;
+use std::collections::HashMap;
 use std::fmt;
 use std::marker::PhantomData;
 use std::rc::Rc;
+
+/// Compact identity for one trusted retained-work owner.
+///
+/// Owners are allocated by [`WorkOwnerRegistry`]. The two reserved values keep
+/// mixed and over-capacity ownership explicit without introducing unbounded
+/// request-derived labels.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[repr(transparent)]
+pub struct WorkOwnerId(u32);
+
+impl WorkOwnerId {
+    /// Work combined from more than one registered owner.
+    pub const MIXED: Self = Self(0);
+
+    /// Work whose trusted owner could not be registered within the bound.
+    pub const UNREGISTERED: Self = Self(1);
+
+    const FIRST_REGISTERED: u32 = 2;
+
+    /// Returns the compact numeric representation.
+    #[must_use]
+    pub const fn as_u32(self) -> u32 {
+        self.0
+    }
+}
+
+/// Bounded registry of trusted pipeline owners.
+///
+/// Only configuration-derived pipeline identities belong here. Raw request or
+/// tenant identity must never be registered because it would turn request
+/// cardinality into retained-work cardinality.
+#[derive(Debug)]
+pub struct WorkOwnerRegistry {
+    max_registered_owners: usize,
+    owners_by_key: HashMap<PipelineKey, WorkOwnerId>,
+    keys_by_owner: Vec<PipelineKey>,
+}
+
+impl WorkOwnerRegistry {
+    /// Creates a registry that stores at most `max_registered_owners` owners.
+    #[must_use]
+    pub fn new(max_registered_owners: usize) -> Self {
+        Self {
+            max_registered_owners: max_registered_owners.min((u32::MAX - 1) as usize),
+            owners_by_key: HashMap::new(),
+            keys_by_owner: Vec::new(),
+        }
+    }
+
+    /// Returns the stable owner for one trusted configured pipeline.
+    ///
+    /// Once the bound is reached, new identities deterministically map to
+    /// [`WorkOwnerId::UNREGISTERED`]. Previously registered identities retain
+    /// their original IDs.
+    pub fn register_pipeline(&mut self, pipeline: &PipelineKey) -> WorkOwnerId {
+        if let Some(owner) = self.owners_by_key.get(pipeline) {
+            return *owner;
+        }
+
+        if self.keys_by_owner.len() >= self.max_registered_owners {
+            return WorkOwnerId::UNREGISTERED;
+        }
+
+        let index =
+            u32::try_from(self.keys_by_owner.len()).expect("owner registry bound must fit in u32");
+        let owner = WorkOwnerId(index + WorkOwnerId::FIRST_REGISTERED);
+        self.keys_by_owner.push(pipeline.clone());
+        let previous = self.owners_by_key.insert(pipeline.clone(), owner);
+        debug_assert!(previous.is_none());
+        owner
+    }
+
+    /// Resolves a registered owner to its configured pipeline identity.
+    #[must_use]
+    pub fn pipeline(&self, owner: WorkOwnerId) -> Option<&PipelineKey> {
+        let index = owner.0.checked_sub(WorkOwnerId::FIRST_REGISTERED)? as usize;
+        self.keys_by_owner.get(index)
+    }
+
+    /// Returns the number of registered owners, excluding sentinels.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.keys_by_owner.len()
+    }
+
+    /// Returns whether the registry contains no configured owners.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.keys_by_owner.is_empty()
+    }
+}
+
+/// Immutable attribution required for every retained-work charge.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct RetainedWorkScopeId {
+    /// Configured pipeline, including its group identity.
+    pub pipeline: PipelineKey,
+    /// Pinned runtime core.
+    pub core_id: usize,
+    /// Live-deployment generation of the runtime.
+    pub runtime_generation: u64,
+    /// Component retaining the work.
+    pub component_id: NodeId,
+    /// Trusted bounded owner of the retained work.
+    pub owner: WorkOwnerId,
+}
+
+/// Static retention site carried by each ticket rather than its scope.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum RetainedWorkSite {
+    /// Payload waiting for retry delivery.
+    RetryBuffer,
+    /// Payload held in a batch processor's pending batch.
+    BatchPending,
+}
+
+#[derive(Debug)]
+struct LocalRetainedScopeInner {
+    account: Rc<LocalRetainedAccount>,
+    id: RetainedWorkScopeId,
+}
+
+/// Runtime-local attributed entrypoint for retained-work charges.
+///
+/// The scope caches its runtime account and immutable attribution once. Charge
+/// sites clone only this local `Rc`; they do not look up runtime state or copy
+/// string fields per item.
+#[derive(Clone, Debug)]
+pub struct LocalRetainedScope {
+    inner: Rc<LocalRetainedScopeInner>,
+}
+
+impl LocalRetainedScope {
+    /// Binds immutable attribution to one runtime-local account.
+    #[must_use]
+    pub fn new(account: Rc<LocalRetainedAccount>, id: RetainedWorkScopeId) -> Self {
+        Self {
+            inner: Rc::new(LocalRetainedScopeInner { account, id }),
+        }
+    }
+
+    /// Returns this scope's immutable attribution.
+    #[must_use]
+    pub fn id(&self) -> &RetainedWorkScopeId {
+        &self.inner.id
+    }
+
+    /// Starts one attributed retained-work interval.
+    pub fn charge(
+        &self,
+        site: RetainedWorkSite,
+        bytes: Option<u64>,
+    ) -> Result<LocalRetainedTicket, LocalAccountingError> {
+        let charge = self.inner.account.start_charge(bytes)?;
+        Ok(LocalRetainedTicket {
+            scope: Rc::clone(&self.inner),
+            site,
+            charge,
+            active: true,
+        })
+    }
+}
 
 /// Identifies the counter whose checked arithmetic failed.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -95,15 +260,11 @@ impl LocalRetainedAccount {
         })
     }
 
-    /// Starts one retained-work interval and returns its ownership ticket.
-    ///
-    /// `Some(bytes)` records a known logical size. `None` records one
-    /// unknown-size item without guessing its byte size.
     #[inline]
-    pub fn charge(
-        self: &Rc<Self>,
+    fn start_charge(
+        &self,
         bytes: Option<u64>,
-    ) -> Result<LocalRetainedTicket, LocalAccountingError> {
+    ) -> Result<LocalRetainedCharge, LocalAccountingError> {
         let charge = match bytes {
             Some(bytes) => {
                 self.checked_add(
@@ -119,11 +280,7 @@ impl LocalRetainedAccount {
             }
         };
 
-        Ok(LocalRetainedTicket {
-            account: Rc::clone(self),
-            charge,
-            active: true,
-        })
+        Ok(charge)
     }
 
     /// Returns the current local counters.
@@ -216,7 +373,8 @@ enum LocalRetainedCharge {
 #[derive(Debug)]
 #[must_use = "the ticket must be completed normally or dropped as abandoned"]
 pub struct LocalRetainedTicket {
-    account: Rc<LocalRetainedAccount>,
+    scope: Rc<LocalRetainedScopeInner>,
+    site: RetainedWorkSite,
     charge: LocalRetainedCharge,
     active: bool,
 }
@@ -231,11 +389,23 @@ impl LocalRetainedTicket {
         }
     }
 
+    /// Returns the immutable attribution for this charge.
+    #[must_use]
+    pub fn scope(&self) -> &RetainedWorkScopeId {
+        &self.scope.id
+    }
+
+    /// Returns the static site retaining this charge.
+    #[must_use]
+    pub const fn site(&self) -> RetainedWorkSite {
+        self.site
+    }
+
     /// Completes this retention interval normally and refunds its charge.
     #[inline]
     pub fn complete(mut self) -> Result<(), LocalAccountingError> {
         self.active = false;
-        self.account.settle(self.charge)
+        self.scope.account.settle(self.charge)
     }
 }
 
@@ -245,8 +415,8 @@ impl Drop for LocalRetainedTicket {
             return;
         }
         self.active = false;
-        let _ = self.account.settle(self.charge);
-        self.account.record_abandonment(self.charge);
+        let _ = self.scope.account.settle(self.charge);
+        self.scope.account.record_abandonment(self.charge);
     }
 }
 
@@ -254,12 +424,28 @@ impl Drop for LocalRetainedTicket {
 mod tests {
     use super::*;
 
+    fn test_scope(account: Rc<LocalRetainedAccount>) -> LocalRetainedScope {
+        LocalRetainedScope::new(
+            account,
+            RetainedWorkScopeId {
+                pipeline: PipelineKey::new("group".into(), "pipeline".into()),
+                core_id: 3,
+                runtime_generation: 7,
+                component_id: "processor".into(),
+                owner: WorkOwnerId(2),
+            },
+        )
+    }
+
     /// Scenario: a known-size ticket reaches its normal terminal path.
     /// Guarantees: completion refunds the bytes once and records no abandonment.
     #[test]
     fn known_charge_completes_normally() {
         let account = LocalRetainedAccount::new();
-        let ticket = account.charge(Some(42)).expect("charge should fit");
+        let scope = test_scope(Rc::clone(&account));
+        let ticket = scope
+            .charge(RetainedWorkSite::RetryBuffer, Some(42))
+            .expect("charge should fit");
 
         assert_eq!(ticket.bytes(), Some(42));
         assert_eq!(account.snapshot().retained_bytes, 42);
@@ -272,7 +458,10 @@ mod tests {
     #[test]
     fn unknown_charge_completes_normally() {
         let account = LocalRetainedAccount::new();
-        let ticket = account.charge(None).expect("charge should fit");
+        let scope = test_scope(Rc::clone(&account));
+        let ticket = scope
+            .charge(RetainedWorkSite::RetryBuffer, None)
+            .expect("charge should fit");
 
         assert_eq!(ticket.bytes(), None);
         assert_eq!(account.snapshot().unknown_items, 1);
@@ -285,7 +474,10 @@ mod tests {
     #[test]
     fn unresolved_known_ticket_refunds_and_records_abandonment() {
         let account = LocalRetainedAccount::new();
-        let ticket = account.charge(Some(17)).expect("charge should fit");
+        let scope = test_scope(Rc::clone(&account));
+        let ticket = scope
+            .charge(RetainedWorkSite::BatchPending, Some(17))
+            .expect("charge should fit");
 
         drop(ticket);
 
@@ -304,7 +496,10 @@ mod tests {
     #[test]
     fn unresolved_unknown_ticket_refunds_and_records_abandonment() {
         let account = LocalRetainedAccount::new();
-        let ticket = account.charge(None).expect("charge should fit");
+        let scope = test_scope(Rc::clone(&account));
+        let ticket = scope
+            .charge(RetainedWorkSite::BatchPending, None)
+            .expect("charge should fit");
 
         drop(ticket);
 
@@ -322,7 +517,10 @@ mod tests {
     #[test]
     fn completion_prevents_drop_from_settling_twice() {
         let account = LocalRetainedAccount::new();
-        let ticket = account.charge(Some(9)).expect("charge should fit");
+        let scope = test_scope(Rc::clone(&account));
+        let ticket = scope
+            .charge(RetainedWorkSite::RetryBuffer, Some(9))
+            .expect("charge should fit");
 
         ticket.complete().expect("completion should settle");
 
@@ -334,10 +532,11 @@ mod tests {
     #[test]
     fn charge_overflow_is_rejected_and_recorded() {
         let account = LocalRetainedAccount::new();
+        let scope = test_scope(Rc::clone(&account));
         account.retained_bytes.set(u64::MAX);
 
-        let error = account
-            .charge(Some(1))
+        let error = scope
+            .charge(RetainedWorkSite::RetryBuffer, Some(1))
             .expect_err("overflowing charge must fail");
 
         assert_eq!(
@@ -353,7 +552,10 @@ mod tests {
     #[test]
     fn settlement_underflow_is_reported_and_recorded() {
         let account = LocalRetainedAccount::new();
-        let ticket = account.charge(Some(5)).expect("charge should fit");
+        let scope = test_scope(Rc::clone(&account));
+        let ticket = scope
+            .charge(RetainedWorkSite::RetryBuffer, Some(5))
+            .expect("charge should fit");
         account.retained_bytes.set(0);
 
         let error = ticket
@@ -367,5 +569,83 @@ mod tests {
         assert_eq!(account.snapshot().retained_bytes, 0);
         assert_eq!(account.snapshot().corruption_count, 1);
         assert_eq!(account.snapshot().abandoned_items, 0);
+    }
+
+    /// Scenario: a configured pipeline is registered more than once.
+    /// Guarantees: repeated registration returns one stable compact owner ID.
+    #[test]
+    fn owner_registration_is_stable() {
+        let mut registry = WorkOwnerRegistry::new(2);
+        let pipeline = PipelineKey::new("group".into(), "pipeline".into());
+
+        let first = registry.register_pipeline(&pipeline);
+        let repeated = registry.register_pipeline(&pipeline);
+
+        assert_eq!(first, repeated);
+        assert_eq!(first.as_u32(), WorkOwnerId::FIRST_REGISTERED);
+        assert_eq!(registry.pipeline(first), Some(&pipeline));
+        assert_eq!(registry.len(), 1);
+    }
+
+    /// Scenario: equal pipeline names exist in different configured groups.
+    /// Guarantees: the registry treats the full group and pipeline pair as identity.
+    #[test]
+    fn owner_registration_includes_pipeline_group() {
+        let mut registry = WorkOwnerRegistry::new(2);
+        let first_pipeline = PipelineKey::new("group-a".into(), "pipeline".into());
+        let second_pipeline = PipelineKey::new("group-b".into(), "pipeline".into());
+
+        let first = registry.register_pipeline(&first_pipeline);
+        let second = registry.register_pipeline(&second_pipeline);
+
+        assert_ne!(first, second);
+        assert_eq!(registry.pipeline(first), Some(&first_pipeline));
+        assert_eq!(registry.pipeline(second), Some(&second_pipeline));
+    }
+
+    /// Scenario: more configured owners are observed than the registry permits.
+    /// Guarantees: excess identities use the deterministic Unregistered sentinel
+    /// while existing owners remain stable and the registry stays bounded.
+    #[test]
+    fn owner_registration_is_bounded() {
+        let mut registry = WorkOwnerRegistry::new(1);
+        let first_pipeline = PipelineKey::new("group".into(), "first".into());
+        let second_pipeline = PipelineKey::new("group".into(), "second".into());
+
+        let registered = registry.register_pipeline(&first_pipeline);
+        let overflow = registry.register_pipeline(&second_pipeline);
+
+        assert_eq!(overflow, WorkOwnerId::UNREGISTERED);
+        assert_eq!(registry.register_pipeline(&first_pipeline), registered);
+        assert_eq!(registry.register_pipeline(&second_pipeline), overflow);
+        assert_eq!(registry.pipeline(WorkOwnerId::MIXED), None);
+        assert_eq!(registry.pipeline(WorkOwnerId::UNREGISTERED), None);
+        assert_eq!(registry.len(), 1);
+    }
+
+    /// Scenario: a component charges retained work through an attributed scope.
+    /// Guarantees: the ticket carries the complete immutable scope and its
+    /// per-charge retention site without copying those fields into the account.
+    #[test]
+    fn ticket_carries_scope_and_retention_site() {
+        let account = LocalRetainedAccount::new();
+        let scope = test_scope(Rc::clone(&account));
+
+        let ticket = scope
+            .charge(RetainedWorkSite::BatchPending, Some(11))
+            .expect("charge should fit");
+
+        assert_eq!(ticket.scope(), scope.id());
+        assert_eq!(ticket.site(), RetainedWorkSite::BatchPending);
+        assert_eq!(
+            ticket.scope().pipeline.pipeline_group_id().as_ref(),
+            "group"
+        );
+        assert_eq!(ticket.scope().pipeline.pipeline_id().as_ref(), "pipeline");
+        assert_eq!(ticket.scope().core_id, 3);
+        assert_eq!(ticket.scope().runtime_generation, 7);
+        assert_eq!(ticket.scope().component_id.as_ref(), "processor");
+        assert_eq!(ticket.scope().owner, WorkOwnerId(2));
+        ticket.complete().expect("completion should settle");
     }
 }

--- a/rust/otap-dataflow/crates/engine/src/retained_work.rs
+++ b/rust/otap-dataflow/crates/engine/src/retained_work.rs
@@ -7,11 +7,12 @@
 //! installation, telemetry export, and production charge sites are layered on
 //! separately.
 
-use otap_df_config::{NodeId, PipelineKey};
+use otap_df_config::{DeployedPipelineKey, NodeId, PipelineKey};
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::fmt;
 use std::marker::PhantomData;
+use std::num::NonZeroUsize;
 use std::rc::Rc;
 
 /// Compact identity for one trusted retained-work owner.
@@ -54,9 +55,9 @@ pub struct WorkOwnerRegistry {
 impl WorkOwnerRegistry {
     /// Creates a registry that stores at most `max_registered_owners` owners.
     #[must_use]
-    pub fn new(max_registered_owners: usize) -> Self {
+    pub fn new(max_registered_owners: NonZeroUsize) -> Self {
         Self {
-            max_registered_owners: max_registered_owners.min((u32::MAX - 1) as usize),
+            max_registered_owners: max_registered_owners.get().min((u32::MAX - 1) as usize),
             owners_by_key: HashMap::new(),
             keys_by_owner: Vec::new(),
         }
@@ -108,12 +109,8 @@ impl WorkOwnerRegistry {
 /// Immutable attribution required for every retained-work charge.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct RetainedWorkScopeId {
-    /// Configured pipeline, including its group identity.
-    pub pipeline: PipelineKey,
-    /// Pinned runtime core.
-    pub core_id: usize,
-    /// Live-deployment generation of the runtime.
-    pub runtime_generation: u64,
+    /// Configured pipeline runtime, including group, core, and generation.
+    pub deployed_pipeline: DeployedPipelineKey,
     /// Component retaining the work.
     pub component_id: NodeId,
     /// Trusted bounded owner of the retained work.
@@ -122,6 +119,7 @@ pub struct RetainedWorkScopeId {
 
 /// Static retention site carried by each ticket rather than its scope.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum RetainedWorkSite {
     /// Payload waiting for retry delivery.
     RetryBuffer,
@@ -161,6 +159,10 @@ impl LocalRetainedScope {
     }
 
     /// Starts one attributed retained-work interval.
+    ///
+    /// Accounting failures are diagnostics, not data-path failures. A charge
+    /// site must continue processing the retained work without a ticket if this
+    /// returns an error; observe-only accounting must never reject or drop it.
     pub fn charge(
         &self,
         site: RetainedWorkSite,
@@ -370,6 +372,32 @@ enum LocalRetainedCharge {
 /// an active ticket still refunds its charge, but records the interval as
 /// abandoned. The ticket is deliberately neither `Send` nor `Sync` because it
 /// holds an `Rc` to runtime-local state.
+///
+/// ```compile_fail
+/// use otap_df_config::DeployedPipelineKey;
+/// use otap_df_engine::retained_work::{
+///     LocalRetainedAccount, LocalRetainedScope, RetainedWorkScopeId,
+///     RetainedWorkSite, WorkOwnerId,
+/// };
+///
+/// let scope = LocalRetainedScope::new(
+///     LocalRetainedAccount::new(),
+///     RetainedWorkScopeId {
+///         deployed_pipeline: DeployedPipelineKey {
+///             pipeline_group_id: "group".into(),
+///             pipeline_id: "pipeline".into(),
+///             core_id: 0,
+///             deployment_generation: 0,
+///         },
+///         component_id: "processor".into(),
+///         owner: WorkOwnerId::UNREGISTERED,
+///     },
+/// );
+/// let ticket = scope
+///     .charge(RetainedWorkSite::RetryBuffer, Some(1))
+///     .expect("charge should fit");
+/// std::thread::spawn(move || drop(ticket));
+/// ```
 #[derive(Debug)]
 #[must_use = "the ticket must be completed normally or dropped as abandoned"]
 pub struct LocalRetainedTicket {
@@ -428,9 +456,12 @@ mod tests {
         LocalRetainedScope::new(
             account,
             RetainedWorkScopeId {
-                pipeline: PipelineKey::new("group".into(), "pipeline".into()),
-                core_id: 3,
-                runtime_generation: 7,
+                deployed_pipeline: DeployedPipelineKey {
+                    pipeline_group_id: "group".into(),
+                    pipeline_id: "pipeline".into(),
+                    core_id: 3,
+                    deployment_generation: 7,
+                },
                 component_id: "processor".into(),
                 owner: WorkOwnerId(2),
             },
@@ -575,7 +606,7 @@ mod tests {
     /// Guarantees: repeated registration returns one stable compact owner ID.
     #[test]
     fn owner_registration_is_stable() {
-        let mut registry = WorkOwnerRegistry::new(2);
+        let mut registry = WorkOwnerRegistry::new(NonZeroUsize::new(2).expect("non-zero bound"));
         let pipeline = PipelineKey::new("group".into(), "pipeline".into());
 
         let first = registry.register_pipeline(&pipeline);
@@ -591,7 +622,7 @@ mod tests {
     /// Guarantees: the registry treats the full group and pipeline pair as identity.
     #[test]
     fn owner_registration_includes_pipeline_group() {
-        let mut registry = WorkOwnerRegistry::new(2);
+        let mut registry = WorkOwnerRegistry::new(NonZeroUsize::new(2).expect("non-zero bound"));
         let first_pipeline = PipelineKey::new("group-a".into(), "pipeline".into());
         let second_pipeline = PipelineKey::new("group-b".into(), "pipeline".into());
 
@@ -608,7 +639,7 @@ mod tests {
     /// while existing owners remain stable and the registry stays bounded.
     #[test]
     fn owner_registration_is_bounded() {
-        let mut registry = WorkOwnerRegistry::new(1);
+        let mut registry = WorkOwnerRegistry::new(NonZeroUsize::new(1).expect("non-zero bound"));
         let first_pipeline = PipelineKey::new("group".into(), "first".into());
         let second_pipeline = PipelineKey::new("group".into(), "second".into());
 
@@ -621,6 +652,18 @@ mod tests {
         assert_eq!(registry.pipeline(WorkOwnerId::MIXED), None);
         assert_eq!(registry.pipeline(WorkOwnerId::UNREGISTERED), None);
         assert_eq!(registry.len(), 1);
+    }
+
+    /// Scenario: owner sentinel values are exported or persisted as compact IDs.
+    /// Guarantees: Mixed and Unregistered stay reserved below registered owners.
+    #[test]
+    fn owner_sentinel_values_are_stable() {
+        let mut registry = WorkOwnerRegistry::new(NonZeroUsize::new(1).expect("non-zero bound"));
+        let pipeline = PipelineKey::new("group".into(), "pipeline".into());
+
+        assert_eq!(WorkOwnerId::MIXED.as_u32(), 0);
+        assert_eq!(WorkOwnerId::UNREGISTERED.as_u32(), 1);
+        assert_eq!(registry.register_pipeline(&pipeline).as_u32(), 2);
     }
 
     /// Scenario: a component charges retained work through an attributed scope.
@@ -638,12 +681,15 @@ mod tests {
         assert_eq!(ticket.scope(), scope.id());
         assert_eq!(ticket.site(), RetainedWorkSite::BatchPending);
         assert_eq!(
-            ticket.scope().pipeline.pipeline_group_id().as_ref(),
+            ticket.scope().deployed_pipeline.pipeline_group_id.as_ref(),
             "group"
         );
-        assert_eq!(ticket.scope().pipeline.pipeline_id().as_ref(), "pipeline");
-        assert_eq!(ticket.scope().core_id, 3);
-        assert_eq!(ticket.scope().runtime_generation, 7);
+        assert_eq!(
+            ticket.scope().deployed_pipeline.pipeline_id.as_ref(),
+            "pipeline"
+        );
+        assert_eq!(ticket.scope().deployed_pipeline.core_id, 3);
+        assert_eq!(ticket.scope().deployed_pipeline.deployment_generation, 7);
         assert_eq!(ticket.scope().component_id.as_ref(), "processor");
         assert_eq!(ticket.scope().owner, WorkOwnerId(2));
         ticket.complete().expect("completion should settle");

--- a/rust/otap-dataflow/crates/engine/src/retained_work.rs
+++ b/rust/otap-dataflow/crates/engine/src/retained_work.rs
@@ -7,7 +7,7 @@
 //! installation, telemetry export, and production charge sites are layered on
 //! separately.
 
-use otap_df_config::{DeployedPipelineKey, NodeId, PipelineKey};
+use otel_arrow_dfe_config::{DeployedPipelineKey, NodeId, PipelineKey};
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::fmt;
@@ -20,6 +20,8 @@ use std::rc::Rc;
 /// Owners are allocated by [`WorkOwnerRegistry`]. The two reserved values keep
 /// mixed and over-capacity ownership explicit without introducing unbounded
 /// request-derived labels.
+/// Registered IDs are meaningful only within the registry that assigned them;
+/// independent registries may assign the same number to different pipelines.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[repr(transparent)]
 pub struct WorkOwnerId(u32);
@@ -160,9 +162,13 @@ impl LocalRetainedScope {
 
     /// Starts one attributed retained-work interval.
     ///
+    /// `Some(bytes)` records a known logical size. `None` records one
+    /// unknown-size item without guessing its byte size.
+    ///
     /// Accounting failures are diagnostics, not data-path failures. A charge
     /// site must continue processing the retained work without a ticket if this
     /// returns an error; observe-only accounting must never reject or drop it.
+    #[inline]
     pub fn charge(
         &self,
         site: RetainedWorkSite,
@@ -374,8 +380,8 @@ enum LocalRetainedCharge {
 /// holds an `Rc` to runtime-local state.
 ///
 /// ```compile_fail
-/// use otap_df_config::DeployedPipelineKey;
-/// use otap_df_engine::retained_work::{
+/// use otel_arrow_dfe_config::DeployedPipelineKey;
+/// use otel_arrow_dfe_engine::retained_work::{
 ///     LocalRetainedAccount, LocalRetainedScope, RetainedWorkScopeId,
 ///     RetainedWorkSite, WorkOwnerId,
 /// };
@@ -693,5 +699,71 @@ mod tests {
         assert_eq!(ticket.scope().component_id.as_ref(), "processor");
         assert_eq!(ticket.scope().owner, WorkOwnerId(2));
         ticket.complete().expect("completion should settle");
+    }
+
+    /// Scenario: outstanding tickets outlive the scope handle that created them.
+    /// Guarantees: attribution survives until settlement, both terminal paths
+    /// refund once, and the scope is freed after the last ticket is settled.
+    #[test]
+    fn tickets_keep_scope_alive_until_settlement() {
+        let account = LocalRetainedAccount::new();
+        let scope = test_scope(Rc::clone(&account));
+        let expected_id = scope.id().clone();
+        let weak_scope = Rc::downgrade(&scope.inner);
+        let completed = scope
+            .charge(RetainedWorkSite::RetryBuffer, Some(11))
+            .expect("charge should fit");
+        let abandoned = scope
+            .charge(RetainedWorkSite::BatchPending, None)
+            .expect("charge should fit");
+
+        drop(scope);
+        assert_eq!(completed.scope(), &expected_id);
+        assert_eq!(abandoned.scope(), &expected_id);
+        completed.complete().expect("completion should settle");
+        assert!(weak_scope.upgrade().is_some());
+        drop(abandoned);
+
+        assert!(weak_scope.upgrade().is_none());
+        assert_eq!(
+            account.snapshot(),
+            LocalRetainedSnapshot {
+                abandoned_items: 1,
+                ..LocalRetainedSnapshot::default()
+            }
+        );
+    }
+
+    /// Scenario: different owners and deployment generations share an account.
+    /// Guarantees: each ticket retains its own attribution and settling one
+    /// scope's work leaves the other scope's outstanding charge intact.
+    #[test]
+    fn scopes_preserve_independent_attribution_and_settlement() {
+        let account = LocalRetainedAccount::new();
+        let first_scope = test_scope(Rc::clone(&account));
+        let mut second_id = first_scope.id().clone();
+        second_id.deployed_pipeline.deployment_generation += 1;
+        second_id.component_id = "batch_processor".into();
+        second_id.owner = WorkOwnerId::MIXED;
+        let second_scope = LocalRetainedScope::new(Rc::clone(&account), second_id);
+        let first = first_scope
+            .charge(RetainedWorkSite::RetryBuffer, Some(11))
+            .expect("charge should fit");
+        let second = second_scope
+            .charge(RetainedWorkSite::BatchPending, Some(23))
+            .expect("charge should fit");
+
+        assert_ne!(first.scope(), second.scope());
+        assert_eq!(first.scope(), first_scope.id());
+        assert_eq!(second.scope(), second_scope.id());
+        assert_eq!(first.site(), RetainedWorkSite::RetryBuffer);
+        assert_eq!(second.site(), RetainedWorkSite::BatchPending);
+        assert_eq!(account.snapshot().retained_bytes, 34);
+
+        first.complete().expect("completion should settle");
+        assert_eq!(account.snapshot().retained_bytes, 23);
+        assert_eq!(second.scope(), second_scope.id());
+        second.complete().expect("completion should settle");
+        assert_eq!(account.snapshot(), LocalRetainedSnapshot::default());
     }
 }


### PR DESCRIPTION
## Change Summary

Builds on the merged accounting primitives from #3756 and implements the bounded-attribution step of #3272. Each retained-work ticket carries its pipeline group, pipeline, core, deployment generation, component, owner, and retention site.

`WorkOwnerRegistry` assigns compact IDs to configured pipelines within a fixed bound. Excess owners use `UNREGISTERED`; work combining owners can use `MIXED`. IDs are local to the registry that assigned them.

Charges now go through `LocalRetainedScope`, making attribution required. Tickets share immutable scope metadata through one local `Rc` clone per charge and preserve #3756's completion, abandonment, and corruption accounting. The charge and completion entrypoints remain inline. Accounting errors remain diagnostic in observe-only mode.

Rebased onto current `main`, which already contains #3756. The diff contains only the attribution layer in `retained_work.rs`.

## Validation

- `cargo check -p otel-arrow-dfe-engine`
- `cargo test -p otel-arrow-dfe-engine retained_work::tests` -- 14 passed
- `cargo test -p otel-arrow-dfe-engine --doc retained_work` -- 2 compile-fail tests passed
- `cargo xtask check`
- `python3 tools/sanitycheck.py`
- `git diff --check`

Tests cover bounded and stable owner registration, group-qualified identities, complete ticket attribution, known and unknown charges, exactly-once settlement, abandonment, arithmetic failures, and non-Send accounts/tickets. Additional lifecycle tests verify that tickets keep scope metadata alive until settlement and that distinct scopes sharing an account retain independent attribution and charges.

## User-facing changes

None. This PR adds internal attribution primitives. Runtime wiring, metrics, production charge sites, enforcement, and shared-boundary escrow remain separate follow-ups. No changelog entry is required for this chore.
