### PR TITLE
chore(clippy): Resolve clippy 1.98 errors in main

### DIFF
--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/kafka_exporter/producer.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/kafka_exporter/producer.rs
@@ -391,6 +391,7 @@ where
     /// See also the [`FutureProducer::send_result`] method, which will not
     /// retry the queue operation if the queue is full.
     #[allow(dead_code)]
+    #[allow(clippy::result_large_err)] // Preserve rdkafka's OwnedDeliveryResult API.
     pub async fn send<K, P, T>(
         &self,
         record: ExporterFutureRecord<'_, K, P>,

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -1482,8 +1482,8 @@ impl MultiContext {
 impl<T: OtapPayloadHelpers> Inputs<T> {
     fn drain(&mut self) -> Self {
         Self {
-            pending: self.pending.drain(..).collect(),
-            context: self.context.drain(..).collect(),
+            pending: std::mem::take(&mut self.pending),
+            context: std::mem::take(&mut self.context),
             weight: std::mem::take(&mut self.weight),
         }
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/fanout_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/fanout_processor/mod.rs
@@ -559,7 +559,7 @@ impl FanoutProcessor {
         inflight: &mut Inflight,
         destinations: &[DestinationConfig],
         effect_handler: &EffectHandler<OtapPdata>,
-    ) -> Result<DeadlineVec, TypedError<OtapPdata>> {
+    ) -> Result<DeadlineVec, Box<TypedError<OtapPdata>>> {
         let mut to_send = DestinationIndexQueue::new();
         let mut new_deadlines = DeadlineVec::new();
         match inflight.mode {
@@ -590,7 +590,8 @@ impl FanoutProcessor {
                 }
                 effect_handler
                     .send_message_to(destinations[idx].port.clone(), payload)
-                    .await?;
+                    .await
+                    .map_err(Box::new)?;
             }
         }
         Ok(new_deadlines)
@@ -726,7 +727,8 @@ impl FanoutProcessor {
             if let Some(inflight) = self.inflight.get_mut(&req) {
                 let deadlines =
                     Self::dispatch_ready(req, inflight, &self.config.destinations, effect_handler)
-                        .await?;
+                        .await
+                        .map_err(|error| *error)?;
                 for d in deadlines {
                     self.deadline_heap.push(Reverse(d));
                 }
@@ -823,7 +825,8 @@ impl FanoutProcessor {
                     &self.config.destinations,
                     effect_handler,
                 )
-                .await?;
+                .await
+                .map_err(|error| *error)?;
                 for d in deadlines {
                     self.deadline_heap.push(Reverse(d));
                 }
@@ -894,7 +897,8 @@ impl FanoutProcessor {
                 &self.config.destinations,
                 effect_handler,
             )
-            .await?;
+            .await
+            .map_err(|error| *error)?;
             for d in deadlines {
                 self.deadline_heap.push(Reverse(d));
             }
@@ -1126,7 +1130,8 @@ impl Processor<OtapPdata> for FanoutProcessor {
                         &self.config.destinations,
                         effect_handler,
                     )
-                    .await?;
+                    .await
+                    .map_err(|error| *error)?;
                     for d in deadlines {
                         self.deadline_heap.push(Reverse(d));
                     }


### PR DESCRIPTION
# Chore Summary

Address clippy error on unrelated PR: https://github.com/open-telemetry/otel-arrow/actions/runs/32402148082/job/96532892549?pr=3834

```text
error: draining all elements of a collection into a new collection of the same type
    --> crates/core-nodes/src/processors/batch_processor/mod.rs:1485:22
     |
1485 |             pending: self.pending.drain(..).collect(),
     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `mem::take` to avoid creating a new allocation: `std::mem::take(&mut self.pending)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#drain_collect
     = note: `-D clippy::drain-collect` implied by `-D clippy::perf`
     = help: to override `-D clippy::perf` add `#[allow(clippy::drain_collect)]`

error: draining all elements of a collection into a new collection of the same type
    --> crates/core-nodes/src/processors/batch_processor/mod.rs:1486:22
     |
1486 |             context: self.context.drain(..).collect(),
     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `mem::take` to avoid creating a new allocation: `std::mem::take(&mut self.context)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#drain_collect

error: the `Err`-variant returned from this function is very large
   --> crates/core-nodes/src/processors/fanout_processor/mod.rs:562:10
    |
562 |     ) -> Result<DeadlineVec, TypedError<OtapPdata>> {
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `Err`-variant is at least 152 bytes
    |
    = help: try reducing the size of `otap_df_engine::error::TypedError<otap_df_otap::pdata::OtapPdata>`, for example by boxing large elements or replacing it with `Box<otap_df_engine::error::TypedError<otap_df_otap::pdata::OtapPdata>>`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#result_large_err
    = note: `-D clippy::result-large-err` implied by `-D clippy::perf`
    = help: to override `-D clippy::perf` add `#[allow(clippy::result_large_err)]`
```

## Related issue

<!-- Link the related issue if one exists. -->
