### PR TITLE
chore(ci): Minor CI tweaks and doc

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,39 @@
+# CI strategy
+
+This directory contains the repository's main CI workflows:
+
+- [`rust-ci.yml`](rust-ci.yml): Rust validation.
+- [`go-ci.yml`](go-ci.yml): Go validation and CodeQL.
+- [`repo-lint.yaml`](repo-lint.yaml): Repository lint and sanity checks.
+- [`changelog.yml`](changelog.yml): Changelog validation.
+- [`post-merge-actions.yml`](post-merge-actions.yml): Shared Rust cache warming.
+
+## Event model
+
+| Event | Rust | Go | Repository |
+| --- | --- | --- | --- |
+| Pull request | Required and non-required jobs | Required jobs | Lint and changelog |
+| Merge queue | Required jobs only | Required jobs | Lint and changelog |
+| Merge to `main` | Shared-cache maintenance | CodeQL | - |
+
+Pull requests provide broad feedback. Merge-queue runs validate only what is
+required for merging. Post-merge workflows avoid repeating validation that
+already passed in the merge queue.
+
+## Required checks
+
+The aggregate Rust and Go status jobs define required validation through their
+`needs` lists. Treat those lists as the source of truth when adding or removing
+required jobs.
+
+## Caching and artifacts
+
+- Pull-request and merge-queue jobs restore shared Rust caches without writing
+  them.
+- Post-merge jobs on trusted `main` own required Linux and Windows cache
+  updates.
+- Exact cache hits skip compilation; misses and fallback restores warm a new
+  cache.
+- Caches provide reusable inputs across runs.
+- Workflow artifacts distribute nextest archives to test partitions within one
+  run.

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,4 +1,5 @@
 name: Go-CI
+# See README.md in this directory for CI event, status, and cache strategy.
 permissions:
   contents: read
 
@@ -6,6 +7,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "go/**"
+      - ".github/workflows/go-ci.yml"
   pull_request:
     branches:
       - main
@@ -19,6 +23,7 @@ concurrency:
 jobs:
 
   test_and_coverage:
+    if: github.event_name != 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -46,6 +51,7 @@ jobs:
           fail_ci_if_error: true
 
   codeql:
+    # Keep the default-branch code-scanning baseline current after merges.
     permissions:
       # needed for codeql
       security-events: write
@@ -66,7 +72,7 @@ jobs:
   # to simplify maintenance - add/remove jobs from the needs list as needed
   go-required-status-check:
     runs-on: ubuntu-latest
-    if: always()
+    if: github.event_name != 'push' && !cancelled()
     needs:
       - test_and_coverage
       - codeql

--- a/.github/workflows/post-merge-actions.yml
+++ b/.github/workflows/post-merge-actions.yml
@@ -1,4 +1,5 @@
 name: Post-Merge Actions
+# See README.md in this directory for CI event, status, and cache strategy.
 permissions:
   contents: read
 
@@ -6,6 +7,11 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "rust/**"
+      - ".github/workflows/rust-ci.yml"
+      - ".github/workflows/post-merge-actions.yml"
+      - ".github/actions/install-symcrypt/**"
   workflow_dispatch:
 
 env:
@@ -28,24 +34,31 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Initialize required build cache
+        id: rust-cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           prefix-key: v1-rust
           shared-key: build_required
           workspaces: ./rust/otap-dataflow
           cache-bin: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      # Exact hits already contain the reusable dependency artifacts. A miss
+      # or fallback restore must compile so the post step can save the new key.
       - name: Free disk space
+        if: steps.rust-cache.outputs.cache-hit != 'true'
         run: |
           sudo rm -rf /usr/lib/jvm /usr/share/dotnet /usr/share/swift /usr/local/.ghcup
           sudo rm -rf /usr/local/julia* /usr/local/lib/android /usr/local/share/chromium
           sudo rm -rf /opt/microsoft /opt/google /opt/az /usr/local/share/powershell
