### PR TITLE
feat(engine): Add opt-in `size` metric to node produced/consumed

### DIFF
--- a/rust/otap-dataflow/.chloggen/node-produced-consumed-size.yaml
+++ b/rust/otap-dataflow/.chloggen/node-produced-consumed-size.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: engine
+note: "Add opt-in logical payload size to node produced and consumed metrics."
+issues: [2884]
+subtext: |
+  Enable with runtime_metrics: detailed for every node, or set policies.telemetry.size: true on individual nodes when runtime_metrics is normal.

--- a/rust/otap-dataflow/configs/README.md
+++ b/rust/otap-dataflow/configs/README.md
@@ -91,21 +91,18 @@ Demonstrates metric-name filtering:
 - Generates synthetic metrics -> filter processor by metric name -> debug processor
   -> noop exporter
 
-### `trafficgen-per-signal-metrics-demo.yaml`
+### `trafficgen-universal-produced-consumed-metrics.yaml`
 
-Demonstrates the opt-in per-signal produced/consumed item counts a node can
-emit:
+Demonstrates universal produced/consumed message, item, and logical payload
+size metrics:
 
 - Generates a mix of logs, metrics and traces -> log-sampling processor -> noop
   exporter
-- Only opted-in nodes report `node.producer.produced.items` and
-  `node.consumer.consumed.items`, each split by the `signal` datapoint attribute;
-  nodes that are not opted in omit these metrics
-  (per-node `policies.telemetry.item_counts: true`, or globally via
-  `runtime_metrics: detailed`); recording requires `runtime_metrics: normal` or
-  higher.
-- View metrics at:
-  `http://127.0.0.1:8080/api/v1/telemetry/metrics?format=json`
+- `runtime_metrics: detailed` enables item and size measurements for every
+  node; the second pipeline demonstrates per-node `item_counts: true` and
+  `size: true` opt-ins at the normal level.
+- An internal observability pipeline filters to only produced/consumed
+  instruments and prints normal-verbosity metrics to stdout.
 
 ### `trafficgen-flow-metrics-demo.yaml`
 

--- a/rust/otap-dataflow/configs/trafficgen-universal-produced-consumed-metrics.yaml
+++ b/rust/otap-dataflow/configs/trafficgen-universal-produced-consumed-metrics.yaml
@@ -1,36 +1,36 @@
-# Demonstrates the per-signal produced/consumed item counts that a node emits
-# on its `node.producer` / `node.consumer` metric sets.
+# Demonstrates the per-signal produced/consumed item counts and logical payload
+# sizes that a node emits on its `node.producer` / `node.consumer` metric sets.
 #
 # Two pipelines in the same engine, each running: receiver -> sampler -> noop
-#   - `full`:    ALL three nodes opt in -> every node emits per-signal counts.
+#   - `full`:    detailed metrics enable both measurements on all three nodes.
 #   - `partial`: only the `sampler` opts in -> only the sampler emits per-signal
-#                counts; the receiver and noop do not.
+#                items and size; the receiver and noop do not.
 # Distinguish them by the `pipeline.id` attribute on each metric set.
 #
 # The traffic generator emits a mix of all three signals (logs, metrics,
 # traces). Each pdata batch is homogeneous (exactly one signal), and the
-# per-signal counts are stamped on the batch as it flows forward, then recorded
-# on each node during ack/nack unwinding. Because these counts extend the
-# existing produced/consumed metrics, they are available uniformly on ALL
-# node kinds -- receivers, processors and exporters alike.
+# measurements are stamped on the batch as it flows forward, then recorded on
+# each node during ack/nack unwinding. They are available uniformly on ALL node
+# kinds -- receivers, processors and exporters alike.
 #
-# Opt-in: counting items is cheap for the Arrow-native representation but
-# expensive for OTLP-encoded payloads (which must be parsed), so it is NOT on by
-# default. A node emits per-signal counts only when either:
-#   - the pipeline's `telemetry.runtime_metrics` is `detailed` (enables it for
-#     every node), or
-#   - the node sets `policies.telemetry.item_counts: true` (per-node
-#     opt-in, shown below). The counts still require `runtime_metrics: normal`
-#     or higher, since they extend the produced/consumed metric sets.
+# Opt-in: item counting and logical payload sizing can require payload
+# inspection, so they are not enabled at the normal metric level by default.
+# A node emits them when either:
+#   - the pipeline sets `telemetry.runtime_metrics: detailed`, or
+#   - the node sets `policies.telemetry.item_counts: true` and/or
+#     `policies.telemetry.size: true`.
+# Per-node opt-ins still require `runtime_metrics: normal` or higher because
+# these measurements extend the produced/consumed metric sets.
 #
 # Metrics emitted per opted-in node:
 #   node.producer: produced.items {item}, with `signal` = logs, metrics, or traces
+#   node.producer: produced.size By, with `signal` = logs, metrics, or traces
 #   node.consumer: consumed.items {item}, with `signal` = logs, metrics, or traces
+#   node.consumer: consumed.size By, with `signal` = logs, metrics, or traces
 #
 # What to look for:
-#   - In `full`, every node reports per-signal counts. In `partial`, only the
-#     sampler does -- the receiver and noop have no per-signal counts because
-#     they did not opt in.
+#   - In `full`, every node reports per-signal items and size. In `partial`,
+#     only the sampler does because the receiver and noop did not opt in.
 #   - receiver `node.producer.produced.items` is the per-signal accepted volume
 #     the traffic generator injected.
 #   - sampler `node.consumer.consumed.*` equals the receiver's produced counts
@@ -41,16 +41,60 @@
 #     isolating the affected signal.
 #   - noop `node.consumer.consumed.*` reflects the surviving per-signal volume.
 #
-# Query metrics while running (add `.attributes["pipeline.id"]` to tell the two
-# pipelines apart):
-#   curl -s 'http://127.0.0.1:8080/api/v1/telemetry/metrics?format=json' \
-#     | jq '[.metric_sets[] | select(.name == "node.producer" or .name == "node.consumer")]'
+# The internal observability pipeline filters out everything except the six
+# produced/consumed message, item, and size instruments, then prints their
+# normal-verbosity representation to stdout once per second.
 #
 # Run with:
-#   cargo run -- --config configs/trafficgen-per-signal-metrics-demo.yaml
+#   cargo run -- --config configs/trafficgen-universal-produced-consumed-metrics.yaml
 
 version: otel_dataflow/v1
-engine: {}
+engine:
+  telemetry:
+    reporting_interval: 1s
+  observability:
+    pipeline:
+      policies:
+        telemetry:
+          pipeline_metrics: false
+          tokio_metrics: false
+          runtime_metrics: none
+      nodes:
+        telemetry:
+          type: receiver:internal_telemetry
+          config:
+            signals: [metrics]
+            metrics:
+              interval: 1s
+        node_metrics_filter:
+          type: processor:filter
+          config:
+            metrics:
+              include:
+                match_type: strict
+                metric_names:
+                  - consumed.messages
+                  - consumed.items
+                  - consumed.size
+                  - produced.messages
+                  - produced.items
+                  - produced.size
+        metrics_debug:
+          type: processor:debug
+          config:
+            verbosity: normal
+            mode: batch
+            signals: [metrics]
+        noop:
+          type: exporter:noop
+          config: {}
+      connections:
+        - from: telemetry
+          to: node_metrics_filter
+        - from: node_metrics_filter
+          to: metrics_debug
+        - from: metrics_debug
+          to: noop
 groups:
   default:
     pipelines:
@@ -62,7 +106,8 @@ groups:
               pipeline: 100
             pdata: 128
           telemetry:
-            # Detailed runtime metrics enables per-signal produced/consumed item counts for every node in the pipeline.
+            # Detailed runtime metrics enables item counts and logical payload
+            # size for every node in the pipeline.
             runtime_metrics: detailed
 
         nodes:
@@ -104,9 +149,8 @@ groups:
           - from: sampler
             to: noop
 
