### PR TITLE
chore: [ETW Receiver] Add debug log for ETW TDH decode failures

### DIFF
--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/session.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/session.rs
@@ -1242,9 +1242,10 @@ fn spawn_etw_session(
                             }
                             Err(e) => {
                                 let _ = telemetry.decode_failed.fetch_add(1, Ordering::Relaxed);
-                                // Per-event diagnostic, off by default. `NotFound`
-                                // is expected for unregistered-manifest, EventSource
-                                // in-band, and opaque events (e.g. EventWriteString);
+                                // Per-event diagnostic at DEBUG (suppressed at the
+                                // default `info` log level). `NotFound` is expected
+                                // for unregistered-manifest, EventSource in-band, and
+                                // opaque events (e.g. EventWriteString);
                                 // `Malformed`/`Win32` signal a truncated payload or a
                                 // real TDH failure.
                                 otel_debug!(

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/session.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/session.rs
@@ -1240,8 +1240,21 @@ fn spawn_etw_session(
                                     result.event_data.event_data(),
                                 );
                             }
-                            Err(_) => {
+                            Err(e) => {
                                 let _ = telemetry.decode_failed.fetch_add(1, Ordering::Relaxed);
+                                // Per-event diagnostic, off by default. `NotFound`
+                                // is expected for unregistered-manifest, EventSource
+                                // in-band, and opaque events (e.g. EventWriteString);
+                                // `Malformed`/`Win32` signal a truncated payload or a
+                                // real TDH failure.
+                                otel_debug!(
+                                    "etw.event.decode_failed",
+                                    provider = %CanonicalGuid::from(anc.provider()),
+                                    event_id = event_id,
+                                    opcode = opcode,
+                                    version = version,
+                                    error = %e,
+                                );
                             }
                         }
                     }


### PR DESCRIPTION
# Change summary

The ETW receiver counted TDH decode failures via the `received_events_invalid` metric but logged nothing per event, so an operator could see that decodes were failing but not which provider or event was responsible.

This adds a per-event `otel_debug!` on the decode-failure path capturing the provider GUID, event ID, opcode, version, and the decode error. It is off by default (the default log level is info) and costs effectively nothing unless an operator opts in.