### PR TITLE
feat(engine): Introduce HttpClientAuthenticationProvider and refactor BearerAuth

### DIFF
--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -7625,6 +7625,7 @@ dependencies = [
  "flume",
  "futures",
  "futures-core",
+ "http 1.5.0",
  "linkme",
  "memory-stats",
  "nix 0.31.3",

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use otap_df_channel::error::RecvError;
 use otap_df_config::SignalType;
 use otap_df_engine::ConsumerEffectHandlerExtension;
+use otap_df_engine::capability::auth::http_client_authentication_provider::HttpClientAuthenticationProviderEvents;
 use otap_df_engine::context::PipelineContext;
 use otap_df_engine::control::{AckMsg, NackMsg, NodeControlMsg};
 use otap_df_engine::error::Error as EngineError;
@@ -27,7 +28,7 @@ use super::in_flight_exports::{CompletedExport, InFlightExports};
 use super::metrics::AzureMonitorExporterMetricsRc;
 use super::state::AzureMonitorExporterState;
 use super::transformer::Transformer;
-use otap_df_otap::bearer_auth::{BearerAuth, BearerAuthEvents};
+use otap_df_otap::bearer_auth::BearerAuth;
 use otap_df_otap::pdata::{Context, OtapPdata};
 
 use otap_df_telemetry::common_attributes::{HttpResponse, Outcome};
@@ -41,18 +42,18 @@ const MAX_IN_FLIGHT_EXPORTS: usize = 16;
 const PERIODIC_EXPORT_INTERVAL: u64 = 3;
 
 /// Raises shared bearer-auth warnings under the Azure Monitor event namespace.
-const AZURE_MONITOR_BEARER_AUTH_EVENTS: BearerAuthEvents = BearerAuthEvents {
-    invalid_token: |error| {
-        otel_warn!("azure_monitor_exporter.auth.invalid_bearer_token", error = %error);
-    },
-    token_stream_closed: || {
-        otel_warn!(
-            "azure_monitor_exporter.auth.token_stream_closed",
-            message =
-                "bearer token provider closed its stream; no further token refreshes will arrive"
-        );
-    },
-};
+const AZURE_MONITOR_BEARER_AUTH_EVENTS: HttpClientAuthenticationProviderEvents =
+    HttpClientAuthenticationProviderEvents {
+        invalid: || {
+            otel_warn!("azure_monitor_exporter.auth.invalid_bearer_token");
+        },
+        stream_closed: || {
+            otel_warn!(
+                "azure_monitor_exporter.auth.token_stream_closed",
+                message = "bearer token provider closed its stream; no further token refreshes will arrive"
+            );
+        },
+    };
 
 /// Azure Monitor exporter.
 pub struct AzureMonitorExporter {
@@ -533,7 +534,6 @@ impl Exporter<OtapPdata> for AzureMonitorExporter {
             self.token_provider
                 .take()
                 .expect("bearer token provider is present before startup"),
-            AZURE_MONITOR_BEARER_AUTH_EVENTS,
         );
 
         self.client_pool
@@ -576,7 +576,7 @@ impl Exporter<OtapPdata> for AzureMonitorExporter {
                     continue;
                 }
 
-                () = auth.poll_refresh(), if auth.is_active() => {
+                () = auth.poll_refresh(&AZURE_MONITOR_BEARER_AUTH_EVENTS), if auth.is_active() => {
                     continue;
                 }
 
@@ -674,7 +674,6 @@ mod tests {
     use bytes::Bytes;
     use futures::StreamExt;
     use http::StatusCode;
-    use http::header::HeaderValue;
     use otap_df_channel::mpsc;
     use otap_df_engine::Interests;
     use otap_df_engine::capability::CapabilityError;
@@ -795,11 +794,8 @@ mod tests {
     }
 
     async fn auth_with_cached_token() -> BearerAuth {
-        let mut auth = BearerAuth::new(
-            Box::new(MockTokenProvider),
-            AZURE_MONITOR_BEARER_AUTH_EVENTS,
-        );
-        auth.poll_refresh().await;
+        let mut auth = BearerAuth::new(Box::new(MockTokenProvider));
+        auth.poll_refresh(&AZURE_MONITOR_BEARER_AUTH_EVENTS).await;
         assert!(auth.is_ready());
         auth
     }
@@ -909,11 +905,8 @@ mod tests {
         let pipeline_ctx = create_test_pipeline_ctx();
         let mut exporter =
             AzureMonitorExporter::new(pipeline_ctx, config, Box::new(MockTokenProvider)).unwrap();
-        let mut auth = BearerAuth::new(
-            Box::new(MockTokenProvider),
-            AZURE_MONITOR_BEARER_AUTH_EVENTS,
-        );
-        auth.poll_refresh().await;
+        let mut auth = BearerAuth::new(Box::new(MockTokenProvider));
+        auth.poll_refresh(&AZURE_MONITOR_BEARER_AUTH_EVENTS).await;
         let (_, token_generation) = auth.header().expect("mock provider publishes a token");
 
         let (_, reporter) = MetricsReporter::create_new_and_receiver(10);
@@ -1022,10 +1015,7 @@ mod tests {
     #[tokio::test]
     async fn pdata_is_refused_while_no_bearer_token_is_cached() {
         let mut exporter = exporter_targeting("http://localhost".to_string()).await;
-        let mut auth = BearerAuth::new(
-            Box::new(MockTokenProvider),
-            AZURE_MONITOR_BEARER_AUTH_EVENTS,
-        );
+        let mut auth = BearerAuth::new(Box::new(MockTokenProvider));
         assert!(!auth.is_ready(), "no token has been polled yet");
         assert!(!auth.not_ready_reason().is_empty());
 
@@ -1185,10 +1175,7 @@ mod tests {
     #[tokio::test]
     async fn shutdown_without_a_token_releases_buffered_messages() {
         let mut exporter = exporter_targeting("http://localhost".to_string()).await;
-        let mut auth = BearerAuth::new(
-            Box::new(MockTokenProvider),
-            AZURE_MONITOR_BEARER_AUTH_EVENTS,
-        );
+        let mut auth = BearerAuth::new(Box::new(MockTokenProvider));
         assert!(!auth.is_ready(), "no token has been polled yet");
 
         exporter
@@ -1209,9 +1196,8 @@ mod tests {
     /// can be raised without panicking.
     #[test]
     fn bearer_auth_events_are_reportable() {
-        let invalid = HeaderValue::from_str("\n").expect_err("control chars are invalid");
-        (AZURE_MONITOR_BEARER_AUTH_EVENTS.invalid_token)(&invalid);
-        (AZURE_MONITOR_BEARER_AUTH_EVENTS.token_stream_closed)();
+        (AZURE_MONITOR_BEARER_AUTH_EVENTS.invalid)();
+        (AZURE_MONITOR_BEARER_AUTH_EVENTS.stream_closed)();
     }
 
     // Azure Monitor can temporarily stop accepting new pdata while it is at

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
@@ -24,12 +24,14 @@ use otap_df_config::SignalType;
 use otap_df_config::node::NodeUserConfig;
 use otap_df_engine::ConsumerEffectHandlerExtension;
 use otap_df_engine::ExporterFactory;
+use otap_df_engine::capability::auth::http_client_authentication_provider::HttpClientAuthenticationProviderEvents;
 use otap_df_engine::config::ExporterConfig;
 use otap_df_engine::context::PipelineContext;
 use otap_df_engine::control::{AckMsg, NackMsg, NodeControlMsg};
 use otap_df_engine::error::{Error, ExporterErrorKind, format_error_sources};
 use otap_df_engine::exporter::ExporterWrapper;
 use otap_df_engine::local::capability::auth::bearer_token_provider::BearerTokenProvider;
+use otap_df_engine::local::capability::auth::http_client_authentication_provider::HttpClientAuthenticationProvider;
 use otap_df_engine::local::exporter::{EffectHandler, Exporter};
 use otap_df_engine::message::{ExporterInbox, Message};
 use otap_df_engine::node::NodeId;
@@ -58,7 +60,7 @@ use tonic::codec::CompressionEncoding;
 use tonic::metadata::{MetadataKey, MetadataMap, MetadataValue};
 use tonic::transport::Channel;
 
-use otap_df_otap::bearer_auth::{BearerAuth, BearerAuthEvents, apply_auth_rejection};
+use otap_df_otap::bearer_auth::BearerAuth;
 
 mod metrics;
 
@@ -68,18 +70,19 @@ use metrics::{OtlpGrpcExporterErrorType, OtlpGrpcExporterMetrics};
 pub const OTLP_EXPORTER_URN: &str = "urn:otel:exporter:otlp_grpc";
 
 /// Raises the shared bearer-auth warnings under this exporter's event namespace.
-const GRPC_BEARER_AUTH_EVENTS: BearerAuthEvents = BearerAuthEvents {
-    invalid_token: |error| {
-        otel_warn!("otlp.exporter.grpc.invalid_bearer_token", error = %error);
-    },
-    token_stream_closed: || {
-        otel_warn!(
-            "otlp.exporter.grpc.token_stream_closed",
-            message = "bearer token provider closed its stream; \
+const GRPC_BEARER_AUTH_EVENTS: HttpClientAuthenticationProviderEvents =
+    HttpClientAuthenticationProviderEvents {
+        invalid: || {
+            otel_warn!("otlp.exporter.grpc.invalid_bearer_token");
+        },
+        stream_closed: || {
+            otel_warn!(
+                "otlp.exporter.grpc.token_stream_closed",
+                message = "bearer token provider closed its stream; \
                 no further token refreshes will arrive"
-        );
-    },
-};
+            );
+        },
+    };
 
 /// Configuration for the OTLP Exporter
 #[derive(Debug, Deserialize)]
@@ -110,11 +113,7 @@ pub(crate) const fn default_num_connections() -> usize {
 pub struct OTLPExporter {
     config: Config,
     metrics: OtlpGrpcExporterMetrics,
-    /// Optional bearer token provider resolved from the
-    /// `bearer_token_provider` capability. When bound, a fresh
-    /// `authorization: Bearer <token>` is injected on every outgoing request;
-    /// when absent, the exporter behaves exactly as before.
-    token_provider: Option<Box<dyn BearerTokenProvider>>,
+    auth_provider: Option<Box<dyn HttpClientAuthenticationProvider>>,
 }
 
 /// Declare the OTLP Exporter as a local exporter factory
@@ -128,6 +127,11 @@ pub static OTLP_EXPORTER: ExporterFactory<OtapPdata> = ExporterFactory {
              node_config: Arc<NodeUserConfig>,
              exporter_config: &ExporterConfig,
              capabilities: &otap_df_engine::capability::registry::Capabilities| {
+        let auth_provider = capabilities
+            .optional_local::<otap_df_engine::capability::auth::http_client_authentication_provider::HttpClientAuthenticationProvider>()
+            .map_err(|e| otap_df_config::error::Error::InvalidUserConfig {
+                error: e.to_string(),
+            })?;
         // Optionally resolve a bound bearer token provider. Absent binding keeps
         // the default (no-auth) behavior; a bound provider (e.g. the
         // `oauth2_client_auth` extension) supplies refreshed OAuth tokens.
@@ -137,7 +141,12 @@ pub static OTLP_EXPORTER: ExporterFactory<OtapPdata> = ExporterFactory {
                 error: e.to_string(),
             })?;
         Ok(ExporterWrapper::local(
-            OTLPExporter::from_config(pipeline, &node_config.config, token_provider)?,
+            OTLPExporter::from_config(
+                pipeline,
+                &node_config.config,
+                auth_provider,
+                token_provider,
+            )?,
             node,
             node_config,
             exporter_config,
@@ -171,6 +180,7 @@ impl OTLPExporter {
     pub fn from_config(
         pipeline_ctx: PipelineContext,
         config: &serde_json::Value,
+        mut auth_provider: Option<Box<dyn HttpClientAuthenticationProvider>>,
         token_provider: Option<Box<dyn BearerTokenProvider>>,
     ) -> Result<Self, otap_df_config::error::Error> {
         let metrics = OtlpGrpcExporterMetrics::register(&pipeline_ctx);
@@ -181,11 +191,27 @@ impl OTLPExporter {
             }
         })?;
 
+        if auth_provider.is_none() {
+            auth_provider = create_auth_provider_from_token_provider(token_provider);
+        }
+
         Ok(Self {
             config,
             metrics,
-            token_provider,
+            auth_provider,
         })
+    }
+}
+
+fn create_auth_provider_from_token_provider(
+    token_provider: Option<Box<dyn BearerTokenProvider>>,
+) -> Option<Box<dyn HttpClientAuthenticationProvider>> {
+    match token_provider {
+        None => None,
+        Some(p) => {
+            let a: Box<dyn HttpClientAuthenticationProvider> = Box::new(BearerAuth::new(p));
+            Some(a)
+        }
     }
 }
 
@@ -266,15 +292,6 @@ impl Exporter<OtapPdata> for OTLPExporter {
         let mut inflight_exports = InFlightExports::new();
         let mut pending_msg: Option<(OtapPdata, Instant)> = None;
 
-        // Consumer-side bearer-token adapter, if a provider is bound. It owns
-        // the token subscription, the cached `authorization` header, and token
-        // usability; the loop below stays auth-agnostic -- it only asks whether
-        // it may send and stamps the header the adapter hands back.
-        let mut auth = self
-            .token_provider
-            .take()
-            .map(|provider| BearerAuth::new(provider, GRPC_BEARER_AUTH_EVENTS));
-
         // Timer that fires when the cached token crosses its usability margin.
         // Hoisted out of the loop and re-armed only when the deadline actually
         // moves (i.e. when a refresh is cached), so a busy exporter does not pay
@@ -295,7 +312,11 @@ impl Exporter<OtapPdata> for OTLPExporter {
                     let (client, rejected_generation) =
                         finalize_completed_export(completed, &effect_handler, &mut self.metrics)
                             .await;
-                    apply_auth_rejection(&mut auth, rejected_generation);
+                    if let (Some(auth), Some(generation)) =
+                        (self.auth_provider.as_mut(), rejected_generation)
+                    {
+                        auth.invalidate(generation);
+                    }
                     grpc_clients.release(client);
                 }
                 continue;
@@ -306,7 +327,11 @@ impl Exporter<OtapPdata> for OTLPExporter {
             {
                 let (client, rejected_generation) =
                     finalize_completed_export(completed, &effect_handler, &mut self.metrics).await;
-                apply_auth_rejection(&mut auth, rejected_generation);
+                if let (Some(auth), Some(generation)) =
+                    (self.auth_provider.as_mut(), rejected_generation)
+                {
+                    auth.invalidate(generation);
+                }
                 grpc_clients.release(client);
             }
 
@@ -317,13 +342,16 @@ impl Exporter<OtapPdata> for OTLPExporter {
             // the extension's readiness probe holds data-path startup until the
             // first publish, and its watch stream stays live while we hold the
             // provider handle -- so waiting (not dropping) is always correct here.
-            let accepting_pdata = auth.as_ref().is_none_or(BearerAuth::is_ready);
+            let accepting_pdata = self.auth_provider.as_ref().is_none_or(|a| a.is_ready());
 
             // Instant at which a currently-usable token crosses the usability
             // margin. Used to wake the loop so `accepting_pdata` re-evaluates
             // (and gates) before a near-expiry batch is admitted, since the recv
             // arm below may already be parked when the margin is reached.
-            let token_margin_deadline = auth.as_ref().and_then(BearerAuth::refresh_deadline);
+            let token_margin_deadline = self
+                .auth_provider
+                .as_ref()
+                .and_then(|a| a.refresh_deadline());
             if token_margin_deadline != armed_margin_deadline {
                 if let Some(deadline) = token_margin_deadline {
                     margin_sleep
@@ -370,11 +398,11 @@ impl Exporter<OtapPdata> for OTLPExporter {
                     // `None` when no provider is bound. The `None` arm is unreachable
                     // while the guard holds; it pends rather than panics.
                     () = async {
-                        match auth.as_mut() {
-                            Some(a) => a.poll_refresh().await,
+                        match self.auth_provider.as_mut() {
+                            Some(a) => a.poll_refresh(&GRPC_BEARER_AUTH_EVENTS).await,
                             None => std::future::pending().await,
                         }
-                    }, if auth.as_ref().is_some_and(BearerAuth::is_active) => {
+                    }, if self.auth_provider.as_ref().is_some_and(|a| a.is_active()) => {
                         // A refresh was drained (the adapter caches it and logs any
                         // anomaly); loop to re-evaluate intake readiness.
                         continue;
@@ -397,7 +425,9 @@ impl Exporter<OtapPdata> for OTLPExporter {
                             // and the retry never reuses the rejected token. A stale
                             // rejection (a newer token was already cached) is ignored by
                             // the generation guard.
-                            apply_auth_rejection(&mut auth, rejected_generation);
+                            if let (Some(auth), Some(generation)) = (self.auth_provider.as_mut(), rejected_generation) {
+                                auth.invalidate(generation);
+                            }
                             grpc_clients.release(client);
                         }
                         continue;
@@ -427,12 +457,13 @@ impl Exporter<OtapPdata> for OTLPExporter {
                     // would be dropped silently.
                     if let Some((pdata, export_started_at)) = pending_msg.take() {
                         debug_assert!(
-                            auth.as_ref().is_some_and(|a| !a.is_ready()),
+                            self.auth_provider.as_ref().is_some_and(|a| !a.is_ready()),
                             "a batch stays parked only while a bound token is unusable"
                         );
-                        let reason = auth
+                        let reason = self
+                            .auth_provider
                             .as_ref()
-                            .map_or("no usable bearer token", BearerAuth::not_ready_reason);
+                            .map_or("no usable bearer token", |a| a.not_ready_reason());
                         nack_without_usable_token(
                             pdata,
                             reason,
@@ -452,7 +483,11 @@ impl Exporter<OtapPdata> for OTLPExporter {
                             .await;
                             // Honor a rejection even while draining, so a later
                             // force-drained request cannot reuse the rejected token.
-                            apply_auth_rejection(&mut auth, rejected_generation);
+                            if let (Some(auth), Some(generation)) =
+                                (self.auth_provider.as_mut(), rejected_generation)
+                            {
+                                auth.invalidate(generation);
+                            }
                             grpc_clients.release(client);
                         }
                     }
@@ -486,7 +521,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
                     // force-drains buffered pdata even while auth is pending: with no
                     // usable token we cannot send, so NACK it as retryable -- a token
                     // may yet arrive, so nothing is dropped.
-                    if let Some(a) = auth.as_ref() {
+                    if let Some(a) = self.auth_provider.as_ref() {
                         if !a.is_ready() {
                             let reason = a.not_ready_reason();
                             nack_without_usable_token(
@@ -509,7 +544,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
                     // completion so an UNAUTHENTICATED response can be matched to the
                     // exact token used and a stale rejection ignored.
                     let (auth_header, token_generation) =
-                        match auth.as_ref().and_then(BearerAuth::header) {
+                        match self.auth_provider.as_ref().and_then(|a| a.header()) {
                             Some((header, generation)) => (Some(header), Some(generation)),
                             None => (None, None),
                         };
@@ -1676,7 +1711,7 @@ mod tests {
                     num_connections: default_num_connections(),
                 },
                 metrics: OtlpGrpcExporterMetrics::register(&pipeline_ctx),
-                token_provider: None,
+                auth_provider: None,
             },
             test_node(test_runtime.config().name.clone()),
             node_config,
@@ -1801,7 +1836,7 @@ mod tests {
                     num_connections: default_num_connections(),
                 },
                 metrics: OtlpGrpcExporterMetrics::register(&pipeline_ctx),
-                token_provider: None,
+                auth_provider: None,
             },
             test_node(test_runtime.config().name.clone()),
             node_config,
@@ -1930,7 +1965,7 @@ mod tests {
                     num_connections: default_num_connections(),
                 },
                 metrics: OtlpGrpcExporterMetrics::register(&pipeline_ctx),
-                token_provider: Some(Box::new(provider)),
+                auth_provider: create_auth_provider_from_token_provider(Some(Box::new(provider))),
             },
             test_node(test_runtime.config().name.clone()),
             node_config,
@@ -2080,7 +2115,9 @@ mod tests {
                     num_connections: default_num_connections(),
                 },
                 metrics: OtlpGrpcExporterMetrics::register(&pipeline_ctx),
-                token_provider: Some(Box::new(MockTokenProvider::never_publishes())),
+                auth_provider: create_auth_provider_from_token_provider(Some(Box::new(
+                    MockTokenProvider::never_publishes(),
+                ))),
             },
             test_node(test_runtime.config().name.clone()),
             node_config,
@@ -2198,7 +2235,7 @@ mod tests {
                     num_connections: default_num_connections(),
                 },
                 metrics: OtlpGrpcExporterMetrics::register(&pipeline_ctx),
-                token_provider: None,
+                auth_provider: None,
             },
             node_id.clone(),
             node_config,
@@ -2783,7 +2820,7 @@ mod tests {
                     num_connections: default_num_connections(),
                 },
                 metrics: OtlpGrpcExporterMetrics::register(&pipeline_ctx),
-                token_provider,
+                auth_provider: create_auth_provider_from_token_provider(token_provider),
             },
             node_id.clone(),
             node_config,

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
@@ -28,12 +28,14 @@ use linkme::distributed_slice;
 use otap_df_config::SignalType;
 use otap_df_config::error::Error as ConfigError;
 use otap_df_config::node::NodeUserConfig;
+use otap_df_engine::capability::auth::http_client_authentication_provider::HttpClientAuthenticationProviderEvents;
 use otap_df_engine::config::ExporterConfig;
 use otap_df_engine::context::PipelineContext;
 use otap_df_engine::control::{AckMsg, NackMsg, NodeControlMsg};
 use otap_df_engine::error::{Error as EngineError, ExporterErrorKind};
 use otap_df_engine::exporter::ExporterWrapper;
 use otap_df_engine::local::capability::auth::bearer_token_provider::BearerTokenProvider;
+use otap_df_engine::local::capability::auth::http_client_authentication_provider::HttpClientAuthenticationProvider;
 use otap_df_engine::local::exporter::{EffectHandler, Exporter};
 use otap_df_engine::message::{ExporterInbox, Message};
 use otap_df_engine::node::NodeId;
@@ -63,7 +65,7 @@ use secrecy::ExposeSecret;
 use self::config::Config;
 use crate::exporters::otlp_grpc_exporter::InFlightExports;
 use otap_df_otap::OTAP_EXPORTER_FACTORIES;
-use otap_df_otap::bearer_auth::{BearerAuth, BearerAuthEvents, apply_auth_rejection};
+use otap_df_otap::bearer_auth::BearerAuth;
 use otap_df_otap::otlp_http::client_settings::{HttpClientError, HttpClientSettings};
 use otap_df_otap::otlp_http::{LOGS_PATH, METRICS_PATH, PROTOBUF_CONTENT_TYPE, TRACES_PATH};
 use otap_df_otap::pdata::{Context, OtapPdata};
@@ -77,28 +79,25 @@ use self::metrics::{OtlpHttpExporterErrorType, OtlpHttpExporterMetrics};
 pub const OTLP_HTTP_EXPORTER_URN: &str = "urn:otel:exporter:otlp_http";
 
 /// Raises the shared bearer-auth warnings under this exporter's event namespace.
-const HTTP_BEARER_AUTH_EVENTS: BearerAuthEvents = BearerAuthEvents {
-    invalid_token: |error| {
-        otel_warn!("otlp.exporter.http.invalid_bearer_token", error = %error);
-    },
-    token_stream_closed: || {
-        otel_warn!(
-            "otlp.exporter.http.token_stream_closed",
-            message = "bearer token provider closed its stream; \
+const HTTP_BEARER_AUTH_EVENTS: HttpClientAuthenticationProviderEvents =
+    HttpClientAuthenticationProviderEvents {
+        invalid: || {
+            otel_warn!("otlp.exporter.http.invalid_bearer_token");
+        },
+        stream_closed: || {
+            otel_warn!(
+                "otlp.exporter.http.token_stream_closed",
+                message = "bearer token provider closed its stream; \
                 no further token refreshes will arrive"
-        );
-    },
-};
+            );
+        },
+    };
 
 /// Exporter that sends OTLP data via HTTP
 pub struct OtlpHttpExporter {
     config: Config,
     metrics: OtlpHttpExporterMetrics,
-    /// Optional bearer token provider resolved from the
-    /// `bearer_token_provider` capability. When bound, a fresh
-    /// `Authorization: Bearer <token>` is injected on every outgoing
-    /// request; when absent, the exporter behaves exactly as before.
-    token_provider: Option<Box<dyn BearerTokenProvider>>,
+    auth_provider: Option<Box<dyn HttpClientAuthenticationProvider>>,
 }
 
 /// Declare the OTLP HTTP Exporter as a local exporter factory
@@ -137,6 +136,11 @@ fn factory_create(
     exporter_config: &ExporterConfig,
     capabilities: &otap_df_engine::capability::registry::Capabilities,
 ) -> Result<ExporterWrapper<OtapPdata>, ConfigError> {
+    let auth_provider = capabilities
+        .optional_local::<otap_df_engine::capability::auth::http_client_authentication_provider::HttpClientAuthenticationProvider>()
+        .map_err(|e| otap_df_config::error::Error::InvalidUserConfig {
+            error: e.to_string(),
+        })?;
     // Optionally resolve a bound bearer token provider. Absent binding keeps the
     // default (no-auth) behavior; a bound provider (e.g. the `azure_identity_auth`
     // extension) supplies refreshed OAuth tokens.
@@ -146,7 +150,12 @@ fn factory_create(
             error: e.to_string(),
         })?;
     Ok(ExporterWrapper::local(
-        OtlpHttpExporter::from_config(pipeline, &node_config.config, token_provider)?,
+        OtlpHttpExporter::from_config(
+            pipeline,
+            &node_config.config,
+            auth_provider,
+            token_provider,
+        )?,
         node,
         node_config,
         exporter_config,
@@ -158,6 +167,7 @@ impl OtlpHttpExporter {
     pub fn from_config(
         pipeline_ctx: PipelineContext,
         config: &serde_json::Value,
+        mut auth_provider: Option<Box<dyn HttpClientAuthenticationProvider>>,
         token_provider: Option<Box<dyn BearerTokenProvider>>,
     ) -> Result<Self, ConfigError> {
         let metrics = OtlpHttpExporterMetrics::register(&pipeline_ctx);
@@ -232,11 +242,27 @@ impl OtlpHttpExporter {
             }
         }
 
+        if auth_provider.is_none() {
+            auth_provider = create_auth_provider_from_token_provider(token_provider);
+        }
+
         Ok(Self {
             config,
             metrics,
-            token_provider,
+            auth_provider,
         })
+    }
+}
+
+fn create_auth_provider_from_token_provider(
+    token_provider: Option<Box<dyn BearerTokenProvider>>,
+) -> Option<Box<dyn HttpClientAuthenticationProvider>> {
+    match token_provider {
+        None => None,
+        Some(p) => {
+            let a: Box<dyn HttpClientAuthenticationProvider> = Box::new(BearerAuth::new(p));
+            Some(a)
+        }
     }
 }
 
@@ -319,15 +345,6 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
         // buffer size.
         let mut compressed_buffer: Vec<u8> = Vec::new();
 
-        // Consumer-side bearer-token adapter, if a provider is bound. It owns
-        // the token subscription, the cached `Authorization` header, and token
-        // usability; the loop below stays auth-agnostic -- it only asks whether
-        // it may send and stamps the header the adapter hands back.
-        let mut auth = self
-            .token_provider
-            .take()
-            .map(|provider| BearerAuth::new(provider, HTTP_BEARER_AUTH_EVENTS));
-
         // Timer that fires when the cached token crosses its usability margin.
         // Hoisted out of the loop and re-armed only when the deadline actually
         // moves (i.e. when a refresh is cached), so a busy exporter does not pay
@@ -347,14 +364,17 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
             // holds data-path startup until the first publish, and its watch stream
             // stays live while we hold the provider handle -- so waiting (not
             // dropping) is always correct here.
-            let accepting_pdata = auth.as_ref().is_none_or(BearerAuth::is_ready)
+            let accepting_pdata = self.auth_provider.as_ref().is_none_or(|a| a.is_ready())
                 && inflight_exports.len() < max_in_flight;
 
             // Instant at which a currently-usable token crosses the usability
             // margin. Used to wake the loop so `accepting_pdata` re-evaluates
             // (and gates) before a near-expiry batch is admitted, since the recv
             // arm below may already be parked when the margin is reached.
-            let token_margin_deadline = auth.as_ref().and_then(BearerAuth::refresh_deadline);
+            let token_margin_deadline = self
+                .auth_provider
+                .as_ref()
+                .and_then(|a| a.refresh_deadline());
             if token_margin_deadline != armed_margin_deadline {
                 if let Some(deadline) = token_margin_deadline {
                     margin_sleep
@@ -383,11 +403,11 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                 // `None` when no provider is bound. The `None` arm is unreachable
                 // while the guard holds; it pends rather than panics.
                 () = async {
-                    match auth.as_mut() {
-                        Some(a) => a.poll_refresh().await,
+                    match self.auth_provider.as_mut() {
+                        Some(a) => a.poll_refresh(&HTTP_BEARER_AUTH_EVENTS).await,
                         None => std::future::pending().await,
                     }
-                }, if auth.as_ref().is_some_and(BearerAuth::is_active) => {
+                }, if self.auth_provider.as_ref().is_some_and(|a| a.is_active()) => {
                     // A refresh was drained (the adapter caches it and logs any
                     // anomaly); loop to re-evaluate intake readiness.
                     continue;
@@ -409,7 +429,9 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                         // `token_stream` delivers a fresh one, and the retry never
                         // reuses the rejected token. A stale 401 (a newer token was
                         // already cached) is ignored by the generation guard.
-                        apply_auth_rejection(&mut auth, rejected_generation);
+                        if let (Some(auth), Some(generation)) = (self.auth_provider.as_mut(), rejected_generation) {
+                            auth.invalidate(generation);
+                        }
                     }
                     continue;
                 }
@@ -436,7 +458,11 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                             .await;
                             // Honor a 401 even while draining, so a later
                             // force-drained request cannot reuse the rejected token.
-                            apply_auth_rejection(&mut auth, rejected_generation);
+                            if let (Some(auth), Some(generation)) =
+                                (self.auth_provider.as_mut(), rejected_generation)
+                            {
+                                auth.invalidate(generation);
+                            }
                         }
                     }
                     return Ok(TerminalState::new(
@@ -457,7 +483,7 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                     // force-drains buffered pdata even while auth was pending: with no
                     // usable token we cannot send, so NACK it as retryable -- a token
                     // may yet arrive, so nothing is dropped.
-                    if let Some(a) = auth.as_ref() {
+                    if let Some(a) = self.auth_provider.as_ref() {
                         if !a.is_ready() {
                             let export_duration = export_started_at.elapsed();
                             // `NackMsg::new` is retryable by construction.
@@ -481,7 +507,7 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                     // generation is echoed back on completion so a 401 can be matched
                     // to the exact token used and a stale rejection ignored.
                     let (auth_header, token_generation) =
-                        match auth.as_ref().and_then(BearerAuth::header) {
+                        match self.auth_provider.as_ref().and_then(|a| a.header()) {
                             Some((header, generation)) => (Some(header), Some(generation)),
                             None => (None, None),
                         };
@@ -607,7 +633,11 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                                 .await;
                                 // Honor a 401 here too, so the next force-drained
                                 // request does not reuse the rejected token.
-                                apply_auth_rejection(&mut auth, rejected_generation);
+                                if let (Some(auth), Some(generation)) =
+                                    (self.auth_provider.as_mut(), rejected_generation)
+                                {
+                                    auth.invalidate(generation);
+                                }
                             }
                             None => break,
                         }
@@ -1628,7 +1658,7 @@ mod test {
             OtlpHttpExporter {
                 config,
                 metrics: OtlpHttpExporterMetrics::register(&pipeline_ctx),
-                token_provider: Some(Box::new(provider)),
+                auth_provider: create_auth_provider_from_token_provider(Some(Box::new(provider))),
             },
             node_id,
             node_config,
@@ -2146,7 +2176,7 @@ mod test {
             OtlpHttpExporter {
                 config,
                 metrics: OtlpHttpExporterMetrics::register(&pipeline_ctx),
-                token_provider: None,
+                auth_provider: None,
             },
             node_id.clone(),
             node_config,
@@ -2236,7 +2266,7 @@ mod test {
             0,
         );
 
-        let result = OtlpHttpExporter::from_config(pipeline_ctx, &invalid_config, None);
+        let result = OtlpHttpExporter::from_config(pipeline_ctx, &invalid_config, None, None);
         assert!(result.is_err());
         let err = result.err().unwrap();
         assert!(matches!(err, ConfigError::InvalidUserConfig { .. }));
@@ -2286,7 +2316,7 @@ mod test {
                 0,
             );
 
-            let result = OtlpHttpExporter::from_config(pipeline_ctx, &invalid_config, None);
+            let result = OtlpHttpExporter::from_config(pipeline_ctx, &invalid_config, None, None);
             assert!(result.is_err());
             let err = result.err().unwrap();
             assert!(matches!(err, ConfigError::InvalidUserConfig { .. }));
@@ -3538,7 +3568,7 @@ mod test {
             0,
         );
 
-        let result = OtlpHttpExporter::from_config(pipeline_ctx, &invalid_config, None);
+        let result = OtlpHttpExporter::from_config(pipeline_ctx, &invalid_config, None, None);
         assert!(result.is_err());
         let err = result.err().unwrap();
         assert!(matches!(err, ConfigError::InvalidUserConfig { .. }));

--- a/rust/otap-dataflow/crates/engine/Cargo.toml
+++ b/rust/otap-dataflow/crates/engine/Cargo.toml
@@ -28,6 +28,7 @@ otap-df-state = { workspace = true }
 otap-df-telemetry = { workspace = true }
 otap-df-telemetry-macros = { workspace = true }
 
+http = { workspace = true }
 thiserror = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/rust/otap-dataflow/crates/engine/src/capability/auth/http_client_authentication_provider.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/auth/http_client_authentication_provider.rs
@@ -1,0 +1,73 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! The `HttpClientAuthenticationProvider` capability.
+
+use std::time::Instant;
+
+use http::HeaderValue;
+use otap_df_engine_macros::capability;
+
+/// Manages credentials and injects HTTP Authorization headers.
+#[capability(
+    name = "http_client_authentication_provider",
+    description = "Adds authentication header to http client requests"
+)]
+#[async_trait(?Send)]
+pub trait HttpClientAuthenticationProvider {
+    /// Whether the credential stream is still live and worth polling. Once the
+    /// provider closes it, this returns `false` and the last cached credentials
+    /// (if any) keeps being used.
+    fn is_active(&self) -> bool;
+
+    /// Whether a usable credential is cached: present and, if it expires,
+    /// comfortably before expiry. Authentication should only be performed when
+    /// this is `true`.
+    fn is_ready(&self) -> bool;
+
+    /// A human-readable reason [`is_ready`](Self::is_ready) is false.
+    fn not_ready_reason(&self) -> &'static str;
+
+    /// The cached `Authorization` header to stamp on a request, together with
+    /// the generation of the credential it was built from, cloned for the
+    /// per-request send (a cheap refcount bump). `None` when no credential is
+    /// cached; callers should gate on [`is_ready`](Self::is_ready) first.
+    fn header(&self) -> Option<(HeaderValue, u64)>;
+
+    /// The instant at which a currently-usable, expiring credential crosses the
+    /// usability margin (when [`is_ready`](Self::is_ready) flips to false).
+    /// `None` when no usable credential is cached or the credential never
+    /// expires, so the caller arms no timer in those cases. When `Some`, it is
+    /// always in the future: a usable credential is by definition still beyond
+    /// the margin.
+    fn refresh_deadline(&self) -> Option<Instant>;
+
+    /// Drops the cached credentials *if* `generation` is still the one
+    /// currently cached. Called when the server rejects a request (HTTP 401, or
+    /// gRPC `UNAUTHENTICATED`) so the rejected credential is not sent again.
+    ///
+    /// The generation guard makes a stale 401 harmless: if a newer credentials
+    /// was cached (or the rejected credentials already cleared) after the
+    /// failing request was sent, `generation` no longer matches the current one
+    /// and the still-valid credentials is kept, avoiding a needless
+    /// back-pressure stall.
+    fn invalidate(&mut self, generation: u64);
+
+    /// Awaits the next published credential and refreshes the cache.
+    async fn poll_refresh(&mut self, events: &HttpClientAuthenticationProviderEvents);
+}
+
+/// The warnings this adapter can raise, supplied by the owning component so
+/// each event name is namespaced to that component (e.g.
+/// `otlp.exporter.grpc.*`) rather than to the provider. Event macros (eg
+/// `otel_warn!`) const-validate the event name, so the name has to be a literal
+/// at the emitting call site; passing the emitters as function pointers
+/// satisfies that without making the adapter generic over a marker type.
+#[derive(Clone, Copy)]
+pub struct HttpClientAuthenticationProviderEvents {
+    /// A published credential could not be turned into an `Authorization` header.
+    pub invalid: fn(),
+
+    /// The provider closed its stream; no further refreshes will arrive.
+    pub stream_closed: fn(),
+}

--- a/rust/otap-dataflow/crates/engine/src/capability/auth/mod.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/auth/mod.rs
@@ -17,5 +17,6 @@ mod models;
 pub mod agent_fed_credential_provider;
 pub mod bearer_token_authorizer;
 pub mod bearer_token_provider;
+pub mod http_client_authentication_provider;
 
 pub use models::{AuthorizedIdentity, AuthzDecision, BearerToken, ClaimValue, DenyReason};

--- a/rust/otap-dataflow/crates/engine/src/local/capability.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/capability.rs
@@ -26,6 +26,10 @@ pub mod auth {
     pub mod bearer_token_provider {
         pub use crate::capability::auth::bearer_token_provider::local::BearerTokenProvider;
     }
+    /// Local (!Send) trait variant of the http-client-authentication-provider capability.
+    pub mod http_client_authentication_provider {
+        pub use crate::capability::auth::http_client_authentication_provider::local::HttpClientAuthenticationProvider;
+    }
 }
 
 /// Local (!Send) trait variant of the vendor-bundle capability.

--- a/rust/otap-dataflow/crates/otap/src/bearer_auth.rs
+++ b/rust/otap-dataflow/crates/otap/src/bearer_auth.rs
@@ -20,25 +20,43 @@
 
 use std::time::Instant;
 
+use async_trait::async_trait;
 use futures::StreamExt;
 use http::HeaderValue;
-use http::header::InvalidHeaderValue;
 use otap_df_engine::capability::auth::bearer_token_provider::{TOKEN_USABLE_MARGIN, TokenStream};
+use otap_df_engine::capability::auth::http_client_authentication_provider::HttpClientAuthenticationProviderEvents;
 use otap_df_engine::local::capability::auth::bearer_token_provider::BearerTokenProvider;
+use otap_df_engine::local::capability::auth::http_client_authentication_provider::HttpClientAuthenticationProvider;
 
-/// The warnings this adapter can raise, supplied by the owning exporter so each
-/// event name is namespaced to that exporter (e.g. `otlp.exporter.grpc.*`)
-/// rather than to the shared adapter. `otel_warn!` const-validates its event
-/// name, so the name has to be a literal at the emitting call site; passing the
-/// emitters as function pointers satisfies that without making the adapter
-/// generic over an exporter marker type.
-#[derive(Clone, Copy)]
-pub struct BearerAuthEvents {
-    /// A published token could not be turned into an `Authorization` header.
-    pub invalid_token: fn(&InvalidHeaderValue),
+#[async_trait(?Send)]
+impl HttpClientAuthenticationProvider for BearerAuth {
+    fn is_active(&self) -> bool {
+        self.is_active()
+    }
 
-    /// The provider closed its token stream; no further refreshes will arrive.
-    pub token_stream_closed: fn(),
+    fn is_ready(&self) -> bool {
+        self.is_ready()
+    }
+
+    fn not_ready_reason(&self) -> &'static str {
+        self.not_ready_reason()
+    }
+
+    fn header(&self) -> Option<(HeaderValue, u64)> {
+        self.header()
+    }
+
+    fn refresh_deadline(&self) -> Option<Instant> {
+        self.refresh_deadline()
+    }
+
+    fn invalidate(&mut self, generation: u64) {
+        self.invalidate(generation)
+    }
+
+    async fn poll_refresh(&mut self, events: &HttpClientAuthenticationProviderEvents) {
+        self.poll_refresh(events).await
+    }
 }
 
 /// Consumer-side bearer-token authenticator: subscribes to a provider's token
@@ -60,8 +78,6 @@ pub struct BearerAuth {
     /// each request so a later 401 can be matched to the exact token generation
     /// it used, letting a rejection for an already-replaced token be ignored.
     generation: u64,
-    /// The owning exporter's namespaced warning emitters.
-    events: BearerAuthEvents,
 }
 
 impl BearerAuth {
@@ -71,14 +87,13 @@ impl BearerAuth {
     /// that current token, so the exporter needs no separate `get_token()`
     /// seeding step.
     #[must_use]
-    pub fn new(provider: Box<dyn BearerTokenProvider>, events: BearerAuthEvents) -> Self {
+    pub fn new(provider: Box<dyn BearerTokenProvider>) -> Self {
         Self {
             stream: provider.token_stream(),
             stream_active: true,
             cached_header: None,
             cached_expiry: None,
             generation: 0,
-            events,
         }
     }
 
@@ -152,7 +167,7 @@ impl BearerAuth {
     /// while [`is_active`](Self::is_active); on stream close it flips inactive
     /// and keeps the last cached token. Malformed tokens and stream closure are
     /// logged internally.
-    pub async fn poll_refresh(&mut self) {
+    pub async fn poll_refresh(&mut self, events: &HttpClientAuthenticationProviderEvents) {
         match self.stream.next().await {
             Some(token) => {
                 match HeaderValue::from_str(&format!("Bearer {}", token.expose_token())) {
@@ -165,9 +180,9 @@ impl BearerAuth {
                         // an earlier token no longer matches and is ignored.
                         self.generation = self.generation.wrapping_add(1);
                     }
-                    Err(e) => {
+                    Err(_) => {
                         // Malformed token: keep the previous cached token (if any).
-                        (self.events.invalid_token)(&e);
+                        (events.invalid)();
                     }
                 }
             }
@@ -176,7 +191,7 @@ impl BearerAuth {
                 // Keep using the last cached token. Not expected with a
                 // watch-backed provider while we hold its handle, so warn.
                 self.stream_active = false;
-                (self.events.token_stream_closed)();
+                (events.stream_closed)();
             }
         }
     }
@@ -294,10 +309,11 @@ mod tests {
     /// Recording event hooks. The hooks take no receiver, so the counters are
     /// thread-local; the test harness gives each test its own thread, and every
     /// test resets them before use.
-    const TEST_EVENTS: BearerAuthEvents = BearerAuthEvents {
-        invalid_token: |_error| INVALID_TOKENS.set(INVALID_TOKENS.get() + 1),
-        token_stream_closed: || STREAM_CLOSURES.set(STREAM_CLOSURES.get() + 1),
-    };
+    const TEST_EVENTS: HttpClientAuthenticationProviderEvents =
+        HttpClientAuthenticationProviderEvents {
+            invalid: || INVALID_TOKENS.set(INVALID_TOKENS.get() + 1),
+            stream_closed: || STREAM_CLOSURES.set(STREAM_CLOSURES.get() + 1),
+        };
 
     fn reset_events() {
         INVALID_TOKENS.set(0);
@@ -313,7 +329,6 @@ mod tests {
             cached_header: Some(HeaderValue::from_static("Bearer test-token")),
             cached_expiry: None,
             generation,
-            events: TEST_EVENTS,
         }
     }
 
@@ -328,7 +343,6 @@ mod tests {
             cached_header: None,
             cached_expiry: None,
             generation: 0,
-            events: TEST_EVENTS,
         }
     }
 
@@ -373,7 +387,7 @@ mod tests {
     async fn poll_refresh_caches_the_published_token_as_a_sensitive_header() {
         let mut auth = auth_over(vec![BearerToken::without_expiry("first")]);
 
-        auth.poll_refresh().await;
+        auth.poll_refresh(&TEST_EVENTS).await;
 
         assert!(
             auth.is_ready(),
@@ -404,8 +418,8 @@ mod tests {
             BearerToken::without_expiry("bad\nvalue"),
         ]);
 
-        auth.poll_refresh().await;
-        auth.poll_refresh().await;
+        auth.poll_refresh(&TEST_EVENTS).await;
+        auth.poll_refresh(&TEST_EVENTS).await;
 
         assert_eq!(
             INVALID_TOKENS.get(),
@@ -428,8 +442,8 @@ mod tests {
     async fn a_closed_stream_is_reported_and_the_last_token_stays_usable() {
         let mut auth = auth_over(vec![BearerToken::without_expiry("last")]);
 
-        auth.poll_refresh().await;
-        auth.poll_refresh().await;
+        auth.poll_refresh(&TEST_EVENTS).await;
+        auth.poll_refresh(&TEST_EVENTS).await;
 
         assert_eq!(
             STREAM_CLOSURES.get(),
@@ -472,7 +486,7 @@ mod tests {
             Some(Instant::now() + TOKEN_USABLE_MARGIN / 2),
         )]);
 
-        auth.poll_refresh().await;
+        auth.poll_refresh(&TEST_EVENTS).await;
 
         assert!(
             !auth.is_ready(),
@@ -501,7 +515,7 @@ mod tests {
             Some(expires_on),
         )]);
 
-        auth.poll_refresh().await;
+        auth.poll_refresh(&TEST_EVENTS).await;
 
         assert!(auth.is_ready());
         assert_eq!(
@@ -518,7 +532,7 @@ mod tests {
     async fn a_non_expiring_token_arms_no_refresh_deadline() {
         let mut auth = auth_over(vec![BearerToken::without_expiry("forever")]);
 
-        auth.poll_refresh().await;
+        auth.poll_refresh(&TEST_EVENTS).await;
 
         assert!(auth.is_ready());
         assert!(auth.refresh_deadline().is_none());


### PR DESCRIPTION
Relates to #3811

# Change summary

* Introduce `HttpClientAuthenticationProvider` and refactor exporters using `BearerAuth` to instead use the provider

## Validation

Existing exporter tests.

## User-facing changes

New capability for extensions add.

# Details

Working towards supporting basic auth in OTLP exporters.

/cc @c-valdebenito @jmacd @gouslu 