-      # Same topology, but only the sampler opts in. The receiver and noop do
-      # NOT set `policies.telemetry.item_counts`, so they emit the message-outcome
-      # produced/consumed counters but no per-signal item counts.
+      # Same topology, but only the sampler opts into items and size. The
+      # receiver and noop emit message outcomes but no optional measurements.
       partial:
         policies:
           channel_capacity:
@@ -136,6 +180,7 @@ groups:
             policies:
               telemetry:
                 item_counts: true
+                size: true
             config:
               policy:
                 ratio:

--- a/rust/otap-dataflow/crates/config/src/node.rs
+++ b/rust/otap-dataflow/crates/config/src/node.rs
@@ -194,6 +194,16 @@ pub struct NodeTelemetryPolicy {
     /// enables it for every node without this flag.
     #[serde(default)]
     pub item_counts: bool,
+
+    /// Opt this node into per-signal produced/consumed logical payload size on
+    /// its `node.producer` / `node.consumer` metric sets.
+    ///
+    /// Off by default because measuring OTAP payloads requires walking their
+    /// Arrow arrays and buffers. Only recorded when the resolved
+    /// `runtime_metrics` is `normal` or higher; `runtime_metrics: detailed`
+    /// enables it for every node without this flag.
+    #[serde(default)]
+    pub size: bool,
 }
 
 /// Node kinds
@@ -519,23 +529,25 @@ mod tests {
         assert!(cfg.outputs.is_empty());
     }
 
-    /// Scenario: a node config opts into item counts through its restricted policy block.
-    /// Guarantees: node telemetry configuration stays namespaced under `policies`.
+    /// Scenario: a node config opts into item counts and payload size through its restricted policy block.
+    /// Guarantees: node telemetry configuration stays namespaced under `policies` with independent measurement controls.
     #[test]
-    fn node_user_config_parses_item_count_policy() {
+    fn node_user_config_parses_measurement_policy() {
         let yaml = r#"
 type: "processor:batch"
 policies:
   telemetry:
     item_counts: true
+    size: true
 "#;
         let cfg: NodeUserConfig = serde_yaml::from_str(yaml).unwrap();
-        assert!(
-            cfg.policies
-                .as_ref()
-                .and_then(|policies| policies.telemetry.as_ref())
-                .is_some_and(|telemetry| telemetry.item_counts)
-        );
+        let telemetry = cfg
+            .policies
+            .as_ref()
+            .and_then(|policies| policies.telemetry.as_ref())
+            .expect("node telemetry policy");
+        assert!(telemetry.item_counts);
+        assert!(telemetry.size);
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/engine/src/channel_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/channel_metrics.rs
@@ -187,6 +187,18 @@ pub struct ConsumedItemMetrics {
     pub consumed_items: Counter<u64>,
 }
 
+/// Optional per-signal logical payload-size metrics for a node input channel.
+#[metric_set(
+    name = "node.consumer",
+    measurement_attributes = SignalOutcomeAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub struct ConsumedSizeMetrics {
+    /// Consumed logical payload size, grouped by `signal` and `outcome`.
+    #[metric(name = "consumed.size", unit = "By")]
+    pub consumed_size: Counter<u64>,
+}
+
 /// Ack/nack metrics for produced messages, owned exclusively by the runtime control manager.
 /// Registered under the output channel entity key so they share the same
 /// channel attributes as the transport metrics.
@@ -218,6 +230,18 @@ pub struct ProducedItemMetrics {
     /// Produced signal items, grouped by the `signal` datapoint attribute.
     #[metric(name = "produced.items", unit = "{item}")]
     pub produced_items: Counter<u64>,
+}
+
+/// Optional per-signal logical payload-size metrics for a node output channel.
+#[metric_set(
+    name = "node.producer",
+    measurement_attributes = SignalOutcomeAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub struct ProducedSizeMetrics {
+    /// Produced logical payload size, grouped by `signal` and `outcome`.
+    #[metric(name = "produced.size", unit = "By")]
+    pub produced_size: Counter<u64>,
 }
 
 pub(crate) fn control_channel_id(name: &str) -> Cow<'static, str> {

--- a/rust/otap-dataflow/crates/engine/src/control.rs
+++ b/rust/otap-dataflow/crates/engine/src/control.rs
@@ -150,6 +150,12 @@ pub struct Frame {
     /// Stamped only when the node has `CONSUMER_METRICS` interest. Saturates
     /// at `u32::MAX`.
     pub consumed_items: u32,
+    /// Logical payload size produced by the node at send time, in bytes.
+    /// Zero means the measurement was disabled, unavailable, or empty.
+    pub produced_size: u64,
+    /// Logical payload size consumed by the node at receive time, in bytes.
+    /// Zero means the measurement was disabled, unavailable, or empty.
+    pub consumed_size: u64,
 }
 
 /// The ACK message.

--- a/rust/otap-dataflow/crates/engine/src/lib.rs
+++ b/rust/otap-dataflow/crates/engine/src/lib.rs
@@ -370,6 +370,10 @@ pub struct Interests: u16 {
     /// level, or per node via `policies.telemetry.item_counts`.
     const PRODUCED_CONSUMED_ITEM_COUNTS = 1 << 8;
 
+    /// Per-signal produced/consumed logical payload size requested. Enabled at
+    /// the `Detailed` metric level, or per node via `policies.telemetry.size`.
+    const PRODUCED_CONSUMED_SIZE = 1 << 9;
+
     /// Pipeline-metrics is either CONSUMER_METRICS or PRODUCER_METRICS.
     const PIPELINE_METRICS = Self::CONSUMER_METRICS.bits() | Self::PRODUCER_METRICS.bits();
 }
@@ -383,6 +387,7 @@ impl Interests {
     /// Normal:   CONSUMER_METRICS | PRODUCER_METRICS | PROCESS_DURATION
     /// Detailed: CONSUMER_METRICS | PRODUCER_METRICS | PROCESS_DURATION
     ///           | ENTRY_TIMESTAMP | PRODUCED_CONSUMED_ITEM_COUNTS
+    ///           | PRODUCED_CONSUMED_SIZE
     #[must_use]
     pub fn from_metric_level(level: MetricLevel) -> Self {
         match level {
@@ -393,6 +398,7 @@ impl Interests {
                     | Self::PROCESS_DURATION
                     | Self::ENTRY_TIMESTAMP
                     | Self::PRODUCED_CONSUMED_ITEM_COUNTS
+                    | Self::PRODUCED_CONSUMED_SIZE
             }
         }
     }
@@ -2663,6 +2669,19 @@ mod test {
         PropagationAction, PropagationDefault, PropagationSelector, PropagationSelectorType,
     };
     use std::time::Duration;
+
+    /// Scenario: runtime metric levels resolve the optional payload measurements.
+    /// Guarantees: detailed metrics enable both item counts and size while normal metrics enable neither by default.
+    #[test]
+    fn detailed_runtime_metrics_enable_payload_measurements() {
+        let normal = Interests::from_metric_level(MetricLevel::Normal);
+        assert!(!normal.contains(Interests::PRODUCED_CONSUMED_ITEM_COUNTS));
+        assert!(!normal.contains(Interests::PRODUCED_CONSUMED_SIZE));
+
+        let detailed = Interests::from_metric_level(MetricLevel::Detailed);
+        assert!(detailed.contains(Interests::PRODUCED_CONSUMED_ITEM_COUNTS));
+        assert!(detailed.contains(Interests::PRODUCED_CONSUMED_SIZE));
+    }
 
     fn admission_policy(unit: RateLimitUnit) -> RateLimiterPolicy {
         RateLimiterPolicy {

--- a/rust/otap-dataflow/crates/engine/src/local/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/processor.rs
@@ -738,6 +738,8 @@ mod tests {
                     route: RouteData::default(),
                     produced_items: 0,
                     consumed_items: 0,
+                    produced_size: 0,
+                    consumed_size: 0,
                 }],
             }
         }
@@ -750,6 +752,8 @@ mod tests {
                     route: RouteData::default(),
                     produced_items: 0,
                     consumed_items: 0,
+                    produced_size: 0,
+                    consumed_size: 0,
                 }],
             }
         }

