### PR TITLE
fix(OTAP query-engine): issue where left-side of or is non-root scoped missing attribute

### DIFF
--- a/rust/otap-dataflow/.chloggen/otap-query-engine-fix-or-absent-attrs.yaml
+++ b/rust/otap-dataflow/.chloggen/otap-query-engine-fix-or-absent-attrs.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: query-engine
+note: fix OR expressions dropping matches when one side references an entirely absent attributes payload
+issues: [3855]

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -228,6 +228,23 @@ impl ShortCircuitStrategy {
         })))
     }
 
+    /// Returns the default value to substitute when a child is absent (returns `None`).
+    ///
+    /// For OR/NotOr: absent data means "no match", so the identity element for OR is
+    /// `false` -- `false OR x == x`.
+    /// For AND/NotAnd: absent data means "no match", so the identity element for AND is
+    /// `true` -- `true AND x == x`. However, for AND with absent data, we actually want
+    /// the result to be "no match" for the absent rows, which is already handled by the
+    /// join producing nulls, so we return `None` to indicate no substitution is needed.
+    fn absent_child_default(&self) -> Option<ScopedValue> {
+        match self {
+            Self::Or | Self::NotOr => {
+                Some(ScopedValue::new_scalar(ScalarValue::Boolean(Some(false))))
+            }
+            Self::And | Self::NotAnd => None,
+        }
+    }
+
     fn invert(&self) -> Self {
         match self {
             Self::And => Self::NotAnd,

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -228,14 +228,15 @@ impl ShortCircuitStrategy {
         })))
     }
 
-    /// Returns the default value to substitute when a child is absent (returns `None`).
+    /// Returns the default value to substitute when a child has missing data and evaluates
+    /// effectively to a null value. (returns `None`).
     ///
     /// For OR/NotOr: absent data means "no match", so the identity element for OR is
     /// `false` -- `false OR x == x`.
-    /// For AND/NotAnd: absent data means "no match", so the identity element for AND is
-    /// `true` -- `true AND x == x`. However, for AND with absent data, we actually want
-    /// the result to be "no match" for the absent rows, which is already handled by the
-    /// join producing nulls, so we return `None` to indicate no substitution is needed.
+    /// For AND/NotAnd: absent data means "no match", so the identity element for AND is `true`, 
+    /// `true AND x == x`. However, for AND with absent data, we actually want the result to be 
+    /// "no match" for the absent rows, which is already handled by the call to check if we
+    /// should short circuit, so we return None indicating no substitution needed
     fn absent_child_default(&self) -> Option<ScopedValue> {
         match self {
             Self::Or | Self::NotOr => {

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr.rs
@@ -228,15 +228,15 @@ impl ShortCircuitStrategy {
         })))
     }
 
-    /// Returns the default value to substitute when a child has missing data and evaluates
-    /// effectively to a null value. (returns `None`).
+    /// Returns the default value to substitute when a child is absent (its data source
+    /// does not exist in the batch), or `None` if no substitution applies.
     ///
