### PR TITLE
feat(console-exporter): add compact histogram percentile estimates

### DIFF
--- a/rust/otap-dataflow/.chloggen/console-compact-histogram-percentiles.yaml
+++ b/rust/otap-dataflow/.chloggen/console-compact-histogram-percentiles.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: pipeline
+note: "Show approximate p50, p90, and p99 values in compact console histogram output."
+issues: [3840]
+subtext:

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/README.md
@@ -119,8 +119,12 @@ RESOURCE [service.name=checkout]
 
 Aggregation temporality and monotonicity are printed before data points.
 Histograms default to compact `count`, `sum`, `avg`, `min`, and `max`
-statistics. `avg` is emitted only when both `sum` is present and `count` is
-non-zero. Percentiles are not currently estimated.
+statistics plus approximate `p50`, `p90`, and `p99` values estimated from
+available bucket data. Approximate values use the `~=` marker. `avg` is emitted
+only when both `sum` is present and `count` is non-zero. Percentiles are omitted
+for empty or bucketless histograms. If an explicit percentile lands in an
+unbounded extreme bucket without the corresponding `min` or `max`, only that
+percentile is omitted.
 
 To inspect the complete histogram representation, including explicit bounds,
 bucket counts, exponential scale, offsets, zero count, and zero threshold,

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/mod.rs
@@ -954,11 +954,11 @@ mod tests {
             "| | | | | +- EXEMPLAR time_unix_nano=150 value_double=1.25 span_id=0102030405060708 trace_id=0102030405060708090a0b0c0d0e0f10 [sampled=true]\n",
             "| | +- METRIC name=latency unit=ms\n",
             "| | | +- HISTOGRAM temporality=delta\n",
-            "| | | | +- DATA_POINT start_time_unix_nano=100 time_unix_nano=200 count=4 sum=20 avg=5 min=0.5 max=12 flags=1 [series=blue]\n",
+            "| | | | +- DATA_POINT start_time_unix_nano=100 time_unix_nano=200 count=4 sum=20 avg=5 p50~=5.5 p90~=11 p99~=11 min=0.5 max=12 flags=1 [series=blue]\n",
             "| | | | | +- EXEMPLAR time_unix_nano=150 value_double=1.25 span_id=0102030405060708 trace_id=0102030405060708090a0b0c0d0e0f10 [sampled=true]\n",
             "| | +- METRIC name=size_distribution unit=By\n",
             "| | | +- EXPONENTIAL_HISTOGRAM temporality=cumulative\n",
-            "| | | | +- DATA_POINT start_time_unix_nano=100 time_unix_nano=200 count=6 sum=30 avg=5 min=-4 max=16 flags=1 [series=blue]\n",
+            "| | | | +- DATA_POINT start_time_unix_nano=100 time_unix_nano=200 count=6 sum=30 avg=5 p50~=0 p90~=16 p99~=16 min=-4 max=16 flags=1 [series=blue]\n",
             "| | | | | +- EXEMPLAR time_unix_nano=150 value_double=1.25 span_id=0102030405060708 trace_id=0102030405060708090a0b0c0d0e0f10 [sampled=true]\n",
             "| | +- METRIC name=request_summary unit=ms\n",
             "| | | +- SUMMARY\n",
@@ -1014,6 +1014,166 @@ mod tests {
              | | | | | +- NEG_BUCKET offset=-2 bucket_index=-2 count=1\n\
              | | | | | +- NEG_BUCKET offset=-2 bucket_index=-1 count=1\n"
         ));