--- a/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
+++ b/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
@@ -10,7 +10,8 @@
 //! Note 2: Other runtime-control messages coordinate shutdown and completion flow.
 
 use crate::channel_metrics::{
-    ConsumedItemMetrics, ConsumedMetrics, ProducedItemMetrics, ProducedMetrics,
+    ConsumedItemMetrics, ConsumedMetrics, ConsumedSizeMetrics, ProducedItemMetrics,
+    ProducedMetrics, ProducedSizeMetrics,
 };
 use crate::clock;
 use crate::completion_emission_metrics::CompletionEmissionMetricsHandle;
@@ -167,10 +168,14 @@ pub(crate) struct NodeMetricHandles {
     pub(crate) input: Option<MeasurementMetricSet<ConsumedMetrics>>,
     /// Optional consumed-item metrics for the node's input channel.
     pub(crate) input_items: Option<MeasurementMetricSet<ConsumedItemMetrics>>,
+    /// Optional consumed-size metrics for the node's input channel.
+    pub(crate) input_size: Option<MeasurementMetricSet<ConsumedSizeMetrics>>,
     /// Produced-message metrics indexed by output port.
     pub(crate) outputs: Vec<MeasurementMetricSet<ProducedMetrics>>,
     /// Optional produced-item metrics indexed by output port.
     pub(crate) output_items: Vec<MeasurementMetricSet<ProducedItemMetrics>>,
+    /// Optional produced-size metrics indexed by output port.
+    pub(crate) output_size: Vec<MeasurementMetricSet<ProducedSizeMetrics>>,
     /// Completion-emission metrics for completions routed by the node.
     pub(crate) completion_emission: Option<CompletionEmissionMetricsHandle>,
 }
@@ -187,11 +192,17 @@ pub(crate) fn report_node_metrics_with_handles(
         if let Some(input_items) = &mut handles.input_items {
             metrics_reporter.report_measurement(input_items)?;
         }
+        if let Some(input_size) = &mut handles.input_size {
+            metrics_reporter.report_measurement(input_size)?;
+        }
         for output in &mut handles.outputs {
             metrics_reporter.report_measurement(output)?;
         }
         for output_items in &mut handles.output_items {
             metrics_reporter.report_measurement(output_items)?;
+        }
+        for output_size in &mut handles.output_size {
+            metrics_reporter.report_measurement(output_size)?;
         }
         if let Some(completion_emission) = &handles.completion_emission {
             let mut completion_emission = completion_emission
@@ -216,11 +227,17 @@ pub(crate) fn snapshot_node_metrics_with_handles(
         if let Some(input_items) = &mut handles.input_items {
             snapshots.extend(input_items.terminal_snapshots());
         }
+        if let Some(input_size) = &mut handles.input_size {
+            snapshots.extend(input_size.terminal_snapshots());
+        }
         for output in &mut handles.outputs {
             snapshots.extend(output.terminal_snapshots());
         }
         for output_items in &mut handles.output_items {
             snapshots.extend(output_items.terminal_snapshots());
+        }
+        for output_size in &mut handles.output_size {
+            snapshots.extend(output_size.terminal_snapshots());
         }
         if let Some(completion_emission) = &handles.completion_emission
             && let Some(snapshot) = completion_emission
@@ -244,6 +261,11 @@ impl Drop for NodeMetricHandles {
                 .registry
                 .unregister_metric_set(input_items.metric_set_key());
         }
+        if let Some(input_size) = self.input_size.take() {
+            let _ = self
+                .registry
+                .unregister_metric_set(input_size.metric_set_key());
+        }
         for output in self.outputs.drain(..) {
             let _ = self.registry.unregister_metric_set(output.metric_set_key());
         }
@@ -251,6 +273,11 @@ impl Drop for NodeMetricHandles {
             let _ = self
                 .registry
                 .unregister_metric_set(output_items.metric_set_key());
+        }
+        for output_size in self.output_size.drain(..) {
+            let _ = self
+                .registry
+                .unregister_metric_set(output_size.metric_set_key());
         }
     }
 }
@@ -1022,6 +1049,8 @@ impl<PData> PipelineCompletionMsgDispatcher<PData> {
         signal: Option<SignalType>,
         produced_items: u32,
         consumed_items: u32,
+        produced_size: u64,
+        consumed_size: u64,
         outcome: RequestOutcome,
         now_ns: u64,
     ) {
@@ -1044,6 +1073,14 @@ impl<PData> PipelineCompletionMsgDispatcher<PData> {
                                 .with(SignalOutcomeAttributes { signal, outcome })
                                 .consumed_items
                                 .add(consumed_items as u64);
+                        }
+                        if consumed_size > 0
+                            && let Some(input_size) = &mut handles.input_size
+                        {
+                            input_size
+                                .with(SignalOutcomeAttributes { signal, outcome })
+                                .consumed_size
+                                .add(consumed_size);
                         }
                         if route.entry_time_ns > 0 && now_ns > 0 {
                             let duration_ns = now_ns.saturating_sub(route.entry_time_ns);
@@ -1070,6 +1107,14 @@ impl<PData> PipelineCompletionMsgDispatcher<PData> {
                                 .with(SignalOutcomeAttributes { signal, outcome })
                                 .produced_items
                                 .add(produced_items as u64);
+                        }
+                        if produced_size > 0
+                            && let Some(output_size) = handles.output_size.get_mut(port)
+                        {
+                            output_size
+                                .with(SignalOutcomeAttributes { signal, outcome })
+                                .produced_size
+                                .add(produced_size);
                         }
                         if !interests.contains(Interests::CONSUMER_METRICS)
                             && route.entry_time_ns > 0
@@ -1200,6 +1245,8 @@ impl<PData: Unwindable> PipelineCompletionMsgDispatcher<PData> {
                             signal,
                             frame.produced_items,
                             frame.consumed_items,
+                            frame.produced_size,
+                            frame.consumed_size,
                             outcome,
                             now_ns,
                         );
@@ -2800,12 +2847,16 @@ mod tests {
     enum MetricLabel {
         RecvProduced,
         RecvProducedItems,
+        RecvProducedSize,
         ProcConsumed,
         ProcConsumedItems,
+        ProcConsumedSize,
         ProcProduced,
         ProcProducedItems,
+        ProcProducedSize,
         ExpConsumed,
         ExpConsumedItems,
+        ExpConsumedSize,
     }
 
     /// Return value from setup_test_manager_with_metrics.
@@ -2902,17 +2953,25 @@ mod tests {
             registry.register_metric_set_with_measurement_attributes_for_entity(recv_out_key);
         let recv_produced_items: MeasurementMetricSet<ProducedItemMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(recv_out_key);
+        let recv_produced_size: MeasurementMetricSet<ProducedSizeMetrics> =
+            registry.register_metric_set_with_measurement_attributes_for_entity(recv_out_key);
         let proc_consumed: MeasurementMetricSet<ConsumedMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(proc_in_key);
         let proc_consumed_items: MeasurementMetricSet<ConsumedItemMetrics> =
+            registry.register_metric_set_with_measurement_attributes_for_entity(proc_in_key);
+        let proc_consumed_size: MeasurementMetricSet<ConsumedSizeMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(proc_in_key);
         let proc_produced: MeasurementMetricSet<ProducedMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(proc_out_key);
         let proc_produced_items: MeasurementMetricSet<ProducedItemMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(proc_out_key);
+        let proc_produced_size: MeasurementMetricSet<ProducedSizeMetrics> =
+            registry.register_metric_set_with_measurement_attributes_for_entity(proc_out_key);
         let exp_consumed: MeasurementMetricSet<ConsumedMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(exp_in_key);
         let exp_consumed_items: MeasurementMetricSet<ConsumedItemMetrics> =
+            registry.register_metric_set_with_measurement_attributes_for_entity(exp_in_key);
+        let exp_consumed_size: MeasurementMetricSet<ConsumedSizeMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(exp_in_key);
 
         // Save metric set keys for snapshot identification.
@@ -2922,20 +2981,36 @@ mod tests {
             recv_produced_items.metric_set_key(),
             MetricLabel::RecvProducedItems,
         );
+        let _ = key_labels.insert(
+            recv_produced_size.metric_set_key(),
+            MetricLabel::RecvProducedSize,
+        );
         let _ = key_labels.insert(proc_consumed.metric_set_key(), MetricLabel::ProcConsumed);
         let _ = key_labels.insert(
             proc_consumed_items.metric_set_key(),
             MetricLabel::ProcConsumedItems,
+        );
+        let _ = key_labels.insert(
+            proc_consumed_size.metric_set_key(),
+            MetricLabel::ProcConsumedSize,
         );
         let _ = key_labels.insert(proc_produced.metric_set_key(), MetricLabel::ProcProduced);
         let _ = key_labels.insert(
             proc_produced_items.metric_set_key(),
             MetricLabel::ProcProducedItems,
         );
+        let _ = key_labels.insert(
+            proc_produced_size.metric_set_key(),
+            MetricLabel::ProcProducedSize,
+        );
         let _ = key_labels.insert(exp_consumed.metric_set_key(), MetricLabel::ExpConsumed);
         let _ = key_labels.insert(
             exp_consumed_items.metric_set_key(),
             MetricLabel::ExpConsumedItems,
+        );
+        let _ = key_labels.insert(
+            exp_consumed_size.metric_set_key(),
+            MetricLabel::ExpConsumedSize,
         );
 
         let mut node_metric_handles: Vec<Option<NodeMetricHandles>> = Vec::new();
@@ -2947,24 +3022,30 @@ mod tests {
             registry: registry.clone(),
             input: None,
             input_items: None,
+            input_size: None,
             outputs: vec![recv_produced],
             output_items: vec![recv_produced_items],
+            output_size: vec![recv_produced_size],
             completion_emission: None,
         });
         node_metric_handles[nodes[1].index] = Some(NodeMetricHandles {
             registry: registry.clone(),
             input: Some(proc_consumed),
             input_items: Some(proc_consumed_items),
+            input_size: Some(proc_consumed_size),
             outputs: vec![proc_produced],
             output_items: vec![proc_produced_items],
+            output_size: vec![proc_produced_size],
             completion_emission: None,
         });
         node_metric_handles[nodes[2].index] = Some(NodeMetricHandles {
             registry: registry.clone(),
             input: Some(exp_consumed),
             input_items: Some(exp_consumed_items),
+            input_size: Some(exp_consumed_size),
             outputs: Vec::new(),
             output_items: Vec::new(),
+            output_size: Vec::new(),
             completion_emission: None,
         });
 
@@ -3073,6 +3154,8 @@ mod tests {
     const PRODUCER_REQUESTS: usize = 1;
     // Item metric set field index:
     const ITEMS: usize = 0;
+    // Size metric set field index:
+    const SIZE: usize = 0;
 
     const RUNTIME_DRAIN_ACTIVE: usize = 0;
     const RUNTIME_DRAIN_PENDING_RECEIVERS: usize = 1;
@@ -3467,6 +3550,8 @@ mod tests {
             },
             produced_items: 10,
             consumed_items: 0,
+            produced_size: 100,
+            consumed_size: 0,
         });
 
         // Node 1 (processor): consumer + producer metrics + acks/nacks
@@ -3489,6 +3574,8 @@ mod tests {
             },
             produced_items: 7,
             consumed_items: 10,
+            produced_size: 70,
+            consumed_size: 100,
         });
 
         // Node 2 (exporter): consumer metrics only (no acks subscription -- terminal node)
@@ -3507,6 +3594,8 @@ mod tests {
             },
             produced_items: 0,
             consumed_items: 7,
+            produced_size: 0,
+            consumed_size: 70,
         });
 
         pdata