-      - name: install nextest
+      - name: Install nextest
+        if: steps.rust-cache.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: cargo-nextest
       - name: Warm required build cache
-        run: cargo nextest archive --locked --all-features --workspace --archive-file nextest-archive.tar.zst
+        if: steps.rust-cache.outputs.cache-hit != 'true'
+        run: cargo nextest list --locked --all-features --workspace --list-type binaries-only --message-format json
         working-directory: ./rust/otap-dataflow
 
   warm-windows:
@@ -57,25 +70,34 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
-      - name: Install SymCrypt
-        uses: ./.github/actions/install-symcrypt
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Initialize required build cache
+        id: rust-cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           prefix-key: v1-rust
           shared-key: build_required
           workspaces: ./rust/otap-dataflow
           cache-bin: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      # Exact hits already contain the reusable dependency artifacts. A miss
+      # or fallback restore must compile so the post step can save the new key.
+      - name: Install SymCrypt
+        if: steps.rust-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/install-symcrypt
       - name: Free disk space
+        if: steps.rust-cache.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           if (Test-Path "C:\Android") { Remove-Item -Recurse -Force "C:\Android" }
           if (Test-Path "C:\SeleniumWebDrivers") { Remove-Item -Recurse -Force "C:\SeleniumWebDrivers" }
           if (Test-Path "C:\imagemagick") { Remove-Item -Recurse -Force "C:\imagemagick" }
-      - name: install nextest
+      - name: Install nextest
+        if: steps.rust-cache.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: cargo-nextest
       - name: Warm required build cache
-        run: cargo nextest archive --locked --no-default-features --features=crypto-symcrypt,mimalloc,azure,aws,azure-monitor-exporter,geneva-exporter,contrib-processors,unsafe-optimizations --workspace --archive-file nextest-archive.tar.zst
+        if: steps.rust-cache.outputs.cache-hit != 'true'
+        # Keep the feature set synchronized with rust-ci.yml's required Windows build.
+        run: cargo nextest list --locked --no-default-features --features=crypto-symcrypt,mimalloc,azure,aws,azure-monitor-exporter,geneva-exporter,contrib-processors,unsafe-optimizations --workspace --list-type binaries-only --message-format json
         working-directory: ./rust/otap-dataflow

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,4 +1,5 @@
 name: Rust-CI
+# See README.md in this directory for CI event, status, and cache strategy.
 permissions:
   contents: read
 
@@ -25,6 +26,7 @@ jobs:
   # - experimental folders run unpartitioned on all OSes (they are small).
   # - otap-dataflow runs on ARM and macOS, split into 3 partitions.
   experimental_tests:
+    if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -56,7 +58,7 @@ jobs:
           if (Test-Path "C:\Android") { Remove-Item -Recurse -Force "C:\Android" }
           if (Test-Path "C:\SeleniumWebDrivers") { Remove-Item -Recurse -Force "C:\SeleniumWebDrivers" }
           if (Test-Path "C:\imagemagick") { Remove-Item -Recurse -Force "C:\imagemagick" }
-      - name: install cargo-llvm-cov and nextest
+      - name: Install cargo-llvm-cov and nextest
         uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: cargo-llvm-cov,cargo-nextest
@@ -95,6 +97,7 @@ jobs:
   # ARM uses a reduced feature set Full feature coverage and
   # validation tests are handled by the required x86 jobs.
   build_nonrequired:
+    if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -120,7 +123,7 @@ jobs:
           sudo rm -rf /usr/lib/jvm /usr/share/dotnet /usr/share/swift /usr/local/.ghcup
           sudo rm -rf /usr/local/julia* /usr/local/lib/android /usr/local/share/chromium
           sudo rm -rf /opt/microsoft /opt/google /opt/az /usr/local/share/powershell
-      - name: install nextest
+      - name: Install nextest
         uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: cargo-nextest
@@ -146,6 +149,7 @@ jobs:
           retention-days: 1
 
   test_nonrequired:
+    if: github.event_name == 'pull_request'
     needs: build_nonrequired
     strategy:
       fail-fast: false
@@ -161,7 +165,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
-      - name: install nextest
+      - name: Install nextest
         uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: cargo-nextest
@@ -237,6 +241,7 @@ jobs:
         working-directory: ./rust/otap-dataflow
 
   fmt:
+    if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -262,7 +267,7 @@ jobs:
         with:
           toolchain: nightly
           components: rustfmt
-      - name: cargo fmt ${{ matrix.folder }}
+      - name: Run cargo fmt for ${{ matrix.folder }}
         run: cargo fmt --all -- --check
         working-directory: ./rust/${{ matrix.folder }}
 
@@ -317,6 +322,7 @@ jobs:
           fi
 
   clippy:
+    if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -348,12 +354,13 @@ jobs:
           workspaces: ./rust/${{ matrix.folder }}
           cache-bin: false
           save-if: false
-      - name: cargo clippy ${{ matrix.folder }}
+      - name: Run cargo clippy for ${{ matrix.folder }}
         run: |
           cargo clippy --all-targets --all-features --workspace -- -D warnings
         working-directory: ./rust/${{ matrix.folder }}
 
   deny:
+    if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -368,25 +375,25 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
-      - name: advisories
+      - name: Advisories
         if: "!cancelled()"
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check advisories
           manifest-path: ./rust/${{ matrix.folder }}/Cargo.toml
-      - name: licenses
+      - name: Licenses
         if: "!cancelled()"
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check licenses
           manifest-path: ./rust/${{ matrix.folder }}/Cargo.toml
-      - name: bans
+      - name: Bans
         if: "!cancelled()"
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check bans
           manifest-path: ./rust/${{ matrix.folder }}/Cargo.toml
-      - name: sources
+      - name: Sources
         if: "!cancelled()"
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
@@ -394,6 +401,7 @@ jobs:
           manifest-path: ./rust/${{ matrix.folder }}/Cargo.toml
 
   docs:
+    if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -408,7 +416,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
-      - name: cargo doc ${{ matrix.folder }}
+      - name: Run cargo doc for ${{ matrix.folder }}
         run: cargo doc --no-deps
         working-directory: ./rust/${{ matrix.folder }}
 
@@ -426,10 +434,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
-      - name: cargo xtask ${{ matrix.folder }}
+      - name: Run cargo xtask for ${{ matrix.folder }}
         run: cargo xtask structure-check
         working-directory: ./rust/${{ matrix.folder }}
-      - name: check telemetry macro usage
+      - name: Check telemetry macro usage
         run: ./scripts/check-direct-telemetry-macros.sh
         working-directory: ./rust/${{ matrix.folder }}
 
@@ -450,10 +458,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
-      - name: cargo xtask compile proto
+      - name: Run cargo xtask compile proto
         run: cargo xtask compile-proto
         working-directory: ./rust/${{ matrix.folder }}
-      - name: check git diff after compile-proto execution
+      - name: Check git diff after compile-proto execution
         run: git diff --exit-code rust/otap-dataflow/crates/pdata/src/proto
 
   # Verify the workspace builds with --no-default-features to catch broken
@@ -471,16 +479,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
-      - name: cargo check --no-default-features --workspace
+      - name: Run cargo check --no-default-features --workspace
         run: cargo check --locked --no-default-features --workspace
         working-directory: ./rust/${{ matrix.folder }}
-      - name: cargo check validation --no-default-features
+      - name: Run cargo check validation --no-default-features
         run: cargo check --locked -p otap-df-validation --lib --no-default-features
         working-directory: ./rust/${{ matrix.folder }}
-      - name: cargo check benchmarks --no-default-features
+      - name: Run cargo check benchmarks --no-default-features
         run: cargo check --locked -p benchmarks --benches --no-default-features
         working-directory: ./rust/${{ matrix.folder }}
