### PR TITLE
chore(release): Setup for first crates.io release of pdata-views crate

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
       pull-requests: read
     runs-on: ubuntu-latest
-    environment: release
+    environment: ${{ inputs.dry_run && '' || 'release' }}
     steps:
       - name: Checkout (dry run)
         if: inputs.dry_run

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -111,7 +111,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
-          toolchain: stable
+          toolchain: 1.98.0
 
       - name: Update Rust lockfile
         run: cargo generate-lockfile --manifest-path rust/otap-dataflow/Cargo.toml

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
       pull-requests: read
     runs-on: ubuntu-latest
-    environment: ${{ inputs.dry_run && '' || 'release' }}
+    environment: ${{ !inputs.dry_run && 'release' || '' }}
     steps:
       - name: Checkout (dry run)
         if: inputs.dry_run

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -116,6 +116,10 @@ jobs:
       - name: Update Rust lockfile
         run: cargo generate-lockfile --manifest-path rust/otap-dataflow/Cargo.toml
 
+      - name: Validate Rust crates.io publish pilot
+        run: cargo xtask crates-publish check
+        working-directory: rust/otap-dataflow
+
       - name: Extract release notes for PR body
         id: changelog
         run: |

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -17,12 +17,18 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: push-release
+  cancel-in-progress: false
+
 jobs:
   push-release:
     permissions:
       contents: read
+      id-token: write
       pull-requests: read
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: release
     steps:
       - name: Checkout (dry run)
@@ -94,6 +100,10 @@ jobs:
           git fetch --quiet origin main --tags
           git checkout --detach "${{ steps.release.outputs.sha }}"
 
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: stable
+
       - name: Verify release preparation
         run: |
           # Check if the version is already in go/CHANGELOG.md.
@@ -120,7 +130,10 @@ jobs:
         id: last_version
         run: |
           # Get the latest tag
-          LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -n1)
+          LAST_TAG=$(
+            git tag --list 'v*' --sort=-version:refname |
+              awk -v current="v${{ inputs.version }}" '$0 != current { print; exit }'
+          )
           if [ -z "$LAST_TAG" ]; then
             echo "No previous tags found"
             LAST_VERSION="0.0.0"
@@ -144,12 +157,25 @@ jobs:
             fi
           fi
 
-      - name: Check if tag already exists
+      - name: Validate existing tags
         run: |
-          if git tag --list | grep -q "^v${{ inputs.version }}$"; then
-            echo "Error: Tag v${{ inputs.version }} already exists"
-            exit 1
-          fi
+          for tag in \
+            "v${{ inputs.version }}" \
+            "go/v${{ inputs.version }}" \
+            "rust/otap-dataflow/v${{ inputs.version }}"; do
+            if git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null; then
+              TAG_COMMIT=$(git rev-parse "${tag}^{commit}")
+              if [ "$TAG_COMMIT" != "${{ steps.release.outputs.sha }}" ]; then
+                echo "Error: Existing tag ${tag} points to ${TAG_COMMIT}"
+                exit 1
+              fi
+              echo "Existing tag ${tag} already points to the release commit"
+            fi
+          done
+
+      - name: Validate Rust crates.io publish pilot
+        run: cargo xtask crates-publish check
+        working-directory: rust/otap-dataflow
 
       - name: Extract changelog content for this release
         id: changelog
@@ -195,7 +221,10 @@ jobs:
             echo ""
             echo "### Rust Workspace"
             echo ""
-            echo "The Rust workspace at \`rust/otap-dataflow/\` is tagged as \`rust/otap-dataflow/v${{ inputs.version }}\`. Crates are not published to crates.io yet; consume this release via git."
+            echo "The Rust workspace at \`rust/otap-dataflow/\` is tagged as \`rust/otap-dataflow/v${{ inputs.version }}\`."
+            echo ""
+            echo "This release tests crates.io publishing with \`otel-arrow-dfe-pdata-views@${{ inputs.version }}\`."
+            echo "All other OTAP Dataflow crates remain unpublished and should be consumed using the Rust workspace git reference."
           } > /tmp/release_content.txt
 
       - name: Dry run - Show planned changes
@@ -217,7 +246,12 @@ jobs:
           ## Git Tags to Create
           - `v${{ inputs.version }}` - Main release tag
           - `go/v${{ inputs.version }}` - Go module tag
-          - `rust/otap-dataflow/v${{ inputs.version }}` - Rust workspace tag (git-tag only; no crates.io publish)
+          - `rust/otap-dataflow/v${{ inputs.version }}` - Rust workspace tag
+
+          ## crates.io
+          - **Package**: `otel-arrow-dfe-pdata-views@${{ inputs.version }}`
+          - **Authentication**: crates.io trusted publishing (OIDC)
+          - Existing matching versions are checksum-verified and skipped.
 
           ## GitHub Release
           - **Title**: Release v${{ inputs.version }}
@@ -247,6 +281,18 @@ jobs:
           **Note**: This is a dry run. To execute the actual release push, set `dry_run` to `false`.
           EOF
 
