### PR TITLE
chore(metrics): Add shared `receiver.received` and `exporter.attempted` metric sets

### DIFF
--- a/rust/otap-dataflow/crates/otap/README.md
+++ b/rust/otap-dataflow/crates/otap/README.md
@@ -27,50 +27,63 @@ Universal node metrics describe internal PData delivery, while receivers and
 exporters own the external boundaries:
 
 ```text
-wire -> receiver.ingress -> node.producer -> ... -> node.consumer -> exporter.egress -> wire
+wire -> receiver.received -> node.producer -> ... -> node.consumer -> exporter.attempted -> wire
 ```
 
 The shared contracts are:
 
 ```text
-receiver.ingress.{messages,wire_bytes,duration}{signal,outcome}
-exporter.egress.{messages,items,wire_bytes,duration}{signal,outcome}
+receiver.received.{messages,payload.size,duration}{signal,outcome}
+exporter.attempted.{messages,items,payload.size,duration}{signal,outcome}
 ```
 
-### Receiver ingress
+### Receiver received
 
 One observation represents one external message after signal classification.
-`success` means receiver-local handoff completed, `refused` means the classified
-message was rejected, and `failure` means receiver-local processing failed.
+`success` means receiver-local handoff was accepted and completed. `refused`
+means validation, policy, admission, capacity, or pipeline handoff explicitly
+rejected the message. `failure` means receiver-local processing was attempted
+but did not complete because of an internal error.
 Duration ends at that receiver-local result and excludes downstream processing
 and Ack/Nack completion. Rejections before signal classification remain
 component-specific diagnostics.
 
-Receiver ingress omits `items` because decoded items are measured by
+Receiver received omits `items` because decoded items are measured by
 `node.producer.produced.items`.
 
-### Exporter egress
+### Exporter attempted
 
-One observation represents one exporter dequeue or invocation through one
-terminal external result. Component-internal retries belong to the same
-observation, while redelivery by a retry processor is a new observation.
-Duration excludes Ack/Nack notification propagation. Items inherit the
-whole-message terminal outcome.
+One observation represents one attempt to submit an encoded application
+payload to an external backend or storage boundary. Component-internal retries
+produce additional observations, as does redelivery by a retry processor.
+`success` means the attempt was accepted or completed by the external boundary,
+`refused` means validation, policy, admission, or capacity at that boundary
+explicitly rejected it, and `failure` means an encoding, transport, timeout,
+backend, or other processing error prevented completion. Retryability is
+independent of the outcome.
 
-### Wire bytes and internal size
+Messages and duration are recorded for every attempt. Payload size and items
+use separately registered optional metric sets under the same
+`exporter.attempted` namespace. Components register payload size only when an
+encoded application payload exists and its size is naturally available at the
+attempt boundary. They register items only when cached item counts are enabled.
+Instrumentation must not encode, parse, or traverse PData solely to populate
+either optional metric.
 
-`wire_bytes` means encoded application payload bytes visible at the external
-boundary. It excludes protocol headers, TLS overhead, and storage amplification.
-Exporter wire bytes accumulate the bytes submitted across every attempt within
-the logical export and are attributed to its terminal outcome. An export that
-fails before submitting bytes records zero. Component-specific diagnostics may
-add per-attempt protocol details.
+The legacy `exporter.exports` set remains during migration but will be
+deprecated. Attempt-level external behavior belongs to `exporter.attempted`,
+while `node.consumer` owns the logical message's terminal pipeline outcome.
 
-Instrumentation must not serialize PData solely to populate `wire_bytes`.
+### Payload size and internal size
 
-The internal `size` measurement is separate: it describes the PData
-representation at `node.producer` and `node.consumer`, not the external encoded
-representation.
+`payload.size` means encoded application payload bytes visible immediately
+before receiver decoding or submitted by an exporter attempt. It excludes
+protocol headers, framing, TLS overhead, and storage amplification. Exporters
+without an encoded application payload, or whose encoder does not expose its
+size, omit the optional metric set rather than reporting zero.
+
+The internal `size` measurement remains separate: it describes the PData
+representation at `node.producer` and `node.consumer`.
 
 ## Node Implementations Using This Crate
 