@@ -3536,6 +3625,8 @@ mod tests {
             },
             produced_items: 10,
             consumed_items: 0,
+            produced_size: 100,
+            consumed_size: 0,
         });
 
         // Node 1 (processor): consumer + producer metrics, no ACKS/NACKS.
@@ -3556,6 +3647,8 @@ mod tests {
             },
             produced_items: 7,
             consumed_items: 10,
+            produced_size: 70,
+            consumed_size: 100,
         });
 
         // Node 2 (exporter): consumer metrics only.
@@ -3574,6 +3667,8 @@ mod tests {
             },
             produced_items: 0,
             consumed_items: 7,
+            produced_size: 0,
+            consumed_size: 70,
         });
 
         pdata
@@ -3838,6 +3933,31 @@ mod tests {
         assert_u64(exp, ITEMS, 7, "Exporter consumed logs");
     }
 
+    /// Scenario: a logs batch flows through receiver, processor, and exporter nodes.
+    /// Guarantees: each node reports its produced or consumed logical payload size in the `signal=logs` bucket.
+    #[tokio::test]
+    async fn test_per_signal_payload_size() {
+        let harness = setup_test_manager_with_metrics();
+        let snapshots = run_and_collect(harness, |nodes| {
+            let pdata = build_3node_pdata_no_subscribers(nodes, false);
+            vec![PipelineCompletionMsg::DeliverAck {
+                ack: AckMsg::new(pdata),
+            }]
+        })
+        .await;
+
+        let recv_p = &snapshots[&MetricLabel::RecvProducedSize];
+        assert_u64(recv_p, SIZE, 100, "Receiver produced size");
+
+        let proc_c = &snapshots[&MetricLabel::ProcConsumedSize];
+        assert_u64(proc_c, SIZE, 100, "Processor consumed size");
+        let proc_p = &snapshots[&MetricLabel::ProcProducedSize];
+        assert_u64(proc_p, SIZE, 70, "Processor produced size");
+
+        let exp = &snapshots[&MetricLabel::ExpConsumedSize];
+        assert_u64(exp, SIZE, 70, "Exporter consumed size");
+    }
+
     /// Scenario: request metrics are enabled while per-signal item counting is not.
     /// Guarantees: request series are emitted but no zero-valued item series are reported.
     #[tokio::test]
@@ -3874,6 +3994,42 @@ mod tests {
         );
     }
 
+    /// Scenario: request metrics are enabled while logical payload sizing is not.
+    /// Guarantees: request series are emitted but no zero-valued size series are reported.
+    #[tokio::test]
+    async fn node_metrics_omit_size_without_optin() {
+        let harness = setup_test_manager_with_metrics();
+        for handles in harness
+            .node_metric_handles
+            .borrow_mut()
+            .iter_mut()
+            .flatten()
+        {
+            let _ = handles.input_size.take();
+            handles.output_size.clear();
+        }
+
+        let snapshots = run_and_collect(harness, |nodes| {
+            let pdata = build_3node_pdata_no_subscribers(nodes, false);
+            vec![PipelineCompletionMsg::DeliverAck {
+                ack: AckMsg::new(pdata),
+            }]
+        })
+        .await;
+
+        assert!(
+            snapshots.contains_key(&MetricLabel::RecvProduced),
+            "Request metrics should remain enabled"
+        );
+        assert!(
+            !snapshots.contains_key(&MetricLabel::RecvProducedSize)
+                && !snapshots.contains_key(&MetricLabel::ProcConsumedSize)
+                && !snapshots.contains_key(&MetricLabel::ProcProducedSize)
+                && !snapshots.contains_key(&MetricLabel::ExpConsumedSize),
+            "Size metrics should be absent when payload sizing is disabled"
+        );
+    }
+
     /// Scenario: one processor records successful logs and failed traces.
     /// Guarantees: produced and consumed request and item snapshots retain distinct `signal` and `outcome` datapoint attributes.
     #[test]
@@ -3901,6 +4057,8 @@ mod tests {
             Some(SignalType::Logs),
             4,
             5,
+            0,
+            0,
             RequestOutcome::Success,
             0,
         );
@@ -3911,6 +4069,8 @@ mod tests {
             Some(SignalType::Traces),
             6,
             7,
+            0,
+            0,
             RequestOutcome::Failure,
             0,
         );
@@ -4204,6 +4364,8 @@ mod tests {
                 },
                 produced_items: 0,
                 consumed_items: 0,
+                produced_size: 0,
+                consumed_size: 0,
             });
             let mut ack2 = AckMsg::new(pdata_recv_only);
             ack2.unwind.return_time_ns = nanos_since_birth();
