### PR TITLE
feat(OTAP query-engine): add short circuit for and/or expression evaluation

### DIFF
--- a/rust/otap-dataflow/.chloggen/otap-query-engine-short-circuit-binary-logical-exprs.yaml
+++ b/rust/otap-dataflow/.chloggen/otap-query-engine-short-circuit-binary-logical-exprs.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: query-engine
+note: add short circuit optimization to OTAP query engine for binary logical expressions having different data scopes
+issues: [3817]

--- a/rust/otap-dataflow/crates/query-engine/benches/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/benches/filter.rs
@@ -121,11 +121,9 @@ fn bench_filter_pipelines(c: &mut Criterion) {
         &rt,
         &batch_sizes,
         "and_short_circuit",
-        // left expr of "and" should be false for all rows
-        //
-        // this is different from the case above in that the "and" here is currently something that
-        // won't get optimized into a Composite<AttributeFilterExec> so we can test the fast path
-        // in Composite<FilterExec>
+        // Cross-scope AND: the left side (root field) is false for all rows, so the
+        // JoinAndEval short-circuit should skip evaluation of the right side (attribute)
+        // and the join entirely.
         "logs | where severity_text == \"invalid value\" and attributes[\"code.line.number\"] == 2",
     );
 
@@ -134,11 +132,9 @@ fn bench_filter_pipelines(c: &mut Criterion) {
         &rt,
         &batch_sizes,
         "or_short_circuit",
-        // left expr of "or" should be true for all rows
-        //
-        // this is different from the case above in that the "and" here is currently something that
-        // won't get optimized into a Composite<AttributeFilterExec> so we can test the fast path
-        // in Composite<FilterExec>
+        // Cross-scope OR: the left side (attribute) is true for all rows, so the
+        // JoinAndEval short-circuit should skip evaluation of the right side and
+        // the join entirely.
         "logs | where attributes[\"code.line.number\"] >= 0 or not(attributes[\"some.attr\"] >= 0 and severity_text == \"WARN\")",
     );
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -42,7 +42,7 @@
 
 use std::sync::{Arc, LazyLock};
 
-use arrow::array::{ArrayRef, RecordBatch};
+use arrow::array::{ArrayRef, AsArray, RecordBatch};
 use arrow::datatypes::{Field, Schema};
 use datafusion::logical_expr::{ColumnarValue, Expr};
 use datafusion::physical_expr::PhysicalExprRef;
@@ -170,19 +170,91 @@ impl From<&ColumnAccessor> for DataScope {
     }
 }
 