--- a/rust/otap-dataflow/crates/otap/README.md
+++ b/rust/otap-dataflow/crates/otap/README.md
@@ -56,7 +56,7 @@ Receiver received omits `items` because decoded items are measured by
 One observation represents one attempt to submit an encoded application
 payload to an external backend or storage boundary. Component-internal retries
 produce additional observations, as does redelivery by a retry processor.
-`success` means the attempt was accepted or completed by the external boundary,
+`success` means the attempt was accepted and completed by the external boundary,
 `refused` means validation, policy, admission, or capacity at that boundary
 explicitly rejected it, and `failure` means an encoding, transport, timeout,
 backend, or other processing error prevented completion. Retryability is

--- a/rust/otap-dataflow/crates/otap/README.md
+++ b/rust/otap-dataflow/crates/otap/README.md
@@ -17,8 +17,60 @@ optional contrib processors) live in `crates/contrib-nodes`.
 - OTLP HTTP client/server support (`src/otlp_http/`, `src/otlp_http.rs`)
 - Compression configuration (`src/compression.rs`)
 - TLS and crypto helpers (`src/tls_utils.rs`, `src/crypto.rs`)
-- Shared receiver metrics (`src/otlp_metrics.rs`)
+- Shared component boundary metrics (`src/metrics.rs`)
+- Shared OTLP receiver metrics (`src/otlp_metrics.rs`)
 - Test fixtures and mocks (`src/otap_mock.rs`, `src/otlp_mock.rs`, `src/testing/`)
+
+## Shared Component Boundary Metrics
+
+Universal node metrics describe internal PData delivery, while receivers and
+exporters own the external boundaries:
+
+```text
+wire -> receiver.ingress -> node.producer -> ... -> node.consumer -> exporter.egress -> wire
+```
+
+The shared contracts are:
+
+```text
+receiver.ingress.{messages,wire_bytes,duration}{signal,outcome}
+exporter.egress.{messages,items,wire_bytes,duration}{signal,outcome}
+```
+
+### Receiver ingress
+
+One observation represents one external message after signal classification.
+`success` means receiver-local handoff completed, `refused` means the classified
+message was rejected, and `failure` means receiver-local processing failed.
+Duration ends at that receiver-local result and excludes downstream processing
+and Ack/Nack completion. Rejections before signal classification remain
+component-specific diagnostics.
+
+Receiver ingress omits `items` because decoded items are measured by
+`node.producer.produced.items`.
+
+### Exporter egress
+
+One observation represents one exporter dequeue or invocation through one
+terminal external result. Component-internal retries belong to the same
+observation, while redelivery by a retry processor is a new observation.
+Duration excludes Ack/Nack notification propagation. Items inherit the
+whole-message terminal outcome.
+
+### Wire bytes and internal size
+
+`wire_bytes` means encoded application payload bytes visible at the external
+boundary. It excludes protocol headers, TLS overhead, and storage amplification.
+Exporter wire bytes accumulate the bytes submitted across every attempt within
+the logical export and are attributed to its terminal outcome. An export that
+fails before submitting bytes records zero. Component-specific diagnostics may
+add per-attempt protocol details.
+
+Instrumentation must not serialize PData solely to populate `wire_bytes`.
+
+The internal `size` measurement is separate: it describes the PData
+representation at `node.producer` and `node.consumer`, not the external encoded
+representation.
 
 ## Node Implementations Using This Crate
 

--- a/rust/otap-dataflow/crates/otap/src/metrics.rs
+++ b/rust/otap-dataflow/crates/otap/src/metrics.rs
@@ -11,71 +11,103 @@ use otel_arrow_dfe_telemetry::instrument::{Counter, HistogramNormal};
 use otel_arrow_dfe_telemetry_macros::metric_set;
 use std::time::Duration;
 