+        assert!(!text.contains("p50~="));
+        assert!(!text.contains("p90~="));
+        assert!(!text.contains("p99~="));
+    }
+
+    /// Scenario: Explicit percentile ranks land in finite and unbounded buckets without extrema.
+    /// Guarantees: The finite estimate is rendered while only estimates needing absent extrema
+    /// are omitted.
+    #[test]
+    fn pretty_metrics_omit_only_unbounded_explicit_percentiles_without_extrema() {
+        let mut metrics_data = metrics_with_all_data_types();
+        let metrics = &mut metrics_data.resource_metrics[0].scope_metrics[0].metrics;
+        metrics.retain(|metric| metric.name == "latency");
+        let Some(metric::Data::Histogram(histogram)) = metrics[0].data.as_mut() else {
+            panic!("expected explicit histogram");
+        };
+        histogram.data_points[0].min = None;
+        histogram.data_points[0].max = None;
+
+        let text = format_pretty_metrics(&metrics_data);
+
+        assert!(text.contains(" avg=5 p50~=5.5"));
+        assert!(!text.contains("p90~="));
+        assert!(!text.contains("p99~="));
+    }
+
+    /// Scenario: Compact histograms are bucketless or disagree with their declared count.
+    /// Guarantees: Percentiles are omitted rather than inferred from summary fields or malformed
+    /// bucket populations.
+    #[test]
+    fn pretty_metrics_omit_percentiles_for_unusable_bucket_data() {
+        let mut metrics_data = metrics_with_all_data_types();
+        let metrics = &mut metrics_data.resource_metrics[0].scope_metrics[0].metrics;
+        metrics.retain(|metric| metric.name == "latency" || metric.name == "size_distribution");
+        let Some(metric::Data::Histogram(histogram)) = metrics[0].data.as_mut() else {
+            panic!("expected explicit histogram");
+        };
+        histogram.data_points[0].bucket_counts.clear();
+        let Some(metric::Data::ExponentialHistogram(histogram)) = metrics[1].data.as_mut() else {
+            panic!("expected exponential histogram");
+        };
+        histogram.data_points[0].count += 1;
+
+        let text = format_pretty_metrics(&metrics_data);
+
+        assert!(!text.contains("p50~="));
+        assert!(!text.contains("p90~="));
+        assert!(!text.contains("p99~="));
+    }
+
+    /// Scenario: Explicit histogram buckets have invalid ordering, shape, totals, or arithmetic.
+    /// Guarantees: Every malformed representation suppresses percentile estimates without
+    /// panicking or changing the exact summary fields.
+    #[test]
+    fn pretty_metrics_reject_malformed_explicit_buckets() {
+        let cases = [
+            (vec![10.0, 1.0], vec![1, 2, 1], 4),
+            (vec![1.0, 10.0], vec![1, 2, 1, 0], 4),
+            (vec![1.0, 10.0], vec![1, 2, 0], 4),
+            (vec![1.0, 10.0], vec![u64::MAX, 1, 0], u64::MAX),
+        ];
+
+        for (bounds, counts, count) in cases {
+            let mut metrics_data = metrics_with_all_data_types();
+            let metrics = &mut metrics_data.resource_metrics[0].scope_metrics[0].metrics;
+            metrics.retain(|metric| metric.name == "latency");
+            let Some(metric::Data::Histogram(histogram)) = metrics[0].data.as_mut() else {
+                panic!("expected explicit histogram");
+            };
+            let point = &mut histogram.data_points[0];
+            point.explicit_bounds = bounds;
+            point.bucket_counts = counts;
+            point.count = count;
+
+            let text = format_pretty_metrics(&metrics_data);
+
+            assert!(text.contains(&format!("count={count}")));
+            assert!(!text.contains("p50~="), "{text}");
+            assert!(!text.contains("p90~="), "{text}");
+            assert!(!text.contains("p99~="), "{text}");
+        }
+    }
+
+    /// Scenario: Exponential percentile ranks span negative, zero, and positive buckets.
+    /// Guarantees: Numeric ordering and geometric bucket midpoints are applied at scale zero.
+    #[test]
+    fn pretty_metrics_order_exponential_buckets_numerically() {
+        let mut metrics_data = metrics_with_all_data_types();
+        let metrics = &mut metrics_data.resource_metrics[0].scope_metrics[0].metrics;
+        metrics.retain(|metric| metric.name == "size_distribution");
+        let Some(metric::Data::ExponentialHistogram(histogram)) = metrics[0].data.as_mut() else {
+            panic!("expected exponential histogram");
+        };
+        let point = &mut histogram.data_points[0];
+        point.count = 10;
+        point.sum = Some(0.0);
+        point.scale = 0;
+        point.zero_count = 1;
+        point.negative = Some(exponential_histogram_data_point::Buckets {
+            offset: 0,
+            bucket_counts: vec![2, 4],
+        });
+        point.positive = Some(exponential_histogram_data_point::Buckets {
+            offset: 0,
+            bucket_counts: vec![1, 2],
+        });
+        point.min = Some(-4.0);
+        point.max = Some(4.0);
+
+        let text = format_pretty_metrics(&metrics_data);
+
+        assert!(text.contains(
+            "p50~=-1.4142135623730951 p90~=2.8284271247461903 \
+             p99~=2.8284271247461903"
+        ));
+    }
+
+    /// Scenario: An exponential histogram contains only observations in its zero bucket.
+    /// Guarantees: Every requested percentile is represented by zero without requiring a valid
+    /// non-zero bucket scale.
+    #[test]
+    fn pretty_metrics_render_zero_bucket_percentiles() {
+        let mut metrics_data = metrics_with_all_data_types();
+        let metrics = &mut metrics_data.resource_metrics[0].scope_metrics[0].metrics;
+        metrics.retain(|metric| metric.name == "size_distribution");
+        let Some(metric::Data::ExponentialHistogram(histogram)) = metrics[0].data.as_mut() else {
+            panic!("expected exponential histogram");
+        };
+        let point = &mut histogram.data_points[0];
+        point.count = 4;
+        point.sum = Some(0.0);
+        point.scale = i32::MAX;
+        point.zero_count = 4;
+        point.positive = None;
+        point.negative = None;
+        point.min = Some(0.0);
+        point.max = Some(0.0);
+
+        let text = format_pretty_metrics(&metrics_data);
+
+        assert!(text.contains("p50~=0 p90~=0 p99~=0"));
+    }
+
+    /// Scenario: A non-zero exponential histogram reports a scale outside the OTLP range.
+    /// Guarantees: Invalid geometry suppresses all percentile estimates without affecting summary
+    /// statistics.
+    #[test]
+    fn pretty_metrics_omit_percentiles_for_invalid_exponential_scale() {
+        let mut metrics_data = metrics_with_all_data_types();
+        let metrics = &mut metrics_data.resource_metrics[0].scope_metrics[0].metrics;
+        metrics.retain(|metric| metric.name == "size_distribution");
+        let Some(metric::Data::ExponentialHistogram(histogram)) = metrics[0].data.as_mut() else {
+            panic!("expected exponential histogram");
+        };
+        histogram.data_points[0].scale = 21;
+
+        let text = format_pretty_metrics(&metrics_data);
+
+        assert!(text.contains("count=6 sum=30 avg=5"));
+        assert!(!text.contains("p50~="));
     }
 
     /// Scenario: Equivalent metrics use compact and raw formatting through both payload models.

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/mod.rs
@@ -1157,11 +1157,10 @@ mod tests {
         assert!(text.contains("p50~=0 p90~=0 p99~=0"));
     }
 
