### PR TITLE
chore(quiver): avoid progress entry allocation

### DIFF
--- a/rust/otap-dataflow/crates/quiver/src/subscriber/progress.rs
+++ b/rust/otap-dataflow/crates/quiver/src/subscriber/progress.rs
@@ -43,6 +43,7 @@
 //! Progress is written via temp file -> fsync -> rename to ensure crash-safe
 //! updates. This avoids partial writes and provides atomic visibility.
 
+use std::borrow::Borrow;
 use std::fs::{self, OpenOptions};
 use std::io::{self, BufReader, Read};
 use std::path::{Path, PathBuf};
@@ -551,28 +552,44 @@ pub async fn write_progress_file(
     oldest_incomplete_seg: SegmentSeq,
     entries: &[SegmentProgressEntry],
 ) -> Result<()> {
-    use tokio::io::AsyncWriteExt;
+    let content = serialize_progress_file(oldest_incomplete_seg, entries.iter());
+    write_progress_file_content(dir, subscriber_id, content).await
+}
 
-    let final_path = progress_file_path(dir, subscriber_id);
-    let temp_path = temp_progress_file_path(dir, subscriber_id);
-
-    // Build the complete file content (in memory - typically small)
+pub(super) fn serialize_progress_file<T>(
+    oldest_incomplete_seg: SegmentSeq,
+    entries: impl ExactSizeIterator<Item = T>,
+) -> Vec<u8>
+where
+    T: Borrow<SegmentProgressEntry>,
+{
     let mut content = Vec::new();
 
-    // Header
     let header = ProgressHeader::new(oldest_incomplete_seg, entries.len() as u32);
     content.extend_from_slice(&header.serialize());
 
-    // Entries
     for entry in entries {
+        let entry = entry.borrow();
         content.extend_from_slice(&entry.serialize());
     }
 
-    // CRC (of header + entries)
     let mut hasher = Crc32Hasher::new();
     hasher.update(&content);
     let crc = hasher.finalize();
     content.extend_from_slice(&crc.to_le_bytes());
+
+    content
+}
+
+pub(super) async fn write_progress_file_content(
+    dir: &Path,
+    subscriber_id: &SubscriberId,
+    content: Vec<u8>,
+) -> Result<()> {
+    use tokio::io::AsyncWriteExt;
+
+    let final_path = progress_file_path(dir, subscriber_id);
+    let temp_path = temp_progress_file_path(dir, subscriber_id);
 
     // Write to temp file using tokio
     {

--- a/rust/otap-dataflow/crates/quiver/src/subscriber/registry.rs
+++ b/rust/otap-dataflow/crates/quiver/src/subscriber/registry.rs
@@ -50,7 +50,7 @@ use super::error::{Result, SubscriberError};
 use super::handle::{BundleHandle, ResolutionCallback};
 use super::progress::{
     delete_progress_file, progress_file_path, read_progress_file, scan_progress_files,
-    write_progress_file,
+    serialize_progress_file, write_progress_file_content,
 };
 use super::state::{SegmentProgress, SubscriberState};
 use super::types::{AckOutcome, BundleIndex, BundleRef, SubscriberId};
@@ -839,18 +839,15 @@ impl<P: SegmentProvider> SubscriberRegistry<P> {
 
         for (sub_id, state_lock) in to_flush {
             // Get state data with per-subscriber lock
-            let (entries, oldest_incomplete) = {
+            let content = {
                 let state = state_lock.read();
-                let entries = state.to_progress_entries();
                 let oldest = state
                     .oldest_incomplete_segment()
                     .unwrap_or_else(|| SegmentSeq::new(0));
-                (entries, oldest)
+                serialize_progress_file(oldest, state.to_progress_entries())
             };
 
-            match write_progress_file(&self.config.data_dir, &sub_id, oldest_incomplete, &entries)
-                .await
-            {
+            match write_progress_file_content(&self.config.data_dir, &sub_id, content).await {
                 Ok(()) => {
                     flushed += 1;
                 }

--- a/rust/otap-dataflow/crates/quiver/src/subscriber/state.rs
+++ b/rust/otap-dataflow/crates/quiver/src/subscriber/state.rs
@@ -404,20 +404,17 @@ impl SubscriberState {
 
     /// Converts this subscriber's state to progress entries for persistence.
     ///
-    /// Returns a vector of segment progress entries in segment order (oldest first).
+    /// Returns segment progress entries in segment order (oldest first).
     /// Used by the registry to serialize state to progress files.
     #[must_use]
-    pub fn to_progress_entries(&self) -> Vec<SegmentProgressEntry> {
-        self.segments
-            .iter()
-            .map(|(&seg_seq, progress)| {
-                SegmentProgressEntry::from_bitmap(
-                    seg_seq,
-                    progress.bundle_count(),
-                    progress.resolved_bitmap(),
-                )
-            })
-            .collect()
+    pub fn to_progress_entries(&self) -> impl ExactSizeIterator<Item = SegmentProgressEntry> + '_ {
+        self.segments.iter().map(|(&seg_seq, progress)| {
+            SegmentProgressEntry::from_bitmap(
+                seg_seq,
+                progress.bundle_count(),
+                progress.resolved_bitmap(),
+            )
+        })
     }
 }
 
@@ -550,6 +547,29 @@ mod tests {
 
         assert_eq!(state.segment_count(), 2);
         assert_eq!(state.pending_count(), 15);
+    }
+
+    /// Scenario: Progress entries are requested for state containing multiple segments.
+    /// Guarantees: The iterator reports its exact length and yields entries oldest first.
+    #[test]
+    fn subscriber_state_progress_entries_are_exact_size_and_ordered() {
+        let mut state = make_state("test-sub");
+        state.add_segment(SegmentSeq::new(2), 3);
+        state.add_segment(SegmentSeq::new(1), 2);
+        assert!(state.record_outcome(
+            BundleRef::new(SegmentSeq::new(1), BundleIndex::new(0)),
+            AckOutcome::Acked,
+        ));
+
+        let entries = state.to_progress_entries();
+        assert_eq!(entries.len(), 2);
+
+        let entries = entries.collect::<Vec<_>>();
+        assert_eq!(entries[0].seg_seq, SegmentSeq::new(1));
+        assert_eq!(entries[0].bundle_count, 2);
+        assert!(entries[0].is_acked(0));
+        assert_eq!(entries[1].seg_seq, SegmentSeq::new(2));
+        assert_eq!(entries[1].bundle_count, 3);
     }
 
     #[test]


### PR DESCRIPTION
# Change summary

Return an ExactSizeIterator from SubscriberState::to_progress_entries and serialize it before asynchronous progress-file I/O.

## Related issue

* Closes #1793 

## Validation

- Unit tests

## User-facing changes

None