@@ -5864,6 +6026,8 @@ mod tests {
                 },
                 produced_items: 0,
                 consumed_items: 0,
+                produced_size: 0,
+                consumed_size: 0,
             });
             pdata
         }
@@ -5996,6 +6160,8 @@ mod tests {
                 },
                 produced_items: 0,
                 consumed_items: 0,
+                produced_size: 0,
+                consumed_size: 0,
             });
             pdata
         }
@@ -6133,6 +6299,8 @@ mod tests {
                 },
                 produced_items: 0,
                 consumed_items: 0,
+                produced_size: 0,
+                consumed_size: 0,
             });
             pdata
         }

--- a/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
+++ b/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
@@ -126,18 +126,23 @@ fn make_produced_size_metrics(
 ///
 /// - `has_input`: whether to register consumed-request metrics (false for receivers).
 /// - `has_outputs`: whether to register produced-request metrics (false for exporters).
-/// - `item_counts_enabled`: whether to register the optional item metric sets.
-/// - `size_enabled`: whether to register the optional size metric sets.
+/// - `node_interests`: the effective metric interests for this node.
 fn make_node_metric_handles(
     telemetry_handle: &Option<NodeTelemetryHandle>,
     pipeline_context: &PipelineContext,
     has_input: bool,
     has_outputs: bool,
-    item_counts_enabled: bool,
-    size_enabled: bool,
+    node_interests: Interests,
     completion_emission: Option<CompletionEmissionMetricsHandle>,
 ) -> NodeMetricHandles {
-    let consumed = if has_input {
+    let consumer_metrics_enabled =
+        has_input && node_interests.contains(Interests::CONSUMER_METRICS);
+    let producer_metrics_enabled =
+        has_outputs && node_interests.contains(Interests::PRODUCER_METRICS);
+    let item_counts_enabled = node_interests.contains(Interests::PRODUCED_CONSUMED_ITEM_COUNTS);
+    let size_enabled = node_interests.contains(Interests::PRODUCED_CONSUMED_SIZE);
+
+    let consumed = if consumer_metrics_enabled {
         telemetry_handle
             .as_ref()
             .and_then(|h| h.input_channel_key())
@@ -147,7 +152,7 @@ fn make_node_metric_handles(
     } else {
         None
     };
-    let consumed_size = if size_enabled && has_input {
+    let consumed_size = if size_enabled && consumer_metrics_enabled {
         telemetry_handle
             .as_ref()
             .and_then(|h| h.input_channel_key())
@@ -159,7 +164,7 @@ fn make_node_metric_handles(
     } else {
         None
     };
-    let consumed_items = if item_counts_enabled && has_input {
+    let consumed_items = if item_counts_enabled && consumer_metrics_enabled {
         telemetry_handle
             .as_ref()
             .and_then(|h| h.input_channel_key())
@@ -171,17 +176,17 @@ fn make_node_metric_handles(
     } else {
         None
     };
-    let produced = if has_outputs {
+    let produced = if producer_metrics_enabled {
         make_produced_metrics(telemetry_handle, pipeline_context)
     } else {
         Vec::new()
     };
-    let produced_items = if item_counts_enabled && has_outputs {
+    let produced_items = if item_counts_enabled && producer_metrics_enabled {
         make_produced_item_metrics(telemetry_handle, pipeline_context)
     } else {
         Vec::new()
     };
-    let produced_size = if size_enabled && has_outputs {
+    let produced_size = if size_enabled && producer_metrics_enabled {
         make_produced_size_metrics(telemetry_handle, pipeline_context)
     } else {
         Vec::new()
@@ -598,8 +603,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
                     &pipeline_context,
                     true,
                     false,
-                    node_interests.contains(Interests::PRODUCED_CONSUMED_ITEM_COUNTS),
-                    node_interests.contains(Interests::PRODUCED_CONSUMED_SIZE),
+                    node_interests,
                     completion_emission_metrics.clone(),
                 ),
             ));
@@ -681,8 +685,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
                     &pipeline_context,
                     true,
                     true,
-                    node_interests.contains(Interests::PRODUCED_CONSUMED_ITEM_COUNTS),
-                    node_interests.contains(Interests::PRODUCED_CONSUMED_SIZE),
+                    node_interests,
                     completion_emission_metrics.clone(),
                 ),
             ));
@@ -795,8 +798,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
                     &pipeline_context,
                     false,
                     true,
-                    node_interests.contains(Interests::PRODUCED_CONSUMED_ITEM_COUNTS),
-                    node_interests.contains(Interests::PRODUCED_CONSUMED_SIZE),
+                    node_interests,
                     None,
                 ),
             ));
@@ -1140,7 +1142,9 @@ impl<PData: 'static + Debug + Clone> RuntimePipeline<PData> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::attributes::EngineEntityAttributeSet;
+    use crate::attributes::{
+        ChannelImplementation, ChannelKind, ChannelMode, ChannelType, EngineEntityAttributeSet,
+    };
     use crate::channel_metrics::ChannelSenderMetrics;
     use crate::entity_context::{NodeTelemetryGuard, NodeTelemetryHandle};
     use otel_arrow_dfe_config::SignalType;
@@ -1149,6 +1153,51 @@ mod tests {
     use otel_arrow_dfe_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
     use otel_arrow_dfe_telemetry::registry::TelemetryRegistryHandle;
     use otel_arrow_dfe_telemetry::{InternalTelemetrySystem, LogContext};
+
+    /// Scenario: optional node measurement interests are present without the normal-level message interests.
+    /// Guarantees: no consumed or produced message, item, or size metric sets are registered below normal.
+    #[test]
+    fn node_metrics_require_direction_interests() {
+        let (pipeline_context, registry) = crate::testing::test_pipeline_ctx();
+        let node_entity_key = pipeline_context.register_node_entity();
+        let telemetry_handle = NodeTelemetryHandle::new(registry.clone(), node_entity_key);
+
+        let input_key = pipeline_context.register_node_channel_entity(
+            "input-channel".into(),
+            "input".into(),
+            ChannelKind::Pdata,
+            ChannelMode::Local,
+            ChannelType::Mpsc,
+            ChannelImplementation::Internal,
+        );
+        telemetry_handle.set_input_channel_key(input_key);
+        let output_key = pipeline_context.register_node_channel_entity(
+            "output-channel".into(),
+            "default".into(),
+            ChannelKind::Pdata,
+            ChannelMode::Local,
+            ChannelType::Mpsc,
+            ChannelImplementation::Internal,
+        );
+        telemetry_handle.add_output_channel_key("default".into(), output_key);
+
+        let handles = make_node_metric_handles(
+            &Some(telemetry_handle),
+            &pipeline_context,
+            true,
+            true,
+            Interests::PRODUCED_CONSUMED_ITEM_COUNTS | Interests::PRODUCED_CONSUMED_SIZE,
+            None,
+        );
+
+        assert!(handles.input.is_none());
+        assert!(handles.input_items.is_none());
+        assert!(handles.input_size.is_none());
+        assert!(handles.outputs.is_empty());
+        assert!(handles.output_items.is_empty());
+        assert!(handles.output_size.is_empty());
+        assert_eq!(registry.metric_set_count(), 0);
+    }
 
     /// Scenario: a pipeline has pending terminal metrics when telemetry cleanup starts.
     /// Guarantees: the final snapshot reaches the registry before entity handles are released.

--- a/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
+++ b/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
@@ -7,8 +7,8 @@ use crate::Interests;
 use crate::ReceivedAtNode;
 use crate::Unwindable;
 use crate::channel_metrics::{
-    ChannelMetricsHandle, ConsumedItemMetrics, ConsumedMetrics, ProducedItemMetrics,
-    ProducedMetrics,
+    ChannelMetricsHandle, ConsumedItemMetrics, ConsumedMetrics, ConsumedSizeMetrics,
+    ProducedItemMetrics, ProducedMetrics, ProducedSizeMetrics,
 };
 use crate::completion_emission_metrics::{
     CompletionEmissionMetricsHandle, make_completion_emission_metrics,
@@ -101,17 +101,40 @@ fn make_produced_item_metrics(
         .unwrap_or_default()
 }
 
+/// Build optional produced-size metric sets indexed by sorted output port name.
+fn make_produced_size_metrics(
+    telemetry_handle: &Option<NodeTelemetryHandle>,
+    pipeline_context: &PipelineContext,
+) -> Vec<MeasurementMetricSet<ProducedSizeMetrics>> {
+    telemetry_handle
+        .as_ref()
+        .map(|h| {
+            let mut keys = h.output_channel_keys();
+            keys.sort_by(|a, b| a.0.cmp(&b.0));
+            keys.iter()
+                .map(|(_, key)| {
+                    ProducedSizeMetrics::register(
+                        &pipeline_context.metric_set_registrar_for_entity(*key),
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Build per-node metric handles for the runtime control manager.
 ///
 /// - `has_input`: whether to register consumed-request metrics (false for receivers).
 /// - `has_outputs`: whether to register produced-request metrics (false for exporters).
 /// - `item_counts_enabled`: whether to register the optional item metric sets.
+/// - `size_enabled`: whether to register the optional size metric sets.
 fn make_node_metric_handles(
     telemetry_handle: &Option<NodeTelemetryHandle>,
     pipeline_context: &PipelineContext,
     has_input: bool,
     has_outputs: bool,
     item_counts_enabled: bool,
+    size_enabled: bool,
     completion_emission: Option<CompletionEmissionMetricsHandle>,
 ) -> NodeMetricHandles {
     let consumed = if has_input {
@@ -120,6 +143,18 @@ fn make_node_metric_handles(
             .and_then(|h| h.input_channel_key())
             .map(|key| {
                 ConsumedMetrics::register(&pipeline_context.metric_set_registrar_for_entity(key))
+            })
+    } else {
+        None
+    };
+    let consumed_size = if size_enabled && has_input {
+        telemetry_handle
+            .as_ref()
+            .and_then(|h| h.input_channel_key())
+            .map(|key| {
+                ConsumedSizeMetrics::register(
+                    &pipeline_context.metric_set_registrar_for_entity(key),
+                )
             })
     } else {
         None
@@ -146,12 +181,19 @@ fn make_node_metric_handles(
     } else {
         Vec::new()
     };
+    let produced_size = if size_enabled && has_outputs {
+        make_produced_size_metrics(telemetry_handle, pipeline_context)
+    } else {
+        Vec::new()
+    };
     NodeMetricHandles {
         registry: pipeline_context.metrics_registry(),
         input: consumed,
         input_items: consumed_items,
+        input_size: consumed_size,
         outputs: produced,
         output_items: produced_items,
+        output_size: produced_size,
         completion_emission,
     }
 }
@@ -393,8 +435,8 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
 
         let metric_level = telemetry_policy.runtime_metrics;
         let base_node_interests = Interests::from_metric_level(metric_level);
-        // Nodes opting in via `node.policies.telemetry.item_counts`
-        // get the counts without requiring the `detailed` metric level.
+        // Per-node measurement opt-ins enable the corresponding detailed-level
+        // measurement without enabling every detailed runtime metric.
         let item_count_optin: HashSet<&str> = pipeline_config
             .node_iter()
             .filter(|(_, cfg)| {
@@ -402,6 +444,16 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
                     .as_ref()
                     .and_then(|policies| policies.telemetry.as_ref())
                     .is_some_and(|telemetry| telemetry.item_counts)
+            })
+            .map(|(node_id, _)| node_id.as_ref())
+            .collect();
+        let size_optin: HashSet<&str> = pipeline_config
+            .node_iter()
+            .filter(|(_, cfg)| {
+                cfg.policies
+                    .as_ref()
+                    .and_then(|policies| policies.telemetry.as_ref())
+                    .is_some_and(|telemetry| telemetry.size)
             })
             .map(|(node_id, _)| node_id.as_ref())
             .collect();
@@ -520,11 +572,13 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
         for exporter in exporters {
             let mut exporter = exporter;
             let node_id = exporter.node_id();
-            let node_interests = if item_count_optin.contains(node_id.name.as_ref()) {
-                base_node_interests | Interests::PRODUCED_CONSUMED_ITEM_COUNTS
-            } else {
-                base_node_interests
-            };
+            let mut node_interests = base_node_interests;
+            if item_count_optin.contains(node_id.name.as_ref()) {
+                node_interests |= Interests::PRODUCED_CONSUMED_ITEM_COUNTS;
+            }
+            if size_optin.contains(node_id.name.as_ref()) {
+                node_interests |= Interests::PRODUCED_CONSUMED_SIZE;
+            }
             control_senders.register(
                 node_id.clone(),
                 NodeType::Exporter,
@@ -545,6 +599,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
                     true,
                     false,
                     node_interests.contains(Interests::PRODUCED_CONSUMED_ITEM_COUNTS),
+                    node_interests.contains(Interests::PRODUCED_CONSUMED_SIZE),
                     completion_emission_metrics.clone(),
                 ),
             ));
@@ -600,11 +655,13 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
         for processor in processors {
             let mut processor = processor;
             let node_id = processor.node_id();
-            let node_interests = if item_count_optin.contains(node_id.name.as_ref()) {
-                base_node_interests | Interests::PRODUCED_CONSUMED_ITEM_COUNTS
-            } else {
-                base_node_interests
-            };
+            let mut node_interests = base_node_interests;
+            if item_count_optin.contains(node_id.name.as_ref()) {
+                node_interests |= Interests::PRODUCED_CONSUMED_ITEM_COUNTS;
+            }
+            if size_optin.contains(node_id.name.as_ref()) {
+                node_interests |= Interests::PRODUCED_CONSUMED_SIZE;
+            }
             control_senders.register(
                 node_id.clone(),
                 NodeType::Processor,
@@ -625,6 +682,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
                     true,
                     true,
                     node_interests.contains(Interests::PRODUCED_CONSUMED_ITEM_COUNTS),
+                    node_interests.contains(Interests::PRODUCED_CONSUMED_SIZE),
                     completion_emission_metrics.clone(),
                 ),
             ));
@@ -713,11 +771,13 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
         for receiver in receivers {
             let mut receiver = receiver;
             let node_id = receiver.node_id();
-            let node_interests = if item_count_optin.contains(node_id.name.as_ref()) {
-                base_node_interests | Interests::PRODUCED_CONSUMED_ITEM_COUNTS
-            } else {
-                base_node_interests
-            };
+            let mut node_interests = base_node_interests;
+            if item_count_optin.contains(node_id.name.as_ref()) {
+                node_interests |= Interests::PRODUCED_CONSUMED_ITEM_COUNTS;
+            }
+            if size_optin.contains(node_id.name.as_ref()) {
+                node_interests |= Interests::PRODUCED_CONSUMED_SIZE;
+            }
             control_senders.register(
                 node_id.clone(),
                 NodeType::Receiver,
@@ -736,6 +796,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
                     false,
                     true,
                     node_interests.contains(Interests::PRODUCED_CONSUMED_ITEM_COUNTS),
+                    node_interests.contains(Interests::PRODUCED_CONSUMED_SIZE),
                     None,
                 ),
             ));

--- a/rust/otap-dataflow/crates/engine/src/testing/dst/common.rs
+++ b/rust/otap-dataflow/crates/engine/src/testing/dst/common.rs
@@ -88,6 +88,8 @@ pub(super) fn frame(node_id: usize, interests: Interests, tag: u64) -> Frame {
         },
         produced_items: 0,
         consumed_items: 0,
+        produced_size: 0,
+        consumed_size: 0,
     }
 }
 

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -123,6 +123,8 @@ impl Context {
             },
             produced_items: 0,
             consumed_items: 0,
+            produced_size: 0,
+            consumed_size: 0,
         });
     }
 
@@ -232,6 +234,8 @@ impl Context {
             route: RouteData::default(),
             produced_items: 0,
             consumed_items: 0,
+            produced_size: 0,
+            consumed_size: 0,
         });
     }
 
@@ -287,6 +291,8 @@ impl Context {
             },
             produced_items: 0,
             consumed_items: 0,
+            produced_size: 0,
+            consumed_size: 0,
         });
     }
 