-    /// Scenario: A non-zero exponential histogram reports a scale outside the OTLP range.
-    /// Guarantees: Invalid geometry suppresses all percentile estimates without affecting summary
-    /// statistics.
+    /// Scenario: An exponential histogram uses a scale finer than common SDK producer limits.
+    /// Guarantees: The protocol's unrestricted scale is accepted and produces finite estimates.
     #[test]
-    fn pretty_metrics_omit_percentiles_for_invalid_exponential_scale() {
+    fn pretty_metrics_render_percentiles_beyond_sdk_scale_limits() {
         let mut metrics_data = metrics_with_all_data_types();
         let metrics = &mut metrics_data.resource_metrics[0].scope_metrics[0].metrics;
         metrics.retain(|metric| metric.name == "size_distribution");
@@ -1173,7 +1172,29 @@ mod tests {
         let text = format_pretty_metrics(&metrics_data);
 
         assert!(text.contains("count=6 sum=30 avg=5"));
-        assert!(!text.contains("p50~="));
+        assert!(text.contains("p50~=0"));
+        assert!(text.contains("p90~="));
+        assert!(text.contains("p99~="));
+    }
+
+    /// Scenario: A non-zero exponential histogram uses the minimum protocol i32 scale.
+    /// Guarantees: Formatting never panics, preserves representable zero-bucket estimates, and
+    /// omits only non-zero bucket midpoints that cannot be represented as finite f64 values.
+    #[test]
+    fn pretty_metrics_omit_unrepresentable_extreme_scale_midpoints() {
+        let mut metrics_data = metrics_with_all_data_types();
+        let metrics = &mut metrics_data.resource_metrics[0].scope_metrics[0].metrics;
+        metrics.retain(|metric| metric.name == "size_distribution");
+        let Some(metric::Data::ExponentialHistogram(histogram)) = metrics[0].data.as_mut() else {
+            panic!("expected exponential histogram");
+        };
+        histogram.data_points[0].scale = i32::MIN;
+
+        let text = format_pretty_metrics(&metrics_data);
+
+        assert!(text.contains("count=6 sum=30 avg=5 p50~=0"));
+        assert!(!text.contains("p90~="), "{text}");
+        assert!(!text.contains("p99~="), "{text}");
     }
 
     /// Scenario: Equivalent metrics use compact and raw formatting through both payload models.

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/pretty_metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/pretty_metrics.rs
@@ -17,6 +17,15 @@ use std::io::{self, Write};
 
 type MetricsWriter<'a> = PrettyWriter<'a, dyn Write + 'a>;
 
+const PERCENTILE_NUMERATORS: [u64; 3] = [50, 90, 99];
+const PERCENTILE_LABELS: [&str; 3] = ["p50", "p90", "p99"];
+const PERCENTILE_DENOMINATOR: u64 = 100;
+const MIN_EXPONENTIAL_HISTOGRAM_SCALE: i32 = -10;
+const MAX_EXPONENTIAL_HISTOGRAM_SCALE: i32 = 20;
+
+#[derive(Default)]
+struct PercentileEstimates([Option<f64>; PERCENTILE_NUMERATORS.len()]);
+
 impl HierarchicalFormatter {
     /// Format metrics from a generic metrics view.
     pub(super) fn format_metrics_data_to<M: MetricsView, W: Write>(
@@ -183,8 +192,8 @@ impl HierarchicalFormatter {
             write!(w, " count={count}")?;
             write_optional_f64(w, "sum", sum)?;
             if self.histogram_mode == PrettyHistogramMode::Compact {
-                // TODO: Add percentile estimates to compact histogram output.
                 write_average(w, sum, count)?;
+                write_percentiles(w, &estimate_explicit_percentiles(point))?;
             }
             write_optional_f64(w, "min", point.min())?;
             write_optional_f64(w, "max", point.max())?;
@@ -243,8 +252,8 @@ impl HierarchicalFormatter {
             }
             write_optional_f64(w, "sum", sum)?;
             if self.histogram_mode == PrettyHistogramMode::Compact {
-                // TODO: Add percentile estimates to compact histogram output.
                 write_average(w, sum, count)?;
+                write_percentiles(w, &estimate_exponential_percentiles(point))?;
             }
             write_optional_f64(w, "min", point.min())?;
             write_optional_f64(w, "max", point.max())?;
@@ -453,6 +462,216 @@ fn write_average(writer: &mut MetricsWriter<'_>, sum: Option<f64>, count: u64) -
         }
     }
     Ok(())
+}
+
+fn write_percentiles(
+    writer: &mut MetricsWriter<'_>,
+    estimates: &PercentileEstimates,
+) -> io::Result<()> {
+    for (label, estimate) in PERCENTILE_LABELS.iter().zip(estimates.0) {
+        if let Some(estimate) = estimate {
+            write!(writer, " {label}~={estimate}")?;
+        }
+    }
+    Ok(())
+}
+
+fn estimate_explicit_percentiles<P: HistogramDataPointView>(point: &P) -> PercentileEstimates {
+    let count = point.count();
+    let Some((min, max)) = valid_range(point.min(), point.max()) else {
+        return PercentileEstimates::default();
+    };
+    if count == 0 {
+        return PercentileEstimates::default();
+    }
+
+    let ranks = percentile_ranks(count);
+    let mut estimates = PercentileEstimates::default();
+    let mut bounds = point.explicit_bounds();
+    let mut bucket_counts = point.bucket_counts();
+    let mut previous_bound = None;
+    let mut lower = min;
+    let mut cumulative = 0_u64;
+    let mut selected = 0_usize;
+    let mut saw_bound = false;
+    let mut saw_overflow_bucket = false;
+
+    for bucket_count in bucket_counts.by_ref() {
+        if saw_overflow_bucket {
+            return PercentileEstimates::default();
+        }
+
+        let upper = match bounds.next() {
+            Some(bound) => {
+                if !bound.is_finite() || previous_bound.is_some_and(|previous| bound <= previous) {
+                    return PercentileEstimates::default();
+                }
+                previous_bound = Some(bound);
+                saw_bound = true;
+                Some(bound)
+            }
+            None => {
+                saw_overflow_bucket = true;
+                max
+            }
+        };
+
+        cumulative = match cumulative.checked_add(bucket_count) {
+            Some(value) => value,
+            None => return PercentileEstimates::default(),
+        };
+
+        while selected < ranks.len() && ranks[selected] <= cumulative {
+            estimates.0[selected] =
+                midpoint(lower, upper).and_then(|value| clamp_estimate(value, min, max));
+            selected += 1;
+        }
+
+        lower = upper;
+    }
+
+    if !saw_bound
+        || !saw_overflow_bucket
+        || bounds.next().is_some()
+        || cumulative != count
+        || selected != ranks.len()
+    {
+        return PercentileEstimates::default();
+    }
+
+    estimates
+}
+
+fn estimate_exponential_percentiles<P: ExponentialHistogramDataPointView>(
+    point: &P,
+) -> PercentileEstimates {
+    let count = point.count();
+    let Some((min, max)) = valid_range(point.min(), point.max()) else {
+        return PercentileEstimates::default();
+    };
+    if count == 0 {
+        return PercentileEstimates::default();
+    }
+
+    let negative_total = match point
+        .negative()
+        .map(|buckets| checked_bucket_sum(buckets.bucket_counts()))
+        .transpose()
+    {
+        Ok(Some(value)) => value,
+        Ok(None) => 0,
+        Err(()) => return PercentileEstimates::default(),
+    };
+    let positive_total = match point
+        .positive()
+        .map(|buckets| checked_bucket_sum(buckets.bucket_counts()))
+        .transpose()
+    {
+        Ok(Some(value)) => value,
+        Ok(None) => 0,
+        Err(()) => return PercentileEstimates::default(),
+    };
+    let zero_count = point.zero_count();
+    let Some(bucket_total) = negative_total
+        .checked_add(zero_count)
+        .and_then(|value| value.checked_add(positive_total))
+    else {
+        return PercentileEstimates::default();
+    };
+    if bucket_total == 0 || bucket_total != count {
+        return PercentileEstimates::default();
+    }
+
+    let scale = point.scale();
+    let has_non_zero_buckets = negative_total > 0 || positive_total > 0;
+    if has_non_zero_buckets
+        && !(MIN_EXPONENTIAL_HISTOGRAM_SCALE..=MAX_EXPONENTIAL_HISTOGRAM_SCALE).contains(&scale)
+    {
+        return PercentileEstimates::default();
+    }
+
+    let mut estimates = PercentileEstimates::default();
+    for (slot, rank) in estimates.0.iter_mut().zip(percentile_ranks(count)) {
+        let estimate = if rank <= negative_total {
+            let forward_rank = negative_total - rank + 1;
+            point.negative().and_then(|buckets| {
+                bucket_at_rank(&buckets, forward_rank)
+                    .and_then(|index| exponential_bucket_midpoint(scale, index, true))
+            })
+        } else if rank <= negative_total + zero_count {
+            Some(0.0)
+        } else {
+            let forward_rank = rank - negative_total - zero_count;
+            point.positive().and_then(|buckets| {
+                bucket_at_rank(&buckets, forward_rank)
+                    .and_then(|index| exponential_bucket_midpoint(scale, index, false))
+            })
+        };
+        *slot = estimate.and_then(|value| clamp_estimate(value, min, max));
+    }
+
+    estimates
+}
+
+fn valid_range(min: Option<f64>, max: Option<f64>) -> Option<(Option<f64>, Option<f64>)> {
+    if min.is_some_and(|value| !value.is_finite())
+        || max.is_some_and(|value| !value.is_finite())
+        || min.zip(max).is_some_and(|(min, max)| min > max)
+    {
+        return None;
+    }
+    Some((min, max))
+}
+
+fn percentile_ranks(count: u64) -> [u64; PERCENTILE_NUMERATORS.len()] {
+    PERCENTILE_NUMERATORS.map(|numerator| {
+        let whole = count / PERCENTILE_DENOMINATOR * numerator;
+        let remainder = count % PERCENTILE_DENOMINATOR * numerator;
+        whole + remainder.div_ceil(PERCENTILE_DENOMINATOR)
+    })
+}
+
+fn midpoint(lower: Option<f64>, upper: Option<f64>) -> Option<f64> {
+    let (lower, upper) = lower.zip(upper)?;
+    if lower > upper {
+        return None;
+    }
+    let value = lower * 0.5 + upper * 0.5;
+    value.is_finite().then_some(value)
+}
+
+fn clamp_estimate(value: f64, min: Option<f64>, max: Option<f64>) -> Option<f64> {
+    if !value.is_finite() {
+        return None;
+    }
+    let value = min.map_or(value, |min| value.max(min));
+    Some(max.map_or(value, |max| value.min(max)))
+}
+
+fn checked_bucket_sum(mut counts: impl Iterator<Item = u64>) -> Result<u64, ()> {
+    counts.try_fold(0_u64, |total, count| total.checked_add(count).ok_or(()))
+}
+
+fn bucket_at_rank<B: BucketsView>(buckets: &B, rank: u64) -> Option<i32> {
+    let mut cumulative = 0_u64;
+    for (position, count) in buckets.bucket_counts().enumerate() {
+        cumulative = cumulative.checked_add(count)?;
+        if cumulative >= rank {
+            let position = i32::try_from(position).ok()?;
+            return buckets.offset().checked_add(position);
+        }
+    }
+    None
+}
+
+fn exponential_bucket_midpoint(scale: i32, index: i32, negative: bool) -> Option<f64> {
+    let bucket_width = 2.0_f64.powi(-scale);
+    let exponent = (f64::from(index) + 0.5) * bucket_width;
+    let magnitude = 2.0_f64.powf(exponent);
+    if !magnitude.is_finite() || magnitude == 0.0 {
+        return None;
+    }
+    Some(if negative { -magnitude } else { magnitude })
 }
 
 fn write_temporality(

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/pretty_metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/pretty_metrics.rs
@@ -20,8 +20,6 @@ type MetricsWriter<'a> = PrettyWriter<'a, dyn Write + 'a>;
 const PERCENTILE_NUMERATORS: [u64; 3] = [50, 90, 99];
 const PERCENTILE_LABELS: [&str; 3] = ["p50", "p90", "p99"];
 const PERCENTILE_DENOMINATOR: u64 = 100;
-const MIN_EXPONENTIAL_HISTOGRAM_SCALE: i32 = -10;
-const MAX_EXPONENTIAL_HISTOGRAM_SCALE: i32 = 20;
 
 #[derive(Default)]
 struct PercentileEstimates([Option<f64>; PERCENTILE_NUMERATORS.len()]);
@@ -583,13 +581,6 @@ fn estimate_exponential_percentiles<P: ExponentialHistogramDataPointView>(
     }
 
     let scale = point.scale();
-    let has_non_zero_buckets = negative_total > 0 || positive_total > 0;
-    if has_non_zero_buckets
-        && !(MIN_EXPONENTIAL_HISTOGRAM_SCALE..=MAX_EXPONENTIAL_HISTOGRAM_SCALE).contains(&scale)
-    {
-        return PercentileEstimates::default();
-    }
-
     let mut estimates = PercentileEstimates::default();
     for (slot, rank) in estimates.0.iter_mut().zip(percentile_ranks(count)) {
         let estimate = if rank <= negative_total {
@@ -665,7 +656,7 @@ fn bucket_at_rank<B: BucketsView>(buckets: &B, rank: u64) -> Option<i32> {
 }
 
 fn exponential_bucket_midpoint(scale: i32, index: i32, negative: bool) -> Option<f64> {
-    let bucket_width = 2.0_f64.powi(-scale);
+    let bucket_width = 2.0_f64.powf(-f64::from(scale));
     let exponent = (f64::from(index) + 0.5) * bucket_width;
     let magnitude = 2.0_f64.powf(exponent);
     if !magnitude.is_finite() || magnitude == 0.0 {

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/decode.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/decode.rs
@@ -710,8 +710,8 @@ pub fn read_varint(buf: &[u8], mut pos: usize) -> Option<(u64, usize)> {
 /// Decode 32 bit zigzag encoding
 #[inline]
 #[must_use]
-pub const fn decode_sint32(val: i32) -> i32 {
-    (val >> 1) ^ -(val & 1)
+pub const fn decode_sint32(val: u32) -> i32 {
+    ((val >> 1) as i32) ^ -((val & 1) as i32)
 }
 
 /// Decode length from byte slice and return a new slice of the buffer and the decoded length.
@@ -789,5 +789,15 @@ mod tests {
             validate_message_wire_format(&oversized_key),
             Err(Error::InvalidProtobufWireFormat)
         ));
+    }
+
+    /// Scenario: ZigZag decoding receives the encoded endpoints of the sint32 range.
+    /// Guarantees: Values using the high bit decode without signed truncation.
+    #[test]
+    fn decodes_full_sint32_range() {
+        assert_eq!(decode_sint32(0), 0);
+        assert_eq!(decode_sint32(1), -1);
+        assert_eq!(decode_sint32(u32::MAX - 1), i32::MAX);
+        assert_eq!(decode_sint32(u32::MAX), i32::MIN);
     }
 }

--- a/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/metrics.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otlp/bytes/metrics.rs
@@ -1889,7 +1889,8 @@ impl ExponentialHistogramDataPointView for RawExpHistogramDatapoint<'_> {
         self.byte_parser
             .advance_to_find_field(EXP_HISTOGRAM_DP_SCALE)
             .and_then(|slice| read_varint(slice, 0))
-            .map(|(val, _)| decode_sint32(val as i32))
+            .and_then(|(val, _)| u32::try_from(val).ok())
+            .map(decode_sint32)
             .unwrap_or_default()
     }
 
@@ -1947,7 +1948,8 @@ impl BucketsView for RawBuckets<'_> {
         self.byte_parser
             .advance_to_find_field(EXP_HISTOGRAM_BUCKET_OFFSET)
             .and_then(|slice| read_varint(slice, 0))
-            .map(|(val, _)| decode_sint32(val as i32))
+            .and_then(|(val, _)| u32::try_from(val).ok())
+            .map(decode_sint32)
             .unwrap_or_default()
     }
 }


### PR DESCRIPTION
# Change summary

Add approximate p50, p90, and p99 values to compact pretty output for explicit
and exponential histograms.

The estimator:

- uses nearest-rank bucket selection;
- uses arithmetic midpoints for explicit buckets and geometric midpoints for
  exponential buckets;
- handles negative, zero, and positive exponential bucket populations;
- supports the full OTLP `sint32` scale range;
- marks estimates with `~=` to distinguish them from exact values;
- omits estimates when bucket data is empty, internally inconsistent, or cannot
  be represented safely;
- produces equivalent output for OTLP and OTAP views.

The PR also corrects raw OTLP ZigZag decoding so exponential histogram `scale`
and bucket `offset` values can use the full `sint32` range.

Raw histogram output remains unchanged.

## Related issue

* Closes #3840

## Validation

- `cargo test -p otap-df-core-nodes console_exporter`
- `cargo test -p otap-df-pdata decodes_full_sint32_range`
- `cargo check -p otap-df-core-nodes`
- `cargo clippy -p otap-df-core-nodes --all-targets -- -D warnings`
- `cargo clippy -p otap-df-pdata --all-targets -- -D warnings`
- `npx markdownlint-cli2 rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/README.md`
- `chloggen validate --config rust/otap-dataflow/.chloggen/config.yaml`
- `cargo xtask check`

## User-facing changes

Compact console histogram output now includes approximate `p50~=`, `p90~=`,
and `p99~=` fields when sufficient valid bucket data is available. Individual
percentiles are omitted when they cannot be estimated safely.

Raw OTLP exponential histogram scale and bucket offset values are now decoded
correctly across the full `sint32` range.

Raw histogram output is unchanged.

Added
`rust/otap-dataflow/.chloggen/console-compact-histogram-percentiles.yaml`.