### PR TITLE
chore(repo): Rebalance PR size labels based on recent data

### DIFF
--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -19,17 +19,17 @@ jobs:
       - uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # v1.10.4
         with:
           xs_label: 'size/XS'
-          xs_max_size: '9'
+          xs_max_size: '10'
           s_label: 'size/S'
-          s_max_size: '29'
+          s_max_size: '30'
           m_label: 'size/M'
-          m_max_size: '99'
+          m_max_size: '250'
           l_label: 'size/L'
-          l_max_size: '499'
+          l_max_size: '1250'
           xl_label: 'size/XL'
           fail_if_xl: 'false'
           message_if_xl: >
-            **This PR is `size/XL` (500+ changed lines).** Large PRs are
+            **This PR is `size/XL` (1,250+ changed lines).** Large PRs are
             harder to review thoroughly and more likely to introduce subtle
             bugs.
 


### PR DESCRIPTION
# Chore Summary

The current thresholds put 63% of the 197 PRs merged between July 21 and August 21, 2026 in `size/L` or `size/XL`. Automation is not driving the result: 72% of the 169 human-authored PRs were labeled L or XL.

| Label | Current range | Current PRs | Current share | New range | Projected PRs | Projected share |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `size/XS` | 0-8 | 30 | 15% | 0-9 | 31 | 16% |
| `size/S` | 9-28 | 20 | 10% | 10-29 | 19 | 10% |
| `size/M` | 29-98 | 23 | 12% | 30-249 | 59 | 30% |
| `size/L` | 99-498 | 57 | 29% | 250-1,249 | 53 | 27% |
| `size/XL` | 499+ | 67 | 34% | 1,250+ | 35 | 18% |

Boundaries at 250 and 1,250 make M and L representative of a typical change while keeping XL as a warning for roughly the largest fifth of PRs.

I am open to discussion of whether or not we should merge this PR versus trying to keep existing limits and encouraging contributors to break up work into multiple pieces.
