### PR TITLE
chore(lint): satisfy clippy 1.98 perf lints in core-nodes

### DIFF
--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -1480,6 +1480,8 @@ impl MultiContext {
 }
 
 impl<T: OtapPayloadHelpers> Inputs<T> {
+    // Draining rather than `mem::take` keeps the accumulator's capacity for the next batch.
+    #[allow(clippy::drain_collect)]
     fn drain(&mut self) -> Self {
         Self {
             pending: std::mem::take(&mut self.pending),

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/fanout_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/fanout_processor/mod.rs
@@ -554,6 +554,7 @@ impl FanoutProcessor {
     }
 
     /// Dispatch ready destinations and return any new deadlines for the heap.
+    #[allow(clippy::result_large_err)]
     async fn dispatch_ready(
         request_id: u64,
         inflight: &mut Inflight,


### PR DESCRIPTION
# Change summary

Rust 1.98 promoted drain_collect and result_large_err under clippy::perf, which the workspace denies, so CI now fails on unmodified code.

Both are silenced with targeted allows rather than rewrites. `Inputs::drain` keeps `drain(..).collect()` on purpose: it preserves the accumulator capacity that the next batch refills, whereas `mem::take` would leave a zero-capacity Vec and regrow it every batch. `dispatch_ready` follows the existing result_large_err convention already used in kafka_exporter, attributes_processor and otlp_http.

## Related issue

n/a

## Validation

n/a

## User-facing changes

None