+      - name: Authenticate to crates.io with trusted publishing
+        if: "!inputs.dry_run"
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Publish views crate with trusted publishing
+        if: "!inputs.dry_run"
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
+        run: cargo xtask crates-publish publish "${{ inputs.version }}"
+        working-directory: rust/otap-dataflow
+
       - name: Create git tags
         if: "!inputs.dry_run"
         run: |
@@ -254,14 +300,18 @@ jobs:
           git config user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
           git config user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
 
-          # Create main release tag
-          git tag -a "v${{ inputs.version }}" "${{ steps.release.outputs.sha }}" -m "Release v${{ inputs.version }}"
+          create_tag() {
+            local tag="$1"
+            if git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null; then
+              echo "Tag ${tag} already exists at the release commit"
+            else
+              git tag -a "$tag" "${{ steps.release.outputs.sha }}" -m "Release ${tag}"
+            fi
+          }
 
-          # Create Go module tags
-          git tag -a "go/v${{ inputs.version }}" "${{ steps.release.outputs.sha }}" -m "Release go/v${{ inputs.version }}"
-
-          # Create Rust workspace tag (git-tag only; no crates.io publish yet)
-          git tag -a "rust/otap-dataflow/v${{ inputs.version }}" "${{ steps.release.outputs.sha }}" -m "Release rust/otap-dataflow/v${{ inputs.version }}"
+          create_tag "v${{ inputs.version }}"
+          create_tag "go/v${{ inputs.version }}"
+          create_tag "rust/otap-dataflow/v${{ inputs.version }}"
 
           echo "Created tags:"
           git tag --list "v${{ inputs.version }}"
@@ -295,12 +345,15 @@ jobs:
           **Full Changelog**: https://github.com/open-telemetry/otel-arrow/compare/v${{ steps.last_version.outputs.last_version }}...v${{ inputs.version }}
           EOF
 
-          # Create the GitHub release using GitHub CLI
-          gh release create "v${{ inputs.version }}" \
-            --title "Release v${{ inputs.version }}" \
-            --notes-file /tmp/release_body.md \
-            --draft \
-            --latest
+          if gh release view "v${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "GitHub release v${{ inputs.version }} already exists; skipping"
+          else
+            gh release create "v${{ inputs.version }}" \
+              --title "Release v${{ inputs.version }}" \
+              --notes-file /tmp/release_body.md \
+              --draft \
+              --latest
+          fi
 
       - name: Summary
         run: |

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -102,7 +102,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
-          toolchain: stable
+          toolchain: 1.98.0
 
       - name: Verify release preparation
         run: |
@@ -251,7 +251,7 @@ jobs:
           ## crates.io
           - **Package**: `otel-arrow-dfe-pdata-views@${{ inputs.version }}`
           - **Authentication**: crates.io trusted publishing (OIDC)
-          - Existing matching versions are checksum-verified and skipped.
+          - Existing versions are detected and skipped.
 
           ## GitHub Release
           - **Title**: Release v${{ inputs.version }}

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -29,7 +29,7 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: ${{ inputs.dry_run && '' || 'release' }}
+    environment: ${{ !inputs.dry_run && 'release' || '' }}
     steps:
       - name: Checkout (dry run)
         if: inputs.dry_run

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -29,7 +29,7 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: release
+    environment: ${{ inputs.dry_run && '' || 'release' }}
     steps:
       - name: Checkout (dry run)
         if: inputs.dry_run

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -437,6 +437,9 @@ jobs:
       - name: Run cargo xtask for ${{ matrix.folder }}
         run: cargo xtask structure-check
         working-directory: ./rust/${{ matrix.folder }}