-    /// For OR/NotOr: absent data means "no match", so the identity element for OR is
-    /// `false` -- `false OR x == x`.
-    /// For AND/NotAnd: absent data means "no match", so the identity element for AND is `true`, 
-    /// `true AND x == x`. However, for AND with absent data, we actually want the result to be 
-    /// "no match" for the absent rows, which is already handled by the call to check if we
-    /// should short circuit, so we return None indicating no substitution needed
+    /// For OR/NotOr: absent data means "no match", so we substitute `false` (the OR
+    /// identity element: `false OR B` evaluates to `B`).
+    ///
+    /// For AND/NotAnd: returns `None`. Absent data in an AND already produces the
+    /// correct "no match" result via the `should_short_circuit` check (which treats
+    /// all-false/all-null as a short-circuit to false).
     fn absent_child_default(&self) -> Option<ScopedValue> {
         match self {
             Self::Or | Self::NotOr => {

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -267,10 +267,9 @@ pub(super) fn join_and_eval_value(
                 } else if let Some((strategy, default)) = short_circuit
                     .and_then(|s| s.absent_child_default().map(|d| (s, d)))
                 {
-                    // The short-circuit strategy can handle absent children (e.g. OR
-                    // treats absent data as "no match"/false). For the common 2-child
-                    // case we can skip the join entirely: evaluate the remaining
-                    // child and return its result directly.
+                    // The short-circuit strategy can handle absent children (e.g. OR treats absent
+                    // data as "no match"/false). For the common 2-child case we can skip the join
+                    // entirely: evaluate the remaining child and return its result directly.
                     if num_children == 2 {
                         return resolve_or_with_absent_child(
                             &mut children[i + 1..],

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -249,9 +249,10 @@ pub(super) fn join_and_eval_value(
     session_ctx: &SessionContext,
 ) -> Result<Option<ScopedValue>> {
     // evaluate all children
-    let mut child_results = Vec::with_capacity(children.len());
-    for child in children.iter_mut() {
-        let result = match child.execute_as_value(otap_batch, session_ctx)? {
+    let num_children = children.len();
+    let mut child_results = Vec::with_capacity(num_children);
+    for i in 0..num_children {
+        let result = match children[i].execute_as_value(otap_batch, session_ctx)? {
             Some(mut result) => {
                 // maybe align children to root if configured. We skip alignment for scalar results
                 // because it's handled by the join below
@@ -263,10 +264,25 @@ pub(super) fn join_and_eval_value(
             None => {
                 if default_null_children {
                     ScopedValue::new_scalar(ScalarValue::Null)
-                } else if let Some(default) = short_circuit.and_then(|s| s.absent_child_default()) {
-                    // For OR, an absent child (e.g. missing attributes payload) is
-                    // treated as "false" so that the other side of the OR still
-                    // determines the outcome.
+                } else if let Some((strategy, default)) = short_circuit
+                    .and_then(|s| s.absent_child_default().map(|d| (s, d)))
+                {
+                    // The short-circuit strategy can handle absent children (e.g. OR
+                    // treats absent data as "no match"/false). For the common 2-child
+                    // case we can skip the join entirely: evaluate the remaining
+                    // child and return its result directly.
+                    if num_children == 2 {
+                        return evaluate_remaining_children_for_absent_short_circuit(
+                            &mut children[i + 1..],
+                            child_results,
+                            align_children_to_root,
+                            strategy,
+                            otap_batch,
+                            session_ctx,
+                        );
+                    }
+                    // For N > 2 children, fall back to substituting the identity
+                    // value and proceeding through the join.
                     default
                 } else {
                     return Ok(None); // if any child is absent, the whole expression is null
@@ -346,6 +362,86 @@ pub(super) fn join_and_eval_value(
     );
 
     Ok(Some(result))
+}
+
+/// When one child of a 2-child OR/NotOr `JoinAndEval` is absent (returns `None`), the
+/// join can be skipped entirely. The non-absent child's result already determines the
+/// outcome: `false OR x == x`.
+///
+/// `already_evaluated` contains results from children evaluated before the absent one was
+/// found (0 elements if the first child was absent, 1 if the second was).
+/// `remaining` contains children not yet evaluated (those after the absent one).
+fn evaluate_remaining_children_for_absent_short_circuit(
+    remaining: &mut [ScopedExpr],
+    already_evaluated: Vec<ScopedValue>,
+    align_children_to_root: bool,
+    strategy: &ShortCircuitStrategy,
+    otap_batch: &OtapArrowRecords,
+    session_ctx: &SessionContext,
+) -> Result<Option<ScopedValue>> {
+    // Collect all non-absent results: those already evaluated plus any remaining children.
+    let mut result = None;
+
+    for sv in already_evaluated {
+        result = Some(sv);
+    }
+    for child in remaining.iter_mut() {
+        if let Some(sv) = child.execute_as_value(otap_batch, session_ctx)? {
+            result = Some(sv);
+        }
+        // If remaining child also returns None, it's also absent -- skip it.
+    }
+
+    match result {
+        None => Ok(None), // all children absent -- no match
+        Some(mut sv) => {
+            if align_children_to_root && matches!(sv.values, ColumnarValue::Array(_)) {
+                sv = align_value_to_root(sv, otap_batch)?;
+            }
+            // For NotOr (NOT(A OR B)), with A absent: NOT(false OR B) = NOT(B).
+            // Invert the surviving child's boolean result.
+            if matches!(strategy, ShortCircuitStrategy::NotOr) {
+                sv = invert_boolean_scoped_value(sv)?;
+            }
+            Ok(Some(sv))
+        }
+    }
+}
+
+/// Invert a boolean `ScopedValue` (flip true/false, preserve scope and ids).
+fn invert_boolean_scoped_value(sv: ScopedValue) -> Result<ScopedValue> {
+    let inverted = match sv.values {
+        ColumnarValue::Scalar(ScalarValue::Boolean(Some(b))) => {
+            ColumnarValue::Scalar(ScalarValue::Boolean(Some(!b)))
+        }
+        ColumnarValue::Scalar(ScalarValue::Boolean(None) | ScalarValue::Null) => {
+            // null stays null (NOT null = null)
+            sv.values
+        }
+        ColumnarValue::Array(ref arr) => {
+            let bool_arr = arr.as_boolean_opt().ok_or_else(|| Error::ExecutionError {
+                cause: format!(
+                    "expected boolean array for NotOr inversion, got {:?}",
+                    arr.data_type()
+                ),
+            })?;
+            ColumnarValue::Array(Arc::new(arrow::compute::not(bool_arr)?))
+        }
+        _ => {
+            return Err(Error::ExecutionError {
+                cause: format!(
+                    "expected boolean value for NotOr inversion, got {:?}",
+                    sv.values.data_type()
+                ),
+            });
+        }
+    };
+    Ok(ScopedValue {
+        values: inverted,
+        scope: sv.scope,
+        ids: sv.ids,
+        parent_ids: sv.parent_ids,
+    })
 }
 
 fn coerce_nulls_for_predicate(

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -271,13 +271,16 @@ pub(super) fn join_and_eval_value(
                     // data as "no match"/false). For the common 2-child case we can skip the join
                     // entirely: evaluate the remaining child and return its result directly.
                     if num_children == 2 {
+                        // The other child is either already evaluated (in
+                        // child_results) or is the next child to evaluate.
+                        let other = child_results.into_iter().next().or(children
+                            [i + 1]
+                            .execute_as_value(otap_batch, session_ctx)?);
                         return resolve_or_with_absent_child(
-                            &mut children[i + 1..],
-                            child_results,
+                            other,
                             align_children_to_root,
                             strategy,
                             otap_batch,
-                            session_ctx,
                         );
                     }
                     // For N > 2 children, fall back to substituting the identity
@@ -366,32 +369,19 @@ pub(super) fn join_and_eval_value(
 /// When one child of a 2-child OR/NotOr `JoinAndEval` is absent (returns `None`), the
 /// join can be skipped entirely. The absent side is the OR identity (`false`), so the
 /// non-absent child's result alone determines the outcome.
-///
-/// Either the other child was already evaluated (passed in `already_evaluated`) or it
-/// still needs evaluation (passed in `unevaluated`). Exactly one of these will contain
-/// the surviving child.
 fn resolve_or_with_absent_child(
-    unevaluated: &mut [ScopedExpr],
-    already_evaluated: Vec<ScopedValue>,
+    other: Option<ScopedValue>,
     align_children_to_root: bool,
     strategy: &ShortCircuitStrategy,
     otap_batch: &OtapArrowRecords,
-    session_ctx: &SessionContext,
 ) -> Result<Option<ScopedValue>> {
-    // Get the surviving child's result: either already computed or evaluate now.
-    let other_result = already_evaluated.into_iter().next().or(unevaluated
-        .first_mut()
-        .and_then(|child| child.execute_as_value(otap_batch, session_ctx).transpose())
-        .transpose()?);
-
-    match other_result {
+    match other {
         None => Ok(None), // both children absent -- no match
         Some(mut sv) => {
             if align_children_to_root && matches!(sv.values, ColumnarValue::Array(_)) {
                 sv = align_value_to_root(sv, otap_batch)?;
             }
             // For NotOr (NOT(A OR B)), with A absent: NOT(false OR B) = NOT(B).
-            // Invert the surviving child's boolean result.
             if matches!(strategy, ShortCircuitStrategy::NotOr) {
                 sv = invert_boolean_scoped_value(sv)?;
             }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -383,19 +383,27 @@ fn resolve_or_with_absent_child(
     strategy: &ShortCircuitStrategy,
     otap_batch: &OtapArrowRecords,
 ) -> Result<Option<ScopedValue>> {
-    match other {
-        None => Ok(None), // both children absent -- no match
+    let mut sv = match other {
+        // Both children absent. The result is the OR identity (false).
+        None => strategy.absent_child_default().expect(
+            "resolve_or_with_absent_child called with strategy lacking absent_child_default",
+        ),
         Some(mut sv) => {
             if align_children_to_root && matches!(sv.values, ColumnarValue::Array(_)) {
                 sv = align_value_to_root(sv, otap_batch)?;
             }
-            // For NotOr (NOT(A OR B)), with A absent: NOT(false OR B) = NOT(B).
-            if matches!(strategy, ShortCircuitStrategy::NotOr) {
-                sv = invert_boolean_scoped_value(sv)?;
-            }
-            Ok(Some(sv))
+            sv
         }
+    };
+
+    // For NotOr (NOT(A OR B)): invert the result.
+    // - one child absent:  NOT(false OR B) = NOT(B)
+    // - both absent:       NOT(false OR false) = NOT(false) = true
+    if matches!(strategy, ShortCircuitStrategy::NotOr) {
+        sv = invert_boolean_scoped_value(sv)?;
     }
+
+    Ok(Some(sv))
 }
 
 /// Invert a boolean `ScopedValue` (flip true/false, preserve scope and ids).

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -267,10 +267,16 @@ pub(super) fn join_and_eval_value(
                 } else if let Some((strategy, default)) = short_circuit
                     .and_then(|s| s.absent_child_default().map(|d| (s, d)))
                 {
-                    // The short-circuit strategy can handle absent children (e.g. OR treats absent
-                    // data as "no match"/false). For the common 2-child case we can skip the join
-                    // entirely: evaluate the remaining child and return its result directly.
-                    if num_children == 2 {
+                    // The short-circuit strategy can handle absent children (e.g. OR
+                    // treats absent data as "no match"/false). For the 2-child OR
+                    // case we skip the join entirely and return the other child's
+                    // result directly.
+                    if num_children == 2
+                        && matches!(
+                            strategy,
+                            ShortCircuitStrategy::Or | ShortCircuitStrategy::NotOr
+                        )
+                    {
                         // The other child is either already evaluated (in
                         // child_results) or is the next child to evaluate.
                         let other = child_results.into_iter().next().or(children
@@ -283,8 +289,8 @@ pub(super) fn join_and_eval_value(
                             otap_batch,
                         );
                     }
-                    // For N > 2 children, fall back to substituting the identity
-                    // value and proceeding through the join.
+                    // Otherwise, fall back to substituting the identity value and
+                    // proceeding through the join.
                     default
                 } else {
                     return Ok(None); // if any child is absent, the whole expression is null

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -279,9 +279,12 @@ pub(super) fn join_and_eval_value(
                     {
                         // The other child is either already evaluated (in
                         // child_results) or is the next child to evaluate.
-                        let other = child_results.into_iter().next().or(children
-                            [i + 1]
-                            .execute_as_value(otap_batch, session_ctx)?);
+                        let other = if let Some(sv) = child_results.into_iter().next()
+                        {
+                            Some(sv)
+                        } else {
+                            children[i + 1].execute_as_value(otap_batch, session_ctx)?
+                        };
                         return resolve_or_with_absent_child(
                             other,
                             align_children_to_root,

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -264,8 +264,8 @@ pub(super) fn join_and_eval_value(
             None => {
                 if default_null_children {
                     ScopedValue::new_scalar(ScalarValue::Null)
-                } else if let Some((strategy, default)) = short_circuit
-                    .and_then(|s| s.absent_child_default().map(|d| (s, d)))
+                } else if let Some((strategy, default)) =
+                    short_circuit.and_then(|s| s.absent_child_default().map(|d| (s, d)))
                 {
                     // The short-circuit strategy can handle absent children (e.g. OR
                     // treats absent data as "no match"/false). For the 2-child OR
@@ -279,8 +279,7 @@ pub(super) fn join_and_eval_value(
                     {
                         // The other child is either already evaluated (in
                         // child_results) or is the next child to evaluate.
-                        let other = if let Some(sv) = child_results.into_iter().next()
-                        {
+                        let other = if let Some(sv) = child_results.into_iter().next() {
                             Some(sv)
                         } else {
                             children[i + 1].execute_as_value(otap_batch, session_ctx)?

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -263,6 +263,11 @@ pub(super) fn join_and_eval_value(
             None => {
                 if default_null_children {
                     ScopedValue::new_scalar(ScalarValue::Null)
+                } else if let Some(default) = short_circuit.and_then(|s| s.absent_child_default()) {
+                    // For OR, an absent child (e.g. missing attributes payload) is
+                    // treated as "false" so that the other side of the OR still
+                    // determines the outcome.
+                    default
                 } else {
                     return Ok(None); // if any child is absent, the whole expression is null
                 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -286,6 +286,7 @@ pub(super) fn join_and_eval_value(
                         };
                         return resolve_or_with_absent_child(
                             other,
+                            default,
                             align_children_to_root,
                             strategy,
                             otap_batch,
@@ -379,15 +380,13 @@ pub(super) fn join_and_eval_value(
 /// non-absent child's result alone determines the outcome.
 fn resolve_or_with_absent_child(
     other: Option<ScopedValue>,
+    absent_default: ScopedValue,
     align_children_to_root: bool,
     strategy: &ShortCircuitStrategy,
     otap_batch: &OtapArrowRecords,
 ) -> Result<Option<ScopedValue>> {
     let mut sv = match other {
-        // Both children absent. The result is the OR identity (false).
-        None => strategy.absent_child_default().expect(
-            "resolve_or_with_absent_child called with strategy lacking absent_child_default",
-        ),
+        None => absent_default,
         Some(mut sv) => {
             if align_children_to_root && matches!(sv.values, ColumnarValue::Array(_)) {
                 sv = align_value_to_root(sv, otap_batch)?;
@@ -396,9 +395,7 @@ fn resolve_or_with_absent_child(
         }
     };
 
-    // For NotOr (NOT(A OR B)): invert the result.
-    // - one child absent:  NOT(false OR B) = NOT(B)
-    // - both absent:       NOT(false OR false) = NOT(false) = true
+    // For NotOr, invert the result.
     if matches!(strategy, ShortCircuitStrategy::NotOr) {
         sv = invert_boolean_scoped_value(sv)?;
     }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -272,7 +272,7 @@ pub(super) fn join_and_eval_value(
                     // case we can skip the join entirely: evaluate the remaining
                     // child and return its result directly.
                     if num_children == 2 {
-                        return evaluate_remaining_children_for_absent_short_circuit(
+                        return resolve_or_with_absent_child(
                             &mut children[i + 1..],
                             child_results,
                             align_children_to_root,
@@ -365,35 +365,28 @@ pub(super) fn join_and_eval_value(
 }
 
 /// When one child of a 2-child OR/NotOr `JoinAndEval` is absent (returns `None`), the
-/// join can be skipped entirely. The non-absent child's result already determines the
-/// outcome: `false OR x == x`.
+/// join can be skipped entirely. The absent side is the OR identity (`false`), so the
+/// non-absent child's result alone determines the outcome.
 ///
-/// `already_evaluated` contains results from children evaluated before the absent one was
-/// found (0 elements if the first child was absent, 1 if the second was).
-/// `remaining` contains children not yet evaluated (those after the absent one).
-fn evaluate_remaining_children_for_absent_short_circuit(
-    remaining: &mut [ScopedExpr],
+/// Either the other child was already evaluated (passed in `already_evaluated`) or it
+/// still needs evaluation (passed in `unevaluated`). Exactly one of these will contain
+/// the surviving child.
+fn resolve_or_with_absent_child(
+    unevaluated: &mut [ScopedExpr],
     already_evaluated: Vec<ScopedValue>,
     align_children_to_root: bool,
     strategy: &ShortCircuitStrategy,
     otap_batch: &OtapArrowRecords,
     session_ctx: &SessionContext,
 ) -> Result<Option<ScopedValue>> {
-    // Collect all non-absent results: those already evaluated plus any remaining children.
-    let mut result = None;
+    // Get the surviving child's result: either already computed or evaluate now.
+    let other_result = already_evaluated.into_iter().next().or(unevaluated
+        .first_mut()
+        .and_then(|child| child.execute_as_value(otap_batch, session_ctx).transpose())
+        .transpose()?);
 
-    for sv in already_evaluated {
-        result = Some(sv);
-    }
-    for child in remaining.iter_mut() {
-        if let Some(sv) = child.execute_as_value(otap_batch, session_ctx)? {
-            result = Some(sv);
-        }
-        // If remaining child also returns None, it's also absent -- skip it.
-    }
-
-    match result {
-        None => Ok(None), // all children absent -- no match
+    match other_result {
+        None => Ok(None), // both children absent -- no match
         Some(mut sv) => {
             if align_children_to_root && matches!(sv.values, ColumnarValue::Array(_)) {
                 sv = align_value_to_root(sv, otap_batch)?;

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -465,28 +465,26 @@ impl ExprPlanner {
                         eval: LeafEval::new_df_expr(left_expr.or(right_expr), downcast_dicts)?,
                     })
                 } else {
-                    let mut align_children_to_root = false;
+                    let left_scope = left.effective_value_scope()?;
+                    let right_scope = right.effective_value_scope()?;
+
+                    // If both sides are AttributesAll with the same ID, the most
+                    // performant path is a bitmap OR over parent_ids.
                     if let (
                         DataScope::AttributesAll(left_attrs_id),
                         DataScope::AttributesAll(right_attrs_id),
-                    ) = (
-                        left.effective_value_scope()?.as_ref(),
-                        right.effective_value_scope()?.as_ref(),
-                    ) {
+                    ) = (left_scope.as_ref(), right_scope.as_ref())
+                    {
                         if left_attrs_id == right_attrs_id {
-                            // most performant way to "or" the results of the children exprs
-                            // is to create a bitmap of the parent_ids passing each side then
-                            // combine the bitmaps
                             return Ok(ScopedExpr::BitmapOr(Box::new(left), Box::new(right)));
-                        } else {
-                            // here we're "or"ing the results of filters on attributes, but the
-                            // parent_id columns represent different IDs, so we can't "or" the
-                            // bitmaps. We set `align_children_to_root` because it's just the most
-                            // performant way to line up the results of the filters on each side in
-                            // join eval
-                            align_children_to_root = true;
                         }
                     }
+
+                    // When either side is attribute-scoped, align children to root
+                    // so that root rows without the attribute get null (not dropped
+                    // by an inner join).
+                    let align_children_to_root =
+                        left_scope.attrs_id().is_some() || right_scope.attrs_id().is_some();
 
                     Ok(ScopedExpr::JoinAndEval {
                         children: vec![left, right],

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -2869,11 +2869,15 @@ mod test {
         assert_eq!(result_records[1].event_name, "3");
     }
 
+    /// Scenario: Evaluate an OR-with-absent-attrs predicate using the OPL parser.
+    /// Guarantees: OPL planning/evaluation returns the same rows as the shared test expects.
     #[tokio::test]
     async fn test_filter_or_with_absent_attrs_payload_opl_parser() {
         test_filter_or_with_absent_attrs_payload::<OplParser>().await;
     }
 
+    /// Scenario: Evaluate an OR-with-absent-attrs predicate using the KQL parser.
+    /// Guarantees: KQL planning/evaluation returns the same rows as the shared test expects.
     #[tokio::test]
     async fn test_filter_or_with_absent_attrs_payload_kql_parser() {
         test_filter_or_with_absent_attrs_payload::<KqlParser>().await;
@@ -2899,11 +2903,15 @@ mod test {
         assert_eq!(result_records[1].event_name, "3");
     }
 
+    /// Scenario: Evaluate a reversed OR-with-absent-attrs predicate using the OPL parser.
+    /// Guarantees: OPL planning/evaluation returns the same rows as the shared test expects.
     #[tokio::test]
     async fn test_filter_or_with_absent_attrs_payload_reversed_opl_parser() {
         test_filter_or_with_absent_attrs_payload_reversed::<OplParser>().await;
     }
 
+    /// Scenario: Evaluate a reversed OR-with-absent-attrs predicate using the KQL parser.
+    /// Guarantees: KQL planning/evaluation returns the same rows as the shared test expects.
     #[tokio::test]
     async fn test_filter_or_with_absent_attrs_payload_reversed_kql_parser() {
         test_filter_or_with_absent_attrs_payload_reversed::<KqlParser>().await;
@@ -2930,11 +2938,15 @@ mod test {
         assert_eq!(result_records[0].event_name, "2");
     }
 
+    /// Scenario: Evaluate a NOT(OR)-with-absent-attrs predicate using the OPL parser.
+    /// Guarantees: OPL planning/evaluation returns the same rows as the shared test expects.
     #[tokio::test]
     async fn test_filter_not_or_with_absent_attrs_payload_opl_parser() {
         test_filter_not_or_with_absent_attrs_payload::<OplParser>().await;
     }
 
+    /// Scenario: Evaluate a NOT(OR)-with-absent-attrs predicate using the KQL parser.
+    /// Guarantees: KQL planning/evaluation returns the same rows as the shared test expects.
     #[tokio::test]
     async fn test_filter_not_or_with_absent_attrs_payload_kql_parser() {
         test_filter_not_or_with_absent_attrs_payload::<KqlParser>().await;

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -2286,6 +2286,10 @@ mod test {
         test_filter_with_or::<OplParser>().await;
     }
 
+    /// Scenario: when left-side of OR expression will execute with data scope of attributes
+    /// and some rows that pass the predicate on right-side do not have such attributes
+    /// Guarantees: we correctly return rows on the RHS that pass this predicate (or the inverse
+    /// of the expected results in the case where the case where the overall predicate is inverted)
     #[tokio::test]
     async fn test_filter_attr_or_record_some_rows_no_attrs() {
         let log_records = vec![

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -2286,6 +2286,35 @@ mod test {
         test_filter_with_or::<OplParser>().await;
     }
 
+    #[tokio::test]
+    async fn test_filter_attr_or_record_some_rows_no_attrs() {
+        let log_records = vec![
+            LogRecord::build()
+                .event_name("1")
+                .severity_text("INFO")
+                .attributes(vec![])
+                .finish(),
+            LogRecord::build()
+                .event_name("1")
+                .severity_text("ERROR")
+                .attributes(vec![
+                    KeyValue::new("x", AnyValue::new_string("a")),
+                    KeyValue::new("z", AnyValue::new_int(4)),
+                ])
+                .finish(),
+        ];
+
+        let result = exec_logs_pipeline::<OplParser>(
+            r#"logs | where attributes["z"] + 1 > 0 or severity_text == "INFO""#,
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        pretty_assertions::assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_records[0].clone(), log_records[1].clone()],
+        );
+    }
+
     async fn test_filter_with_not<P: Parser>() {
         let log_records = vec![
             LogRecord::build()

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -2826,13 +2826,10 @@ mod test {
         test_filter_no_attrs::<OplParser>().await;
     }
 
-    /// Scenario: OR expression where the left side references an absent attributes
-    /// payload and the right side matches root-scoped fields.
-    /// Guarantees: when evaluating `attributes["x"] == 10 or severity_text == "WARN"`
-    /// on a batch with no attributes payload at all, rows matching the right side of
-    /// the OR are still returned -- the absent left side does not suppress them.
-    async fn test_filter_or_with_absent_attrs_payload<P: Parser>() {
-        let log_records = vec![
+    /// Helper: build 3 log records with no attributes for OR-with-absent-attrs tests.
+    /// severity_text values: ["WARN", "ERROR", "WARN"].
+    fn logs_no_attrs() -> Vec<LogRecord> {
+        vec![
             LogRecord::build()
                 .event_name("1")
                 .severity_text("WARN")
@@ -2845,28 +2842,29 @@ mod test {
                 .event_name("3")
                 .severity_text("WARN")
                 .finish(),
-        ];
+        ]
+    }
+
+    /// Scenario: OR expression where the left side references an absent attributes
+    /// payload and the right side matches root-scoped fields.
+    /// Guarantees: when evaluating `attributes["x"] == 10 or severity_text == "WARN"`
+    /// on a batch with no attributes payload at all, rows matching the right side of
+    /// the OR are still returned -- the absent left side does not suppress them.
+    async fn test_filter_or_with_absent_attrs_payload<P: Parser>() {
+        let log_records = logs_no_attrs();
 
         // attributes["x"] == 10 or severity_text == "WARN"
         //
         // No log records have attributes, so the left side of the OR references an
         // entirely absent attributes payload. The right side matches rows 0 and 2.
         // The OR should still return rows 0 and 2.
-        let parser_result =
-            P::parse("logs | where attributes[\"x\"] == 10 or severity_text == \"WARN\"").unwrap();
-        let mut pipeline = Pipeline::new(parser_result.pipeline);
-        let result = pipeline
-            .execute(to_otap_logs(log_records.clone()))
-            .await
-            .unwrap();
-        let result_logs = otap_to_logs_data(result);
-        let result_records = &result_logs.resource_logs[0].scope_logs[0].log_records;
-        assert_eq!(
-            result_records.len(),
-            2,
-            "expected 2 rows matching severity_text == WARN, got {}",
-            result_records.len()
-        );
+        let result = exec_logs_pipeline::<P>(
+            "logs | where attributes[\"x\"] == 10 or severity_text == \"WARN\"",
+            to_logs_data(log_records),
+        )
+        .await;
+        let result_records = &result.resource_logs[0].scope_logs[0].log_records;
+        assert_eq!(result_records.len(), 2);
         assert_eq!(result_records[0].event_name, "1");
         assert_eq!(result_records[1].event_name, "3");
     }
@@ -2879,6 +2877,67 @@ mod test {
     #[tokio::test]
     async fn test_filter_or_with_absent_attrs_payload_kql_parser() {
         test_filter_or_with_absent_attrs_payload::<KqlParser>().await;
+    }
+
+    /// Scenario: OR expression where the right side references an absent attributes
+    /// payload and the left side matches root-scoped fields.
+    /// Guarantees: same correctness as the left-absent case, but exercises the code
+    /// path where the first child has already been evaluated when the second child
+    /// is found to be absent.
+    async fn test_filter_or_with_absent_attrs_payload_reversed<P: Parser>() {
+        let log_records = logs_no_attrs();
+
+        // severity_text == "WARN" or attributes["x"] == 10
+        let result = exec_logs_pipeline::<P>(
+            "logs | where severity_text == \"WARN\" or attributes[\"x\"] == 10",
+            to_logs_data(log_records),
+        )
+        .await;
+        let result_records = &result.resource_logs[0].scope_logs[0].log_records;
+        assert_eq!(result_records.len(), 2);
+        assert_eq!(result_records[0].event_name, "1");
+        assert_eq!(result_records[1].event_name, "3");
+    }
+
+    #[tokio::test]
+    async fn test_filter_or_with_absent_attrs_payload_reversed_opl_parser() {
+        test_filter_or_with_absent_attrs_payload_reversed::<OplParser>().await;
+    }
+
+    #[tokio::test]
+    async fn test_filter_or_with_absent_attrs_payload_reversed_kql_parser() {
+        test_filter_or_with_absent_attrs_payload_reversed::<KqlParser>().await;
+    }
+
+    /// Scenario: NOT(OR) expression where one side references an absent attributes
+    /// payload.
+    /// Guarantees: NOT(false OR severity_text == "WARN") correctly inverts to return
+    /// only the rows where severity_text != "WARN".
+    async fn test_filter_not_or_with_absent_attrs_payload<P: Parser>() {
+        let log_records = logs_no_attrs();
+
+        // not(attributes["x"] == 10 or severity_text == "WARN")
+        //
+        // With absent attrs: NOT(false OR severity_text == "WARN") = NOT(severity_text == "WARN")
+        // Only row 1 (ERROR) should pass.
+        let result = exec_logs_pipeline::<P>(
+            "logs | where not(attributes[\"x\"] == 10 or severity_text == \"WARN\")",
+            to_logs_data(log_records),
+        )
+        .await;
+        let result_records = &result.resource_logs[0].scope_logs[0].log_records;
+        assert_eq!(result_records.len(), 1);
+        assert_eq!(result_records[0].event_name, "2");
+    }
+
+    #[tokio::test]
+    async fn test_filter_not_or_with_absent_attrs_payload_opl_parser() {
+        test_filter_not_or_with_absent_attrs_payload::<OplParser>().await;
+    }
+
+    #[tokio::test]
+    async fn test_filter_not_or_with_absent_attrs_payload_kql_parser() {
+        test_filter_not_or_with_absent_attrs_payload::<KqlParser>().await;
     }
 
     async fn test_filter_property_is_null<P: Parser>(null_lit: &str) {

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -2826,6 +2826,61 @@ mod test {
         test_filter_no_attrs::<OplParser>().await;
     }
 
+    /// Scenario: OR expression where the left side references an absent attributes
+    /// payload and the right side matches root-scoped fields.
+    /// Guarantees: when evaluating `attributes["x"] == 10 or severity_text == "WARN"`
+    /// on a batch with no attributes payload at all, rows matching the right side of
+    /// the OR are still returned -- the absent left side does not suppress them.
+    async fn test_filter_or_with_absent_attrs_payload<P: Parser>() {
+        let log_records = vec![
+            LogRecord::build()
+                .event_name("1")
+                .severity_text("WARN")
+                .finish(),
+            LogRecord::build()
+                .event_name("2")
+                .severity_text("ERROR")
+                .finish(),
+            LogRecord::build()
+                .event_name("3")
+                .severity_text("WARN")
+                .finish(),
+        ];
+
+        // attributes["x"] == 10 or severity_text == "WARN"
+        //
+        // No log records have attributes, so the left side of the OR references an
+        // entirely absent attributes payload. The right side matches rows 0 and 2.
+        // The OR should still return rows 0 and 2.
+        let parser_result =
+            P::parse("logs | where attributes[\"x\"] == 10 or severity_text == \"WARN\"").unwrap();
+        let mut pipeline = Pipeline::new(parser_result.pipeline);
+        let result = pipeline
+            .execute(to_otap_logs(log_records.clone()))
+            .await
+            .unwrap();
+        let result_logs = otap_to_logs_data(result);
+        let result_records = &result_logs.resource_logs[0].scope_logs[0].log_records;
+        assert_eq!(
+            result_records.len(),
+            2,
+            "expected 2 rows matching severity_text == WARN, got {}",
+            result_records.len()
+        );
+        assert_eq!(result_records[0].event_name, "1");
+        assert_eq!(result_records[1].event_name, "3");
+    }
+
+    #[tokio::test]
+    async fn test_filter_or_with_absent_attrs_payload_opl_parser() {
+        test_filter_or_with_absent_attrs_payload::<OplParser>().await;
+    }
+
+    #[tokio::test]
+    async fn test_filter_or_with_absent_attrs_payload_kql_parser() {
+        test_filter_or_with_absent_attrs_payload::<KqlParser>().await;
+    }
+
     async fn test_filter_property_is_null<P: Parser>(null_lit: &str) {
         let log_records = vec![
             LogRecord::build()

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/filter.rs
@@ -2313,6 +2313,16 @@ mod test {
             &result.resource_logs[0].scope_logs[0].log_records,
             &[log_records[0].clone(), log_records[1].clone()],
         );
+
+        let result = exec_logs_pipeline::<OplParser>(
+            r#"logs | where not(attributes["z"] + 1 > 0 or severity_text == "ERROR")"#,
+            to_logs_data(log_records.clone()),
+        )
+        .await;
+        pretty_assertions::assert_eq!(
+            &result.resource_logs[0].scope_logs[0].log_records,
+            &[log_records[0].clone()],
+        );
     }
 
     async fn test_filter_with_not<P: Parser>() {

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_substr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_substr.rs
@@ -322,7 +322,7 @@ fn invoke_for_dict_source<K: ArrowDictionaryKeyType>(
     groups: &ColumnarValue,
 ) -> Result<ArrayRef> {
     let dict_arr = source_arr.as_dictionary::<K>();
-let dict_vals = dict_arr.values();
+    let dict_vals = dict_arr.values();
 
     let all_extra_scalar = matches!(patterns, ColumnarValue::Scalar(_))
         && matches!(starts, ColumnarValue::Scalar(_))

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_substr.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/regexp_substr.rs
@@ -322,7 +322,7 @@ fn invoke_for_dict_source<K: ArrowDictionaryKeyType>(
     groups: &ColumnarValue,
 ) -> Result<ArrayRef> {
     let dict_arr = source_arr.as_dictionary::<K>();
-    let dict_vals = dict_arr.values();
+let dict_vals = dict_arr.values();
 
     let all_extra_scalar = matches!(patterns, ColumnarValue::Scalar(_))
         && matches!(starts, ColumnarValue::Scalar(_))


### PR DESCRIPTION
I noticed this when working on https://github.com/open-telemetry/otel-arrow/pull/3827

# Change summary

Fix issue where in a query like `logs | where attributes["x"] == "hello" or severity_text == "INFO"` If some log that doesn't have this attribute has severity_text == "INFO" (e.g. if LHS of or is false, but RHS is `true), it can actually be excluded from the result incorrectly.

This happens b/c the LHS gets evaluated on rows having the given attribute key, and then:
- 1 if it evaluated to something we INNER join those rows to whatever was on the right hand side. The join should effectively be an outer join.
- 2 if it didn't evaluate (missing data), we just return `None` instead of evaluating the other side.

**Fix case 1**: Since we don't have a data scope that describes like, "whatever the result of that outer join would be" the best thing to do is just to align to root when/before doing the join.

**Fix case 2**:  When the expression is an "or", instead of missing data evaluating to `None`, we have it evaluate to `false` which can be OR'd with the other sides (in the case we have something like `x or y or z`). 

But we also do a shortcut here in the common case where it's really only two children (e.g. `x or y`), we can simply take the result of one side without having to actually compute (`false or <other side>`), so we also implement this shortcut. Interestingly, this short cut also works when we end up with children like `<LHS> or false` (we can just take the result of the LHS).

<!--Replace with a brief summary of the change in this PR-->

## Related issue

<!--We highly recommend correlation of every PR to an issue-->

* Closes #3855

## Validation

Unit tests

<!--How did you confirm your change has the intended effect?-->

## User-facing changes

None

<!--
Describe the impact, or write `None`.
User-facing changes require a `.chloggen/*.yaml` entry. If no entry is needed,
include `chore` in the PR title. Documentation-only changes are exempt.
-->