@@ -316,6 +322,22 @@ impl Context {
         self.capture_signal(signal);
         if let Some(top) = self.stack.last_mut() {
             top.consumed_items = items;
+        }
+    }
+
+    /// Record the logical payload size produced by the current node at send
+    /// time onto the top frame.
+    pub(crate) fn stamp_produced_size(&mut self, size: u64) {
+        if let Some(top) = self.stack.last_mut() {
+            top.produced_size = size;
+        }
+    }
+
+    /// Record the logical payload size consumed by the current node at receive
+    /// time onto the top frame.
+    pub(crate) fn stamp_consumed_size(&mut self, size: u64) {
+        if let Some(top) = self.stack.last_mut() {
+            top.consumed_size = size;
         }
     }
 
@@ -361,6 +383,8 @@ impl Context {
             },
             produced_items: 0,
             consumed_items: 0,
+            produced_size: 0,
+            consumed_size: 0,
         });
     }
 
@@ -778,6 +802,13 @@ impl OtapPdata {
                 let signal = self.signal_type();
                 self.context.stamp_produced_items(items, signal);
             }
+            if node_interests.contains(Interests::PRODUCED_CONSUMED_SIZE)
+                && node_interests.contains(Interests::PRODUCER_METRICS)
+                && let Some(size) = self.num_bytes()
+            {
+                self.context
+                    .stamp_produced_size(u64::try_from(size).unwrap_or(u64::MAX));
+            }
         }
     }
 