-/// Receiver-local handling of classified messages at the external ingress boundary.
+/// Receiver-local handling of classified messages received at the external boundary.
 #[metric_set(
-    name = "receiver.ingress",
+    name = "receiver.received",
     measurement_attributes = SignalOutcomeAttributes
 )]
 #[derive(Debug, Default, Clone)]
-pub struct ReceiverIngressMetrics {
+pub struct ReceiverReceivedMetrics {
     /// Number of classified external messages whose receiver-local handling terminated.
     #[metric(unit = "{message}")]
     pub messages: Counter<u64>,
-    /// Encoded application payload bytes observed at the receiver ingress boundary.
-    #[metric(name = "wire_bytes", unit = "By")]
-    pub wire_bytes: Counter<u64>,
+    /// Encoded application payload size observed before receiver decoding.
+    #[metric(name = "payload.size", unit = "By")]
+    pub payload_size: Counter<u64>,
     /// Receiver-local time from observing the classified message through termination.
     /// Downstream processing and Ack/Nack completion are excluded.
     #[metric(unit = "s")]
     pub duration: HistogramNormal,
 }
 
-impl ReceiverIngressMetrics {
+impl ReceiverReceivedMetrics {
     /// Records one classified external message when receiver-local handling terminates.
     #[inline]
-    pub fn record(&mut self, duration: Duration, wire_bytes: u64) {
+    pub fn record(&mut self, duration: Duration, payload_size: u64) {
         self.messages.inc();
-        self.wire_bytes.add(wire_bytes);
+        self.payload_size.add(payload_size);
         self.duration.record(duration.as_secs_f64());
     }
 }
 
-/// Terminal external results observed at an exporter egress boundary.
+/// Individual attempts to submit encoded application payloads from an exporter.
 #[metric_set(
-    name = "exporter.egress",
+    name = "exporter.attempted",
     measurement_attributes = SignalOutcomeAttributes
 )]
 #[derive(Debug, Default, Clone)]
-pub struct ExporterEgressMetrics {
-    /// Number of PData messages whose export reached a terminal external result.
+pub struct ExporterAttemptedMetrics {
+    /// Number of PData messages submitted across export attempts.
     #[metric(unit = "{message}")]
     pub messages: Counter<u64>,
-    /// Number of signal items whose export reached the terminal external result.
-    #[metric(unit = "{item}")]
-    pub items: Counter<u64>,
-    /// Encoded application payload bytes submitted across all export attempts.
-    #[metric(name = "wire_bytes", unit = "By")]
-    pub wire_bytes: Counter<u64>,
-    /// Time from dequeuing PData through its terminal local or backend export result.
-    /// Ack/Nack notification time is excluded.
+    /// Time spent performing export attempts.
     #[metric(unit = "s")]
     pub duration: HistogramNormal,
 }
 
-impl ExporterEgressMetrics {
-    /// Records one terminal export result.
+impl ExporterAttemptedMetrics {
+    /// Records one export attempt.
     #[inline]
-    pub fn record(&mut self, duration: Duration, items: u64, wire_bytes: u64) {
+    pub fn record(&mut self, duration: Duration) {
         self.messages.inc();
-        self.items.add(items);
-        self.wire_bytes.add(wire_bytes);
         self.duration.record(duration.as_secs_f64());
+    }
+}
+
+/// Optional payload-size accounting for individual exporter attempts.
+#[metric_set(
+    name = "exporter.attempted",
+    measurement_attributes = SignalOutcomeAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub struct ExporterAttemptedPayloadMetrics {
+    /// Encoded application payload size submitted across export attempts.
+    #[metric(name = "payload.size", unit = "By")]
+    pub payload_size: Counter<u64>,
+}
+
+impl ExporterAttemptedPayloadMetrics {
+    /// Records the encoded application payload size for one export attempt.
+    #[inline]
+    pub fn record(&mut self, payload_size: u64) {
+        self.payload_size.add(payload_size);
+    }
+}
+
+/// Optional item accounting for individual exporter attempts.
+#[metric_set(
+    name = "exporter.attempted",
+    measurement_attributes = SignalOutcomeAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub struct ExporterAttemptedItemsMetrics {
+    /// Number of signal items submitted across export attempts.
+    #[metric(unit = "{item}")]
+    pub items: Counter<u64>,
+}
+
+impl ExporterAttemptedItemsMetrics {
+    /// Records the item count for one export attempt.
+    #[inline]
+    pub fn record(&mut self, items: u64) {
+        self.items.add(items);
     }
 }
 
 /// Completed export operations.
 ///
-/// This set will be deprecated after exporters migrate to [`ExporterEgressMetrics`].
+/// This set will be deprecated after exporters migrate to
+/// [`ExporterAttemptedMetrics`] and node-consumer terminal accounting.
 #[metric_set(
     name = "exporter.exports",
     measurement_attributes = SignalOutcomeAttributes
@@ -102,7 +134,7 @@ impl ExporterExportMetrics {
 
 /// Lifecycle and wire bytes for messages admitted by a receiver.
 ///
-/// This set will be deprecated after receivers migrate to [`ReceiverIngressMetrics`].
+/// This set will be deprecated after receivers migrate to [`ReceiverReceivedMetrics`].
 #[metric_set(
     name = "receiver.messages",
     measurement_attributes = SignalAttributes
@@ -129,20 +161,36 @@ mod tests {
     use otel_arrow_dfe_telemetry::metrics::MeasurementMetricSet;
     use otel_arrow_dfe_telemetry::registry::TelemetryRegistryHandle;
 
-    fn new_egress_metrics() -> MeasurementMetricSet<ExporterEgressMetrics> {
+    fn new_attempted_metrics() -> MeasurementMetricSet<ExporterAttemptedMetrics> {
         let registry = TelemetryRegistryHandle::new();
         let controller = ControllerContext::new(registry);
         let pipeline_ctx =
             controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
-        ExporterEgressMetrics::register(&pipeline_ctx)
+        ExporterAttemptedMetrics::register(&pipeline_ctx)
     }
 
-    fn new_ingress_metrics() -> MeasurementMetricSet<ReceiverIngressMetrics> {
+    fn new_attempted_items_metrics() -> MeasurementMetricSet<ExporterAttemptedItemsMetrics> {
         let registry = TelemetryRegistryHandle::new();
         let controller = ControllerContext::new(registry);
         let pipeline_ctx =
             controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
-        ReceiverIngressMetrics::register(&pipeline_ctx)
+        ExporterAttemptedItemsMetrics::register(&pipeline_ctx)
+    }
+
+    fn new_attempted_payload_metrics() -> MeasurementMetricSet<ExporterAttemptedPayloadMetrics> {
+        let registry = TelemetryRegistryHandle::new();
+        let controller = ControllerContext::new(registry);
+        let pipeline_ctx =
+            controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        ExporterAttemptedPayloadMetrics::register(&pipeline_ctx)
+    }
+
+    fn new_received_metrics() -> MeasurementMetricSet<ReceiverReceivedMetrics> {
+        let registry = TelemetryRegistryHandle::new();
+        let controller = ControllerContext::new(registry);
+        let pipeline_ctx =
+            controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        ReceiverReceivedMetrics::register(&pipeline_ctx)
     }
 
     fn new_export_metrics() -> MeasurementMetricSet<ExporterExportMetrics> {
@@ -161,88 +209,167 @@ mod tests {
         ReceiverMessageMetrics::register(&pipeline_ctx)
     }
 
-    /// Scenario: Shared ingress and egress sets produce terminal snapshots.
+    /// Scenario: Shared received and attempted sets produce terminal snapshots.
     /// Guarantees: Metric namespaces, units, and bounded dimensions match the external-boundary contract.
     #[test]
     fn external_boundary_metric_descriptors_are_stable() {
-        let mut ingress = new_ingress_metrics();
-        ingress
+        let mut received = new_received_metrics();
+        received
             .with(SignalOutcomeAttributes {
                 signal: SignalType::Metrics,
                 outcome: Outcome::Success,
             })
             .record(Duration::from_millis(10), 64);
-        let ingress_snapshot = ingress
+        let received_snapshot = received
             .terminal_snapshots()
             .into_iter()
             .next()
-            .expect("ingress snapshot");
-        assert_eq!(ingress_snapshot.descriptor().name, "receiver.ingress");
+            .expect("received snapshot");
+        assert_eq!(received_snapshot.descriptor().name, "receiver.received");
         assert_eq!(
-            ingress_snapshot.measurement_attribute_value("signal"),
+            received_snapshot.measurement_attribute_value("signal"),
             Some("metrics")
         );
         assert_eq!(
-            ingress_snapshot.measurement_attribute_value("outcome"),
+            received_snapshot.measurement_attribute_value("outcome"),
             Some("success")
         );
         assert!(
-            ingress_snapshot
+            received_snapshot
                 .descriptor()
                 .metrics
                 .iter()
                 .any(|metric| metric.name == "messages" && metric.unit == "{message}")
         );
         assert!(
-            ingress_snapshot
+            received_snapshot
                 .descriptor()
                 .metrics
                 .iter()
-                .any(|metric| metric.name == "wire_bytes" && metric.unit == "By")
+                .any(|metric| metric.name == "payload.size" && metric.unit == "By")
         );
         assert!(
-            ingress_snapshot
+            received_snapshot
                 .descriptor()
                 .metrics
                 .iter()
                 .any(|metric| metric.name == "duration" && metric.unit == "s")
         );
 
-        let mut egress = new_egress_metrics();
-        egress
+        let mut attempted = new_attempted_metrics();
+        attempted
             .with(SignalOutcomeAttributes {
                 signal: SignalType::Logs,
                 outcome: Outcome::Success,
             })
-            .record(Duration::from_millis(20), 2, 96);
-        let egress_snapshot = egress
+            .record(Duration::from_millis(20));
+        let attempted_snapshot = attempted
             .terminal_snapshots()
             .into_iter()
             .next()
-            .expect("egress snapshot");
-        assert_eq!(egress_snapshot.descriptor().name, "exporter.egress");
+            .expect("attempted snapshot");
+        assert_eq!(attempted_snapshot.descriptor().name, "exporter.attempted");
         assert_eq!(
-            egress_snapshot.measurement_attribute_value("signal"),
+            attempted_snapshot.measurement_attribute_value("signal"),
             Some("logs")
         );
         assert_eq!(
-            egress_snapshot.measurement_attribute_value("outcome"),
+            attempted_snapshot.measurement_attribute_value("outcome"),
             Some("success")
         );
         assert!(
-            egress_snapshot
+            attempted_snapshot
+                .descriptor()
+                .metrics
+                .iter()
+                .all(|metric| metric.name != "items")
+        );
+        assert!(
+            attempted_snapshot
+                .descriptor()
+                .metrics
+                .iter()
+                .all(|metric| metric.name != "payload.size")
+        );
+
+        let mut attempted_payload = new_attempted_payload_metrics();
+        attempted_payload
+            .with(SignalOutcomeAttributes {
+                signal: SignalType::Logs,
+                outcome: Outcome::Success,
+            })
+            .record(96);
+        let attempted_payload_snapshot = attempted_payload
+            .terminal_snapshots()
+            .into_iter()
+            .next()
+            .expect("attempted payload snapshot");
+        assert_eq!(
+            attempted_payload_snapshot.descriptor().name,
+            "exporter.attempted"
+        );
+        assert!(
+            attempted_payload_snapshot
+                .descriptor()
+                .metrics
+                .iter()
+                .any(|metric| metric.name == "payload.size" && metric.unit == "By")
+        );
+
+        let mut attempted_items = new_attempted_items_metrics();
+        attempted_items
+            .with(SignalOutcomeAttributes {
+                signal: SignalType::Logs,
+                outcome: Outcome::Success,
+            })
+            .record(2);
+        let attempted_items_snapshot = attempted_items
+            .terminal_snapshots()
+            .into_iter()
+            .next()
+            .expect("attempted items snapshot");
+        assert_eq!(
+            attempted_items_snapshot.descriptor().name,
+            "exporter.attempted"
+        );
+        assert!(
+            attempted_items_snapshot
                 .descriptor()
                 .metrics
                 .iter()
                 .any(|metric| metric.name == "items" && metric.unit == "{item}")
         );
-        assert!(
-            egress_snapshot
-                .descriptor()
-                .metrics
-                .iter()
-                .any(|metric| metric.name == "wire_bytes" && metric.unit == "By")
-        );
+    }
+
+    /// Scenario: One logical export requires a failed attempt followed by a successful retry.
+    /// Guarantees: Every attempt records its own message under its attempt outcome.
+    #[test]
+    fn exporter_attempts_are_recorded_independently() {
+        let mut metrics = new_attempted_metrics();
+        metrics
+            .with(SignalOutcomeAttributes {
+                signal: SignalType::Logs,
+                outcome: Outcome::Failure,
+            })
+            .record(Duration::from_millis(10));
+        metrics
+            .with(SignalOutcomeAttributes {
+                signal: SignalType::Logs,
+                outcome: Outcome::Success,
+            })
+            .record(Duration::from_millis(20));
+
+        let failed = metrics.get(SignalOutcomeAttributes {
+            signal: SignalType::Logs,
+            outcome: Outcome::Failure,
+        });
+        assert_eq!(failed.messages.get(), 1);
+
+        let succeeded = metrics.get(SignalOutcomeAttributes {
+            signal: SignalType::Logs,
+            outcome: Outcome::Success,
+        });
+        assert_eq!(succeeded.messages.get(), 1);
     }
 
     /// Scenario: An exporter completes successful and failed exports for multiple signals.

--- a/rust/otap-dataflow/crates/otap/src/metrics.rs
+++ b/rust/otap-dataflow/crates/otap/src/metrics.rs
@@ -11,7 +11,71 @@ use otel_arrow_dfe_telemetry::instrument::{Counter, HistogramNormal};
 use otel_arrow_dfe_telemetry_macros::metric_set;
 use std::time::Duration;
 
+/// Receiver-local handling of classified messages at the external ingress boundary.
+#[metric_set(
+    name = "receiver.ingress",
+    measurement_attributes = SignalOutcomeAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub struct ReceiverIngressMetrics {
+    /// Number of classified external messages whose receiver-local handling terminated.
+    #[metric(unit = "{message}")]
+    pub messages: Counter<u64>,
+    /// Encoded application payload bytes observed at the receiver ingress boundary.
+    #[metric(name = "wire_bytes", unit = "By")]
+    pub wire_bytes: Counter<u64>,
+    /// Receiver-local time from observing the classified message through termination.
+    /// Downstream processing and Ack/Nack completion are excluded.
+    #[metric(unit = "s")]
+    pub duration: HistogramNormal,
+}
+
+impl ReceiverIngressMetrics {
+    /// Records one classified external message when receiver-local handling terminates.
+    #[inline]
+    pub fn record(&mut self, duration: Duration, wire_bytes: u64) {
+        self.messages.inc();
+        self.wire_bytes.add(wire_bytes);
+        self.duration.record(duration.as_secs_f64());
+    }
+}
+
+/// Terminal external results observed at an exporter egress boundary.
+#[metric_set(
+    name = "exporter.egress",
+    measurement_attributes = SignalOutcomeAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub struct ExporterEgressMetrics {
+    /// Number of PData messages whose export reached a terminal external result.
+    #[metric(unit = "{message}")]
+    pub messages: Counter<u64>,
+    /// Number of signal items whose export reached the terminal external result.
+    #[metric(unit = "{item}")]
+    pub items: Counter<u64>,
+    /// Encoded application payload bytes submitted across all export attempts.
+    #[metric(name = "wire_bytes", unit = "By")]
+    pub wire_bytes: Counter<u64>,
+    /// Time from dequeuing PData through its terminal local or backend export result.
+    /// Ack/Nack notification time is excluded.
+    #[metric(unit = "s")]
+    pub duration: HistogramNormal,
+}
+
+impl ExporterEgressMetrics {
+    /// Records one terminal export result.
+    #[inline]
+    pub fn record(&mut self, duration: Duration, items: u64, wire_bytes: u64) {
+        self.messages.inc();
+        self.items.add(items);
+        self.wire_bytes.add(wire_bytes);
+        self.duration.record(duration.as_secs_f64());
+    }
+}
+
 /// Completed export operations.
+///
+/// This set will be deprecated after exporters migrate to [`ExporterEgressMetrics`].
 #[metric_set(
     name = "exporter.exports",
     measurement_attributes = SignalOutcomeAttributes
@@ -37,6 +101,8 @@ impl ExporterExportMetrics {
 }
 
 /// Lifecycle and wire bytes for messages admitted by a receiver.
+///
+/// This set will be deprecated after receivers migrate to [`ReceiverIngressMetrics`].
 #[metric_set(
     name = "receiver.messages",
     measurement_attributes = SignalAttributes
@@ -63,6 +129,22 @@ mod tests {
     use otel_arrow_dfe_telemetry::metrics::MeasurementMetricSet;
     use otel_arrow_dfe_telemetry::registry::TelemetryRegistryHandle;
 
+    fn new_egress_metrics() -> MeasurementMetricSet<ExporterEgressMetrics> {
+        let registry = TelemetryRegistryHandle::new();
+        let controller = ControllerContext::new(registry);
+        let pipeline_ctx =
+            controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        ExporterEgressMetrics::register(&pipeline_ctx)
+    }
+
+    fn new_ingress_metrics() -> MeasurementMetricSet<ReceiverIngressMetrics> {
+        let registry = TelemetryRegistryHandle::new();
+        let controller = ControllerContext::new(registry);
+        let pipeline_ctx =
+            controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        ReceiverIngressMetrics::register(&pipeline_ctx)
+    }
+
     fn new_export_metrics() -> MeasurementMetricSet<ExporterExportMetrics> {
         let registry = TelemetryRegistryHandle::new();
         let controller = ControllerContext::new(registry);
@@ -77,6 +159,90 @@ mod tests {
         let pipeline_ctx =
             controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
         ReceiverMessageMetrics::register(&pipeline_ctx)
+    }
+
+    /// Scenario: Shared ingress and egress sets produce terminal snapshots.
+    /// Guarantees: Metric namespaces, units, and bounded dimensions match the external-boundary contract.
+    #[test]
+    fn external_boundary_metric_descriptors_are_stable() {
+        let mut ingress = new_ingress_metrics();
+        ingress
+            .with(SignalOutcomeAttributes {
+                signal: SignalType::Metrics,
+                outcome: Outcome::Success,
+            })
+            .record(Duration::from_millis(10), 64);
+        let ingress_snapshot = ingress
+            .terminal_snapshots()
+            .into_iter()
+            .next()
+            .expect("ingress snapshot");
+        assert_eq!(ingress_snapshot.descriptor().name, "receiver.ingress");
+        assert_eq!(
+            ingress_snapshot.measurement_attribute_value("signal"),
+            Some("metrics")
+        );
+        assert_eq!(
+            ingress_snapshot.measurement_attribute_value("outcome"),
+            Some("success")
+        );
+        assert!(
+            ingress_snapshot
+                .descriptor()
+                .metrics
+                .iter()
+                .any(|metric| metric.name == "messages" && metric.unit == "{message}")
+        );
+        assert!(
+            ingress_snapshot
+                .descriptor()
+                .metrics
+                .iter()
+                .any(|metric| metric.name == "wire_bytes" && metric.unit == "By")
+        );
+        assert!(
+            ingress_snapshot
+                .descriptor()
+                .metrics
+                .iter()
+                .any(|metric| metric.name == "duration" && metric.unit == "s")
+        );
+
+        let mut egress = new_egress_metrics();
+        egress
+            .with(SignalOutcomeAttributes {
+                signal: SignalType::Logs,
+                outcome: Outcome::Success,
+            })
+            .record(Duration::from_millis(20), 2, 96);
+        let egress_snapshot = egress
+            .terminal_snapshots()
+            .into_iter()
+            .next()
+            .expect("egress snapshot");
+        assert_eq!(egress_snapshot.descriptor().name, "exporter.egress");
+        assert_eq!(
+            egress_snapshot.measurement_attribute_value("signal"),
+            Some("logs")
+        );
+        assert_eq!(
+            egress_snapshot.measurement_attribute_value("outcome"),
+            Some("success")
+        );
+        assert!(
+            egress_snapshot
+                .descriptor()
+                .metrics
+                .iter()
+                .any(|metric| metric.name == "items" && metric.unit == "{item}")
+        );
+        assert!(
+            egress_snapshot
+                .descriptor()
+                .metrics
+                .iter()
+                .any(|metric| metric.name == "wire_bytes" && metric.unit == "By")
+        );
     }
 
     /// Scenario: An exporter completes successful and failed exports for multiple signals.

--- a/rust/otap-dataflow/crates/telemetry/src/common_attributes.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/common_attributes.rs
@@ -30,11 +30,12 @@ impl AttributeEnum for SignalType {
 /// Outcome of a pipeline component operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, AttributeEnum)]
 pub enum Outcome {
-    /// The component completed the operation successfully.
+    /// The operation was accepted and completed at the measured boundary.
     Success,
-    /// The component itself failed the operation.
+    /// The operation was attempted but did not complete because of an error.
     Failure,
-    /// A downstream component refused the operation.
+    /// The operation was explicitly not accepted because of validation, policy,
+    /// admission, or capacity.
     Refused,
 }
 


### PR DESCRIPTION
# Change summary

First part of #3822

Define shared receiver and exporter metric contracts for external pipeline boundaries.

The contracts use:

- `receiver.received.{messages,payload.size,duration}{signal,outcome}` for incoming messages
- `exporter.attempted.{messages,duration}{signal,outcome}` for each backend, storage, or compatible exporter attempt
- Optional `exporter.attempted.payload.size{signal,outcome}` when an encoded application payload exists and its size is naturally available
- Optional `exporter.attempted.items{signal,outcome}` when cached item counts are enabled

`payload.size` follows OpenTelemetry naming guidance by keeping the `By` unit in metric metadata rather than the metric name. It describes encoded application payload bytes and excludes protocol headers, framing, TLS overhead, and storage amplification.

Exporter payload size and item counts are separately registered metric sets so components do not perform additional encoding or PData traversal, and unknown values are omitted rather than reported as zero. This lets exporters without an encoded payload still adopt the shared attempt contract.

The shared `outcome` values describe how an operation terminated at its measured boundary:

- `success`: accepted and completed
- `refused`: explicitly not accepted because of validation, policy, admission, or capacity
- `failure`: attempted but not completed because of a processing, encoding, transport, timeout, or backend error

`exporter.attempted` owns per-attempt external behavior, including component-internal retries. `node.consumer` remains the logical message's terminal pipeline outcome. The legacy `exporter.exports` set remains during migration and will be deprecated.

Follow-up PRs will migrate exporters and receivers to use these metric sets.

## Related issue

* Part of #3822

## Validation

Unit tests

## User-facing changes

None