-/// Short-circuit strategy for logical binary expressions within
+/// Short-circuit strategy for logical binary expressions.
 ///
 /// When evaluating a binary expression, this can be used to identify when to short-circuit
 /// evaluation based on the results of one side of the expression, which may avoid costly and
 /// unnecessary evaluation of the other-side
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ShortCircuitStrategy {
-    /// AND semantics: short-circuit to all-false when any child evaluates to
-    /// all-false
+    /// AND semantics: short-circuit to all-false when any child evaluates to all-false
     And,
-    /// OR semantics: short-circuit to all-true when any child evaluates to
-    /// all-true
+
+    /// AND semantics but the result of the expression should be inverted.
+    /// This is used for expressions such as not(A and B)
+    NotAnd,
+
+    /// OR semantics: short-circuit to all-true when any child evaluates to all-true
     Or,
+
+    /// OR semantics but the result of the expression should be inverted.
+    /// This is used for expressions such as not(A or B)
+    NotOr,
+}
+
+impl ShortCircuitStrategy {
+    /// Check whether a child result allows the parent `JoinAndEval` to short-circuit.
+    ///
+    /// For `And`: returns `true` when the value is definitively all-false (or all-null),
+    /// meaning the AND result will be all-false regardless of remaining children.
+    ///
+    /// For `Or`: returns `true` when the value is definitively all-true, meaning the OR
+    /// result will be all-true regardless of remaining children.
+    fn should_short_circuit(&self, values: &ColumnarValue) -> bool {
+        match self {
+            Self::And | Self::NotAnd => Self::is_all_false_or_null(values),
+            Self::Or | Self::NotOr => Self::is_all_true(values),
+        }
+    }
+
+    /// Produce the short-circuit result value for a given strategy.
+    pub(crate) fn value(&self) -> ScopedValue {
+        ScopedValue::new_scalar(ScalarValue::Boolean(Some(match self {
+            Self::And => false,
+            Self::NotAnd => true,
+            Self::Or => true,
+            Self::NotOr => false,
+        })))
+    }
+
+    fn invert(&self) -> Self {
+        match self {
+            Self::And => Self::NotAnd,
+            Self::NotAnd => Self::And,
+            Self::Or => Self::NotOr,
+            Self::NotOr => Self::Or,
+        }
+    }
+
+    fn is_all_false_or_null(values: &ColumnarValue) -> bool {
+        match values {
+            ColumnarValue::Scalar(ScalarValue::Boolean(Some(false)))
+            | ColumnarValue::Scalar(ScalarValue::Boolean(None))
+            | ColumnarValue::Scalar(ScalarValue::Null) => true,
+            ColumnarValue::Array(arr) => {
+                if let Some(boolean_arr) = arr.as_boolean_opt() {
+                    boolean_arr.true_count() == 0
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
+
+    fn is_all_true(values: &ColumnarValue) -> bool {
+        match values {
+            ColumnarValue::Scalar(ScalarValue::Boolean(Some(true))) => true,
+            ColumnarValue::Array(arr) => {
+                if let Some(boolean_arr) = arr.as_boolean_opt() {
+                    boolean_arr.true_count() == boolean_arr.len()
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
 }
 
 /// An execution tree node for evaluating expressions on OTAP data.

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -171,18 +171,17 @@ impl From<&ColumnAccessor> for DataScope {
 }
 
 /// Short-circuit strategy for logical binary expressions within
-/// [`ScopedExpr::JoinAndEval`].
 ///
-/// When a `JoinAndEval` node carries a short-circuit strategy, child evaluation
-/// may terminate early when an intermediate result already determines the final
-/// outcome -- avoiding the join and subsequent DataFusion evaluation.
+/// When evaluating a binary expression, this can be used to identify when to short-circuit
+/// evaluation based on the results of one side of the expression, which may avoid costly and
+/// unnecessary evaluation of the other-side
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ShortCircuitStrategy {
     /// AND semantics: short-circuit to all-false when any child evaluates to
-    /// all-false (or all-null).
+    /// all-false
     And,
     /// OR semantics: short-circuit to all-true when any child evaluates to
-    /// all-true.
+    /// all-true
     Or,
 }
 
@@ -202,8 +201,6 @@ pub(crate) enum ShortCircuitStrategy {
 /// materializing intermediate arrays.
 #[derive(Debug)]
 pub(crate) enum ScopedExpr {
-    // NOTE: when adding new fields to any variant below, check all match sites in this file,
-    // eval.rs, bitmap.rs, planner.rs, assign.rs, and pipeline/planner.rs.
     /// Leaf: evaluate an expression on a specific data scope (RecordBatch).
     ///
     /// For `LeafEval::DatafusionExpr`, this reads from the scope's RecordBatch and evaluates a

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -170,6 +170,22 @@ impl From<&ColumnAccessor> for DataScope {
     }
 }
 
+/// Short-circuit strategy for logical binary expressions within
+/// [`ScopedExpr::JoinAndEval`].
+///
+/// When a `JoinAndEval` node carries a short-circuit strategy, child evaluation
+/// may terminate early when an intermediate result already determines the final
+/// outcome -- avoiding the join and subsequent DataFusion evaluation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShortCircuitStrategy {
+    /// AND semantics: short-circuit to all-false when any child evaluates to
+    /// all-false (or all-null).
+    And,
+    /// OR semantics: short-circuit to all-true when any child evaluates to
+    /// all-true.
+    Or,
+}
+
 /// An execution tree node for evaluating expressions on OTAP data.
 ///
 /// Every node supports two execution methods:
@@ -186,6 +202,8 @@ impl From<&ColumnAccessor> for DataScope {
 /// materializing intermediate arrays.
 #[derive(Debug)]
 pub(crate) enum ScopedExpr {
+    // NOTE: when adding new fields to any variant below, check all match sites in this file,
+    // eval.rs, bitmap.rs, planner.rs, assign.rs, and pipeline/planner.rs.
     /// Leaf: evaluate an expression on a specific data scope (RecordBatch).
     ///
     /// For `LeafEval::DatafusionExpr`, this reads from the scope's RecordBatch and evaluates a
@@ -218,6 +236,14 @@ pub(crate) enum ScopedExpr {
         /// flag overrides the dynamic join choice and forces root alignment when combining the
         /// child results.
         align_children_to_root: bool,
+
+        /// Optional short-circuit strategy for logical binary expressions.
+        ///
+        /// When set, evaluation will check each child's result as it is computed and may skip
+        /// remaining children and the join when the outcome is already determined:
+        /// - `And`: short-circuits to all-false when any child is all-false/null.
+        /// - `Or`: short-circuits to all-true when any child is all-true.
+        short_circuit: Option<ShortCircuitStrategy>,
     },
 
     /// Combine two boolean-producing children via IdMask bitmap intersection (AND).
@@ -429,7 +455,9 @@ mod test {
 
     use crate::pipeline::Pipeline;
     use crate::pipeline::expr::{DataScope, VALUE_COLUMN_NAME, arg_column_name};
-    use crate::pipeline::expr::{LeafEval, ScopedExpr, ScopedValue, SignalTypePredicate};
+    use crate::pipeline::expr::{
+        LeafEval, ScopedExpr, ScopedValue, ShortCircuitStrategy, SignalTypePredicate,
+    };
     use crate::pipeline::id_mask::IdMask;
     use crate::pipeline::planner::AttributesIdentifier;
 
@@ -675,6 +703,7 @@ mod test {
             children: vec![left_child, right_child],
             default_null_children: false,
             align_children_to_root: false,
+            short_circuit: None,
             eval: LeafEval::new_df_expr(
                 Expr::BinaryExpr(datafusion::logical_expr::BinaryExpr::new(
                     Box::new(col(arg_column_name(0))),
@@ -873,5 +902,124 @@ mod test {
             }
             other => panic!("expected IdMask::Some, got {other:?}"),
         }
+    }
+
+    /// Scenario: JoinAndEval with And short-circuit skips the right child and join
+    /// when the left child evaluates to all-false.
+    /// Guarantees: when the left child of a cross-scope AND produces no true values,
+    /// the result is all-false without evaluating the right child or performing the join.
+    #[test]
+    fn test_join_and_eval_and_short_circuit() {
+        let otap = test_logs_data();
+        let session_ctx = Pipeline::create_session_context();
+
+        // Left child: severity_text == "NONEXISTENT" -> all false for all 3 rows
+        let left_child = root_eval(col(consts::SEVERITY_TEXT).eq(lit("NONEXISTENT")));
+
+        // Right child: attributes["code.namespace"] == "main"
+        let right_child = attrs_eval_dict_downcast(
+            AttributesIdentifier::Root,
+            "code.namespace",
+            col(VALUE_COLUMN_NAME).eq(lit("main")),
+        );
+
+        let mut op = ScopedExpr::JoinAndEval {
+            children: vec![left_child, right_child],
+            default_null_children: false,
+            align_children_to_root: false,
+            short_circuit: Some(ShortCircuitStrategy::And),
+            eval: LeafEval::new_df_expr(
+                col(arg_column_name(0)).and(col(arg_column_name(1))),
+                false,
+            )
+            .unwrap(),
+        };
+
+        let result = op.execute_as_value(&otap, &session_ctx).unwrap().unwrap();
+
+        // Short-circuit should produce a scalar false
+        match &result.values {
+            ColumnarValue::Scalar(ScalarValue::Boolean(Some(false))) => {}
+            other => panic!("expected scalar false from AND short-circuit, got {other:?}"),
+        }
+    }
+
+    /// Scenario: JoinAndEval with Or short-circuit skips the right child and join
+    /// when the left child evaluates to all-true.
+    /// Guarantees: when the left child of a cross-scope OR produces all-true values,
+    /// the result is all-true without evaluating the right child or performing the join.
+    #[test]
+    fn test_join_and_eval_or_short_circuit() {
+        let otap = test_logs_data();
+        let session_ctx = Pipeline::create_session_context();
+
+        // Left child: severity_number > 0 -> all true for all 3 rows
+        let left_child = root_eval(col(consts::SEVERITY_NUMBER).gt(lit(0)));
+
+        // Right child: attributes["code.namespace"] == "main"
+        let right_child = attrs_eval_dict_downcast(
+            AttributesIdentifier::Root,
+            "code.namespace",
+            col(VALUE_COLUMN_NAME).eq(lit("main")),
+        );
+
+        let mut op = ScopedExpr::JoinAndEval {
+            children: vec![left_child, right_child],
+            default_null_children: false,
+            align_children_to_root: false,
+            short_circuit: Some(ShortCircuitStrategy::Or),
+            eval: LeafEval::new_df_expr(col(arg_column_name(0)).or(col(arg_column_name(1))), false)
+                .unwrap(),
+        };
+
+        let result = op.execute_as_value(&otap, &session_ctx).unwrap().unwrap();
+
+        // Short-circuit should produce a scalar true
+        match &result.values {
+            ColumnarValue::Scalar(ScalarValue::Boolean(Some(true))) => {}
+            other => panic!("expected scalar true from OR short-circuit, got {other:?}"),
+        }
+    }
+
+    /// Scenario: JoinAndEval with And short-circuit does not fire when the left
+    /// child has mixed true/false values.
+    /// Guarantees: when the left child has at least one true value, normal
+    /// join-and-eval executes and the combined result reflects both children.
+    #[test]
+    fn test_join_and_eval_no_short_circuit_on_mixed_values() {
+        let otap = test_logs_data();
+        let session_ctx = Pipeline::create_session_context();
+
+        // Left child: severity_text == "WARN" -> rows 0,2 true, row 1 false (mixed)
+        let left_child = root_eval(col(consts::SEVERITY_TEXT).eq(lit("WARN")));
+
+        // Right child: attributes["code.namespace"] == "main" -> rows 0,2 true, row 1 false
+        let right_child = attrs_eval_dict_downcast(
+            AttributesIdentifier::Root,
+            "code.namespace",
+            col(VALUE_COLUMN_NAME).eq(lit("main")),
+        );
+
+        let mut op = ScopedExpr::JoinAndEval {
+            children: vec![left_child, right_child],
+            default_null_children: false,
+            align_children_to_root: false,
+            short_circuit: Some(ShortCircuitStrategy::And),
+            eval: LeafEval::new_df_expr(
+                col(arg_column_name(0)).and(col(arg_column_name(1))),
+                false,
+            )
+            .unwrap(),
+        };
+
+        let result = op.execute_as_value(&otap, &session_ctx).unwrap().unwrap();
+
+        // Should NOT short-circuit -- should produce a full array result
+        let bool_arr = as_bool_arr(&result);
+        assert_eq!(bool_arr.len(), 3);
+        // rows 0 and 2 have severity_text="WARN" AND code.namespace="main"
+        assert!(bool_arr.value(0));
+        assert!(!bool_arr.value(1));
+        assert!(bool_arr.value(2));
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -200,10 +200,21 @@ impl ShortCircuitStrategy {
     ///
     /// For `Or`: returns `true` when the value is definitively all-true, meaning the OR
     /// result will be all-true regardless of remaining children.
-    fn should_short_circuit(&self, values: &ColumnarValue) -> bool {
+    fn should_short_circuit(&self, data_scope: &DataScope, values: &ColumnarValue) -> bool {
         match self {
             Self::And | Self::NotAnd => Self::is_all_false_or_null(values),
-            Self::Or | Self::NotOr => Self::is_all_true(values),
+            Self::Or | Self::NotOr => {
+                // we only apply "or" short circuiting for data scopes where all rows from the
+                // batch have a resolved value. These scopes are in contrast to something like,
+                // attributes scoped, where rows are only present where the attribute had some key.
+                // if we check that all present attributes have passed some predicate, it doesn't
+                // necessarily mean that rows not having these attributes pass the predicate we're
+                // short circuiting, hence why the "or"/all-true short-circuit strategy can't apply
+                matches!(
+                    data_scope,
+                    DataScope::Root | DataScope::RootParent(_) | DataScope::StaticScalar
+                ) && Self::is_all_true(values)
+            }
         }
     }
 
@@ -527,6 +538,7 @@ mod test {
     use crate::pipeline::expr::{
         LeafEval, ScopedExpr, ScopedValue, ShortCircuitStrategy, SignalTypePredicate,
     };
+    use crate::pipeline::functions::test::always_panic;
     use crate::pipeline::id_mask::IdMask;
     use crate::pipeline::planner::AttributesIdentifier;
 
@@ -594,6 +606,10 @@ mod test {
                 .attributes(vec![
                     KeyValue::new("code.namespace", AnyValue::new_string("main")),
                     KeyValue::new("code.line.number", AnyValue::new_int(7)),
+                    KeyValue::new(
+                        "exception.type",
+                        AnyValue::new_string("java.net.IOException"),
+                    ),
                 ])
                 .event_name("e3")
                 .finish(),
@@ -989,7 +1005,8 @@ mod test {
         let right_child = attrs_eval_dict_downcast(
             AttributesIdentifier::Root,
             "code.namespace",
-            col(VALUE_COLUMN_NAME).eq(lit("main")),
+            // will panic if actually evaluated
+            always_panic().call(vec![col(VALUE_COLUMN_NAME)]),
         );
 
         let mut op = ScopedExpr::JoinAndEval {
@@ -1029,7 +1046,8 @@ mod test {
         let right_child = attrs_eval_dict_downcast(
             AttributesIdentifier::Root,
             "code.namespace",
-            col(VALUE_COLUMN_NAME).eq(lit("main")),
+            // will panic if actually evaluated
+            always_panic().call(vec![col(VALUE_COLUMN_NAME)]),
         );
 
         let mut op = ScopedExpr::JoinAndEval {
@@ -1090,5 +1108,37 @@ mod test {
         assert!(bool_arr.value(0));
         assert!(!bool_arr.value(1));
         assert!(bool_arr.value(2));
+    }
+
+    #[test]
+    /// Scenario: JoinAndEval with Or short circuit does not fire when the left
+    /// child has a non-root scope (e.g. attributes)
+    /// Guarantees: we don't erroneously interpret "all present attributes" passing
+    /// some predicate meaning that all root rows actually have these attributes
+    fn test_join_or_eval_no_short_circuit_on_non_root_scoped_left() {
+        let otap = test_logs_data();
+        let session_ctx = Pipeline::create_session_context();
+
+        // something scoped to attributes that will pass for all rows having the attribute
+        let left_child = attrs_eval(
+            AttributesIdentifier::Root,
+            "exception.type",
+            col(VALUE_COLUMN_NAME).eq(lit("java.net.IOException")),
+        );
+
+        let right_child = root_eval(col(consts::SEVERITY_TEXT).eq(lit("ERROR")));
+        let mut op = ScopedExpr::JoinAndEval {
+            children: vec![left_child, right_child],
+            default_null_children: false,
+            align_children_to_root: false,
+            short_circuit: Some(ShortCircuitStrategy::Or),
+            eval: LeafEval::new_df_expr(col(arg_column_name(0)).or(col(arg_column_name(1))), false)
+                .unwrap(),
+        };
+
+        let result = op.execute_as_value(&otap, &session_ctx).unwrap().unwrap();
+
+        // we should be returning a selection vec, not a scalar (which is returned by short-circuit)
+        assert!(!matches!(result.values, ColumnarValue::Scalar(_)));
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/bitmap.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/bitmap.rs
@@ -22,7 +22,7 @@ use crate::pipeline::expr::DataScope;
 use crate::pipeline::id_mask::IdMask;
 
 use super::eval::{eval_datafusion_expr_value, invert_id_mask, join_and_eval_value};
-use super::{LeafEval, ScopedExpr, ScopedValue};
+use super::{LeafEval, ScopedExpr, ScopedValue, ShortCircuitStrategy};
 
 pub struct ScopedIdMask {
     pub scope: Option<DataScope>,
@@ -50,11 +50,13 @@ impl ScopedExpr {
                 eval,
                 default_null_children,
                 align_children_to_root,
+                short_circuit,
             } => execute_join_and_eval_as_id_mask(
                 children.as_mut_slice(),
                 eval,
                 *default_null_children,
                 *align_children_to_root,
+                short_circuit.as_ref(),
                 otap_batch,
                 session_ctx,
                 pool,
@@ -177,6 +179,7 @@ fn execute_join_and_eval_as_id_mask(
     eval: &mut LeafEval,
     default_null_children: bool,
     align_children_to_root: bool,
+    short_circuit: Option<&ShortCircuitStrategy>,
     otap_batch: &OtapArrowRecords,
     session_ctx: &SessionContext,
     pool: &mut IdBitmapPool,
@@ -188,6 +191,7 @@ fn execute_join_and_eval_as_id_mask(
         eval,
         default_null_children,
         align_children_to_root,
+        short_circuit,
         otap_batch,
         session_ctx,
     )?;

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -272,8 +272,8 @@ pub(super) fn join_and_eval_value(
         // Check for short-circuit: skip remaining children and the join when the
         // outcome is already determined by this child's result.
         if let Some(strategy) = short_circuit {
-            if should_short_circuit(&result.values, strategy) {
-                return Ok(Some(short_circuit_value(strategy)));
+            if strategy.should_short_circuit(&result.values) {
+                return Ok(Some(strategy.value()));
             }
         }
 
@@ -368,60 +368,6 @@ fn coerce_nulls_for_predicate(
     }
 
     result_vals
-}
-
-/// Check whether a child result allows the parent `JoinAndEval` to short-circuit.
-///
-/// For `And`: returns `true` when the value is definitively all-false (or all-null),
-/// meaning the AND result will be all-false regardless of remaining children.
-///
-/// For `Or`: returns `true` when the value is definitively all-true, meaning the OR
-/// result will be all-true regardless of remaining children.
-fn should_short_circuit(values: &ColumnarValue, strategy: &ShortCircuitStrategy) -> bool {
-    match strategy {
-        ShortCircuitStrategy::And => is_all_false_or_null(values),
-        ShortCircuitStrategy::Or => is_all_true(values),
-    }
-}
-
-/// Returns `true` when the columnar value is a boolean that is entirely false or null.
-fn is_all_false_or_null(values: &ColumnarValue) -> bool {
-    match values {
-        ColumnarValue::Scalar(ScalarValue::Boolean(Some(false)))
-        | ColumnarValue::Scalar(ScalarValue::Boolean(None))
-        | ColumnarValue::Scalar(ScalarValue::Null) => true,
-        ColumnarValue::Array(arr) => {
-            if let Some(boolean_arr) = arr.as_boolean_opt() {
-                boolean_arr.true_count() == 0
-            } else {
-                false
-            }
-        }
-        _ => false,
-    }
-}
-
-/// Returns `true` when the columnar value is a boolean that is entirely true.
-fn is_all_true(values: &ColumnarValue) -> bool {
-    match values {
-        ColumnarValue::Scalar(ScalarValue::Boolean(Some(true))) => true,
-        ColumnarValue::Array(arr) => {
-            if let Some(boolean_arr) = arr.as_boolean_opt() {
-                boolean_arr.true_count() == boolean_arr.len()
-            } else {
-                false
-            }
-        }
-        _ => false,
-    }
-}
-
-/// Produce the short-circuit result value for a given strategy.
-fn short_circuit_value(strategy: &ShortCircuitStrategy) -> ScopedValue {
-    match strategy {
-        ShortCircuitStrategy::And => ScopedValue::new_scalar(ScalarValue::Boolean(Some(false))),
-        ShortCircuitStrategy::Or => ScopedValue::new_scalar(ScalarValue::Boolean(Some(true))),
-    }
 }
 
 /// Execute a `BitmapAnd` node as a value.

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -272,7 +272,7 @@ pub(super) fn join_and_eval_value(
         // Check for short-circuit: skip remaining children and the join when the
         // outcome is already determined by this child's result.
         if let Some(strategy) = short_circuit {
-            if strategy.should_short_circuit(&result.values) {
+            if strategy.should_short_circuit(&result.scope, &result.values) {
                 return Ok(Some(strategy.value()));
             }
         }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -39,8 +39,8 @@ use crate::error::{Error, Result};
 use crate::pipeline::expr::bitmap::combine_scope;
 use crate::pipeline::expr::join::{JoinInput, join, multi_join};
 use crate::pipeline::expr::{
-    DataScope, LeafEval, SCALAR_RECORD_BATCH_INPUT, ScopedExpr, ScopedValue, VALUE_COLUMN_NAME,
-    arg_column_name,
+    DataScope, LeafEval, SCALAR_RECORD_BATCH_INPUT, ScopedExpr, ScopedValue, ShortCircuitStrategy,
+    VALUE_COLUMN_NAME, arg_column_name,
 };
 use crate::pipeline::id_mask::IdMask;
 use crate::pipeline::planner::AttributesIdentifier;
@@ -72,11 +72,13 @@ impl ScopedExpr {
                 eval,
                 default_null_children,
                 align_children_to_root,
+                short_circuit,
             } => join_and_eval_value(
                 children.as_mut_slice(),
                 eval,
                 *default_null_children,
                 *align_children_to_root,
+                short_circuit.as_ref(),
                 otap_batch,
                 session_ctx,
             ),
@@ -242,6 +244,7 @@ pub(super) fn join_and_eval_value(
     eval: &mut LeafEval,
     default_null_children: bool,
     align_children_to_root: bool,
+    short_circuit: Option<&ShortCircuitStrategy>,
     otap_batch: &OtapArrowRecords,
     session_ctx: &SessionContext,
 ) -> Result<Option<ScopedValue>> {
@@ -265,6 +268,14 @@ pub(super) fn join_and_eval_value(
                 }
             }
         };
+
+        // Check for short-circuit: skip remaining children and the join when the
+        // outcome is already determined by this child's result.
+        if let Some(strategy) = short_circuit {
+            if should_short_circuit(&result.values, strategy) {
+                return Ok(Some(short_circuit_value(strategy)));
+            }
+        }
 
         child_results.push(result)
     }
@@ -357,6 +368,60 @@ fn coerce_nulls_for_predicate(
     }
 
     result_vals
+}
+
+/// Check whether a child result allows the parent `JoinAndEval` to short-circuit.
+///
+/// For `And`: returns `true` when the value is definitively all-false (or all-null),
+/// meaning the AND result will be all-false regardless of remaining children.
+///
+/// For `Or`: returns `true` when the value is definitively all-true, meaning the OR
+/// result will be all-true regardless of remaining children.
+fn should_short_circuit(values: &ColumnarValue, strategy: &ShortCircuitStrategy) -> bool {
+    match strategy {
+        ShortCircuitStrategy::And => is_all_false_or_null(values),
+        ShortCircuitStrategy::Or => is_all_true(values),
+    }
+}
+
+/// Returns `true` when the columnar value is a boolean that is entirely false or null.
+fn is_all_false_or_null(values: &ColumnarValue) -> bool {
+    match values {
+        ColumnarValue::Scalar(ScalarValue::Boolean(Some(false)))
+        | ColumnarValue::Scalar(ScalarValue::Boolean(None))
+        | ColumnarValue::Scalar(ScalarValue::Null) => true,
+        ColumnarValue::Array(arr) => {
+            if let Some(boolean_arr) = arr.as_boolean_opt() {
+                boolean_arr.true_count() == 0
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Returns `true` when the columnar value is a boolean that is entirely true.
+fn is_all_true(values: &ColumnarValue) -> bool {
+    match values {
+        ColumnarValue::Scalar(ScalarValue::Boolean(Some(true))) => true,
+        ColumnarValue::Array(arr) => {
+            if let Some(boolean_arr) = arr.as_boolean_opt() {
+                boolean_arr.true_count() == boolean_arr.len()
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Produce the short-circuit result value for a given strategy.
+fn short_circuit_value(strategy: &ShortCircuitStrategy) -> ScopedValue {
+    match strategy {
+        ShortCircuitStrategy::And => ScopedValue::new_scalar(ScalarValue::Boolean(Some(false))),
+        ShortCircuitStrategy::Or => ScopedValue::new_scalar(ScalarValue::Boolean(Some(true))),
+    }
 }
 
 /// Execute a `BitmapAnd` node as a value.

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -51,7 +51,9 @@ use crate::pipeline::expr::types::{
     ExprLogicalType, coerce_arithmetic, nested_struct_field_type, root_field_type,
 };
 use crate::pipeline::expr::{DataScope, VALUE_COLUMN_NAME, arg_column_name};
-use crate::pipeline::expr::{LeafEval, RootParentStruct, ScopedExpr, SignalTypePredicate};
+use crate::pipeline::expr::{
+    LeafEval, RootParentStruct, ScopedExpr, ShortCircuitStrategy, SignalTypePredicate,
+};
 use crate::pipeline::functions::compare::CompareFunc;
 use crate::pipeline::functions::expr_fn::contains;
 use crate::pipeline::functions::is_type::IsTypeFunc;
@@ -418,6 +420,7 @@ impl ExprPlanner {
                         )?,
                         align_children_to_root,
                         default_null_children: false,
+                        short_circuit: Some(ShortCircuitStrategy::And),
                     })
                 }
             }
@@ -493,6 +496,7 @@ impl ExprPlanner {
                         )?,
                         align_children_to_root,
                         default_null_children: false,
+                        short_circuit: Some(ShortCircuitStrategy::Or),
                     })
                 }
             }
@@ -558,6 +562,7 @@ impl ExprPlanner {
                         eval,
                         default_null_children,
                         align_children_to_root,
+                        short_circuit,
                     } if !is_attrs_all_scope => match eval {
                         LeafEval::DatafusionExpr {
                             logical_expr,
@@ -571,6 +576,7 @@ impl ExprPlanner {
                             children,
                             default_null_children,
                             align_children_to_root,
+                            short_circuit,
                             eval: LeafEval::DatafusionExpr {
                                 logical_expr: not(logical_expr),
                                 physical_expr: None,
@@ -586,6 +592,7 @@ impl ExprPlanner {
                             eval,
                             default_null_children,
                             align_children_to_root,
+                            short_circuit,
                         })),
                     },
                     _ => ScopedExpr::BitmapNot(Box::new(inner)),
@@ -1167,6 +1174,7 @@ impl ExprPlanner {
                 children,
                 default_null_children: true,
                 align_children_to_root: op == Operator::Eq,
+                short_circuit: None,
                 eval: transform_leaf(eval),
             },
             other => other,
@@ -1408,6 +1416,7 @@ impl ExprPlanner {
                 children: vec![haystack.expr, needle.expr],
                 default_null_children: false,
                 align_children_to_root: false,
+                short_circuit: None,
                 eval: LeafEval::new_df_expr(
                     contains(col(arg_column_name(0)), col(arg_column_name(1))),
                     true,
@@ -1789,6 +1798,7 @@ impl ExprPlanner {
                 children: vec![left.expr, right.expr],
                 default_null_children: false,
                 align_children_to_root: false,
+                short_circuit: None,
                 eval: LeafEval::new_df_expr(
                     Expr::BinaryExpr(BinaryExpr::new(
                         Box::new(col(arg_column_name(0))),
@@ -1822,6 +1832,7 @@ impl ExprPlanner {
                 children,
                 default_null_children: false,
                 align_children_to_root: false,
+                short_circuit: None,
                 eval: LeafEval::new_df_expr(expr, dict_downcast)?,
             }),
         }
@@ -2312,7 +2323,7 @@ mod test {
     use otap_df_pdata::testing::round_trip::{otlp_to_otap, to_logs_data};
 
     use crate::pipeline::Pipeline;
-    use crate::pipeline::expr::{DataScope, ScopedExpr};
+    use crate::pipeline::expr::{DataScope, ScopedExpr, ShortCircuitStrategy};
     use crate::pipeline::id_mask::IdMask;
     use crate::pipeline::planner::AttributesIdentifier;
 
@@ -2946,6 +2957,117 @@ mod test {
             }
             IdMask::All => {} // Also acceptable
             other => panic!("expected Some or All, got {other:?}"),
+        }
+    }
+
+    /// Scenario: cross-scope AND (root field AND attribute predicate) produces
+    /// a JoinAndEval with ShortCircuitStrategy::And.
+    /// Guarantees: the planner assigns And short-circuit strategy to cross-scope
+    /// AND expressions so the evaluator can skip the right child and join when
+    /// the left child is all-false.
+    #[test]
+    fn test_plan_cross_scope_and_has_short_circuit_strategy() {
+        let planner = ExprPlanner::new();
+
+        // severity_text == "WARN" AND attributes["x"] == "a"
+        // Root scope vs Attribute scope -> cross-scope -> JoinAndEval
+        let left_eq = LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+            ql(),
+            make_column_expr("severity_text"),
+            make_string_literal("WARN"),
+            false,
+        ));
+        let right_eq = LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+            ql(),
+            make_attr_expr("x"),
+            make_string_literal("a"),
+            false,
+        ));
+
+        let and_expr = data_engine_expressions::AndLogicalExpression::new(ql(), left_eq, right_eq);
+        let logical = LogicalExpression::And(and_expr);
+        let op = planner.plan_logical(&logical, &[]).unwrap();
+
+        match &op {
+            ScopedExpr::JoinAndEval { short_circuit, .. } => {
+                assert_eq!(
+                    *short_circuit,
+                    Some(ShortCircuitStrategy::And),
+                    "cross-scope AND should have And short-circuit strategy"
+                );
+            }
+            other => panic!("expected JoinAndEval, got {other:?}"),
+        }
+    }
+
+    /// Scenario: cross-scope OR (root field OR attribute predicate) produces
+    /// a JoinAndEval with ShortCircuitStrategy::Or.
+    /// Guarantees: the planner assigns Or short-circuit strategy to cross-scope
+    /// OR expressions so the evaluator can skip the right child and join when
+    /// the left child is all-true.
+    #[test]
+    fn test_plan_cross_scope_or_has_short_circuit_strategy() {
+        let planner = ExprPlanner::new();
+
+        // severity_text == "WARN" OR attributes["x"] == "a"
+        // Root scope vs Attribute scope -> cross-scope -> JoinAndEval
+        let left_eq = LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+            ql(),
+            make_column_expr("severity_text"),
+            make_string_literal("WARN"),
+            false,
+        ));
+        let right_eq = LogicalExpression::EqualTo(EqualToLogicalExpression::new(
+            ql(),
+            make_attr_expr("x"),
+            make_string_literal("a"),
+            false,
+        ));
+
+        let or_expr = data_engine_expressions::OrLogicalExpression::new(ql(), left_eq, right_eq);
+        let logical = LogicalExpression::Or(or_expr);
+        let op = planner.plan_logical(&logical, &[]).unwrap();
+
+        match &op {
+            ScopedExpr::JoinAndEval { short_circuit, .. } => {
+                assert_eq!(
+                    *short_circuit,
+                    Some(ShortCircuitStrategy::Or),
+                    "cross-scope OR should have Or short-circuit strategy"
+                );
+            }
+            other => panic!("expected JoinAndEval, got {other:?}"),
+        }
+    }
+
+    /// Scenario: cross-scope arithmetic (root + attribute) produces a JoinAndEval
+    /// with no short-circuit strategy.
+    /// Guarantees: non-logical cross-scope expressions do not receive a short-circuit
+    /// strategy, preventing incorrect early termination of arithmetic evaluation.
+    #[test]
+    fn test_plan_cross_scope_arithmetic_no_short_circuit_strategy() {
+        use data_engine_expressions::{BinaryMathematicalScalarExpression, MathScalarExpression};
+
+        let planner = ExprPlanner::new();
+
+        // severity_number + attributes["x"]
+        let binary = BinaryMathematicalScalarExpression::new(
+            ql(),
+            make_column_expr("severity_number"),
+            make_attr_expr("x"),
+        );
+        let math_expr = ScalarExpression::Math(MathScalarExpression::Add(binary));
+
+        let planned = planner.plan_scalar(&math_expr, &[]).unwrap();
+
+        match &planned.expr {
+            ScopedExpr::JoinAndEval { short_circuit, .. } => {
+                assert_eq!(
+                    *short_circuit, None,
+                    "cross-scope arithmetic should have no short-circuit strategy"
+                );
+            }
+            other => panic!("expected JoinAndEval, got {other:?}"),
         }
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -576,7 +576,7 @@ impl ExprPlanner {
                             children,
                             default_null_children,
                             align_children_to_root,
-                            short_circuit,
+                            short_circuit: short_circuit.map(|s| s.invert()),
                             eval: LeafEval::DatafusionExpr {
                                 logical_expr: not(logical_expr),
                                 physical_expr: None,

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -2398,7 +2398,6 @@ mod test {
         );
 
         // check simple inverted "and" filter with mixed attributes & properties predicates
-        // check simple inverted "and" filter with attributes predicates
         let result = exec_logs_pipeline::<P>(
             "logs | where not(attributes[\"x\"] == \"c\" and severity_text == \"DEBUG\")",
             to_logs_data(log_records.clone()),
@@ -2408,6 +2407,31 @@ mod test {
             &result.resource_logs[0].scope_logs[0].log_records,
             &[log_records[0].clone(), log_records[1].clone()],
         );
+
+        // check that the inverted "and" produces all matches when one side has no matches and each
+        // side of the "and" is from different data sources. This will be planned with a short
+        // circuit strategy and we want to ensure the value produced by is properly inverted
+        let result = exec_logs_pipeline::<P>(
+            "logs | where not(severity_text == \"TRACE\" and attributes[\"x\"] == \"a\")",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        pretty_assertions::assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[
+                log_records[0].clone(),
+                log_records[1].clone(),
+                log_records[2].clone()
+            ],
+        );
+
+        // same test case as above - but now with double not, so no records should pass filter
+        let result = exec_logs_pipeline::<P>(
+            "logs | where not(not(severity_text == \"TRACE\" and attributes[\"x\"] == \"a\"))",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        pretty_assertions::assert_eq!(result.resource_logs.len(), 0);
     }
 
     #[tokio::test]
@@ -2425,6 +2449,7 @@ mod test {
             LogRecord::build()
                 .event_name("1")
                 .severity_text("INFO")
+                .severity_number(9i32)
                 .attributes(vec![
                     KeyValue::new("x", AnyValue::new_string("a")),
                     KeyValue::new("y", AnyValue::new_string("d")),
@@ -2433,6 +2458,7 @@ mod test {
             LogRecord::build()
                 .event_name("2")
                 .severity_text("ERROR")
+                .severity_number(17i32)
                 .attributes(vec![
                     KeyValue::new("x", AnyValue::new_string("b")),
                     KeyValue::new("y", AnyValue::new_string("e")),
@@ -2441,6 +2467,7 @@ mod test {
             LogRecord::build()
                 .event_name("3")
                 .severity_text("DEBUG")
+                .severity_number(5i32)
                 .attributes(vec![
                     KeyValue::new("x", AnyValue::new_string("c")),
                     KeyValue::new("y", AnyValue::new_string("f")),
@@ -2479,6 +2506,31 @@ mod test {
         pretty_assertions::assert_eq!(
             &result.resource_logs[0].scope_logs[0].log_records,
             &[log_records[1].clone()],
+        );
+
+        // check that the inverted "or" produces all matches when one side has is all true and each
+        // side of the "or" is from different data sources. This will be planned with a short
+        // circuit strategy and we want to ensure the value produced by is properly inverted
+        let result = exec_logs_pipeline::<P>(
+            "logs | where not(severity_number > 0 or attributes[\"x\"] == \"a\")",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        pretty_assertions::assert_eq!(result.resource_logs.len(), 0);
+
+        // same test case as above but now with double not - so all rows should be returned
+        let result = exec_logs_pipeline::<P>(
+            "logs | where not(not(severity_number > 0 or attributes[\"x\"] == \"a\"))",
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        pretty_assertions::assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[
+                log_records[0].clone(),
+                log_records[1].clone(),
+                log_records[2].clone()
+            ],
         );
     }
 

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions.rs
@@ -92,3 +92,56 @@ pub(crate) fn arity_range(signature: &TypeSignature) -> Option<Range<usize>> {
         }
     }
 }
+
+#[cfg(test)]
+pub(crate) mod test {
+    use arrow::datatypes::DataType;
+    use datafusion::error::Result;
+    use datafusion::functions::make_udf_function;
+    use datafusion::logical_expr::{
+        self as datafusion_expr, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+    };
+
+    make_udf_function!(AlwaysPanicUdf, always_panic);
+
+    /// UDF that will always panic when evaluated.
+    ///
+    /// This can be used in tests that are asserting that some expression does not evaluate
+    #[derive(Debug, Hash, Eq, PartialEq)]
+    struct AlwaysPanicUdf {
+        signature: Signature,
+    }
+
+    impl AlwaysPanicUdf {
+        fn new() -> Self {
+            Self {
+                signature: Signature::any(1, Volatility::Volatile),
+            }
+        }
+    }
+
+    impl ScalarUDFImpl for AlwaysPanicUdf {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn name(&self) -> &str {
+            "always_panic"
+        }
+
+        fn signature(&self) -> &Signature {
+            &self.signature
+        }
+
+        fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+            Ok(DataType::Boolean)
+        }
+
+        fn invoke_with_args(
+            &self,
+            _args: ScalarFunctionArgs,
+        ) -> Result<datafusion::logical_expr::ColumnarValue> {
+            panic!("AlwaysPanicUdf not expected to evaluate")
+        }
+    }
+}


### PR DESCRIPTION
# Change summary

<!--Replace with a brief summary of the change in this PR-->

**motivation**

Consider evaluating a binary expressions in the OTAP query engine where data comes from different sources (say one side is attributes, and the other is the Logs record batch) such as:
```
severity_text == "WARN" and attributes["some.attr"] == "x"
```

The expression evaluation will evaluate the left side, then the right side, then align the rows (e.g. join on left.id == right.parent_id) to create a new record batch, and then the DF expression containing the binary expr (e.g. `col("left").and(col("right"))`) is evaluated on this joined batch.

However if the binary operator is `and` and one side is all `false`, there's no point evaluating the other side! We know `false and <anything>` is always `false` (same logic applies for `or` when one side is `true`).

**changes**
This PR adds a short-circuit mechanism for these types of evaluations.

Specifically, this type of expression is evaluated by a variant of `ScopedExpr` called `JoinAndEval`. This adds a new field to this variant which is an `Option<ShortCircuitStrategy>`. When evaluating, we check if the strategy is `Some`, then check if the value returned by some child expression meets the criteria for short circuiting and return a short-circuit value without evaluating the other children.

Note - when both sides have the same source (e.g.an expression like `severity_text == "WARN" or severity_number == 13`, these both get evaluated by the same DataFusion expression (`col("severity_text").eq(lit("WARN")).or(col("severity_number").eq(lit(13)))`) in a variant of `ScoledExpr` called `eval`, which has its own internal short circuit logic, so for these types of expressions we don't need to manually add this type of short-circuit optimization.

**benchmarks:**

Interesting - we already had benchmarks covering such a short circuit, but they were referencing code that got deleted (and with the deletion, the short circuit mechanism was broken). This PR also corrects the commentary on these benchmarks and lo-and-behold by the grace of this PRs changes the benchmark result have improved:

Benchmark|Batch Size|Before|After|Change
---|---|---|---|---|
and_short_circuit|32|3.57 µs|0.78 µs|-78%
 ||1024|6.74 µs|1.26 µs|-81%
 ||8192|30.64 µs|4.83 µs|-84%
or_short_circuit|32|6.15 µs|3.44 µs|-44%
 ||1024|12.36 µs|9.15 µs|-26%
 ||8192|58.41 µs|51.50 µs|-12%

## Related issue

<!--We highly recommend correlation of every PR to an issue-->

* Closes #3817

## Validation

<!--How did you confirm your change has the intended effect?-->

Unit tests

## User-facing changes

<!--
Describe the impact, or write `None`.
User-facing changes require a `.chloggen/*.yaml` entry. If no entry is needed,
include `chore` in the PR title. Documentation-only changes are exempt.
-->

None

(its just perf improvement)