@@ -1068,6 +1099,13 @@ impl otel_arrow_dfe_engine::ReceivedAtNode for OtapPdata {
             let items = u32::try_from(self.num_items()).unwrap_or(u32::MAX);
             let signal = self.signal_type();
             self.context.stamp_consumed_items(items, signal);
+        }
+        if node_interests.contains(Interests::PRODUCED_CONSUMED_SIZE)
+            && node_interests.contains(Interests::CONSUMER_METRICS)
+            && let Some(size) = self.num_bytes()
+        {
+            self.context
+                .stamp_consumed_size(u64::try_from(size).unwrap_or(u64::MAX));
         }
     }
 }
@@ -1820,6 +1858,37 @@ mod test {
         assert_eq!(pdata4.context.signal(), None);
     }
 
+    /// Scenario: a node opts into consumed payload size at the normal runtime metric level.
+    /// Guarantees: the receive frame captures size only when both consumer metrics and size measurement are enabled.
+    #[test]
+    fn test_received_at_node_stamps_consumed_size() {
+        use otap_df_engine::ReceivedAtNode;
+
+        let mut pdata = create_test_pdata();
+        let size =
+            u64::try_from(pdata.num_bytes().expect("test payload size")).expect("size fits u64");
+        assert!(size > 0);
+        pdata.received_at_node(
+            42,
+            Interests::CONSUMER_METRICS | Interests::PRODUCED_CONSUMED_SIZE,
+        );
+        let frame = pdata.context.frames().last().expect("consumer frame");
+        assert_eq!(frame.consumed_size, size);
+
+        let mut pdata_no_optin = create_test_pdata();
+        pdata_no_optin.received_at_node(43, Interests::CONSUMER_METRICS);
+        let frame_no_optin = pdata_no_optin
+            .context
+            .frames()
+            .last()
+            .expect("consumer frame");
+        assert_eq!(frame_no_optin.consumed_size, 0);
+
+        let mut pdata_without_metrics = create_test_pdata();
+        pdata_without_metrics.received_at_node(44, Interests::PRODUCED_CONSUMED_SIZE);
+        assert!(pdata_without_metrics.context.frames().is_empty());
+    }
+
     /// Scenario: a source records normal-level produced messages without item-count opt-in.
     /// Guarantees: the real pdata retains its signal for message metric attribution without parsing item counts.
     #[test]
