### PR TITLE
chore(pdata): cache payload bytes() inside `OtapPayload`

### DIFF
--- a/rust/otap-dataflow/benchmarks/benches/payload_measurements/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/payload_measurements/main.rs
@@ -147,5 +147,42 @@ fn count_payload_items(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(payload_measurements, count_logs, count_payload_items);
+fn measure_payload_size(c: &mut Criterion) {
+    let mut group = c.benchmark_group("PData size overhead");
+
+    for record_count in [10, 100, 1_000] {
+        let message = OtlpProtoMessage::Logs(create_logs_data(record_count));
+        let otlp_bytes: OtlpProtoBytes = otlp_message_to_bytes(&message);
+        let otap_records: OtapArrowRecords = otlp_to_otap(&message);
+
+        _ = group.bench_function(BenchmarkId::new("OTLP/size/direct", record_count), |b| {
+            let mut pdata =
+                OtapPdata::new(Context::default(), black_box(otlp_bytes.clone().into()));
+            b.iter(|| black_box(pdata.num_bytes()))
+        });
+
+        _ = group.bench_function(BenchmarkId::new("OTAP/size/uncached", record_count), |b| {
+            b.iter_batched_ref(
+                || OtapPdata::new(Context::default(), black_box(otap_records.clone().into())),
+                |pdata| black_box(pdata.num_bytes()),
+                BatchSize::SmallInput,
+            )
+        });
+
+        let mut cached = OtapPdata::new(Context::default(), black_box(otap_records.clone().into()));
+        _ = black_box(cached.num_bytes());
+        _ = group.bench_function(BenchmarkId::new("OTAP/size/cached", record_count), |b| {
+            b.iter(|| black_box(cached.num_bytes()))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    payload_measurements,
+    count_logs,
+    count_payload_items,
+    measure_payload_size
+);
 criterion_main!(payload_measurements);

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
@@ -327,7 +327,7 @@ enum EnqueueResult {
     Done,
     /// The stream queue was full. The caller should wait for capacity while
     /// continuing to poll the control channel, then retry.
-    QueueFull(Box<StreamBatch>, Instant, usize),
+    QueueFull(StreamBatch, Instant, usize),
 }
 
 impl OTAPExporter {
@@ -418,11 +418,7 @@ impl OTAPExporter {
             Err(tokio::sync::mpsc::error::TrySendError::Full(item)) => {
                 // Queue is full -- return to caller so it can wait for capacity
                 // while still polling the control channel in the main select.
-                Ok(EnqueueResult::QueueFull(
-                    Box::new(item),
-                    enqueue_start,
-                    queue_depth,
-                ))
+                Ok(EnqueueResult::QueueFull(item, enqueue_start, queue_depth))
             }
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
                 self.stream_metrics.record_stream_enqueue(
@@ -752,7 +748,7 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                         {
                             pending = Some((
                                 sender.clone(),
-                                *item,
+                                item,
                                 enqueue_start,
                                 signal_type,
                                 queue_depth,

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
@@ -327,7 +327,7 @@ enum EnqueueResult {
     Done,
     /// The stream queue was full. The caller should wait for capacity while
     /// continuing to poll the control channel, then retry.
-    QueueFull(StreamBatch, Instant, usize),
+    QueueFull(Box<StreamBatch>, Instant, usize),
 }
 
 impl OTAPExporter {
@@ -418,7 +418,11 @@ impl OTAPExporter {
             Err(tokio::sync::mpsc::error::TrySendError::Full(item)) => {
                 // Queue is full -- return to caller so it can wait for capacity
                 // while still polling the control channel in the main select.
-                Ok(EnqueueResult::QueueFull(item, enqueue_start, queue_depth))
+                Ok(EnqueueResult::QueueFull(
+                    Box::new(item),
+                    enqueue_start,
+                    queue_depth,
+                ))
             }
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
                 self.stream_metrics.record_stream_enqueue(
@@ -748,7 +752,7 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                         {
                             pending = Some((
                                 sender.clone(),
-                                item,
+                                *item,
                                 enqueue_start,
                                 signal_type,
                                 queue_depth,

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/fanout_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/fanout_processor/mod.rs
@@ -559,7 +559,7 @@ impl FanoutProcessor {
         inflight: &mut Inflight,
         destinations: &[DestinationConfig],
         effect_handler: &EffectHandler<OtapPdata>,
-    ) -> Result<DeadlineVec, Box<TypedError<OtapPdata>>> {
+    ) -> Result<DeadlineVec, TypedError<OtapPdata>> {
         let mut to_send = DestinationIndexQueue::new();
         let mut new_deadlines = DeadlineVec::new();
         match inflight.mode {
@@ -590,8 +590,7 @@ impl FanoutProcessor {
                 }
                 effect_handler
                     .send_message_to(destinations[idx].port.clone(), payload)
-                    .await
-                    .map_err(Box::new)?;
+                    .await?;
             }
         }
         Ok(new_deadlines)
@@ -727,8 +726,7 @@ impl FanoutProcessor {
             if let Some(inflight) = self.inflight.get_mut(&req) {
                 let deadlines =
                     Self::dispatch_ready(req, inflight, &self.config.destinations, effect_handler)
-                        .await
-                        .map_err(|error| *error)?;
+                        .await?;
                 for d in deadlines {
                     self.deadline_heap.push(Reverse(d));
                 }
@@ -825,8 +823,7 @@ impl FanoutProcessor {
                     &self.config.destinations,
                     effect_handler,
                 )
-                .await
-                .map_err(|error| *error)?;
+                .await?;
                 for d in deadlines {
                     self.deadline_heap.push(Reverse(d));
                 }
@@ -897,8 +894,7 @@ impl FanoutProcessor {
                 &self.config.destinations,
                 effect_handler,
             )
-            .await
-            .map_err(|error| *error)?;
+            .await?;
             for d in deadlines {
                 self.deadline_heap.push(Reverse(d));
             }
@@ -1130,8 +1126,7 @@ impl Processor<OtapPdata> for FanoutProcessor {
                         &self.config.destinations,
                         effect_handler,
                     )
-                    .await
-                    .map_err(|error| *error)?;
+                    .await?;
                     for d in deadlines {
                         self.deadline_heap.push(Reverse(d));
                     }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/fanout_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/fanout_processor/mod.rs
@@ -559,7 +559,7 @@ impl FanoutProcessor {
         inflight: &mut Inflight,
         destinations: &[DestinationConfig],
         effect_handler: &EffectHandler<OtapPdata>,
-    ) -> Result<DeadlineVec, TypedError<OtapPdata>> {
+    ) -> Result<DeadlineVec, Box<TypedError<OtapPdata>>> {
         let mut to_send = DestinationIndexQueue::new();
         let mut new_deadlines = DeadlineVec::new();
         match inflight.mode {
@@ -590,7 +590,8 @@ impl FanoutProcessor {
                 }
                 effect_handler
                     .send_message_to(destinations[idx].port.clone(), payload)
-                    .await?;
+                    .await
+                    .map_err(Box::new)?;
             }
         }
         Ok(new_deadlines)
@@ -726,7 +727,8 @@ impl FanoutProcessor {
             if let Some(inflight) = self.inflight.get_mut(&req) {
                 let deadlines =
                     Self::dispatch_ready(req, inflight, &self.config.destinations, effect_handler)
-                        .await?;
+                        .await
+                        .map_err(|error| *error)?;
                 for d in deadlines {
                     self.deadline_heap.push(Reverse(d));
                 }
@@ -823,7 +825,8 @@ impl FanoutProcessor {
                     &self.config.destinations,
                     effect_handler,
                 )
-                .await?;
+                .await
+                .map_err(|error| *error)?;
                 for d in deadlines {
                     self.deadline_heap.push(Reverse(d));
                 }
@@ -894,7 +897,8 @@ impl FanoutProcessor {
                 &self.config.destinations,
                 effect_handler,
             )
-            .await?;
+            .await
+            .map_err(|error| *error)?;
             for d in deadlines {
                 self.deadline_heap.push(Reverse(d));
             }
@@ -1126,7 +1130,8 @@ impl Processor<OtapPdata> for FanoutProcessor {
                         &self.config.destinations,
                         effect_handler,
                     )
-                    .await?;
+                    .await
+                    .map_err(|error| *error)?;
                     for d in deadlines {
                         self.deadline_heap.push(Reverse(d));
                     }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/mod.rs
@@ -389,7 +389,7 @@ impl TrafficGeneratorReceiver {
     ) -> Result<Result<u64, OtapPdata>, Error> {
         let signal = pdata.signal_type();
         let count = pdata.num_items() as u64;
-        let payload_bytes = pdata.payload_ref().num_bytes();
+        let payload_bytes = pdata.num_bytes();
         match handler.try_send_message_with_source_node(pdata) {
             Ok(()) => {
                 match signal {

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/producer.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/traffic_generator/producer.rs
@@ -720,7 +720,7 @@ mod tests {
 
         let shape = create_shape(&cfg);
         let mut generator = synthetic_generator();
-        let payloads =
+        let mut payloads =
             create_fresh_payloads(&mut generator, &shape).expect("pre-generation should succeed");
         let expected_count = payloads.len();
 
@@ -736,7 +736,7 @@ mod tests {
             produced_count: 0,
         };
 
-        let results: Vec<GenerateResult> = producer
+        let mut results: Vec<GenerateResult> = producer
             .next_run()
             .expect("generation should succeed")
             .expect("should get a run")
@@ -744,8 +744,8 @@ mod tests {
         assert_eq!(results.len(), expected_count);
 
         // Each replayed payload should match the original pre-generated payload.
-        for (i, (result, original)) in results.iter().zip(payloads.iter()).enumerate() {
-            let payload = result.as_ref().expect("replay should always succeed");
+        for (i, (result, original)) in results.iter_mut().zip(payloads.iter_mut()).enumerate() {
+            let payload = result.as_mut().expect("replay should always succeed");
             assert_eq!(
                 payload.num_bytes(),
                 original.num_bytes(),
@@ -851,10 +851,10 @@ mod tests {
         // synthetic_generator() has empty entries and rotation -- no custom resource attrs.
         let mut generator = synthetic_generator();
 
-        let batch_1 = generator
+        let mut batch_1 = generator
             .generate_logs(1)
             .expect("batch 1 with empty attrs");
-        let batch_2 = generator
+        let mut batch_2 = generator
             .generate_logs(1)
             .expect("batch 2 with empty attrs");
 

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server_new.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server_new.rs
@@ -400,7 +400,7 @@ impl UnaryService<OtapPdata> for OtapBatchService {
 
     fn call(&mut self, request: tonic::Request<OtapPdata>) -> Self::Future {
         let (metadata, extensions, mut otap_batch) = request.into_parts();
-        let payload_size = otap_batch.payload_ref().num_bytes();
+        let payload_size = otap_batch.num_bytes();
 
         // Keep the final weighted admission decision at the request-service
         // boundary, where both transport metadata and the raw payload weight

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -688,6 +688,12 @@ impl OtapPdata {
         self.payload.num_items()
     }
 
+    /// Returns the logical byte size of the current payload representation.
+    #[must_use]
+    pub fn num_bytes(&mut self) -> Option<usize> {
+        self.payload.num_bytes()
+    }
+
     /// Enable testing Ack/Nack without an effect handler. Consumes,
     /// modifies and returns self.
     #[cfg(any(test, feature = "test-utils"))]
@@ -1099,6 +1105,14 @@ mod test {
 
     fn create_test() -> (TestCallData, OtapPdata) {
         (TestCallData::default(), create_test_pdata())
+    }
+
+    fn create_test_otap_pdata() -> OtapPdata {
+        use otap_df_pdata::{OtapArrowRecords, TryIntoWithOptions};
+
+        let payload = create_test_pdata().into_parts().1;
+        let records: OtapArrowRecords = payload.try_into_with_default().expect("OTAP conversion");
+        OtapPdata::new_default(records.into())
     }
 
     struct FakeFlowMetricHandler {
@@ -2829,20 +2843,57 @@ mod test {
     /// Guarantees: the direct Arrow row count leaves the OTLP item-count cache empty.
     #[test]
     fn otap_item_count_bypasses_cache() {
-        use otap_df_pdata::{OtapArrowRecords, TryIntoWithOptions};
-
-        let payload = create_test_pdata().into_parts().1;
-        let records: OtapArrowRecords = payload.try_into_with_default().expect("OTAP conversion");
-        let mut otap = OtapPdata::new_default(records.into());
+        let mut otap = create_test_otap_pdata();
         let expected_items = otap.payload.num_items();
         assert_eq!(otap.num_items(), expected_items);
         assert!(!otap.payload_ref().test_has_cached_item_count());
     }
 
-    /// Scenario: cached measurements exist before the payload is taken from PData.
-    /// Guarantees: taking the payload replaces the cache so the empty payload cannot reuse stale values.
+    /// Scenario: an OTAP PData is cloned before and after its logical size is measured.
+    /// Guarantees: clones copy existing cached values but do not share later cache updates.
     #[test]
-    fn take_payload_invalidates_cached_measurements() {
+    fn otap_size_cache_is_copied_across_clones() {
+        let mut pdata = create_test_otap_pdata();
+        assert!(!pdata.payload_ref().test_has_cached_size());
+        let mut cloned_before_measurement = pdata.clone();
+        let expected_bytes = pdata.num_bytes();
+        assert!(expected_bytes.is_some());
+        assert!(pdata.payload_ref().test_has_cached_size());
+        assert!(
+            !cloned_before_measurement
+                .payload_ref()
+                .test_has_cached_size()
+        );
+
+        assert_eq!(cloned_before_measurement.num_bytes(), expected_bytes);
+        assert!(
+            cloned_before_measurement
+                .payload_ref()
+                .test_has_cached_size()
+        );
+
+        let detached_after_measurement = pdata.clone_without_context();
+        assert!(
+            detached_after_measurement
+                .payload_ref()
+                .test_has_cached_size()
+        );
+    }
+
+    /// Scenario: an OTLP payload's encoded byte length is requested.
+    /// Guarantees: the constant-time OTLP length bypasses the OTAP size cache.
+    #[test]
+    fn otlp_num_bytes_bypasses_size_cache() {
+        let mut pdata = create_test_pdata();
+
+        assert!(pdata.num_bytes().is_some());
+        assert!(!pdata.payload_ref().test_has_cached_size());
+    }
+
+    /// Scenario: a cached item count exists before the payload is taken from PData.
+    /// Guarantees: taking the payload replaces the cache so the empty payload cannot reuse the item count.
+    #[test]
+    fn take_payload_invalidates_cached_item_count() {
         let mut pdata = create_test_pdata();
         assert!(pdata.num_items() > 0);
         let payload = pdata.take_payload();
@@ -2852,6 +2903,23 @@ mod test {
         assert!(!pdata.payload_ref().test_has_cached_item_count());
         assert_eq!(pdata.num_items(), 0);
         assert!(pdata.payload_ref().test_has_cached_item_count());
+    }
+
+    /// Scenario: a cached OTAP size exists before the payload is taken.
+    /// Guarantees: the returned payload keeps the count and the empty replacement starts uncached.
+    #[test]
+    fn take_payload_invalidates_cached_size() {
+        let mut pdata = create_test_otap_pdata();
+        let expected_bytes = pdata.num_bytes();
+        assert!(expected_bytes.is_some());
+        let mut payload = pdata.take_payload();
+
+        assert!(!payload.is_empty());
+        assert!(payload.test_has_cached_size());
+        assert_eq!(payload.num_bytes(), expected_bytes);
+        assert!(!pdata.payload_ref().test_has_cached_size());
+        assert_eq!(pdata.num_bytes(), Some(0));
+        assert!(pdata.payload_ref().test_has_cached_size());
     }
 
     /// Scenario: an unchanged payload's cache is queried, split via `into_parts`, and the

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -2906,7 +2906,7 @@ mod test {
     }
 
     /// Scenario: a cached OTAP size exists before the payload is taken.
-    /// Guarantees: the returned payload keeps the count and the empty replacement starts uncached.
+    /// Guarantees: the returned payload keeps the cached size and the empty replacement starts uncached.
     #[test]
     fn take_payload_invalidates_cached_size() {
         let mut pdata = create_test_otap_pdata();

--- a/rust/otap-dataflow/crates/pdata/src/otap/memory.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/memory.rs
@@ -387,7 +387,7 @@ mod tests {
     #[test]
     fn otlp_payload_num_bytes_matches_retained_memory_bytes() {
         let otlp_bytes = OtlpProtoBytes::ExportLogsRequest(Bytes::from_static(b"abc"));
-        let otlp_payload: OtapPayload = otlp_bytes.clone().into();
+        let mut otlp_payload: OtapPayload = otlp_bytes.clone().into();
 
         assert_eq!(otlp_bytes.num_bytes(), otlp_bytes.retained_memory_bytes());
         assert_eq!(

--- a/rust/otap-dataflow/crates/pdata/src/payload.rs
+++ b/rust/otap-dataflow/crates/pdata/src/payload.rs
@@ -170,9 +170,9 @@ impl PayloadData {
 /// Container for the various representations of the telemetry data.
 ///
 /// `OtapPayload` owns both the concrete [`PayloadData`] and cached expensive
-/// measurements. The only cached measurement currently implemented is the
-/// OTLP item count. The cache is scoped to the exact logical payload version
-/// it was created for:
+/// measurements. OTLP item counts and OTAP logical byte sizes are cached when
+/// first requested. The cache is scoped to the exact logical payload version it
+/// was created for:
 ///
 /// - Constructing a new `OtapPayload` (via `From`, [`Self::empty`], or
 ///   [`Self::take_payload`]'s emptied remainder) always starts with a fresh,
@@ -188,6 +188,7 @@ impl PayloadData {
 pub struct OtapPayload {
     data: PayloadData,
     item_count: Option<usize>,
+    size: Option<usize>,
 }
 
 impl OtapPayload {
@@ -197,6 +198,7 @@ impl OtapPayload {
         Self {
             data,
             item_count: None,
+            size: None,
         }
     }
 
@@ -263,6 +265,7 @@ impl OtapPayload {
         Self {
             data: old_data,
             item_count: self.item_count.take(),
+            size: self.size.take(),
         }
     }
 
@@ -291,8 +294,20 @@ impl OtapPayload {
     /// Arrow's logical slice-memory estimate. Returns `None` if the current
     /// representation cannot be measured.
     #[must_use]
-    pub fn num_bytes(&self) -> Option<usize> {
-        self.data.num_bytes()
+    pub fn num_bytes(&mut self) -> Option<usize> {
+        match &self.data {
+            // OTLP already stores the exact encoded length in Bytes metadata.
+            PayloadData::OtlpBytes(_) => self.data.num_bytes(),
+            // Cache OTAP sizing because it walks every Arrow array and buffer.
+            PayloadData::OtapArrowRecords(_) => {
+                if let Some(size) = self.size {
+                    return Some(size);
+                }
+                let size = self.data.num_bytes()?;
+                self.size = Some(size);
+                Some(size)
+            }
+        }
     }
 
     /// Returns the best available retained-memory byte estimate.
@@ -312,6 +327,7 @@ impl OtapPayload {
         Self {
             data: PayloadData::OtlpBytes(OtlpProtoBytes::empty(signal)),
             item_count: None,
+            size: None,
         }
     }
 
@@ -321,6 +337,13 @@ impl OtapPayload {
     #[must_use]
     pub fn test_has_cached_item_count(&self) -> bool {
         self.item_count.is_some()
+    }
+
+    /// Test-only introspection: true if the OTAP size cache has been computed.
+    #[cfg(any(test, feature = "testing"))]
+    #[must_use]
+    pub fn test_has_cached_size(&self) -> bool {
+        self.size.is_some()
     }
 }
 


### PR DESCRIPTION
# Chore Summary

Cache the logical Arrow size for unchanged OTAP PData so universal node metrics do not repeatedly walk the same Arrow arrays and buffers.

OTAP logical sizing scales with the number and structure of Arrow arrays and buffers. OTLP payloads already expose their protobuf length directly through `Bytes::len()`, so OTLP sizing remains uncached.

### Approach

| Representation | Behavior | Reason |
| --- | --- | --- |
| OTLP | Read size directly without populating the cache | `Bytes::len()` is already constant time. |
| OTAP | Cache `size` on `OtapPayload` | Logical sizing walks the Arrow arrays and buffers. |

`OtapPayload` owns `data: PayloadData` and the cached measurements `item_count` and `size`.

Constructing a payload starts with an empty measurement cache. Clones copy values computed before cloning; clones created while the cache is empty compute independently. Taking or replacing a payload automatically gives the empty or newly constructed payload a fresh cache.

### Benchmarks

```bash
cd rust/otap-dataflow
cargo bench -p benchmarks --bench payload_measurements -- \
  'PData size overhead'
```

| Format | Measurement | 10 records | 100 records | 1,000 records | 10 -> 1,000 |
| --- | --- | ---: | ---: | ---: | ---: |
| OTLP | Size, direct | 8.10 ns | 8.12 ns | 7.96 ns | 0.98x |
| OTAP | Size, uncached | 3.78 us | 3.89 us | 3.68 us | 0.97x |
| OTAP | Size, cached | 7.85 ns | 7.92 ns | 8.13 ns | 1.04x |

| Cached measurement | 10 records | 100 records | 1,000 records |
| --- | ---: | ---: | ---: |
| OTAP size | 99.792% lower (481x) | 99.797% lower (491x) | 99.779% lower (452x) |

The uncached OTAP path is approximately constant across these record counts because logical sizing walks array and buffer metadata rather than individual values. Caching makes repeated OTAP sizing comparable to the direct OTLP `Bytes::len()` path.

More complex payload shapes can add batches, columns, child arrays, or dictionaries and increase the uncached cost. Caching when possible avoids that traversal.

## Related issue

- Related to #2884 
- Follows #3819 