-      - name: cargo test otap integration targets --no-run
+      - name: Run cargo test for otap integration targets
         run: cargo test --locked -p otap-df-otap --tests --no-run
         working-directory: ./rust/${{ matrix.folder }}
 
@@ -488,6 +496,8 @@ jobs:
   # Linux test partitions depend only on this job, not the Windows build.
   build_required_linux:
     runs-on: ubuntu-latest
+    outputs:
+      cache-hit: ${{ steps.rust-cache.outputs.cache-hit }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -495,7 +505,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Initialize required build cache
+        id: rust-cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           prefix-key: v1-rust
           # Keep one stable required-build namespace; platform and Rust hashes
@@ -509,7 +521,7 @@ jobs:
           sudo rm -rf /usr/lib/jvm /usr/share/dotnet /usr/share/swift /usr/local/.ghcup
           sudo rm -rf /usr/local/julia* /usr/local/lib/android /usr/local/share/chromium
           sudo rm -rf /opt/microsoft /opt/google /opt/az /usr/local/share/powershell
-      - name: install nextest
+      - name: Install nextest
         uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: cargo-nextest
@@ -527,6 +539,8 @@ jobs:
   # Windows test partitions depend only on this job, not the Linux build.
   build_required_windows:
     runs-on: windows-latest
+    outputs:
+      cache-hit: ${{ steps.rust-cache.outputs.cache-hit }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -536,7 +550,9 @@ jobs:
           toolchain: stable
       - name: Install SymCrypt
         uses: ./.github/actions/install-symcrypt
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Initialize required build cache
+        id: rust-cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           prefix-key: v1-rust
           # Keep one stable required-build namespace; platform and Rust hashes
@@ -551,11 +567,13 @@ jobs:
           if (Test-Path "C:\Android") { Remove-Item -Recurse -Force "C:\Android" }
           if (Test-Path "C:\SeleniumWebDrivers") { Remove-Item -Recurse -Force "C:\SeleniumWebDrivers" }
           if (Test-Path "C:\imagemagick") { Remove-Item -Recurse -Force "C:\imagemagick" }
-      - name: install nextest
+      - name: Install nextest
         uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: cargo-nextest
       - name: Build and archive tests
+        # Keep this feature set synchronized with the Windows post-merge cache
+        # warmer so PR and merge-queue builds can reuse its target artifacts.
         run: cargo nextest archive --locked --no-default-features --features=crypto-symcrypt,mimalloc,azure,aws,azure-monitor-exporter,geneva-exporter,contrib-processors,unsafe-optimizations --workspace --archive-file nextest-archive.tar.zst
         working-directory: ./rust/otap-dataflow
       - name: Upload nextest archive
@@ -580,7 +598,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
-      - name: install nextest
+      - name: Install nextest
         uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: cargo-nextest
@@ -635,7 +653,7 @@ jobs:
           toolchain: stable
       - name: Install SymCrypt
         uses: ./.github/actions/install-symcrypt
-      - name: install nextest
+      - name: Install nextest
         uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: cargo-nextest
@@ -667,6 +685,7 @@ jobs:
   # Coverage runs unpartitioned on Linux x86_64 (does not block merge).
   # This compiles from scratch with coverage instrumentation and runs all tests.
   coverage:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -686,7 +705,7 @@ jobs:
           sudo rm -rf /usr/lib/jvm /usr/share/dotnet /usr/share/swift /usr/local/.ghcup
           sudo rm -rf /usr/local/julia* /usr/local/lib/android /usr/local/share/chromium
           sudo rm -rf /opt/microsoft /opt/google /opt/az /usr/local/share/powershell
-      - name: install cargo-llvm-cov and nextest
+      - name: Install cargo-llvm-cov and nextest
         uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: cargo-llvm-cov,cargo-nextest
@@ -723,7 +742,7 @@ jobs:
         with:
           toolchain: nightly
           components: rustfmt
-      - name: cargo fmt ${{ matrix.folder }}
+      - name: Run cargo fmt for ${{ matrix.folder }}
         run: cargo fmt --all -- --check
         working-directory: ./rust/${{ matrix.folder }}
 
@@ -759,7 +778,7 @@ jobs:
       - name: Install SymCrypt (Windows)
         if: runner.os == 'Windows'
         uses: ./.github/actions/install-symcrypt
-      - name: cargo clippy ${{ matrix.folder }}
+      - name: Run cargo clippy for ${{ matrix.folder }}
         run: |
           cargo clippy --locked --all-targets --all-features --workspace -- -D warnings
         working-directory: ./rust/${{ matrix.folder }}
@@ -801,6 +820,7 @@ jobs:
   # parallel with `host-metrics-semconv` so the two approaches can be compared
   # before deciding which one to keep.
   host-metrics-weaver-live-check:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     env:
       WEAVER_VERSION: v0.25.1
@@ -1045,25 +1065,25 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
-      - name: advisories
+      - name: Advisories
         if: "!cancelled()"
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check advisories
           manifest-path: ./rust/otap-dataflow/Cargo.toml
-      - name: licenses
+      - name: Licenses
         if: "!cancelled()"
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check licenses
           manifest-path: ./rust/otap-dataflow/Cargo.toml
-      - name: bans
+      - name: Bans
         if: "!cancelled()"
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check bans
           manifest-path: ./rust/otap-dataflow/Cargo.toml
-      - name: sources
+      - name: Sources
         if: "!cancelled()"
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
@@ -1080,11 +1100,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
-      - name: cargo doc otap-dataflow
+      - name: Run cargo doc for otap-dataflow
         run: cargo doc --locked --no-deps
         working-directory: ./rust/otap-dataflow
 
   validate-configs:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1112,7 +1133,7 @@ jobs:
   # Runs after all test jobs and posts a summary to the workflow run.
   test-report:
     runs-on: ubuntu-latest
-    if: always()
+    if: github.event_name == 'pull_request' && !cancelled()
     needs:
       - test_required_linux
       - test_required_windows
@@ -1184,6 +1205,8 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
+      - build_required_linux
+      - build_required_windows
       - test_required_linux
       - test_required_windows
       - fmt_required
@@ -1200,6 +1223,29 @@ jobs:
       - etw_windows_smoke
       - license-header-check
     steps:
+      - name: Summarize required-build caches
+        env:
+          LINUX_CACHE_HIT: ${{ needs.build_required_linux.outputs.cache-hit }}
+          WINDOWS_CACHE_HIT: ${{ needs.build_required_windows.outputs.cache-hit }}
+        run: |
+          cache_status() {
+            case "$1" in
+              true) echo "Exact hit" ;;
+              false) echo "Miss or fallback restore" ;;
+              *) echo "Unavailable" ;;
+            esac
+          }
+
+          {
+            echo "## Required build caches"
+            echo
+            echo "| OS | Restore result | Target artifacts | Writes |"
+            echo "| --- | --- | --- | --- |"
+            echo "| Linux | $(cache_status "$LINUX_CACHE_HIT") | enabled | disabled |"
+            echo "| Windows | $(cache_status "$WINDOWS_CACHE_HIT") | enabled | disabled |"
+            echo
+            echo "> A fallback restore can reuse an older compatible cache even when the exact-key result is false."
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Check if all required jobs succeeded
         run: |
           if [[ "${{ needs.test_required_linux.result }}" != "success" ]]; then


### PR DESCRIPTION
# Chore Summary

- Add short doc about main CI workflows
- Avoid full Go CI run in post-merge
  - Saves runner Compute
- Avoid updating cache if post-merge experiences cache hit
  - i.e. don't do it after doc-only merges, prevent cache churn
- Avoid running Rust-CI non-required steps in merge queue runs
  - Failures would be ignored anyway, saves runner Compute
- Normalize step name casing

## Related issue

N/A