+      - name: Validate crates.io publish pilot
+        run: cargo xtask crates-publish check
+        working-directory: ./rust/${{ matrix.folder }}
       - name: Check telemetry macro usage
         run: ./scripts/check-direct-telemetry-macros.sh
         working-directory: ./rust/${{ matrix.folder }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -141,8 +141,9 @@ Before publishing the release, run the push workflow in dry-run mode:
    - Resolve the merged `otelbot/release-vX.Y.Z` pull request and use its
      merge commit as the release commit.
    - Obtain a short-lived crates.io token through trusted publishing.
-   - Publish `otel-arrow-dfe-pdata-views`, or verify and skip an existing
-     version with the expected package checksum.
+   - Publish `otel-arrow-dfe-pdata-views`, or skip the version if it already
+     exists.
+   - Wait until crates.io reports the version before creating release tags.
    - Create git tags for the main release, the Go modules, and the Rust
      workspace at that release commit.
    - Publish the GitHub release with the combined changelog content.
@@ -218,11 +219,10 @@ If the workflow fails partway through:
 
 1. Check whether `otel-arrow-dfe-pdata-views@X.Y.Z` exists on crates.io.
 2. If it exists, publication is irreversible. Re-run Push Release with the
-   same version and merged release commit. The publisher verifies the checksum
-   and skips the existing crate before resuming tags and the GitHub release.
-3. Never delete and recreate the release branch for a published version. A new
-   merge commit produces a different package checksum. If the published
-   checksum does not match, prepare a new patch version.
+   same version. The publisher skips the existing crate before resuming tags
+   and the GitHub release.
+3. Never attempt to replace an existing crates.io version. Prepare a new patch
+   version if the published contents are wrong.
 4. If publication did not occur, fix the underlying issue and re-run the
    workflow normally.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,7 +10,8 @@ The repository uses two GitHub Actions workflows to manage releases:
 
 1. **Prepare Release**: Renders pending changelog entries, bumps versions,
    and opens a pull request.
-2. **Push Release**: Creates git tags and publishes the GitHub release.
+2. **Push Release**: Publishes opted-in Rust crates, creates git tags, and
+   publishes the GitHub release.
 
 This two-step process ensures that all changes are reviewed before the release
 is published.
@@ -25,6 +26,11 @@ is published.
    YAML fragment under `go/.chloggen/` (for Go changes) or
    `rust/otap-dataflow/.chloggen/` (for Rust changes). The release workflow
    collapses these into the appropriate CHANGELOG at release time.
+4. **Protected environment**: The `release` GitHub environment exists with
+   the required maintainers as approvers.
+5. **Trusted publishing**: crates.io trusts
+   `.github/workflows/push-release.yml` in this repository with the `release`
+   environment.
 
 ## Changelog management
 
@@ -134,6 +140,9 @@ Before publishing the release, run the push workflow in dry-run mode:
 2. The workflow will:
    - Resolve the merged `otelbot/release-vX.Y.Z` pull request and use its
      merge commit as the release commit.
+   - Obtain a short-lived crates.io token through trusted publishing.
+   - Publish `otel-arrow-dfe-pdata-views`, or verify and skip an existing
+     version with the expected package checksum.
    - Create git tags for the main release, the Go modules, and the Rust
      workspace at that release commit.
    - Publish the GitHub release with the combined changelog content.
@@ -160,9 +169,9 @@ The release process handles:
 
 **Rust Workspace:**
 
-- `rust/otap-dataflow/` (git-tag only; **not** published to crates.io
-  yet). Consumers wire the workspace directly via a git reference until
-  the Rust side is ready for end-user releases.
+- `rust/otap-dataflow/` aggregate git tag.
+- `otel-arrow-dfe-pdata-views` on crates.io. All other Rust workspace
+  packages remain unpublished during the pilot.
 
 ## Troubleshooting
 
@@ -195,19 +204,31 @@ The release process handles:
 - Ensure the new version follows semantic versioning and is greater than
   the current version.
 
+#### crates.io trusted publishing authentication fails
+
+- Confirm the crate's trusted publisher names `open-telemetry/otel-arrow`,
+  workflow `push-release.yml`, and environment `release`.
+- Confirm the workflow was started from an event and ref allowed by the
+  protected `release` environment.
+- Do not restore or add a long-lived crates.io token to the workflow.
+
 ### Manual Recovery
 
 If the workflow fails partway through:
 
-1. Delete the release branch if it was created:
+1. Check whether `otel-arrow-dfe-pdata-views@X.Y.Z` exists on crates.io.
+2. If it exists, publication is irreversible. Re-run Push Release with the
+   same version and merged release commit. The publisher verifies the checksum
+   and skips the existing crate before resuming tags and the GitHub release.
+3. Never delete and recreate the release branch for a published version. A new
+   merge commit produces a different package checksum. If the published
+   checksum does not match, prepare a new patch version.
+4. If publication did not occur, fix the underlying issue and re-run the
+   workflow normally.
 
-   ```bash
-   git push origin --delete otelbot/release-vX.Y.Z
-   ```
-
-2. Delete the draft release from the GitHub UI if it was created.
-
-3. Fix the underlying issue and re-run the workflow.
+Do not yank a version merely because a later tag or GitHub release step failed.
+Yanking prevents normal dependency resolution and does not permit republishing
+the same version.
 
 ### Emergency Release Process
 
@@ -230,7 +251,18 @@ release:
 
 3. Commit the changes, open and merge a PR.
 
-4. Create and push the release tags:
+4. From the merged release commit, publish or verify the views crate with a
+   short-lived crates.io token:
+
+   ```bash
+   cd rust/otap-dataflow
+   export CARGO_REGISTRY_TOKEN="REPLACE_WITH_SHORT_LIVED_TOKEN"
+   cargo xtask crates-publish publish X.Y.Z
+   unset CARGO_REGISTRY_TOKEN
+   cd ../..
+   ```
+
+5. Create and push the release tags:
 
    ```bash
    git tag -a vX.Y.Z -m "Release vX.Y.Z"
@@ -241,7 +273,7 @@ release:
      rust/otap-dataflow/vX.Y.Z
    ```
 
-5. Create a GitHub release manually.
+6. Create a GitHub release manually.
 
 ## Version Strategy
 
@@ -253,5 +285,5 @@ release:
   changes.
 - Pre-release versions are not currently supported through the automated
   workflow.
-- Rust crates are **not** published to crates.io yet. The Rust release is
-  git-tag-only until the Rust side is ready for end-user releases.
+- Only `otel-arrow-dfe-pdata-views` is published to crates.io during the
+  pilot. Consume every other Rust crate using the Rust workspace git tag.

--- a/rust/otap-dataflow/.chloggen/publish-pdata-views.yaml
+++ b/rust/otap-dataflow/.chloggen/publish-pdata-views.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: pdata
+note: "Publish the zero-dependency `otel-arrow-dfe-pdata-views` crate through the guarded release workflow."
+issues: [2691]
+subtext:

--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -12727,6 +12727,7 @@ dependencies = [
  "prost-build 0.14.4",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "syn 2.0.119",
  "toml",
  "tonic-prost-build",

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -29,6 +29,7 @@ description = "OTel-Arrow Dataflow Engine supporting natively OTLP and OTAP Data
 edition.workspace = true
 repository.workspace = true
 license.workspace = true
+publish.workspace = true
 keywords = ["OpenTelemetry", "OTLP", "OTAP", "Dataflow", "Engine"]
 categories = ["asynchronous", "network-programming"]
 

--- a/rust/otap-dataflow/crates/pdata-views/Cargo.toml
+++ b/rust/otap-dataflow/crates/pdata-views/Cargo.toml
@@ -4,10 +4,15 @@ version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true
+homepage = "https://github.com/open-telemetry/otel-arrow"
+documentation = "https://docs.rs/otel-arrow-dfe-pdata-views"
 license.workspace = true
-publish.workspace = true
+readme = "README.md"
+publish = true
 rust-version.workspace = true
 description = "Zero-dependency view traits for OTLP/OTAP telemetry data"
+keywords = ["opentelemetry", "otlp", "otap", "telemetry", "views"]
+categories = ["data-structures"]
 
 [dependencies]
 # intentionally empty

--- a/rust/otap-dataflow/crates/pdata-views/README.md
+++ b/rust/otap-dataflow/crates/pdata-views/README.md
@@ -5,7 +5,7 @@ Zero-dependency, backend-agnostic view traits for OTLP/OTAP telemetry data.
 ## Overview
 
 This crate provides read-only view traits for traversing hierarchical
-telemetry data structures (logs, traces, resources) without any external
+telemetry data structures (logs, metrics, traces, resources) without external
 dependencies. It is designed to be consumed both within the
 `otap-dataflow` workspace and by external crates that need a lightweight
 integration point without pulling in the full `otel-arrow-dfe-pdata` stack.
@@ -14,6 +14,8 @@ integration point without pulling in the full `otel-arrow-dfe-pdata` stack.
 
 - `views::logs`: `LogsDataView`, `ResourceLogsView`, `ScopeLogsView`,
   `LogRecordView`
+- `views::metrics`: `MetricsView`, resource and scope views, metric data
+  views, data-point views, exemplars, and histogram bucket views
 - `views::trace`: `TracesView`, `ResourceSpansView`, `ScopeSpansView`,
   `SpanView`, `EventView`, `LinkView`, `StatusView`
 - `views::resource`: `ResourceView`
@@ -22,8 +24,24 @@ integration point without pulling in the full `otel-arrow-dfe-pdata` stack.
 
 ## Usage
 
+```sh
+cargo add otel-arrow-dfe-pdata-views
+```
+
 Implement the relevant view trait over your existing data structure to
 plug into any pipeline that consumes these traits (e.g. `geneva-uploader`).
+Consumers can write generic code against those traits:
+
+```rust
+use otel_arrow_dfe_pdata_views::views::metrics::MetricsView;
+
+fn resource_group_count(metrics: &impl MetricsView) -> usize {
+    metrics.resources().count()
+}
+```
+
+This crate is currently pre-1.0. Its public API may evolve between minor
+releases.
 
 ## Dependencies
 

--- a/rust/otap-dataflow/xtask/Cargo.toml
+++ b/rust/otap-dataflow/xtask/Cargo.toml
@@ -12,6 +12,7 @@ rust-version.workspace = true
 anyhow = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 syn = { workspace = true }
 # `span-locations` gives us `Span::start().line` for informational file:line in
 # the inventory output (line is not part of the baseline diff).

--- a/rust/otap-dataflow/xtask/src/crates_publish.rs
+++ b/rust/otap-dataflow/xtask/src/crates_publish.rs
@@ -3,12 +3,16 @@
 
 //! Publication policy and release commands for the crates.io pilot.
 
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::thread;
 use std::time::Duration;
 
 use anyhow::{Context, bail};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 const PILOT_PACKAGE: &str = "otel-arrow-dfe-pdata-views";
 const CRATES_IO_API: &str = "https://crates.io/api/v1";
@@ -17,6 +21,7 @@ const VISIBILITY_DELAYS: [u64; 8] = [0, 5, 10, 20, 40, 80, 160, 300];
 #[derive(Debug, Deserialize)]
 struct CargoMetadata {
     packages: Vec<CargoPackage>,
+    target_directory: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -35,6 +40,8 @@ struct CargoDependency {
 #[derive(Debug, Eq, PartialEq, Serialize)]
 struct PublishPlan {
     packages: Vec<PublishPackage>,
+    #[serde(skip_serializing)]
+    target_directory: PathBuf,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize)]
@@ -50,6 +57,7 @@ struct CratesIoResponse {
 
 #[derive(Debug, Deserialize)]
 struct CratesIoVersion {
+    checksum: String,
     yanked: bool,
 }
 
@@ -91,10 +99,13 @@ fn load_plan() -> anyhow::Result<PublishPlan> {
 
     let metadata: CargoMetadata =
         serde_json::from_slice(&output.stdout).context("failed to parse cargo metadata")?;
-    build_plan(metadata.packages)
+    build_plan(metadata.packages, PathBuf::from(metadata.target_directory))
 }
 
-fn build_plan(packages: Vec<CargoPackage>) -> anyhow::Result<PublishPlan> {
+fn build_plan(
+    packages: Vec<CargoPackage>,
+    target_directory: PathBuf,
+) -> anyhow::Result<PublishPlan> {
     let mut publishable = packages
         .into_iter()
         .filter(|package| {
@@ -131,6 +142,7 @@ fn build_plan(packages: Vec<CargoPackage>) -> anyhow::Result<PublishPlan> {
             name: package.name,
             version: package.version,
         }],
+        target_directory,
     })
 }
 
@@ -144,10 +156,17 @@ fn publish(expected_version: &str) -> anyhow::Result<()> {
         );
     }
 
+    let expected_checksum = package_checksum(package, &plan.target_directory)?;
     if let Some(version) = crates_io_version(&package.name, &package.version)? {
         ensure_not_yanked(&package.name, &package.version, version.yanked)?;
+        verify_checksum(
+            &package.name,
+            &package.version,
+            &expected_checksum,
+            &version.checksum,
+        )?;
         println!(
-            "{} {} already exists on crates.io; skipping",
+            "{} {} already exists on crates.io with the expected checksum; skipping",
             package.name, package.version
         );
         return Ok(());
@@ -157,7 +176,34 @@ fn publish(expected_version: &str) -> anyhow::Result<()> {
         bail!("CARGO_REGISTRY_TOKEN is required to publish a missing version");
     }
     run_cargo(&["publish", "--locked", "-p", &package.name])?;
-    wait_until_visible(package)
+    wait_until_visible(package, &expected_checksum)
+}
+
+fn package_checksum(package: &PublishPackage, target_directory: &Path) -> anyhow::Result<String> {
+    run_cargo(&["package", "--locked", "-p", &package.name])?;
+
+    let artifact = target_directory
+        .join("package")
+        .join(format!("{}-{}.crate", package.name, package.version));
+    let mut file =
+        File::open(&artifact).with_context(|| format!("failed to open {}", artifact.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 16 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .with_context(|| format!("failed to read {}", artifact.display()))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+
+    Ok(hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect())
 }
 
 fn crates_io_version(name: &str, version: &str) -> anyhow::Result<Option<CratesIoVersion>> {
@@ -206,7 +252,7 @@ fn parse_crates_io_response(output: &Output) -> anyhow::Result<Option<CratesIoVe
     }
 }
 
-fn wait_until_visible(package: &PublishPackage) -> anyhow::Result<()> {
+fn wait_until_visible(package: &PublishPackage, expected_checksum: &str) -> anyhow::Result<()> {
     for delay in VISIBILITY_DELAYS {
         if delay > 0 {
             thread::sleep(Duration::from_secs(delay));
@@ -214,8 +260,14 @@ fn wait_until_visible(package: &PublishPackage) -> anyhow::Result<()> {
         match crates_io_version(&package.name, &package.version) {
             Ok(Some(version)) => {
                 ensure_not_yanked(&package.name, &package.version, version.yanked)?;
+                verify_checksum(
+                    &package.name,
+                    &package.version,
+                    expected_checksum,
+                    &version.checksum,
+                )?;
                 println!(
-                    "verified {} {} is visible on crates.io",
+                    "verified {} {} is visible on crates.io with the expected checksum",
                     package.name, package.version
                 );
                 return Ok(());
@@ -228,6 +280,13 @@ fn wait_until_visible(package: &PublishPackage) -> anyhow::Result<()> {
         package.name,
         package.version
     )
+}
+
+fn verify_checksum(name: &str, version: &str, expected: &str, actual: &str) -> anyhow::Result<()> {
+    if expected != actual {
+        bail!("{name} {version} exists on crates.io with checksum {actual}, expected {expected}");
+    }
+    Ok(())
 }
 
 fn ensure_not_yanked(name: &str, version: &str, yanked: bool) -> anyhow::Result<()> {
@@ -273,12 +332,13 @@ mod tests {
         ];
 
         assert_eq!(
-            build_plan(packages).expect("pilot plan should be valid"),
+            build_plan(packages, PathBuf::from("/target")).expect("pilot plan should be valid"),
             PublishPlan {
                 packages: vec![PublishPackage {
                     name: PILOT_PACKAGE.to_owned(),
                     version: "0.51.0".to_owned(),
                 }],
+                target_directory: PathBuf::from("/target"),
             }
         );
     }
@@ -292,13 +352,33 @@ mod tests {
             package("otel-arrow-dfe", None, &[]),
         ];
 
-        assert!(build_plan(packages).is_err());
+        assert!(build_plan(packages, PathBuf::from("/target")).is_err());
     }
 
     /// Scenario: the views crate gains a dependency during the pilot.
     /// Guarantees: the pilot remains isolated from dependency publication ordering.
     #[test]
     fn plan_rejects_views_dependency() {
-        assert!(build_plan(vec![package(PILOT_PACKAGE, None, &["dependency"])]).is_err());
+        assert!(
+            build_plan(
+                vec![package(PILOT_PACKAGE, None, &["dependency"])],
+                PathBuf::from("/target")
+            )
+            .is_err()
+        );
+    }
+
+    /// Scenario: crates.io reports the checksum built from the release commit.
+    /// Guarantees: an existing matching crate version is safe to skip.
+    #[test]
+    fn checksum_accepts_matching_crate() {
+        assert!(verify_checksum(PILOT_PACKAGE, "0.51.0", "abc", "abc").is_ok());
+    }
+
+    /// Scenario: crates.io reports a checksum from different source content.
+    /// Guarantees: the release fails instead of tagging the wrong crate contents.
+    #[test]
+    fn checksum_rejects_different_crate() {
+        assert!(verify_checksum(PILOT_PACKAGE, "0.51.0", "abc", "def").is_err());
     }
 }

--- a/rust/otap-dataflow/xtask/src/crates_publish.rs
+++ b/rust/otap-dataflow/xtask/src/crates_publish.rs
@@ -1,0 +1,304 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Publication policy and release commands for the crates.io pilot.
+
+use std::process::{Command, Output};
+use std::thread;
+use std::time::Duration;
+
+use anyhow::{Context, bail};
+use serde::{Deserialize, Serialize};
+
+const PILOT_PACKAGE: &str = "otel-arrow-dfe-pdata-views";
+const CRATES_IO_API: &str = "https://crates.io/api/v1";
+const VISIBILITY_DELAYS: [u64; 8] = [0, 5, 10, 20, 40, 80, 160, 300];
+
+#[derive(Debug, Deserialize)]
+struct CargoMetadata {
+    packages: Vec<CargoPackage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoPackage {
+    name: String,
+    version: String,
+    publish: Option<Vec<String>>,
+    dependencies: Vec<CargoDependency>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoDependency {
+    name: String,
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+struct PublishPlan {
+    packages: Vec<PublishPackage>,
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+struct PublishPackage {
+    name: String,
+    version: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CratesIoResponse {
+    version: CratesIoVersion,
+}
+
+#[derive(Debug, Deserialize)]
+struct CratesIoVersion {
+    yanked: bool,
+}
+
+pub fn run(args: &[String]) -> anyhow::Result<()> {
+    match args {
+        [command] if command == "plan" => print_plan(),
+        [command] if command == "check" => {
+            print_plan()?;
+            run_cargo(&[
+                "publish",
+                "--dry-run",
+                "--locked",
+                "--allow-dirty",
+                "-p",
+                PILOT_PACKAGE,
+            ])
+        }
+        [command, version] if command == "publish" => publish(version),
+        _ => bail!("Usage: cargo xtask crates-publish <plan|check|publish VERSION>"),
+    }
+}
+
+fn print_plan() -> anyhow::Result<()> {
+    println!("{}", serde_json::to_string_pretty(&load_plan()?)?);
+    Ok(())
+}
+
+fn load_plan() -> anyhow::Result<PublishPlan> {
+    let output = Command::new("cargo")
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .output()
+        .context("failed to run cargo metadata")?;
+    if !output.status.success() {
+        bail!(
+            "cargo metadata failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let metadata: CargoMetadata =
+        serde_json::from_slice(&output.stdout).context("failed to parse cargo metadata")?;
+    build_plan(metadata.packages)
+}
+
+fn build_plan(packages: Vec<CargoPackage>) -> anyhow::Result<PublishPlan> {
+    let mut publishable = packages
+        .into_iter()
+        .filter(|package| {
+            package
+                .publish
+                .as_ref()
+                .is_none_or(|registries| !registries.is_empty())
+        })
+        .collect::<Vec<_>>();
+    publishable.sort_by(|left, right| left.name.cmp(&right.name));
+
+    let names = publishable
+        .iter()
+        .map(|package| package.name.as_str())
+        .collect::<Vec<_>>();
+    if names != [PILOT_PACKAGE] {
+        bail!("pilot publish set must be exactly [\"{PILOT_PACKAGE}\"], found {names:?}");
+    }
+
+    let package = publishable
+        .pop()
+        .expect("the singleton publish set was validated");
+    if !package.dependencies.is_empty() {
+        let dependencies = package
+            .dependencies
+            .iter()
+            .map(|dependency| dependency.name.as_str())
+            .collect::<Vec<_>>();
+        bail!("pilot package {PILOT_PACKAGE} must have no dependencies, found {dependencies:?}");
+    }
+
+    Ok(PublishPlan {
+        packages: vec![PublishPackage {
+            name: package.name,
+            version: package.version,
+        }],
+    })
+}
+
+fn publish(expected_version: &str) -> anyhow::Result<()> {
+    let plan = load_plan()?;
+    let package = &plan.packages[0];
+    if package.version != expected_version {
+        bail!(
+            "publish plan version {} does not match requested version {expected_version}",
+            package.version
+        );
+    }
+
+    if let Some(version) = crates_io_version(&package.name, &package.version)? {
+        ensure_not_yanked(&package.name, &package.version, version.yanked)?;
+        println!(
+            "{} {} already exists on crates.io; skipping",
+            package.name, package.version
+        );
+        return Ok(());
+    }
+
+    if std::env::var_os("CARGO_REGISTRY_TOKEN").is_none() {
+        bail!("CARGO_REGISTRY_TOKEN is required to publish a missing version");
+    }
+    run_cargo(&["publish", "--locked", "-p", &package.name])?;
+    wait_until_visible(package)
+}
+
+fn crates_io_version(name: &str, version: &str) -> anyhow::Result<Option<CratesIoVersion>> {
+    let url = format!("{CRATES_IO_API}/crates/{name}/{version}");
+    let output = Command::new("curl")
+        .args([
+            "--silent",
+            "--show-error",
+            "--location",
+            "--connect-timeout",
+            "10",
+            "--max-time",
+            "30",
+            "--user-agent",
+            "otel-arrow-release-publisher",
+            "--write-out",
+            "\n%{http_code}",
+            &url,
+        ])
+        .output()
+        .context("failed to query crates.io")?;
+    parse_crates_io_response(&output)
+}
+
+fn parse_crates_io_response(output: &Output) -> anyhow::Result<Option<CratesIoVersion>> {
+    if !output.status.success() {
+        bail!(
+            "crates.io request failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let stdout = String::from_utf8(output.stdout.clone())
+        .context("crates.io returned a non-UTF-8 response")?;
+    let (body, status) = stdout
+        .rsplit_once('\n')
+        .context("crates.io response did not include an HTTP status")?;
+    match status {
+        "200" => {
+            let response: CratesIoResponse =
+                serde_json::from_str(body).context("failed to parse crates.io response")?;
+            Ok(Some(response.version))
+        }
+        "404" => Ok(None),
+        _ => bail!("crates.io returned HTTP {status}: {}", body.trim()),
+    }
+}
+
+fn wait_until_visible(package: &PublishPackage) -> anyhow::Result<()> {
+    for delay in VISIBILITY_DELAYS {
+        if delay > 0 {
+            thread::sleep(Duration::from_secs(delay));
+        }
+        match crates_io_version(&package.name, &package.version) {
+            Ok(Some(version)) => {
+                ensure_not_yanked(&package.name, &package.version, version.yanked)?;
+                println!(
+                    "verified {} {} is visible on crates.io",
+                    package.name, package.version
+                );
+                return Ok(());
+            }
+            Ok(None) | Err(_) => continue,
+        }
+    }
+    bail!(
+        "{} {} was not visible on crates.io before the retry deadline",
+        package.name,
+        package.version
+    )
+}
+
+fn ensure_not_yanked(name: &str, version: &str, yanked: bool) -> anyhow::Result<()> {
+    if yanked {
+        bail!("{name} {version} is yanked on crates.io; prepare a new version");
+    }
+    Ok(())
+}
+
+fn run_cargo(args: &[&str]) -> anyhow::Result<()> {
+    let status = Command::new("cargo").args(args).status()?;
+    if !status.success() {
+        bail!("cargo {} failed", args.join(" "));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn package(name: &str, publish: Option<Vec<String>>, dependencies: &[&str]) -> CargoPackage {
+        CargoPackage {
+            name: name.to_owned(),
+            version: "0.51.0".to_owned(),
+            publish,
+            dependencies: dependencies
+                .iter()
+                .map(|name| CargoDependency {
+                    name: (*name).to_owned(),
+                })
+                .collect(),
+        }
+    }
+
+    /// Scenario: only the dependency-free views crate is marked publishable.
+    /// Guarantees: the pilot plan contains exactly the approved crate and version.
+    #[test]
+    fn plan_accepts_views_only() {
+        let packages = vec![
+            package(PILOT_PACKAGE, None, &[]),
+            package("otel-arrow-dfe", Some(vec![]), &[]),
+        ];
+
+        assert_eq!(
+            build_plan(packages).expect("pilot plan should be valid"),
+            PublishPlan {
+                packages: vec![PublishPackage {
+                    name: PILOT_PACKAGE.to_owned(),
+                    version: "0.51.0".to_owned(),
+                }],
+            }
+        );
+    }
+
+    /// Scenario: another workspace package is marked publishable.
+    /// Guarantees: the pilot cannot expand beyond the views crate accidentally.
+    #[test]
+    fn plan_rejects_additional_package() {
+        let packages = vec![
+            package(PILOT_PACKAGE, None, &[]),
+            package("otel-arrow-dfe", None, &[]),
+        ];
+
+        assert!(build_plan(packages).is_err());
+    }
+
+    /// Scenario: the views crate gains a dependency during the pilot.
+    /// Guarantees: the pilot remains isolated from dependency publication ordering.
+    #[test]
+    fn plan_rejects_views_dependency() {
+        assert!(build_plan(vec![package(PILOT_PACKAGE, None, &["dependency"])]).is_err());
+    }
+}

--- a/rust/otap-dataflow/xtask/src/main.rs
+++ b/rust/otap-dataflow/xtask/src/main.rs
@@ -20,6 +20,7 @@ use std::thread;
 use std::time::Instant;
 
 mod component_inventory;
+mod crates_publish;
 mod diagnostics;
 mod genproto;
 mod structure_check;
@@ -51,6 +52,7 @@ fn main() -> anyhow::Result<()> {
                 structure_check::run()
             }
             "component-inventory" => component_inventory::run(&args.collect::<Vec<_>>()),
+            "crates-publish" => crates_publish::run(&args.collect::<Vec<_>>()),
             "help" => {
                 ensure_no_extra_args("help", &args.collect::<Vec<_>>())?;
                 print_help()
@@ -77,6 +79,7 @@ Tasks:
   - structure-check: Validate the entire structure of the project.
   - compile-proto: Compile the protobufs files
   - component-inventory [--check <baseline>] [--update-baseline] [--format <table|json|yaml>]: Manage and verify the component inventory baseline.
+  - crates-publish <plan|check|publish VERSION>: Plan, validate, or publish the pilot crate.
 "
     );
     Ok(())

--- a/rust/otap-dataflow/xtask/src/structure_check.rs
+++ b/rust/otap-dataflow/xtask/src/structure_check.rs
@@ -8,6 +8,8 @@ use std::path::Path;
 use anyhow::Error;
 use toml::{Table, Value};
 
+const PUBLISH_PILOT_PACKAGE: &str = "otel-arrow-dfe-pdata-views";
+
 /// Validates the entire structure of the project.
 ///
 /// This procedure checks that the following rules are properly followed for
@@ -175,7 +177,7 @@ fn check_package<P: AsRef<Path>>(cargo_toml_path: P, toml: &Table) -> anyhow::Re
         package,
     )?;
     check_path_is_true(cargo_toml_path.as_ref(), &["license", "workspace"], package)?;
-    check_path_is_true(cargo_toml_path.as_ref(), &["publish", "workspace"], package)?;
+    check_publish_policy(cargo_toml_path.as_ref(), package_name, package)?;
     check_path_is_true(cargo_toml_path.as_ref(), &["edition", "workspace"], package)?;
     check_path_is_true(
         cargo_toml_path.as_ref(),
@@ -184,6 +186,19 @@ fn check_package<P: AsRef<Path>>(cargo_toml_path: P, toml: &Table) -> anyhow::Re
     )?;
 
     Ok(())
+}
+
+#[cfg(not(tarpaulin_include))]
+fn check_publish_policy(
+    cargo_toml_path: &Path,
+    package_name: &str,
+    package: &Value,
+) -> anyhow::Result<()> {
+    if package_name == PUBLISH_PILOT_PACKAGE {
+        check_path_is_true(cargo_toml_path, &["publish"], package)
+    } else {
+        check_path_is_true(cargo_toml_path, &["publish", "workspace"], package)
+    }
 }
 
 /// Checks the `lints` section of a Cargo.toml file.
@@ -224,4 +239,52 @@ workspace = true
         ));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn package(contents: &str) -> Value {
+        contents
+            .parse::<Table>()
+            .expect("manifest should parse")
+            .remove("package")
+            .expect("manifest should contain package")
+    }
+
+    /// Scenario: the views pilot explicitly enables publication.
+    /// Guarantees: structure validation accepts the sole approved publication override.
+    #[test]
+    fn publish_policy_accepts_views_pilot() {
+        let manifest = package(
+            r#"
+            [package]
+            name = "otel-arrow-dfe-pdata-views"
+            publish = true
+            "#,
+        );
+
+        assert!(
+            check_publish_policy(Path::new("Cargo.toml"), PUBLISH_PILOT_PACKAGE, &manifest).is_ok()
+        );
+    }
+
+    /// Scenario: a non-pilot package explicitly enables publication.
+    /// Guarantees: structure validation requires every other crate to inherit workspace policy.
+    #[test]
+    fn publish_policy_rejects_other_override() {
+        let manifest = package(
+            r#"
+            [package]
+            name = "otel-arrow-dfe-pdata"
+            publish = true
+            "#,
+        );
+
+        assert!(
+            check_publish_policy(Path::new("Cargo.toml"), "otel-arrow-dfe-pdata", &manifest)
+                .is_err()
+        );
+    }
 }


### PR DESCRIPTION
# Chore Summary

- Publish only `otel-arrow-dfe-pdata-views` as the initial crates.io proof of concept from #2691

I plan to:
- Merge this PR
- Merge the `v0.52.0` release prep PR
- Manually publish `otel-arrow-dfe-pdata-views` `v0.52.0` from that commit
- Run the `push-release` for `v0.52.0` which should see manual publish matching and skip

And then release `v0.53.0` will exercise the full E2E automation.

## Related issue

- Closes #2691 
- Part of #1340