@@ -1867,6 +1936,43 @@ mod test {
         let frame3 = pdata3.context.frames().last().expect("source frame");
         assert_eq!(frame3.produced_items, 0);
         assert_eq!(pdata3.context.signal(), None);
+    }
+
+    /// Scenario: a source opts into produced payload size at the normal runtime metric level.
+    /// Guarantees: the source frame captures size only when both producer metrics and size measurement are enabled.
+    #[test]
+    fn test_prepare_source_send_stamps_produced_size() {
+        let mut pdata = create_test_pdata();
+        let size =
+            u64::try_from(pdata.num_bytes().expect("test payload size")).expect("size fits u64");
+        assert!(size > 0);
+        pdata.prepare_source_send(
+            Interests::PRODUCER_METRICS | Interests::PRODUCED_CONSUMED_SIZE,
+            5,
+        );
+        let frame = pdata.context.frames().last().expect("source frame");
+        assert_eq!(frame.produced_size, size);
+
+        let mut pdata_no_optin = create_test_pdata();
+        pdata_no_optin.prepare_source_send(Interests::PRODUCER_METRICS, 6);
+        let frame_no_optin = pdata_no_optin
+            .context
+            .frames()
+            .last()
+            .expect("source frame");
+        assert_eq!(frame_no_optin.produced_size, 0);
+
+        let mut pdata_without_metrics = create_test_pdata();
+        pdata_without_metrics.prepare_source_send(
+            Interests::SOURCE_TAGGING | Interests::PRODUCED_CONSUMED_SIZE,
+            7,
+        );
+        let frame_without_metrics = pdata_without_metrics
+            .context
+            .frames()
+            .last()
+            .expect("source tagging frame");
+        assert_eq!(frame_without_metrics.produced_size, 0);
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -1862,7 +1862,7 @@ mod test {
     /// Guarantees: the receive frame captures size only when both consumer metrics and size measurement are enabled.
     #[test]
     fn test_received_at_node_stamps_consumed_size() {
-        use otap_df_engine::ReceivedAtNode;
+        use otel_arrow_dfe_engine::ReceivedAtNode;
 
         let mut pdata = create_test_pdata();
         let size =

--- a/rust/otap-dataflow/crates/pdata/src/otap/memory.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/memory.rs
@@ -24,11 +24,13 @@
 //! IPC-decoded OTAP batches are Rust-allocated today, but future zero-copy or
 //! mmap ingest would be under-counted by retained-memory accounting.
 //!
-//! This module does not cache sizes inside pdata. `OtapArrowRecords` and its
-//! stores are cloneable and mutable through `set()` and `remove()`, so an
-//! internal cache would be easy to stale. Consumers that need charge/refund
-//! symmetry should compute once when retention starts and store the value with
-//! their retained state or ticket.
+//! `OtapArrowRecords` does not cache these sizes. Its stores are cloneable and
+//! mutable through `set()` and `remove()`, so a cache owned by the records could
+//! become stale. [`crate::OtapPayload`] safely caches logical size at the wrapper
+//! level because accessing records for mutation consumes the wrapper; wrapping
+//! the resulting records again starts with a fresh cache. Consumers retaining
+//! bare records should compute once when retention starts and store the value
+//! with their retained state or ticket.
 //!
 //! Sizing performance is proportional to the number of arrays and buffers, not
 //! to the number of rows or byte values. Each column calls `to_data()`, which

--- a/rust/otap-dataflow/crates/pdata/src/payload.rs
+++ b/rust/otap-dataflow/crates/pdata/src/payload.rs
@@ -182,8 +182,10 @@ impl PayloadData {
 /// - [`Self::take_payload`]'s returned value preserves the cache of the
 ///   payload version it contains.
 ///
-/// This makes it impossible for a processor to observe stale measurements
-/// without any manual invalidation step.
+/// [`Self::data`] exposes only a shared reference. Accessing the underlying
+/// representation for mutation requires consuming the wrapper through
+/// [`Self::into_data`] or [`Self::into_otap`], and wrapping the mutated
+/// representation creates a fresh cache. No manual invalidation is required.
 #[derive(Clone, Debug)]
 pub struct OtapPayload {
     data: PayloadData,

--- a/rust/otap-dataflow/docs/node-and-flow-metrics.md
+++ b/rust/otap-dataflow/docs/node-and-flow-metrics.md
@@ -11,10 +11,11 @@ receiver --> processor A --> processor B --> exporter
                 `-- flow metrics (processors only)
 ```
 
-Use **node metrics** to see the signal items a specific receiver, processor, or
-exporter consumes and produces. Use **flow metrics** to measure a selected,
-contiguous processor range as one operation: how many items entered and left,
-how long processing took, and which decision nodes removed items.
+Use **node metrics** to see the messages, signal items, and logical payload size
+a specific receiver, processor, or exporter consumes and produces. Use **flow
+metrics** to measure a selected, contiguous processor range as one operation:
+how many items entered and left, how long processing took, and which decision
+nodes removed items.
 
 Both metric layers are emitted through the engine's internal observability
 pipeline. Configure an `engine.observability.pipeline` to export them, or use
@@ -37,12 +38,13 @@ With `policies.telemetry.runtime_metrics: normal` or `detailed`, every node
 emits message outcome counters on its existing `node.consumer` and
 `node.producer` metric sets:
 
-### Messages and Items
+### Messages, Items, and Size
 
 A message is the PData batch that moves between nodes. An item is an individual
 log record, metric data point, or span in that batch. One message can contain
 multiple items, so message counts measure batch traffic while item counts
-measure the volume of telemetry data inside those batches.
+measure the number of telemetry records inside those batches. Size measures the
+logical byte size of the current payload representation.
 
 | Metric | Meaning | Emitted by | Availability |
 | --- | --- | --- | --- |
@@ -50,25 +52,27 @@ measure the volume of telemetry data inside those batches.
 | `produced.messages` | Messages emitted by a node | `node.producer` | `normal` or `detailed` |
 | `consumed.items` | Items a node receives | `node.consumer` | `detailed`, or `normal` plus item-count opt-in |
 | `produced.items` | Items a node emits | `node.producer` | `detailed`, or `normal` plus item-count opt-in |
+| `consumed.size` | Logical payload bytes a node receives | `node.consumer` | `detailed`, or `normal` plus size opt-in |
+| `produced.size` | Logical payload bytes a node emits | `node.producer` | `detailed`, or `normal` plus size opt-in |
 
-Both message and item counters have bounded `signal` and `outcome` data-point
+Message, item, and size counters have bounded `signal` and `outcome` data-point
 attributes. `signal` is one of `logs`, `metrics`, or `traces`; `outcome` is
 `success`, `failure`, or `refused`, recorded during terminal ACK/NACK
 unwinding. The metric-set entity attributes identify the pipeline and node, so
 group by those attributes when comparing nodes.
 
-### Enable Item Counts
+### Enable Item Counts and Size
 
-Item counting is disabled by default because examining OTLP payloads can be
-expensive. It requires `policies.telemetry.runtime_metrics: detailed` or
-`normal` with a per-node opt in; `normal` alone does not enable item counts.
+Item counting and logical payload sizing are disabled at the normal level
+because they can require payload inspection. They require
+`policies.telemetry.runtime_metrics: detailed` or `normal` with a per-node opt
+in.
 
 > [!WARNING]
-> Item counting adds work to the data path. Its cost depends on the signal
-> representation and batch size; in particular, OTLP-encoded payloads must be
-> inspected to count their items. Measure the impact on a representative
-> workload before enabling it broadly. Prefer per-node opt-in when only a
-> specific stage needs signal-level accounting.
+> Item counting and sizing add work to the data path. Their cost depends on the
+> payload representation and structure. Measure the impact on a representative
+> workload before enabling them broadly. Prefer per-node opt-in when only a
+> specific stage needs these measurements.
 
 To enable it for every node in a pipeline, use `detailed`:
 
@@ -91,12 +95,13 @@ nodes:
     policies:
       telemetry:
         item_counts: true
+        size: true
     config: {}
 ```
 
 This narrower configuration is appropriate when only a small part of a
-pipeline needs signal-level accounting. `detailed` enables item counts for
-every node without a node-level `item_counts` setting.
+pipeline needs payload measurements. `detailed` enables item counts and size
+for every node without node-level settings.
 
 ### Interpret Node Counts
 
@@ -109,7 +114,7 @@ topology behavior being investigated.
 Node metrics are the right choice when operators need to locate where a signal
 count changes, including receiver admission, processors, and exporter output.
 Use the runnable
-[`trafficgen-per-signal-metrics-demo.yaml`](../configs/trafficgen-per-signal-metrics-demo.yaml)
+[`trafficgen-universal-produced-consumed-metrics.yaml`](../configs/trafficgen-universal-produced-consumed-metrics.yaml)
 example to inspect the metrics on every node or on an individually opted-in
 processor.
 


### PR DESCRIPTION
# Change summary

Closing the loop on final piece to match the [Go Collector universal telemetry RFC on auto-instrumented metrics](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/rfcs/component-universal-telemetry.md#auto-instrumented-metrics) 🥳 

Adds logical payload size to the engine-owned node outcome metrics:

- `node.producer.produced.size{signal,outcome}`
- `node.consumer.consumed.size{signal,outcome}`

Size follows the existing item-count policy model. `runtime_metrics: detailed` enables both measurements for every node. At `runtime_metrics: normal`, nodes can independently opt in with:

```yaml
policies:
  telemetry:
    size: true
```

The forward path measures the payload once at each produced or consumed boundary and stores the value on the context frame. Ack/Nack unwinding records the stored size with the same signal and outcome as the corresponding message metric.

OTLP payloads report their encoded protobuf length. OTAP payloads report logical Arrow bytes. Cached OTAP sizing avoids repeating the Arrow array and buffer walk when the payload is unchanged.

The `trafficgen-universal-produced-consumed-metrics.yaml` demo includes both item and size policies and prints only produced/consumed node metrics through its internal observability pipeline.

### Sample config run

The `full` pipeline uses `runtime_metrics: detailed`. Its log sampler keeps one third of log records while metrics and traces pass through unchanged:

| Signal | Receiver produced | Sampler consumed | Sampler produced | Noop consumed |
| --- | ---: | ---: | ---: | ---: |
| Logs messages | 4 | 4 | 4 | 4 |
| Logs items | 30 | 30 | 10 | 10 |
| Logs size (By) | 7,472 | 7,472 | 6,448 | 6,448 |
| Metrics messages | 2 | 2 | 2 | 2 |
| Metrics items | 18 | 18 | 18 | 18 |
| Metrics size (By) | 3,710 | 3,710 | 3,710 | 3,710 |
| Traces messages | 2 | 2 | 2 | 2 |
| Traces items | 12 | 12 | 12 | 12 |
| Traces size (By) | 2,290 | 2,290 | 2,290 | 2,290 |

Dropping two thirds of the log records reduces logical size from `7,472 By` to `6,448 By` rather than by two thirds. OTAP is a columnar, relational representation: resource, scope, attribute, and dictionary buffers remain largely unchanged, while sampling removes primarily the per-record offsets and dictionary keys. The synthetic records also repeat values that are stored once in dictionaries. Logical Arrow size therefore describes the resulting representation, not an average record size multiplied by the item count.

The `partial` pipeline uses `runtime_metrics: normal` and opts only the sampler into `item_counts` and `size`:

| Node boundary | Messages (logs / metrics / traces) | Items (logs / metrics / traces) | Size in By (logs / metrics / traces) |
| --- | ---: | ---: | ---: |
| Receiver produced | 4 / 2 / 2 | Not present | Not present |
| Sampler consumed | 4 / 2 / 2 | 30 / 18 / 12 | 7,472 / 3,710 / 2,290 |
| Sampler produced | 4 / 2 / 2 | 10 / 18 / 12 | 6,448 / 3,710 / 2,290 |
| Noop consumed | 4 / 2 / 2 | Not present | Not present |

## Related issue

* Closes #2884

## Validation

Local engine runs

## User-facing changes

Yes. Users can enable node-level logical payload size metrics globally with `runtime_metrics: detailed` or per node with `policies.telemetry.size: true`.
