### PR TITLE
Prototype pluggable Arrow internal-log stacktraces 

### DIFF
--- a/rust/otap-dataflow/.chloggen/internal-logs-extended-stacktraces.yaml
+++ b/rust/otap-dataflow/.chloggen/internal-logs-extended-stacktraces.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: observability
+note: "Internal logs can capture bounded caller stacks and emit extended OTAP Arrow logs with symbolized stacktraces."
+issues: [3452]
+subtext: |
+  Enable engine.telemetry.logs.stacktraces and set the internal telemetry receiver logs representation to arrow_extended.

--- a/rust/otap-dataflow/.chloggen/internal-logs-extended-stacktraces.yaml
+++ b/rust/otap-dataflow/.chloggen/internal-logs-extended-stacktraces.yaml
@@ -1,6 +1,6 @@
 change_type: enhancement
 component: observability
-note: "Internal logs can capture bounded caller stacks and emit extended OTAP Arrow logs with symbolized stacktraces."
+note: "Internal logs can batch events and emit extended OTAP Arrow logs with bounded, symbolized caller stacktraces."
 issues: [3452]
 subtext: |
-  Enable engine.telemetry.logs.stacktraces and set the internal telemetry receiver logs representation to arrow_extended.
+  Configure ITR log batch size and latency bounds. Enable stacktraces and select arrow_extended to include compact stack tables.

--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -7527,6 +7527,7 @@ dependencies = [
  "arrow-schema",
  "async-stream",
  "async-trait",
+ "backtrace",
  "base64 0.23.1",
  "blake3",
  "byte-unit",
@@ -7935,6 +7936,7 @@ name = "otel-arrow-dfe-telemetry"
 version = "0.51.0"
 dependencies = [
  "arc-swap",
+ "backtrace",
  "bytes",
  "chrono",
  "criterion",

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -96,6 +96,7 @@ async-trait = "0.1.88"
 async-unsync = "0.3.0"
 axum = { version = "0.8.4", features = ["ws"] }
 base64 = "0.23.0"
+backtrace = "0.3.76"
 bitflags = "2.10"
 bytes = "1.11.1"
 bytemuck = "1.24"

--- a/rust/otap-dataflow/configs/internal-telemetry-logs.yaml
+++ b/rust/otap-dataflow/configs/internal-telemetry-logs.yaml
@@ -16,6 +16,9 @@ engine:
         engine: its
         internal: console_direct
         admin: its
+      stacktraces:
+        enabled: true
+        max_frames: 32
     resource:
       service.id: 1234
       service.name: test
@@ -38,6 +41,8 @@ engine:
           type: "receiver:internal_telemetry"
           config:
             signals: [logs]
+            logs:
+              representation: arrow_extended
         console:
           type: "exporter:console"
           config:

--- a/rust/otap-dataflow/configs/internal-telemetry-logs.yaml
+++ b/rust/otap-dataflow/configs/internal-telemetry-logs.yaml
@@ -43,6 +43,9 @@ engine:
             signals: [logs]
             logs:
               representation: arrow_extended
+              min_size: 65536
+              max_size: 2097152
+              max_batch_duration: 200ms
         console:
           type: "exporter:console"
           config:

--- a/rust/otap-dataflow/crates/config/src/settings/telemetry/logs.rs
+++ b/rust/otap-dataflow/crates/config/src/settings/telemetry/logs.rs
@@ -39,6 +39,22 @@ pub struct LogsConfig {
     /// Internal log tap configuration.
     #[serde(default)]
     pub tap: InternalLogTapConfig,
+
+    /// Caller stack capture configuration for asynchronous log providers.
+    #[serde(default)]
+    pub stacktraces: StackTraceConfig,
+}
+
+/// Caller-thread stack capture configuration.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct StackTraceConfig {
+    /// Capture instruction pointers for each asynchronous internal log.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Maximum number of captured frames per log.
+    #[serde(default = "default_stacktrace_max_frames")]
+    pub max_frames: usize,
 }
 
 /// Configuration for the internal log tap used by admin/MCP-style consumers.
@@ -235,6 +251,19 @@ const fn default_tap_max_bytes() -> usize {
     16 * 1024 * 1024
 }
 
+const fn default_stacktrace_max_frames() -> usize {
+    32
+}
+
+impl Default for StackTraceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_frames: default_stacktrace_max_frames(),
+        }
+    }
+}
+
 impl Default for InternalLogTapConfig {
     fn default() -> Self {
         Self {
@@ -251,6 +280,7 @@ impl Default for LogsConfig {
             level: LogLevel::default(),
             providers: default_providers(),
             tap: InternalLogTapConfig::default(),
+            stacktraces: StackTraceConfig::default(),
         }
     }
 }
@@ -288,6 +318,16 @@ impl LogsConfig {
         if self.tap.enabled && self.tap.max_bytes == 0 {
             return Err(Error::InvalidUserConfig {
                 error: "logs.tap.max_bytes must be greater than zero".into(),
+            });
+        }
+        if self.stacktraces.enabled && self.stacktraces.max_frames == 0 {
+            return Err(Error::InvalidUserConfig {
+                error: "logs.stacktraces.max_frames must be greater than zero".into(),
+            });
+        }
+        if self.stacktraces.max_frames > 128 {
+            return Err(Error::InvalidUserConfig {
+                error: "logs.stacktraces.max_frames must not exceed 128".into(),
             });
         }
         if self.tap.enabled
@@ -364,6 +404,8 @@ mod tests {
         assert!(!config.tap.enabled);
         assert_eq!(config.tap.max_entries, 2048);
         assert_eq!(config.tap.max_bytes, 16 * 1024 * 1024);
+        assert!(!config.stacktraces.enabled);
+        assert_eq!(config.stacktraces.max_frames, 32);
 
         // Serde defaults should match Rust Default
         let parsed = parse("{}");
@@ -375,6 +417,20 @@ mod tests {
         assert_eq!(parsed.tap.enabled, config.tap.enabled);
         assert_eq!(parsed.tap.max_entries, config.tap.max_entries);
         assert_eq!(parsed.tap.max_bytes, config.tap.max_bytes);
+    }
+
+    /// Scenario: stacktrace capture is enabled with zero or excessive frame limits.
+    /// Guarantees: validation rejects unbounded or non-producing caller capture configurations.
+    #[test]
+    fn test_validate_stacktrace_frame_bounds() {
+        let mut config = LogsConfig::default();
+        config.stacktraces.enabled = true;
+        config.stacktraces.max_frames = 0;
+        assert_invalid(&config, "logs.stacktraces.max_frames");
+
+        let mut config = LogsConfig::default();
+        config.stacktraces.max_frames = 129;
+        assert_invalid(&config, "logs.stacktraces.max_frames");
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/core-nodes/Cargo.toml
+++ b/rust/otap-dataflow/crates/core-nodes/Cargo.toml
@@ -28,6 +28,7 @@ otel-arrow-dfe-telemetry-macros = { workspace = true }
 arrow = { workspace = true }
 async-trait.workspace = true
 base64.workspace = true
+backtrace.workspace = true
 blake3.workspace = true
 byte-unit.workspace = true
 bytes.workspace = true

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/mod.rs
@@ -30,6 +30,9 @@ use otel_arrow_dfe_engine::terminal_state::TerminalState;
 use otel_arrow_dfe_engine::{ConsumerEffectHandlerExtension, ExporterFactory};
 use otel_arrow_dfe_otap::OTAP_EXPORTER_FACTORIES;
 use otel_arrow_dfe_otap::pdata::OtapPdata;
+use otel_arrow_dfe_pdata::extended_logs::{
+    EXTENDED_LOGS_FORMAT_ID, ExtendedLogStackFrame, ExtendedLogsView,
+};
 use otel_arrow_dfe_pdata::views::otap::{OtapLogsView, OtapMetricsView};
 use otel_arrow_dfe_pdata::views::otlp::bytes::logs::RawLogsData;
 use otel_arrow_dfe_pdata::views::otlp::bytes::metrics::RawMetricsData;
@@ -317,6 +320,27 @@ impl ConsoleExporter {
                     Err(ConsoleExportErrorType::OtapViewCreation)
                 }
             },
+            PayloadData::PluggableArrowRecords(records) => {
+                if records.format_id() == EXTENDED_LOGS_FORMAT_ID {
+                    return self.formatter.print_extended_logs(records).await;
+                }
+                otel_error!(
+                    "console.logs_view.unsupported_representation",
+                    format_id = records.format_id(),
+                    message =
+                        "Console exporter does not support this pluggable Arrow representation"
+                );
+                Err(ConsoleExportErrorType::UnsupportedSignal)
+            }
+            PayloadData::PluggableBytes(bytes) => {
+                otel_error!(
+                    "console.logs_view.unsupported_representation",
+                    format_id = bytes.format_id(),
+                    message =
+                        "Console exporter does not support this pluggable byte representation"
+                );
+                Err(ConsoleExportErrorType::UnsupportedSignal)
+            }
         }
     }
 
@@ -346,6 +370,24 @@ impl ConsoleExporter {
                     Err(ConsoleExportErrorType::OtapViewCreation)
                 }
             },
+            PayloadData::PluggableArrowRecords(records) => {
+                otel_error!(
+                    "console.metrics_view.unsupported_representation",
+                    format_id = records.format_id(),
+                    message =
+                        "Console exporter does not support this pluggable Arrow representation"
+                );
+                Err(ConsoleExportErrorType::UnsupportedSignal)
+            }
+            PayloadData::PluggableBytes(bytes) => {
+                otel_error!(
+                    "console.metrics_view.unsupported_representation",
+                    format_id = bytes.format_id(),
+                    message =
+                        "Console exporter does not support this pluggable byte representation"
+                );
+                Err(ConsoleExportErrorType::UnsupportedSignal)
+            }
         }
     }
 
@@ -417,6 +459,85 @@ impl ConsoleFormatter {
         Ok(())
     }
 
+    async fn print_extended_logs(
+        &self,
+        records: &otel_arrow_dfe_pdata::PDataArrowRecordSet,
+    ) -> Result<(), ConsoleExportErrorType> {
+        let extended = ExtendedLogsView::try_from(records).map_err(|error| {
+            otel_error!(
+                "console.logs_view.extended_create_failed",
+                error = ?error,
+                message = "Failed to create extended logs view"
+            );
+            ConsoleExportErrorType::OtapViewCreation
+        })?;
+        let standard = extended.standard_logs().map_err(|error| {
+            otel_error!(
+                "console.logs_view.extended_standard_logs_failed",
+                error = ?error,
+                message = "Failed to reconstruct standard OTAP logs"
+            );
+            ConsoleExportErrorType::OtapViewCreation
+        })?;
+        let logs = OtapLogsView::try_from(&standard).map_err(|error| {
+            otel_error!(
+                "console.logs_view.extended_otap_create_failed",
+                error = ?error,
+                message = "Failed to create OTAP logs view"
+            );
+            ConsoleExportErrorType::OtapViewCreation
+        })?;
+        let stacks = extended.stacks().map_err(|error| {
+            otel_error!(
+                "console.logs_view.extended_stacks_failed",
+                error = ?error,
+                message = "Failed to read extended log stacks"
+            );
+            ConsoleExportErrorType::OtapViewCreation
+        })?;
+
+        let mut output = Vec::new();
+        match self {
+            Self::Pretty(formatter) => {
+                formatter.format_logs_data_to(&logs, &mut output);
+                format_pretty_stacks(&stacks, &mut output).map_err(|error| {
+                    otel_error!(
+                        "console.format_failed",
+                        error = ?error,
+                        message = "Could not format extended stacktrace"
+                    );
+                    ConsoleExportErrorType::Formatting
+                })?;
+            }
+            Self::RecordJson(formatter) => {
+                formatter
+                    .format_logs_data_to(&logs, &mut output)
+                    .map_err(|error| {
+                        otel_error!(
+                            "console.format_failed",
+                            error = ?error,
+                            message = "Could not format console output"
+                        );
+                        ConsoleExportErrorType::Formatting
+                    })?;
+                format_json_stacks(&stacks, &mut output)?;
+            }
+        }
+
+        use tokio::io::AsyncWriteExt;
+        tokio::io::stdout()
+            .write_all(&output)
+            .await
+            .map_err(|error| {
+                otel_error!(
+                    "console.write_failed",
+                    error = ?error,
+                    message = "Could not write to console"
+                );
+                ConsoleExportErrorType::Write
+            })
+    }
+
     /// Format metrics and write the complete payload to stdout.
     async fn print_metrics_data<M: MetricsView>(
         &self,
@@ -447,6 +568,65 @@ impl ConsoleFormatter {
 
         Ok(())
     }
+}
+
+fn format_pretty_stacks(
+    stacks: &std::collections::BTreeMap<u16, Vec<ExtendedLogStackFrame>>,
+    output: &mut Vec<u8>,
+) -> std::io::Result<()> {
+    for (log_id, frames) in stacks {
+        writeln!(output, "STACKTRACE log_id={log_id}")?;
+        for frame in frames {
+            write!(output, "  at ")?;
+            if let Some(function_name) = &frame.function_name {
+                write!(output, "{function_name}")?;
+            } else {
+                write!(output, "0x{:x}", frame.address)?;
+            }
+            if let Some(filename) = &frame.filename {
+                write!(output, " ({filename}")?;
+                if let Some(line) = frame.line {
+                    write!(output, ":{line}")?;
+                }
+                write!(output, ")")?;
+            }
+            writeln!(output)?;
+        }
+    }
+    Ok(())
+}
+
+fn format_json_stacks(
+    stacks: &std::collections::BTreeMap<u16, Vec<ExtendedLogStackFrame>>,
+    output: &mut Vec<u8>,
+) -> Result<(), ConsoleExportErrorType> {
+    for (log_id, frames) in stacks {
+        let frames: Vec<_> = frames
+            .iter()
+            .map(|frame| {
+                serde_json::json!({
+                    "address": format!("0x{:x}", frame.address),
+                    "function": frame.function_name,
+                    "file": frame.filename,
+                    "line": frame.line,
+                })
+            })
+            .collect();
+        serde_json::to_writer(
+            &mut *output,
+            &serde_json::json!({"otap_log_id": log_id, "stacktrace": frames}),
+        )
+        .map_err(|error| {
+            otel_error!(
+                "console.format_failed",
+                error = ?error,
+                message = "Could not format extended stacktrace JSON"
+            );
+            ConsoleExportErrorType::Formatting
+        })?;
+        output.push(b'\n');
+    }
+    Ok(())
 }
 
 /// Tree drawing characters (Unicode or ASCII).
@@ -702,6 +882,37 @@ mod tests {
     use otel_arrow_dfe_pdata::views::otap::OtapLogsView;
     use prost::Message;
     use serde_json::{Value, json};
+
+    /// Scenario: a resolved and an unresolved extended-log frame are rendered for console output.
+    /// Guarantees: pretty output preserves symbol/source details and falls back to hexadecimal addresses.
+    #[test]
+    fn pretty_extended_stacks_show_symbols_and_raw_addresses() {
+        let mut stacks = std::collections::BTreeMap::new();
+        let _ = stacks.insert(
+            7,
+            vec![
+                ExtendedLogStackFrame {
+                    address: 0x1234,
+                    function_name: Some("example::work".to_owned()),
+                    filename: Some("src/example.rs".to_owned()),
+                    line: Some(42),
+                },
+                ExtendedLogStackFrame {
+                    address: 0xabcd,
+                    function_name: None,
+                    filename: None,
+                    line: None,
+                },
+            ],
+        );
+
+        let mut output = Vec::new();
+        format_pretty_stacks(&stacks, &mut output).unwrap();
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("STACKTRACE log_id=7"));
+        assert!(output.contains("example::work (src/example.rs:42)"));
+        assert!(output.contains("0xabcd"));
+    }
 
     /// Format proto logs through the raw OTLP view and parse the resulting JSON lines.
     fn format_record_json(logs_data: &LogsData, formatter: &RecordJsonFormatter) -> Vec<Value> {

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/file_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/file_exporter/mod.rs
@@ -360,6 +360,8 @@ enum EncodeFailure {
     View(String),
     #[error(transparent)]
     Frame(#[from] FrameEncodeError),
+    #[error("unsupported pluggable pdata representation `{0}`")]
+    UnsupportedRepresentation(String),
 }
 
 fn encode_payload(
@@ -403,6 +405,16 @@ fn encode_payload(
                 encode_traces(&view, frame, max_frame_bytes)?;
             }
         },
+        PayloadData::PluggableArrowRecords(records) => {
+            return Err(EncodeFailure::UnsupportedRepresentation(
+                records.format_id().to_owned(),
+            ));
+        }
+        PayloadData::PluggableBytes(bytes) => {
+            return Err(EncodeFailure::UnsupportedRepresentation(
+                bytes.format_id().to_owned(),
+            ));
+        }
     }
     Ok(())
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
@@ -631,6 +631,31 @@ impl Exporter<OtapPdata> for OTLPExporter {
                             let future = make_export_future(prepared, client);
                             inflight_exports.push(future);
                         }
+                        (
+                            _,
+                            data @ (PayloadData::PluggableArrowRecords(_)
+                            | PayloadData::PluggableBytes(_)),
+                        ) => {
+                            let format_id = match &data {
+                                PayloadData::PluggableArrowRecords(records) => records.format_id(),
+                                PayloadData::PluggableBytes(bytes) => bytes.format_id(),
+                                _ => unreachable!(),
+                            };
+                            let message = format!(
+                                "OTLP gRPC exporter does not support pluggable representation `{format_id}`"
+                            );
+                            otel_error!(
+                                "otlp_grpc_exporter.representation.unsupported",
+                                format_id,
+                                message = message.as_str()
+                            );
+                            effect_handler
+                                .notify_nack(NackMsg::new_permanent(
+                                    message,
+                                    OtapPdata::new(context, data.into()),
+                                ))
+                                .await?;
+                        }
                     }
                 }
                 _ => {

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
@@ -549,6 +549,29 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
 
                             (Uncompressed::InProtoBuffer, otap_batch.into())
                         }
+                        data @ (PayloadData::PluggableArrowRecords(_)
+                        | PayloadData::PluggableBytes(_)) => {
+                            let format_id = match &data {
+                                PayloadData::PluggableArrowRecords(records) => records.format_id(),
+                                PayloadData::PluggableBytes(bytes) => bytes.format_id(),
+                                _ => unreachable!(),
+                            };
+                            let message = format!(
+                                "OTLP HTTP exporter does not support pluggable representation `{format_id}`"
+                            );
+                            otel_error!(
+                                "otlp_http_exporter.representation.unsupported",
+                                format_id,
+                                message = message.as_str()
+                            );
+                            effect_handler
+                                .notify_nack(NackMsg::new_permanent(
+                                    message,
+                                    OtapPdata::new(context, data.into()),
+                                ))
+                                .await?;
+                            continue;
+                        }
                     };
 
                     let body = match compression {

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -835,6 +835,22 @@ impl BatchProcessor {
                     return Err(Self::no_active_format_error());
                 }
             }
+            PayloadData::PluggableArrowRecords(records) => {
+                return Err(EngineError::PdataConversionError {
+                    error: format!(
+                        "batch processor does not support pluggable Arrow representation `{}`",
+                        records.format_id()
+                    ),
+                });
+            }
+            PayloadData::PluggableBytes(bytes) => {
+                return Err(EngineError::PdataConversionError {
+                    error: format!(
+                        "batch processor does not support pluggable byte representation `{}`",
+                        bytes.format_id()
+                    ),
+                });
+            }
         };
         Ok(())
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/content_router/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/content_router/mod.rs
@@ -604,6 +604,9 @@ impl ContentRouter {
                     },
                 }
             }
+            PayloadData::PluggableArrowRecords(_) | PayloadData::PluggableBytes(_) => {
+                RouteResolution::ConversionError
+            }
         }
     }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -1079,6 +1079,28 @@ impl DurableBuffer {
                 };
                 (result, num_items)
             }
+            data @ (PayloadData::PluggableArrowRecords(_) | PayloadData::PluggableBytes(_)) => {
+                let format_id = match &data {
+                    PayloadData::PluggableArrowRecords(records) => records.format_id(),
+                    PayloadData::PluggableBytes(bytes) => bytes.format_id(),
+                    _ => unreachable!(),
+                };
+                let message = format!(
+                    "durable buffer has no registered encoding for pluggable representation `{format_id}`"
+                );
+                otel_error!(
+                    "durable_buffer.representation.unsupported",
+                    format_id,
+                    message = message.as_str()
+                );
+                effect_handler
+                    .notify_nack(NackMsg::new_permanent(
+                        message,
+                        OtapPdata::new(context, data.into()),
+                    ))
+                    .await?;
+                return Ok(());
+            }
         };
 
         // Handle ingest result

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/log_sampling_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/log_sampling_processor/mod.rs
@@ -324,6 +324,9 @@ mod tests {
                 let output_otap = match output_payload.into_data() {
                     PayloadData::OtlpBytes(_) => panic!("Unexpected otlp bytes"),
                     PayloadData::OtapArrowRecords(otap_arrow_records) => otap_arrow_records,
+                    PayloadData::PluggableArrowRecords(_) | PayloadData::PluggableBytes(_) => {
+                        panic!("Unexpected pluggable representation")
+                    }
                 };
 
                 let output_attrs = output_otap.get(ArrowPayloadType::LogAttrs).unwrap();

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
@@ -641,6 +641,28 @@ impl TemporalReaggregationProcessor {
                 let view = RawMetricsData::new(otlp.as_bytes());
                 self.process_view(effect_handler, &view).await
             }
+            PayloadData::PluggableArrowRecords(records) => {
+                let message = format!(
+                    "temporal reaggregation does not support pluggable Arrow representation `{}`",
+                    records.format_id()
+                );
+                self.metrics.batches_rejected.inc();
+                effect_handler
+                    .notify_nack(NackMsg::new_permanent(message, pdata))
+                    .await?;
+                return Ok(());
+            }
+            PayloadData::PluggableBytes(bytes) => {
+                let message = format!(
+                    "temporal reaggregation does not support pluggable byte representation `{}`",
+                    bytes.format_id()
+                );
+                self.metrics.batches_rejected.inc();
+                effect_handler
+                    .notify_nack(NackMsg::new_permanent(message, pdata))
+                    .await?;
+                return Ok(());
+            }
         };
 
         match result {

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/testing.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/testing.rs
@@ -350,6 +350,9 @@ fn payload_to_otlp(payload: &OtapPayload) -> otel_arrow_dfe_pdata::proto::OtlpPr
         PayloadData::OtlpBytes(bytes) => {
             otel_arrow_dfe_pdata::testing::round_trip::otlp_bytes_to_message(bytes.clone())
         }
+        PayloadData::PluggableArrowRecords(_) | PayloadData::PluggableBytes(_) => {
+            panic!("test helper does not support pluggable representations")
+        }
     }
 }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/internal_telemetry_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/internal_telemetry_receiver/README.md
@@ -72,10 +72,24 @@ block or its `interval` field is omitted, the receiver uses
 `engine.telemetry.reporting_interval`. That engine setting also controls the
 metric-set snapshot cadence. Setting `metrics` to `null` is invalid.
 
+The `logs` block selects the output representation and controls bounded
+receiver-side batching. `min_size` flushes a batch after it retains that many
+estimated bytes. `max_size` prevents adding an event to a partial batch when
+their combined estimate would exceed the configured limit; one individually
+bounded event is still sent whole. `max_size` cannot exceed 2 MiB.
+`max_batch_duration` bounds how long the oldest event waits. Defaults are
+64 KiB, 2 MiB, and 200 ms. Logs sharing an instrumentation scope are encoded in
+one `ScopeLogs`.
+
 ```yaml
 type: receiver:internal_telemetry
 config:
   signals: [logs, metrics]
+  logs:
+    representation: otlp # otlp or arrow_extended
+    min_size: 65536
+    max_size: 2097152
+    max_batch_duration: 200ms
   metrics:
     interval: 2s
     views:
@@ -125,6 +139,8 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
   telemetry receiver.
 - Logs and metrics can be selected independently with a non-empty `signals`
   list.
+- Receiver-side log batches have a non-configurable 2 MiB retained-size
+  estimate ceiling and a configurable flush threshold and latency bound.
 - Internal metric batches use the receiver's `metrics.interval`, or
   `engine.telemetry.reporting_interval` when no receiver interval is set.
 - Receiver-local views support exact scope name, scalar scope attribute, and

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/internal_telemetry_receiver/extended_logs.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/internal_telemetry_receiver/extended_logs.rs
@@ -16,7 +16,7 @@ use otel_arrow_dfe_pdata::{
     OtapPayload, OtlpProtoBytes, PDataArrowRecordSet, PDataArrowTable, TryFromWithOptions,
 };
 use otel_arrow_dfe_telemetry::event::LogEvent;
-use otel_arrow_dfe_telemetry::self_tracing::{ScopeToBytesMap, encode_export_logs_request};
+use otel_arrow_dfe_telemetry::self_tracing::{ScopeToBytesMap, encode_export_logs_request_batch};
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::sync::Arc;
@@ -58,13 +58,17 @@ impl SymbolCache {
 }
 
 pub(super) fn encode(
-    log_event: &LogEvent,
+    log_events: &[LogEvent],
     resource_field_bytes: &Bytes,
     scope_cache: &mut ScopeToBytesMap,
     symbol_cache: &mut SymbolCache,
 ) -> Result<PDataArrowRecordSet, String> {
-    let mut buf = ProtoBuffer::with_capacity(512);
-    encode_export_logs_request(&mut buf, log_event, resource_field_bytes, scope_cache);
+    let capacity = log_events.iter().fold(512usize, |capacity, event| {
+        capacity.saturating_add(event.record.body_attrs_bytes.len())
+    });
+    let mut buf = ProtoBuffer::with_capacity(capacity);
+    let output_order =
+        encode_export_logs_request_batch(&mut buf, log_events, resource_field_bytes, scope_cache);
     let standard = otel_arrow_dfe_pdata::OtapArrowRecords::try_from_with_default(
         OtapPayload::from(OtlpProtoBytes::ExportLogsRequest(buf.into_bytes())),
     )
@@ -85,22 +89,13 @@ pub(super) fn encode(
         }
     }
 
-    if let Some(stacktrace) = &log_event.record.stacktrace {
-        let callsite = log_event.record.callsite();
-        add_stack_tables(
-            &mut tables,
-            stacktrace.frames(),
-            callsite.file(),
-            callsite.line(),
-            symbol_cache,
-        )?;
-    }
+    add_stack_tables(&mut tables, log_events, &output_order, symbol_cache)?;
 
     PDataArrowRecordSet::new(
         EXTENDED_LOGS_FORMAT_ID,
         EXTENDED_LOGS_VERSION,
         otel_arrow_dfe_config::SignalType::Logs,
-        1,
+        log_events.len(),
         tables,
     )
     .map_err(|error| error.to_string())
@@ -108,12 +103,82 @@ pub(super) fn encode(
 
 fn add_stack_tables(
     tables: &mut Vec<PDataArrowTable>,
-    frames: &[usize],
-    callsite_file: Option<&str>,
-    callsite_line: Option<u32>,
+    log_events: &[LogEvent],
+    output_order: &[usize],
     symbol_cache: &mut SymbolCache,
 ) -> Result<(), String> {
-    if frames.is_empty() {
+    let mut log_ids = Vec::new();
+    let mut stack_ids = Vec::new();
+    let mut frame_stack_ids = Vec::new();
+    let mut ordinals = Vec::new();
+    let mut frame_location_ids = Vec::new();
+    let mut location_ids = Vec::new();
+    let mut addresses = Vec::new();
+    let mut symbols = Vec::new();
+    let mut stack_ids_by_trace = HashMap::new();
+    let mut location_ids_by_source = HashMap::new();
+
+    for (log_id, &input_index) in output_order.iter().enumerate() {
+        let event = &log_events[input_index];
+        let Some(stacktrace) = &event.record.stacktrace else {
+            continue;
+        };
+        if stacktrace.frames().is_empty() {
+            continue;
+        }
+
+        let log_id = u16::try_from(log_id).map_err(|_| "extended log batch exceeds u16 log IDs")?;
+        let callsite = event.record.callsite();
+        let stack_key = (
+            stacktrace.frames().to_vec(),
+            callsite.file(),
+            callsite.line(),
+        );
+        let stack_id = if let Some(stack_id) = stack_ids_by_trace.get(&stack_key) {
+            *stack_id
+        } else {
+            let stack_id = u32::try_from(stack_ids_by_trace.len())
+                .map_err(|_| "extended log batch has too many stacks")?;
+            let _ = stack_ids_by_trace.insert(stack_key, stack_id);
+
+            for (ordinal, address) in stacktrace.frames().iter().copied().enumerate() {
+                let ordinal =
+                    u16::try_from(ordinal).map_err(|_| "extended log stack exceeds u16 frames")?;
+                let source = if ordinal == 0 {
+                    (callsite.file(), callsite.line())
+                } else {
+                    (None, None)
+                };
+                let location_key = (address, source.0, source.1);
+                let location_id =
+                    if let Some(location_id) = location_ids_by_source.get(&location_key) {
+                        *location_id
+                    } else {
+                        let location_id = u32::try_from(addresses.len())
+                            .map_err(|_| "extended log batch has too many locations")?;
+                        let mut symbol = symbol_cache.resolve(address).clone();
+                        if ordinal == 0 {
+                            symbol.filename = source.0.map(ToOwned::to_owned);
+                            symbol.line = source.1;
+                        }
+                        location_ids.push(location_id);
+                        addresses.push(address as u64);
+                        symbols.push(symbol);
+                        let _ = location_ids_by_source.insert(location_key, location_id);
+                        location_id
+                    };
+
+                frame_stack_ids.push(stack_id);
+                ordinals.push(ordinal);
+                frame_location_ids.push(location_id);
+            }
+            stack_id
+        };
+        log_ids.push(log_id);
+        stack_ids.push(stack_id);
+    }
+
+    if log_ids.is_empty() {
         return Ok(());
     }
 
@@ -125,8 +190,8 @@ fn add_stack_tables(
                 Field::new("stack_id", DataType::UInt32, false),
             ])),
             vec![
-                Arc::new(UInt16Array::from(vec![0])),
-                Arc::new(UInt32Array::from(vec![0])),
+                Arc::new(UInt16Array::from(log_ids)),
+                Arc::new(UInt32Array::from(stack_ids)),
             ],
         )
         .map_err(|error| error.to_string())?,
@@ -141,13 +206,9 @@ fn add_stack_tables(
                 Field::new("location_id", DataType::UInt32, false),
             ])),
             vec![
-                Arc::new(UInt32Array::from(vec![0; frames.len()])),
-                Arc::new(UInt16Array::from_iter_values(
-                    (0..frames.len()).map(|ordinal| ordinal as u16),
-                )),
-                Arc::new(UInt32Array::from_iter_values(
-                    (0..frames.len()).map(|location_id| location_id as u32),
-                )),
+                Arc::new(UInt32Array::from(frame_stack_ids)),
+                Arc::new(UInt16Array::from(ordinals)),
+                Arc::new(UInt32Array::from(frame_location_ids)),
             ],
         )
         .map_err(|error| error.to_string())?,
@@ -161,25 +222,13 @@ fn add_stack_tables(
                 Field::new("address", DataType::UInt64, false),
             ])),
             vec![
-                Arc::new(UInt32Array::from_iter_values(
-                    (0..frames.len()).map(|location_id| location_id as u32),
-                )),
-                Arc::new(UInt64Array::from_iter_values(
-                    frames.iter().map(|address| *address as u64),
-                )),
+                Arc::new(UInt32Array::from(location_ids.clone())),
+                Arc::new(UInt64Array::from(addresses)),
             ],
         )
         .map_err(|error| error.to_string())?,
     });
 
-    let mut symbols: Vec<_> = frames
-        .iter()
-        .map(|address| symbol_cache.resolve(*address).clone())
-        .collect();
-    if let Some(callsite) = symbols.first_mut() {
-        callsite.filename = callsite_file.map(ToOwned::to_owned);
-        callsite.line = callsite_line;
-    }
     tables.push(PDataArrowTable {
         table_id: SYMBOLS_TABLE_ID,
         batch: RecordBatch::try_new(
@@ -190,9 +239,7 @@ fn add_stack_tables(
                 Field::new("line", DataType::UInt32, true),
             ])),
             vec![
-                Arc::new(UInt32Array::from_iter_values(
-                    (0..frames.len()).map(|location_id| location_id as u32),
-                )),
+                Arc::new(UInt32Array::from(location_ids)),
                 Arc::new(StringArray::from(
                     symbols
                         .iter()
@@ -257,8 +304,13 @@ mod tests {
         let registry = TelemetryRegistryHandle::new();
         let mut scope_cache = ScopeToBytesMap::new(registry);
         let mut symbol_cache = SymbolCache::default();
-        let records = encode(&event, &Bytes::new(), &mut scope_cache, &mut symbol_cache)
-            .expect("extended logs encode");
+        let records = encode(
+            std::slice::from_ref(&event),
+            &Bytes::new(),
+            &mut scope_cache,
+            &mut symbol_cache,
+        )
+        .expect("extended logs encode");
         let view = ExtendedLogsView::try_from(&records).expect("extended logs view");
 
         assert_eq!(view.standard_logs().unwrap().num_items(), 1);
@@ -274,5 +326,125 @@ mod tests {
                 .as_deref()
                 .is_some_and(|name| name.contains("otel_arrow_dfe_telemetry"))
         );
+    }
+
+    /// Scenario: two logs contain the same captured stack.
+    /// Guarantees: compact extension tables share one stack and its locations.
+    #[test]
+    fn deduplicates_identical_stacks_and_locations() {
+        let (sender, receiver) = flume::bounded(1);
+        let reporter = ObservedEventReporter::new(SendPolicy::default(), sender);
+        let level: LogLevel = serde_json::from_str("\"info\"").unwrap();
+        let setup = TracingSetup::new(
+            ProviderSetup::InternalAsync {
+                reporter,
+                stacktraces: StackTraceConfig {
+                    enabled: true,
+                    max_frames: 8,
+                },
+            },
+            level,
+            LogContext::new,
+        );
+
+        setup.with_subscriber(|| otel_info!("extended.stacktrace.shared"));
+        let ObservedEvent::Log(event) = receiver.try_recv().expect("captured internal log") else {
+            panic!("expected log event");
+        };
+        let frame_count = event
+            .record
+            .stacktrace
+            .as_ref()
+            .expect("captured stack")
+            .frames()
+            .len();
+
+        let registry = TelemetryRegistryHandle::new();
+        let mut scope_cache = ScopeToBytesMap::new(registry);
+        let mut symbol_cache = SymbolCache::default();
+        let records = encode(
+            &[event.clone(), event],
+            &Bytes::new(),
+            &mut scope_cache,
+            &mut symbol_cache,
+        )
+        .expect("extended logs encode");
+
+        let log_stacks = records.table(LOG_STACKS_TABLE_ID).expect("log stacks");
+        let stack_ids = log_stacks
+            .column_by_name("stack_id")
+            .and_then(|column| column.as_any().downcast_ref::<UInt32Array>())
+            .expect("stack IDs");
+        assert_eq!(stack_ids.values(), &[0, 0]);
+        assert_eq!(
+            records
+                .table(STACK_FRAMES_TABLE_ID)
+                .expect("stack frames")
+                .num_rows(),
+            frame_count
+        );
+        assert_eq!(
+            records
+                .table(LOCATIONS_TABLE_ID)
+                .expect("locations")
+                .num_rows(),
+            frame_count
+        );
+    }
+
+    /// Scenario: a batch interleaves stack-bearing logs from two tracing targets.
+    /// Guarantees: scope grouping preserves each stack's join to its reordered log row.
+    #[test]
+    fn batched_stacks_follow_scope_grouped_log_order() {
+        let (sender, receiver) = flume::bounded(3);
+        let reporter = ObservedEventReporter::new(SendPolicy::default(), sender);
+        let level: LogLevel = serde_json::from_str("\"info\"").unwrap();
+        let setup = TracingSetup::new(
+            ProviderSetup::InternalAsync {
+                reporter,
+                stacktraces: StackTraceConfig {
+                    enabled: true,
+                    max_frames: 8,
+                },
+            },
+            level,
+            LogContext::new,
+        );
+
+        setup.with_subscriber(|| {
+            otel_info!(target: "z-target", "extended.stacktrace.z-first");
+            otel_info!(target: "a-target", "extended.stacktrace.a");
+            otel_info!(target: "z-target", "extended.stacktrace.z-second");
+        });
+        let events: Vec<_> = receiver
+            .try_iter()
+            .map(|event| match event {
+                ObservedEvent::Log(event) => event,
+                ObservedEvent::Engine(_) => panic!("expected log event"),
+            })
+            .collect();
+        assert_eq!(events.len(), 3);
+        let expected_lines = [
+            events[1].record.callsite().line(),
+            events[0].record.callsite().line(),
+            events[2].record.callsite().line(),
+        ];
+
+        let registry = TelemetryRegistryHandle::new();
+        let mut scope_cache = ScopeToBytesMap::new(registry);
+        let mut symbol_cache = SymbolCache::default();
+        let records = encode(&events, &Bytes::new(), &mut scope_cache, &mut symbol_cache)
+            .expect("extended logs encode");
+        let view = ExtendedLogsView::try_from(&records).expect("extended logs view");
+        assert_eq!(view.standard_logs().unwrap().num_items(), 3);
+        let stacks = view.stacks().expect("stack tables");
+
+        for (log_id, expected_line) in expected_lines.into_iter().enumerate() {
+            assert_eq!(
+                stacks[&(log_id as u16)][0].line,
+                expected_line,
+                "stack must remain attached after scope grouping"
+            );
+        }
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/internal_telemetry_receiver/extended_logs.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/internal_telemetry_receiver/extended_logs.rs
@@ -1,0 +1,278 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Internal-log encoding for the compact extended Arrow representation.
+
+use arrow::array::{RecordBatch, StringArray, UInt16Array, UInt32Array, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema};
+use bytes::Bytes;
+use otel_arrow_dfe_pdata::extended_logs::{
+    EXTENDED_LOGS_FORMAT_ID, EXTENDED_LOGS_VERSION, LOCATIONS_TABLE_ID, LOG_STACKS_TABLE_ID,
+    STACK_FRAMES_TABLE_ID, SYMBOLS_TABLE_ID,
+};
+use otel_arrow_dfe_pdata::otlp::ProtoBuffer;
+use otel_arrow_dfe_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
+use otel_arrow_dfe_pdata::{
+    OtapPayload, OtlpProtoBytes, PDataArrowRecordSet, PDataArrowTable, TryFromWithOptions,
+};
+use otel_arrow_dfe_telemetry::event::LogEvent;
+use otel_arrow_dfe_telemetry::self_tracing::{ScopeToBytesMap, encode_export_logs_request};
+use std::collections::HashMap;
+use std::ffi::c_void;
+use std::sync::Arc;
+
+const MAX_SYMBOL_CACHE_ENTRIES: usize = 16 * 1024;
+
+#[derive(Clone, Debug, Default)]
+struct ResolvedSymbol {
+    function_name: Option<String>,
+    filename: Option<String>,
+    line: Option<u32>,
+}
+
+/// Receiver-local address-to-symbol cache.
+#[derive(Default)]
+pub(super) struct SymbolCache {
+    symbols: HashMap<usize, ResolvedSymbol>,
+}
+
+impl SymbolCache {
+    fn resolve(&mut self, address: usize) -> &ResolvedSymbol {
+        if self.symbols.len() >= MAX_SYMBOL_CACHE_ENTRIES && !self.symbols.contains_key(&address) {
+            self.symbols.clear();
+        }
+        self.symbols.entry(address).or_insert_with(|| {
+            let mut resolved = ResolvedSymbol::default();
+            backtrace::resolve(address as *mut c_void, |symbol| {
+                if resolved.function_name.is_none() {
+                    resolved.function_name = symbol.name().map(|name| name.to_string());
+                    resolved.filename = symbol
+                        .filename()
+                        .map(|path| path.to_string_lossy().into_owned());
+                    resolved.line = symbol.lineno();
+                }
+            });
+            resolved
+        })
+    }
+}
+
+pub(super) fn encode(
+    log_event: &LogEvent,
+    resource_field_bytes: &Bytes,
+    scope_cache: &mut ScopeToBytesMap,
+    symbol_cache: &mut SymbolCache,
+) -> Result<PDataArrowRecordSet, String> {
+    let mut buf = ProtoBuffer::with_capacity(512);
+    encode_export_logs_request(&mut buf, log_event, resource_field_bytes, scope_cache);
+    let standard = otel_arrow_dfe_pdata::OtapArrowRecords::try_from_with_default(
+        OtapPayload::from(OtlpProtoBytes::ExportLogsRequest(buf.into_bytes())),
+    )
+    .map_err(|error| error.to_string())?;
+
+    let mut tables = Vec::new();
+    for payload_type in [
+        ArrowPayloadType::ResourceAttrs,
+        ArrowPayloadType::ScopeAttrs,
+        ArrowPayloadType::Logs,
+        ArrowPayloadType::LogAttrs,
+    ] {
+        if let Some(batch) = standard.get(payload_type) {
+            tables.push(PDataArrowTable {
+                table_id: payload_type as u32,
+                batch: batch.clone(),
+            });
+        }
+    }
+
+    if let Some(stacktrace) = &log_event.record.stacktrace {
+        let callsite = log_event.record.callsite();
+        add_stack_tables(
+            &mut tables,
+            stacktrace.frames(),
+            callsite.file(),
+            callsite.line(),
+            symbol_cache,
+        )?;
+    }
+
+    PDataArrowRecordSet::new(
+        EXTENDED_LOGS_FORMAT_ID,
+        EXTENDED_LOGS_VERSION,
+        otel_arrow_dfe_config::SignalType::Logs,
+        1,
+        tables,
+    )
+    .map_err(|error| error.to_string())
+}
+
+fn add_stack_tables(
+    tables: &mut Vec<PDataArrowTable>,
+    frames: &[usize],
+    callsite_file: Option<&str>,
+    callsite_line: Option<u32>,
+    symbol_cache: &mut SymbolCache,
+) -> Result<(), String> {
+    if frames.is_empty() {
+        return Ok(());
+    }
+
+    tables.push(PDataArrowTable {
+        table_id: LOG_STACKS_TABLE_ID,
+        batch: RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("log_id", DataType::UInt16, false),
+                Field::new("stack_id", DataType::UInt32, false),
+            ])),
+            vec![
+                Arc::new(UInt16Array::from(vec![0])),
+                Arc::new(UInt32Array::from(vec![0])),
+            ],
+        )
+        .map_err(|error| error.to_string())?,
+    });
+
+    tables.push(PDataArrowTable {
+        table_id: STACK_FRAMES_TABLE_ID,
+        batch: RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("stack_id", DataType::UInt32, false),
+                Field::new("ordinal", DataType::UInt16, false),
+                Field::new("location_id", DataType::UInt32, false),
+            ])),
+            vec![
+                Arc::new(UInt32Array::from(vec![0; frames.len()])),
+                Arc::new(UInt16Array::from_iter_values(
+                    (0..frames.len()).map(|ordinal| ordinal as u16),
+                )),
+                Arc::new(UInt32Array::from_iter_values(
+                    (0..frames.len()).map(|location_id| location_id as u32),
+                )),
+            ],
+        )
+        .map_err(|error| error.to_string())?,
+    });
+
+    tables.push(PDataArrowTable {
+        table_id: LOCATIONS_TABLE_ID,
+        batch: RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("id", DataType::UInt32, false),
+                Field::new("address", DataType::UInt64, false),
+            ])),
+            vec![
+                Arc::new(UInt32Array::from_iter_values(
+                    (0..frames.len()).map(|location_id| location_id as u32),
+                )),
+                Arc::new(UInt64Array::from_iter_values(
+                    frames.iter().map(|address| *address as u64),
+                )),
+            ],
+        )
+        .map_err(|error| error.to_string())?,
+    });
+
+    let mut symbols: Vec<_> = frames
+        .iter()
+        .map(|address| symbol_cache.resolve(*address).clone())
+        .collect();
+    if let Some(callsite) = symbols.first_mut() {
+        callsite.filename = callsite_file.map(ToOwned::to_owned);
+        callsite.line = callsite_line;
+    }
+    tables.push(PDataArrowTable {
+        table_id: SYMBOLS_TABLE_ID,
+        batch: RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("location_id", DataType::UInt32, false),
+                Field::new("function_name", DataType::Utf8, true),
+                Field::new("filename", DataType::Utf8, true),
+                Field::new("line", DataType::UInt32, true),
+            ])),
+            vec![
+                Arc::new(UInt32Array::from_iter_values(
+                    (0..frames.len()).map(|location_id| location_id as u32),
+                )),
+                Arc::new(StringArray::from(
+                    symbols
+                        .iter()
+                        .map(|symbol| symbol.function_name.as_deref())
+                        .collect::<Vec<_>>(),
+                )),
+                Arc::new(StringArray::from(
+                    symbols
+                        .iter()
+                        .map(|symbol| symbol.filename.as_deref())
+                        .collect::<Vec<_>>(),
+                )),
+                Arc::new(UInt32Array::from(
+                    symbols.iter().map(|symbol| symbol.line).collect::<Vec<_>>(),
+                )),
+            ],
+        )
+        .map_err(|error| error.to_string())?,
+    });
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use otel_arrow_dfe_config::observed_state::SendPolicy;
+    use otel_arrow_dfe_config::settings::telemetry::logs::{LogLevel, StackTraceConfig};
+    use otel_arrow_dfe_pdata::extended_logs::ExtendedLogsView;
+    use otel_arrow_dfe_telemetry::event::{ObservedEvent, ObservedEventReporter};
+    use otel_arrow_dfe_telemetry::registry::TelemetryRegistryHandle;
+    use otel_arrow_dfe_telemetry::self_tracing::LogContext;
+    use otel_arrow_dfe_telemetry::tracing_init::ProviderSetup;
+    use otel_arrow_dfe_telemetry::{TracingSetup, otel_info};
+
+    /// Scenario: a caller-captured internal log is encoded as extended OTAP logs.
+    /// Guarantees: canonical logs and ordered stack frames survive the ITR encoding boundary.
+    #[test]
+    fn encodes_captured_stack_as_extended_log_tables() {
+        let (sender, receiver) = flume::bounded(1);
+        let reporter = ObservedEventReporter::new(SendPolicy::default(), sender);
+        let level: LogLevel = serde_json::from_str("\"info\"").unwrap();
+        let setup = TracingSetup::new(
+            ProviderSetup::InternalAsync {
+                reporter,
+                stacktraces: StackTraceConfig {
+                    enabled: true,
+                    max_frames: 8,
+                },
+            },
+            level,
+            LogContext::new,
+        );
+
+        setup.with_subscriber(|| otel_info!("extended.stacktrace.test"));
+        let ObservedEvent::Log(event) = receiver.try_recv().expect("captured internal log") else {
+            panic!("expected log event");
+        };
+        let expected_callsite_file = event.record.callsite().file().map(ToOwned::to_owned);
+        let expected_callsite_line = event.record.callsite().line();
+
+        let registry = TelemetryRegistryHandle::new();
+        let mut scope_cache = ScopeToBytesMap::new(registry);
+        let mut symbol_cache = SymbolCache::default();
+        let records = encode(&event, &Bytes::new(), &mut scope_cache, &mut symbol_cache)
+            .expect("extended logs encode");
+        let view = ExtendedLogsView::try_from(&records).expect("extended logs view");
+
+        assert_eq!(view.standard_logs().unwrap().num_items(), 1);
+        let stacks = view.stacks().expect("stack tables");
+        let frames = stacks.get(&0).expect("log stack");
+        assert!(!frames.is_empty());
+        assert!(frames.len() <= 8);
+        assert_eq!(frames[0].filename, expected_callsite_file);
+        assert_eq!(frames[0].line, expected_callsite_line);
+        assert!(
+            !frames[0]
+                .function_name
+                .as_deref()
+                .is_some_and(|name| name.contains("otel_arrow_dfe_telemetry"))
+        );
+    }
+}

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/internal_telemetry_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/internal_telemetry_receiver/mod.rs
@@ -28,6 +28,8 @@
 //!           description: Uptime of the pipeline process.
 //! ```
 
+mod extended_logs;
+
 otel_arrow_dfe_telemetry::otel_component_scope!(
     urn = INTERNAL_TELEMETRY_RECEIVER_URN,
     target = "otel.receiver.internal_telemetry",
@@ -64,6 +66,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::{Instant, MissedTickBehavior, interval_at};
+
+use self::extended_logs::SymbolCache;
 
 /// The URN for the internal telemetry receiver.
 pub use otel_arrow_dfe_config::engine::INTERNAL_TELEMETRY_RECEIVER_URN;
@@ -105,6 +109,10 @@ pub struct Config {
     /// Configuration for registry-backed internal metrics.
     #[serde(default)]
     pub metrics: MetricsConfig,
+
+    /// Configuration for internal log output.
+    #[serde(default)]
+    pub logs: LogsConfig,
 }
 
 impl Default for Config {
@@ -112,8 +120,29 @@ impl Default for Config {
         Self {
             signals: default_signals(),
             metrics: MetricsConfig::default(),
+            logs: LogsConfig::default(),
         }
     }
+}
+
+/// Physical representation emitted for internal logs.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LogsRepresentation {
+    /// Existing direct OTLP protobuf encoding.
+    #[default]
+    Otlp,
+    /// Canonical OTAP log tables with compact stacktrace extension tables.
+    ArrowExtended,
+}
+
+/// Configuration for internal log output.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LogsConfig {
+    /// Physical representation emitted by the receiver.
+    #[serde(default)]
+    pub representation: LogsRepresentation,
 }
 
 /// Registry-backed internal metrics configuration.
@@ -324,6 +353,8 @@ impl local::Receiver<OtapPdata> for InternalTelemetryReceiver {
     ) -> Result<TerminalState, Error> {
         let internal = self.internal_telemetry.clone();
         let mut scope_cache = ScopeToBytesMap::new(internal.registry.clone());
+        let mut symbol_cache = SymbolCache::default();
+        let logs_representation = self.config.logs.representation;
         let logs_enabled = self.config.logs_enabled();
         let metrics_enabled = self.config.metrics_enabled();
         let metrics_interval = self
@@ -367,6 +398,8 @@ impl local::Receiver<OtapPdata> for InternalTelemetryReceiver {
                                 &internal,
                                 logs_enabled,
                                 &mut scope_cache,
+                                &mut symbol_cache,
+                                logs_representation,
                                 metrics_encoder.as_ref(),
                                 deadline,
                             ).await?;
@@ -380,6 +413,8 @@ impl local::Receiver<OtapPdata> for InternalTelemetryReceiver {
                                 &internal,
                                 logs_enabled,
                                 &mut scope_cache,
+                                &mut symbol_cache,
+                                logs_representation,
                                 metrics_encoder.as_ref(),
                                 deadline,
                             ).await?;
@@ -429,6 +464,8 @@ impl local::Receiver<OtapPdata> for InternalTelemetryReceiver {
                                 log_event,
                                 &internal.resource_field_bytes,
                                 &mut scope_cache,
+                                &mut symbol_cache,
+                                logs_representation,
                             ).await?;
                         }
                         Ok(ObservedEvent::Engine(_)) => {
@@ -451,6 +488,8 @@ impl InternalTelemetryReceiver {
         internal: &otel_arrow_dfe_telemetry::InternalTelemetrySettings,
         logs_enabled: bool,
         scope_cache: &mut ScopeToBytesMap,
+        symbol_cache: &mut SymbolCache,
+        logs_representation: LogsRepresentation,
         encoder: Option<&MetricsOtlpEncoder>,
         deadline: std::time::Instant,
     ) -> Result<(), Error> {
@@ -465,6 +504,8 @@ impl InternalTelemetryReceiver {
                         log_event,
                         &internal.resource_field_bytes,
                         scope_cache,
+                        symbol_cache,
+                        logs_representation,
                     )
                     .await?;
                 }
@@ -541,15 +582,22 @@ impl InternalTelemetryReceiver {
         log_event: LogEvent,
         resource_field_bytes: &Bytes,
         scope_cache: &mut ScopeToBytesMap,
+        symbol_cache: &mut SymbolCache,
+        representation: LogsRepresentation,
     ) -> Result<(), Error> {
-        let mut buf = ProtoBuffer::with_capacity(512);
-
-        encode_export_logs_request(&mut buf, &log_event, resource_field_bytes, scope_cache);
-
-        let pdata = OtapPdata::new(
-            Context::default(),
-            OtlpProtoBytes::ExportLogsRequest(buf.into_bytes()).into(),
-        );
+        let payload = match representation {
+            LogsRepresentation::Otlp => {
+                let mut buf = ProtoBuffer::with_capacity(512);
+                encode_export_logs_request(&mut buf, &log_event, resource_field_bytes, scope_cache);
+                OtlpProtoBytes::ExportLogsRequest(buf.into_bytes()).into()
+            }
+            LogsRepresentation::ArrowExtended => {
+                extended_logs::encode(&log_event, resource_field_bytes, scope_cache, symbol_cache)
+                    .map_err(|error| Error::PdataConversionError { error })?
+                    .into()
+            }
+        };
+        let pdata = OtapPdata::new(Context::default(), payload);
         effect_handler.send_message(pdata).await?;
         Ok(())
     }
@@ -561,7 +609,7 @@ mod tests {
     use otel_arrow_dfe_config::observed_state::SendPolicy;
     use otel_arrow_dfe_config::pipeline::telemetry::TelemetryConfig;
     use otel_arrow_dfe_config::settings::telemetry::logs::{
-        LoggingProviders, LogsConfig, ProviderMode,
+        LoggingProviders, LogsConfig as TelemetryLogsConfig, ProviderMode,
     };
     use otel_arrow_dfe_engine::control::{
         NodeControlMsg, RuntimeControlMsg, runtime_ctrl_msg_channel,
@@ -772,6 +820,7 @@ mod tests {
                 interval: Some(Duration::from_secs(5)),
                 views: Vec::new(),
             },
+            logs: LogsConfig::default(),
         };
         assert_eq!(
             configured.metric_drain_interval(Duration::from_secs(60)),
@@ -784,6 +833,7 @@ mod tests {
                 interval: Some(Duration::from_secs(5)),
                 views: Vec::new(),
             },
+            logs: LogsConfig::default(),
         };
         assert_eq!(
             logs_only.metric_drain_interval(Duration::from_secs(60)),
@@ -911,6 +961,7 @@ mod tests {
                         interval: Some(Duration::from_millis(10)),
                         views: Vec::new(),
                     },
+                    logs: LogsConfig::default(),
                 },
                 otel_arrow_dfe_telemetry::InternalTelemetrySettings {
                     logs_receiver,
@@ -984,14 +1035,14 @@ mod tests {
             let registry = TelemetryRegistryHandle::new();
             let config = TelemetryConfig {
                 reporting_interval: engine_reporting_interval,
-                logs: LogsConfig {
+                logs: TelemetryLogsConfig {
                     providers: LoggingProviders {
                         global: ProviderMode::Noop,
                         engine: ProviderMode::Noop,
                         internal: ProviderMode::Noop,
                         admin: ProviderMode::Noop,
                     },
-                    ..LogsConfig::default()
+                    ..TelemetryLogsConfig::default()
                 },
                 ..TelemetryConfig::default()
             };
@@ -1016,6 +1067,7 @@ mod tests {
                         interval: Some(receiver_interval),
                         views: Vec::new(),
                     },
+                    logs: LogsConfig::default(),
                 },
                 telemetry.internal_telemetry_settings(),
             );

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/internal_telemetry_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/internal_telemetry_receiver/mod.rs
@@ -59,10 +59,12 @@ use otel_arrow_dfe_telemetry::metrics::otlp::{
     MetricView, MetricViewSelector, MetricViewStream, MetricsOtlpEncoder,
 };
 use otel_arrow_dfe_telemetry::registry::TelemetryRegistryHandle;
-use otel_arrow_dfe_telemetry::self_tracing::{ScopeToBytesMap, encode_export_logs_request};
+use otel_arrow_dfe_telemetry::self_tracing::{ScopeToBytesMap, encode_export_logs_request_batch};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::mem::size_of;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::{Instant, MissedTickBehavior, interval_at};
@@ -96,6 +98,22 @@ fn default_signals() -> Vec<InternalTelemetrySignal> {
         InternalTelemetrySignal::Logs,
         InternalTelemetrySignal::Metrics,
     ]
+}
+
+const MAX_LOG_BATCH_BYTES: usize = 2 * 1024 * 1024;
+const DEFAULT_LOG_BATCH_MIN_BYTES: usize = 64 * 1024;
+const DEFAULT_LOG_BATCH_DURATION: Duration = Duration::from_millis(200);
+
+const fn default_log_batch_min_size() -> NonZeroUsize {
+    NonZeroUsize::new(DEFAULT_LOG_BATCH_MIN_BYTES).expect("default batch size is nonzero")
+}
+
+const fn default_log_batch_max_size() -> NonZeroUsize {
+    NonZeroUsize::new(MAX_LOG_BATCH_BYTES).expect("maximum batch size is nonzero")
+}
+
+const fn default_log_batch_duration() -> Duration {
+    DEFAULT_LOG_BATCH_DURATION
 }
 
 /// Configuration for the internal telemetry receiver.
@@ -137,12 +155,70 @@ pub enum LogsRepresentation {
 }
 
 /// Configuration for internal log output.
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct LogsConfig {
     /// Physical representation emitted by the receiver.
     #[serde(default)]
     pub representation: LogsRepresentation,
+
+    /// Retained bytes that trigger a log batch flush.
+    #[serde(default = "default_log_batch_min_size")]
+    pub min_size: NonZeroUsize,
+
+    /// Maximum retained bytes in a log batch.
+    #[serde(default = "default_log_batch_max_size")]
+    pub max_size: NonZeroUsize,
+
+    /// Maximum time the oldest log can wait in a partial batch.
+    #[serde(default = "default_log_batch_duration", with = "humantime_serde")]
+    pub max_batch_duration: Duration,
+}
+
+impl Default for LogsConfig {
+    fn default() -> Self {
+        Self {
+            representation: LogsRepresentation::default(),
+            min_size: default_log_batch_min_size(),
+            max_size: default_log_batch_max_size(),
+            max_batch_duration: default_log_batch_duration(),
+        }
+    }
+}
+
+#[derive(Default)]
+struct LogBatch {
+    events: Vec<LogEvent>,
+    retained_bytes: usize,
+}
+
+impl LogBatch {
+    fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    fn clear(&mut self) {
+        self.events.clear();
+        self.retained_bytes = 0;
+    }
+}
+
+fn retained_log_bytes(event: &LogEvent) -> usize {
+    let context_bytes = if event.record.context.spilled() {
+        event.record.context.capacity() * size_of::<otel_arrow_dfe_telemetry::registry::EntityKey>()
+    } else {
+        0
+    };
+    size_of::<LogEvent>()
+        .saturating_add(event.record.body_attrs_bytes.len())
+        .saturating_add(context_bytes)
+        .saturating_add(
+            event
+                .record
+                .stacktrace
+                .as_ref()
+                .map_or(0, |stacktrace| stacktrace.retained_bytes()),
+        )
 }
 
 /// Registry-backed internal metrics configuration.
@@ -324,6 +400,28 @@ impl Config {
                 ),
             });
         }
+        if self.logs.min_size > self.logs.max_size {
+            return Err(otel_arrow_dfe_config::error::Error::InvalidUserConfig {
+                error: format!(
+                    "internal telemetry receiver logs min_size ({}) must not exceed max_size ({})",
+                    self.logs.min_size, self.logs.max_size
+                ),
+            });
+        }
+        if self.logs.max_size.get() > MAX_LOG_BATCH_BYTES {
+            return Err(otel_arrow_dfe_config::error::Error::InvalidUserConfig {
+                error: format!(
+                    "internal telemetry receiver logs max_size must not exceed {MAX_LOG_BATCH_BYTES} bytes"
+                ),
+            });
+        }
+        if self.logs.max_batch_duration.is_zero() {
+            return Err(otel_arrow_dfe_config::error::Error::InvalidUserConfig {
+                error:
+                    "internal telemetry receiver logs max_batch_duration must be greater than zero"
+                        .to_owned(),
+            });
+        }
         Ok(())
     }
 
@@ -354,7 +452,7 @@ impl local::Receiver<OtapPdata> for InternalTelemetryReceiver {
         let internal = self.internal_telemetry.clone();
         let mut scope_cache = ScopeToBytesMap::new(internal.registry.clone());
         let mut symbol_cache = SymbolCache::default();
-        let logs_representation = self.config.logs.representation;
+        let logs_config = self.config.logs;
         let logs_enabled = self.config.logs_enabled();
         let metrics_enabled = self.config.metrics_enabled();
         let metrics_interval = self
@@ -379,8 +477,23 @@ impl local::Receiver<OtapPdata> for InternalTelemetryReceiver {
         metrics_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
         let mut logs_channel_open = logs_enabled;
         let mut pending_metric_export = None;
+        let mut log_batch = LogBatch::default();
+        let mut log_batch_deadline = None;
 
         loop {
+            if log_batch_deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+                Self::flush_log_batch(
+                    &effect_handler,
+                    &mut log_batch,
+                    &internal.resource_field_bytes,
+                    &mut scope_cache,
+                    &mut symbol_cache,
+                    logs_config.representation,
+                )
+                .await?;
+                log_batch_deadline = None;
+            }
+
             tokio::select! {
                 biased;
 
@@ -397,9 +510,10 @@ impl local::Receiver<OtapPdata> for InternalTelemetryReceiver {
                                 &effect_handler,
                                 &internal,
                                 logs_enabled,
+                                &mut log_batch,
                                 &mut scope_cache,
                                 &mut symbol_cache,
-                                logs_representation,
+                                logs_config,
                                 metrics_encoder.as_ref(),
                                 deadline,
                             ).await?;
@@ -412,9 +526,10 @@ impl local::Receiver<OtapPdata> for InternalTelemetryReceiver {
                                 &effect_handler,
                                 &internal,
                                 logs_enabled,
+                                &mut log_batch,
                                 &mut scope_cache,
                                 &mut symbol_cache,
-                                logs_representation,
+                                logs_config,
                                 metrics_encoder.as_ref(),
                                 deadline,
                             ).await?;
@@ -456,26 +571,44 @@ impl local::Receiver<OtapPdata> for InternalTelemetryReceiver {
                 result = internal.logs_receiver.recv_async(), if logs_channel_open => {
                     match result {
                         Ok(ObservedEvent::Log(log_event)) => {
-                            if let Some(log_tap) = internal.log_tap.as_ref() {
-                                log_tap.record(log_event.clone());
-                            }
-                            Self::send_log_event(
+                            let started_new_batch = Self::buffer_log_event(
                                 &effect_handler,
+                                &mut log_batch,
                                 log_event,
                                 &internal.resource_field_bytes,
                                 &mut scope_cache,
                                 &mut symbol_cache,
-                                logs_representation,
+                                internal.log_tap.as_ref(),
+                                logs_config,
                             ).await?;
+                            if log_batch.is_empty() {
+                                log_batch_deadline = None;
+                            } else if started_new_batch {
+                                log_batch_deadline =
+                                    Some(Instant::now() + logs_config.max_batch_duration);
+                            }
                         }
                         Ok(ObservedEvent::Engine(_)) => {
                             // Engine events are not yet processed
                         }
                         Err(_) => {
+                            Self::flush_log_batch(
+                                &effect_handler,
+                                &mut log_batch,
+                                &internal.resource_field_bytes,
+                                &mut scope_cache,
+                                &mut symbol_cache,
+                                logs_config.representation,
+                            ).await?;
+                            log_batch_deadline = None;
                             logs_channel_open = false;
                         }
                     }
                 }
+
+                _ = tokio::time::sleep_until(
+                    log_batch_deadline.unwrap_or_else(Instant::now)
+                ), if log_batch_deadline.is_some() => {}
             }
         }
     }
@@ -487,29 +620,44 @@ impl InternalTelemetryReceiver {
         effect_handler: &local::EffectHandler<OtapPdata>,
         internal: &otel_arrow_dfe_telemetry::InternalTelemetrySettings,
         logs_enabled: bool,
+        log_batch: &mut LogBatch,
         scope_cache: &mut ScopeToBytesMap,
         symbol_cache: &mut SymbolCache,
-        logs_representation: LogsRepresentation,
+        logs_config: LogsConfig,
         encoder: Option<&MetricsOtlpEncoder>,
         deadline: std::time::Instant,
     ) -> Result<(), Error> {
         if logs_enabled {
-            while let Ok(event) = internal.logs_receiver.try_recv() {
-                if let ObservedEvent::Log(log_event) = event {
-                    if let Some(log_tap) = internal.log_tap.as_ref() {
-                        log_tap.record(log_event.clone());
+            tokio::time::timeout_at(Instant::from_std(deadline), async {
+                while let Ok(event) = internal.logs_receiver.try_recv() {
+                    if let ObservedEvent::Log(log_event) = event {
+                        let _ = Self::buffer_log_event(
+                            effect_handler,
+                            log_batch,
+                            log_event,
+                            &internal.resource_field_bytes,
+                            scope_cache,
+                            symbol_cache,
+                            internal.log_tap.as_ref(),
+                            logs_config,
+                        )
+                        .await?;
                     }
-                    Self::send_log_event(
-                        effect_handler,
-                        log_event,
-                        &internal.resource_field_bytes,
-                        scope_cache,
-                        symbol_cache,
-                        logs_representation,
-                    )
-                    .await?;
                 }
-            }
+                Self::flush_log_batch(
+                    effect_handler,
+                    log_batch,
+                    &internal.resource_field_bytes,
+                    scope_cache,
+                    symbol_cache,
+                    logs_config.representation,
+                )
+                .await
+            })
+            .await
+            .map_err(|_| Error::InternalError {
+                message: "timed out while flushing internal logs during shutdown".to_owned(),
+            })??;
         }
 
         Self::process_metric_batch_until(effect_handler, &internal.registry, encoder, deadline)
@@ -576,29 +724,99 @@ impl InternalTelemetryReceiver {
         Ok(())
     }
 
-    /// Send a log event as OTLP logs with scope attributes from entity context.
-    async fn send_log_event(
+    /// Add a log to the bounded receiver-side batch, flushing as required.
+    ///
+    /// Returns true when the event starts a partial batch whose deadline must
+    /// be scheduled by the caller.
+    async fn buffer_log_event(
         effect_handler: &local::EffectHandler<OtapPdata>,
+        batch: &mut LogBatch,
         log_event: LogEvent,
+        resource_field_bytes: &Bytes,
+        scope_cache: &mut ScopeToBytesMap,
+        symbol_cache: &mut SymbolCache,
+        log_tap: Option<&otel_arrow_dfe_telemetry::log_tap::InternalLogTapHandle>,
+        config: LogsConfig,
+    ) -> Result<bool, Error> {
+        if let Some(log_tap) = log_tap {
+            log_tap.record(log_event.clone());
+        }
+
+        let event_bytes = retained_log_bytes(&log_event);
+        let mut started_new_batch = batch.is_empty();
+        if !batch.is_empty()
+            && batch.retained_bytes.saturating_add(event_bytes) > config.max_size.get()
+        {
+            Self::flush_log_batch(
+                effect_handler,
+                batch,
+                resource_field_bytes,
+                scope_cache,
+                symbol_cache,
+                config.representation,
+            )
+            .await?;
+            started_new_batch = true;
+        }
+
+        batch.retained_bytes = batch.retained_bytes.saturating_add(event_bytes);
+        batch.events.push(log_event);
+        if batch.retained_bytes >= config.min_size.get() {
+            Self::flush_log_batch(
+                effect_handler,
+                batch,
+                resource_field_bytes,
+                scope_cache,
+                symbol_cache,
+                config.representation,
+            )
+            .await?;
+            return Ok(false);
+        }
+
+        Ok(started_new_batch)
+    }
+
+    /// Encode and send all currently buffered logs as one pdata message.
+    async fn flush_log_batch(
+        effect_handler: &local::EffectHandler<OtapPdata>,
+        batch: &mut LogBatch,
         resource_field_bytes: &Bytes,
         scope_cache: &mut ScopeToBytesMap,
         symbol_cache: &mut SymbolCache,
         representation: LogsRepresentation,
     ) -> Result<(), Error> {
+        if batch.is_empty() {
+            return Ok(());
+        }
+
         let payload = match representation {
             LogsRepresentation::Otlp => {
-                let mut buf = ProtoBuffer::with_capacity(512);
-                encode_export_logs_request(&mut buf, &log_event, resource_field_bytes, scope_cache);
+                let capacity = batch.events.iter().fold(
+                    resource_field_bytes.len().saturating_add(512),
+                    |capacity, event| capacity.saturating_add(event.record.body_attrs_bytes.len()),
+                );
+                let mut buf = ProtoBuffer::with_capacity(capacity);
+                let _ = encode_export_logs_request_batch(
+                    &mut buf,
+                    &batch.events,
+                    resource_field_bytes,
+                    scope_cache,
+                );
                 OtlpProtoBytes::ExportLogsRequest(buf.into_bytes()).into()
             }
-            LogsRepresentation::ArrowExtended => {
-                extended_logs::encode(&log_event, resource_field_bytes, scope_cache, symbol_cache)
-                    .map_err(|error| Error::PdataConversionError { error })?
-                    .into()
-            }
+            LogsRepresentation::ArrowExtended => extended_logs::encode(
+                &batch.events,
+                resource_field_bytes,
+                scope_cache,
+                symbol_cache,
+            )
+            .map_err(|error| Error::PdataConversionError { error })?
+            .into(),
         };
         let pdata = OtapPdata::new(Context::default(), payload);
         effect_handler.send_message(pdata).await?;
+        batch.clear();
         Ok(())
     }
 }
@@ -619,17 +837,20 @@ mod tests {
     use otel_arrow_dfe_engine::message::{Receiver as EngineReceiver, Sender as EngineSender};
     use otel_arrow_dfe_engine::testing::{create_not_send_channel, setup_test_runtime, test_node};
     use otel_arrow_dfe_pdata::PayloadData;
+    use otel_arrow_dfe_pdata::proto::opentelemetry::collector::logs::v1::ExportLogsServiceRequest;
     use otel_arrow_dfe_pdata::proto::opentelemetry::collector::metrics::v1::ExportMetricsServiceRequest;
     use otel_arrow_dfe_pdata::proto::opentelemetry::logs::v1::ResourceLogs;
     use otel_arrow_dfe_pdata::proto::opentelemetry::metrics::v1::{metric, number_data_point};
     use otel_arrow_dfe_telemetry::instrument::Counter;
     use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
     use otel_arrow_dfe_telemetry::testing::EmptyAttributes;
-    use otel_arrow_dfe_telemetry::{InternalTelemetrySystem, LogContext};
+    use otel_arrow_dfe_telemetry::{
+        __log_record_impl, InternalTelemetrySettings, InternalTelemetrySystem, Level, LogContext,
+    };
     use otel_arrow_dfe_telemetry_macros::metric_set;
     use prost::Message as _;
     use std::collections::HashMap;
-    use std::time::{Duration, Instant as StdInstant};
+    use std::time::{Duration, Instant as StdInstant, SystemTime};
     use tokio_util::sync::CancellationToken;
 
     #[metric_set(name = "receiver.internal_telemetry.test")]
@@ -672,6 +893,29 @@ mod tests {
             panic!("expected an integer metric data point")
         };
         value
+    }
+
+    fn test_log_event() -> LogEvent {
+        LogEvent {
+            time: SystemTime::UNIX_EPOCH,
+            record: __log_record_impl!(Level::INFO, "test.itr.batching")
+                .into_record(LogContext::new()),
+        }
+    }
+
+    fn decode_log_count(pdata: OtapPdata) -> usize {
+        let PayloadData::OtlpBytes(OtlpProtoBytes::ExportLogsRequest(bytes)) =
+            pdata.payload().into_data()
+        else {
+            panic!("internal telemetry receiver emitted a non-logs payload")
+        };
+        let request = ExportLogsServiceRequest::decode(bytes).expect("valid OTLP logs request");
+        request
+            .resource_logs
+            .iter()
+            .flat_map(|resource| &resource.scope_logs)
+            .map(|scope| scope.log_records.len())
+            .sum()
     }
 
     /// Scenario: metric settings include an interval, views, and scalar selectors.
@@ -786,6 +1030,30 @@ mod tests {
         assert!(logs_only.logs_enabled());
         assert!(!logs_only.metrics_enabled());
 
+        for (logs, expected) in [
+            (
+                serde_json::json!({ "min_size": 1024, "max_size": 512 }),
+                "must not exceed max_size",
+            ),
+            (
+                serde_json::json!({ "max_size": MAX_LOG_BATCH_BYTES + 1 }),
+                "must not exceed 2097152 bytes",
+            ),
+            (
+                serde_json::json!({ "max_batch_duration": "0s" }),
+                "must be greater than zero",
+            ),
+        ] {
+            let error = InternalTelemetryReceiver::parse_config(&serde_json::json!({
+                "logs": logs
+            }))
+            .expect_err("invalid log batching settings must be rejected");
+            assert!(
+                error.to_string().contains(expected),
+                "unexpected error: {error}"
+            );
+        }
+
         for (signals, expected) in [
             (serde_json::json!([]), "must not be empty"),
             (
@@ -802,6 +1070,148 @@ mod tests {
                 "unexpected error: {error}"
             );
         }
+    }
+
+    /// Scenario: two logs remain below the byte threshold until the batch deadline.
+    /// Guarantees: the timer emits one scope-grouped OTLP request before shutdown.
+    #[test]
+    fn timer_flushes_partial_log_batch() {
+        let (runtime, local_tasks) = setup_test_runtime();
+        runtime.block_on(local_tasks.run_until(async move {
+            let (logs_sender, logs_receiver) = flume::bounded(4);
+            let receiver = InternalTelemetryReceiver::new_with_telemetry(
+                Config {
+                    signals: vec![InternalTelemetrySignal::Logs],
+                    metrics: MetricsConfig::default(),
+                    logs: LogsConfig {
+                        min_size: default_log_batch_max_size(),
+                        max_batch_duration: Duration::from_millis(20),
+                        ..LogsConfig::default()
+                    },
+                },
+                InternalTelemetrySettings {
+                    logs_receiver,
+                    resource_field_bytes: Bytes::new(),
+                    registry: TelemetryRegistryHandle::new(),
+                    default_metric_drain_interval: Duration::from_secs(60),
+                    log_tap: None,
+                },
+            );
+
+            let (output_tx, output_rx) = create_not_send_channel(2);
+            let mut outputs = HashMap::new();
+            let _ = outputs.insert("".into(), EngineSender::Local(LocalSender::mpsc(output_tx)));
+            let (runtime_ctrl_tx, _runtime_ctrl_rx) = runtime_ctrl_msg_channel(2);
+            let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(2);
+            let effect_handler = local::EffectHandler::new(
+                test_node("internal_telemetry_receiver"),
+                outputs,
+                None,
+                runtime_ctrl_tx,
+                metrics_reporter,
+            );
+            let (ctrl_tx, ctrl_rx) = create_not_send_channel::<NodeControlMsg<OtapPdata>>(2);
+            let ctrl_channel =
+                local::ControlChannel::new(EngineReceiver::Local(LocalReceiver::mpsc(ctrl_rx)));
+            let receiver_task = tokio::task::spawn_local(async move {
+                Box::new(receiver).start(ctrl_channel, effect_handler).await
+            });
+
+            logs_sender
+                .send(ObservedEvent::Log(test_log_event()))
+                .expect("first log should enqueue");
+            logs_sender
+                .send(ObservedEvent::Log(test_log_event()))
+                .expect("second log should enqueue");
+
+            let output = tokio::time::timeout(Duration::from_millis(150), output_rx.recv())
+                .await
+                .expect("timer should flush before timeout")
+                .expect("output channel should remain open");
+            assert_eq!(decode_log_count(output), 2);
+
+            ctrl_tx
+                .send(NodeControlMsg::Shutdown {
+                    deadline: StdInstant::now() + Duration::from_secs(1),
+                    reason: "test complete".to_owned(),
+                })
+                .expect("shutdown should enqueue");
+            let receiver_result = receiver_task.await.expect("receiver task should join");
+            assert!(receiver_result.is_ok(), "receiver should shut down cleanly");
+        }));
+    }
+
+    /// Scenario: shutdown finds a partial log batch while downstream is blocked.
+    /// Guarantees: the terminal log flush fails at the shutdown deadline instead of hanging.
+    #[test]
+    fn shutdown_bounds_log_flush_blocked_by_downstream_backpressure() {
+        let (runtime, local_tasks) = setup_test_runtime();
+        runtime.block_on(local_tasks.run_until(async move {
+            let (logs_sender, logs_receiver) = flume::bounded(1);
+            let receiver = InternalTelemetryReceiver::new_with_telemetry(
+                Config {
+                    signals: vec![InternalTelemetrySignal::Logs],
+                    ..Config::default()
+                },
+                InternalTelemetrySettings {
+                    logs_receiver,
+                    resource_field_bytes: Bytes::new(),
+                    registry: TelemetryRegistryHandle::new(),
+                    default_metric_drain_interval: Duration::from_secs(60),
+                    log_tap: None,
+                },
+            );
+
+            let (output_tx, _output_rx) = create_not_send_channel(1);
+            output_tx
+                .send(OtapPdata::new(
+                    Context::default(),
+                    OtlpProtoBytes::ExportLogsRequest(Bytes::new()).into(),
+                ))
+                .expect("downstream blocker should enqueue");
+            let mut outputs = HashMap::new();
+            let _ = outputs.insert("".into(), EngineSender::Local(LocalSender::mpsc(output_tx)));
+            let (runtime_ctrl_tx, _runtime_ctrl_rx) = runtime_ctrl_msg_channel(2);
+            let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(2);
+            let effect_handler = local::EffectHandler::new(
+                test_node("internal_telemetry_receiver"),
+                outputs,
+                None,
+                runtime_ctrl_tx,
+                metrics_reporter,
+            );
+            let (ctrl_tx, ctrl_rx) = create_not_send_channel::<NodeControlMsg<OtapPdata>>(2);
+            let ctrl_channel =
+                local::ControlChannel::new(EngineReceiver::Local(LocalReceiver::mpsc(ctrl_rx)));
+            let receiver_task = tokio::task::spawn_local(async move {
+                Box::new(receiver).start(ctrl_channel, effect_handler).await
+            });
+
+            logs_sender
+                .send(ObservedEvent::Log(test_log_event()))
+                .expect("log should enqueue");
+            ctrl_tx
+                .send(NodeControlMsg::Shutdown {
+                    deadline: StdInstant::now() + Duration::from_millis(20),
+                    reason: "test deadline".to_owned(),
+                })
+                .expect("shutdown should enqueue");
+
+            let result = tokio::time::timeout(Duration::from_millis(500), receiver_task)
+                .await
+                .expect("shutdown deadline must bound the blocked log flush")
+                .expect("receiver task should join");
+            let error = match result {
+                Ok(_) => panic!("blocked terminal log flush should fail"),
+                Err(error) => error,
+            };
+            assert!(
+                error
+                    .to_string()
+                    .contains("timed out while flushing internal logs"),
+                "unexpected error: {error}"
+            );
+        }));
     }
 
     /// Scenario: metric emission has and does not have a receiver-local interval override.
@@ -963,7 +1373,7 @@ mod tests {
                     },
                     logs: LogsConfig::default(),
                 },
-                otel_arrow_dfe_telemetry::InternalTelemetrySettings {
+                InternalTelemetrySettings {
                     logs_receiver,
                     resource_field_bytes: ResourceLogs::default().encode_to_vec().into(),
                     registry: registry.clone(),

--- a/rust/otap-dataflow/crates/pdata/src/error.rs
+++ b/rust/otap-dataflow/crates/pdata/src/error.rs
@@ -122,6 +122,9 @@ pub enum Error {
     #[error("Unsupported payload type, got: {}", actual)]
     UnsupportedPayloadType { actual: i32 },
 
+    #[error("unsupported pluggable pdata representation `{format_id}`")]
+    UnsupportedRepresentation { format_id: String },
+
     #[error("Failed to build stream reader: {}", source)]
     BuildStreamReader { source: ArrowError },
 

--- a/rust/otap-dataflow/crates/pdata/src/extended_logs.rs
+++ b/rust/otap-dataflow/crates/pdata/src/extended_logs.rs
@@ -76,7 +76,8 @@ impl ExtendedLogsView<'_> {
         Ok(Logs::try_from(raw)?.into())
     }
 
-    /// Resolves compact extension tables into stacks keyed by canonical log row ID.
+    /// Resolves compact extension tables into stacks keyed by zero-based row
+    /// position in the canonical OTAP Logs table.
     pub fn stacks(&self) -> crate::error::Result<BTreeMap<u16, Vec<ExtendedLogStackFrame>>> {
         let Some(log_stacks) = self.records.table(LOG_STACKS_TABLE_ID) else {
             return Ok(BTreeMap::new());

--- a/rust/otap-dataflow/crates/pdata/src/extended_logs.rs
+++ b/rust/otap-dataflow/crates/pdata/src/extended_logs.rs
@@ -1,0 +1,358 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Compact stacktrace extension for canonical OTAP log records.
+
+use crate::otap::raw_batch_store::RawLogsStore;
+use crate::otap::{Logs, OtapArrowRecords};
+use crate::proto::opentelemetry::arrow::v1::ArrowPayloadType;
+use crate::representation::{PDataArrowRecordSet, RepresentationVersion};
+use arrow::array::{Array, StringArray, UInt16Array, UInt32Array, UInt64Array};
+use otel_arrow_dfe_config::SignalType;
+use std::collections::BTreeMap;
+
+/// Stable format ID for canonical OTAP logs with compact stacktrace tables.
+pub const EXTENDED_LOGS_FORMAT_ID: &str = "otap.logs.extended";
+/// Current extended-logs representation version.
+pub const EXTENDED_LOGS_VERSION: RepresentationVersion = RepresentationVersion::new(1, 0);
+
+/// Format-local table containing log-to-stack relations.
+pub const LOG_STACKS_TABLE_ID: u32 = 100;
+/// Format-local table containing ordered stack frames.
+pub const STACK_FRAMES_TABLE_ID: u32 = 101;
+/// Format-local table containing unique instruction-pointer locations.
+pub const LOCATIONS_TABLE_ID: u32 = 102;
+/// Format-local table containing resolved symbols.
+pub const SYMBOLS_TABLE_ID: u32 = 103;
+
+/// One resolved stack frame associated with an OTAP log row.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExtendedLogStackFrame {
+    /// Instruction pointer.
+    pub address: u64,
+    /// Resolved function name.
+    pub function_name: Option<String>,
+    /// Resolved source filename.
+    pub filename: Option<String>,
+    /// Resolved source line.
+    pub line: Option<u32>,
+}
+
+/// Validated view of an extended-log representation.
+pub struct ExtendedLogsView<'a> {
+    records: &'a PDataArrowRecordSet,
+}
+
+impl<'a> TryFrom<&'a PDataArrowRecordSet> for ExtendedLogsView<'a> {
+    type Error = crate::error::Error;
+
+    fn try_from(records: &'a PDataArrowRecordSet) -> Result<Self, Self::Error> {
+        if records.format_id() != EXTENDED_LOGS_FORMAT_ID
+            || records.version().major != EXTENDED_LOGS_VERSION.major
+            || records.signal_type() != SignalType::Logs
+        {
+            return Err(crate::error::Error::UnsupportedRepresentation {
+                format_id: records.format_id().to_owned(),
+            });
+        }
+        Ok(Self { records })
+    }
+}
+
+impl ExtendedLogsView<'_> {
+    /// Reconstructs the canonical four-table OTAP logs representation.
+    pub fn standard_logs(&self) -> crate::error::Result<OtapArrowRecords> {
+        let mut raw = RawLogsStore::new();
+        for payload_type in [
+            ArrowPayloadType::ResourceAttrs,
+            ArrowPayloadType::ScopeAttrs,
+            ArrowPayloadType::Logs,
+            ArrowPayloadType::LogAttrs,
+        ] {
+            if let Some(batch) = self.records.table(payload_type as u32) {
+                raw.set(payload_type, batch.clone());
+            }
+        }
+        Ok(Logs::try_from(raw)?.into())
+    }
+
+    /// Resolves compact extension tables into stacks keyed by canonical log row ID.
+    pub fn stacks(&self) -> crate::error::Result<BTreeMap<u16, Vec<ExtendedLogStackFrame>>> {
+        let Some(log_stacks) = self.records.table(LOG_STACKS_TABLE_ID) else {
+            return Ok(BTreeMap::new());
+        };
+        let stack_frames = self.required_table(STACK_FRAMES_TABLE_ID, "stack frames")?;
+        let locations = self.required_table(LOCATIONS_TABLE_ID, "locations")?;
+
+        let log_ids = required_u16(log_stacks, "log_id")?;
+        let stack_ids = required_u32(log_stacks, "stack_id")?;
+        let frame_stack_ids = required_u32(stack_frames, "stack_id")?;
+        let ordinals = required_u16(stack_frames, "ordinal")?;
+        let location_ids = required_u32(stack_frames, "location_id")?;
+        let ids = required_u32(locations, "id")?;
+        let addresses = required_u64(locations, "address")?;
+
+        let mut location_by_id = BTreeMap::new();
+        for row in 0..locations.num_rows() {
+            let _ = location_by_id.insert(ids.value(row), addresses.value(row));
+        }
+
+        let mut symbols_by_location = BTreeMap::new();
+        if let Some(symbols) = self.records.table(SYMBOLS_TABLE_ID) {
+            let symbol_location_ids = required_u32(symbols, "location_id")?;
+            let function_names = optional_string(symbols, "function_name")?;
+            let filenames = optional_string(symbols, "filename")?;
+            let lines = optional_u32(symbols, "line")?;
+            for row in 0..symbols.num_rows() {
+                let _ = symbols_by_location.insert(
+                    symbol_location_ids.value(row),
+                    (
+                        string_at(function_names, row),
+                        string_at(filenames, row),
+                        lines.and_then(|array| (!array.is_null(row)).then(|| array.value(row))),
+                    ),
+                );
+            }
+        }
+
+        let mut frames_by_stack: BTreeMap<u32, Vec<(u16, ExtendedLogStackFrame)>> = BTreeMap::new();
+        for row in 0..stack_frames.num_rows() {
+            let location_id = location_ids.value(row);
+            let (function_name, filename, line) = symbols_by_location
+                .get(&location_id)
+                .cloned()
+                .unwrap_or_default();
+            frames_by_stack
+                .entry(frame_stack_ids.value(row))
+                .or_default()
+                .push((
+                    ordinals.value(row),
+                    ExtendedLogStackFrame {
+                        address: *location_by_id.get(&location_id).ok_or_else(|| {
+                            crate::error::Error::UnexpectedRecordBatchState {
+                                reason: format!(
+                                    "stack frame references missing location {location_id}"
+                                ),
+                            }
+                        })?,
+                        function_name,
+                        filename,
+                        line,
+                    },
+                ));
+        }
+        for frames in frames_by_stack.values_mut() {
+            frames.sort_by_key(|(ordinal, _)| *ordinal);
+        }
+
+        let mut result = BTreeMap::new();
+        for row in 0..log_stacks.num_rows() {
+            let frames = frames_by_stack
+                .get(&stack_ids.value(row))
+                .cloned()
+                .unwrap_or_default();
+            let _ = result.insert(
+                log_ids.value(row),
+                frames.into_iter().map(|(_, frame)| frame).collect(),
+            );
+        }
+        Ok(result)
+    }
+
+    fn required_table(
+        &self,
+        table_id: u32,
+        table_name: &str,
+    ) -> crate::error::Result<&arrow::array::RecordBatch> {
+        self.records.table(table_id).ok_or_else(|| {
+            crate::error::Error::UnexpectedRecordBatchState {
+                reason: format!(
+                    "extended logs with log stacks require the {table_name} table ({table_id})"
+                ),
+            }
+        })
+    }
+}
+
+fn required_u16<'a>(
+    batch: &'a arrow::array::RecordBatch,
+    name: &str,
+) -> crate::error::Result<&'a UInt16Array> {
+    batch
+        .column_by_name(name)
+        .and_then(|column| column.as_any().downcast_ref())
+        .ok_or_else(|| crate::error::Error::UnexpectedRecordBatchState {
+            reason: format!("extended logs table requires UInt16 column `{name}`"),
+        })
+}
+
+fn required_u32<'a>(
+    batch: &'a arrow::array::RecordBatch,
+    name: &str,
+) -> crate::error::Result<&'a UInt32Array> {
+    batch
+        .column_by_name(name)
+        .and_then(|column| column.as_any().downcast_ref())
+        .ok_or_else(|| crate::error::Error::UnexpectedRecordBatchState {
+            reason: format!("extended logs table requires UInt32 column `{name}`"),
+        })
+}
+
+fn required_u64<'a>(
+    batch: &'a arrow::array::RecordBatch,
+    name: &str,
+) -> crate::error::Result<&'a UInt64Array> {
+    batch
+        .column_by_name(name)
+        .and_then(|column| column.as_any().downcast_ref())
+        .ok_or_else(|| crate::error::Error::UnexpectedRecordBatchState {
+            reason: format!("extended logs table requires UInt64 column `{name}`"),
+        })
+}
+
+fn optional_u32<'a>(
+    batch: &'a arrow::array::RecordBatch,
+    name: &str,
+) -> crate::error::Result<Option<&'a UInt32Array>> {
+    batch
+        .column_by_name(name)
+        .map(|column| {
+            column.as_any().downcast_ref().ok_or_else(|| {
+                crate::error::Error::UnexpectedRecordBatchState {
+                    reason: format!("extended logs table requires UInt32 column `{name}`"),
+                }
+            })
+        })
+        .transpose()
+}
+
+fn optional_string<'a>(
+    batch: &'a arrow::array::RecordBatch,
+    name: &str,
+) -> crate::error::Result<Option<&'a StringArray>> {
+    batch
+        .column_by_name(name)
+        .map(|column| {
+            column.as_any().downcast_ref().ok_or_else(|| {
+                crate::error::Error::UnexpectedRecordBatchState {
+                    reason: format!("extended logs table requires Utf8 column `{name}`"),
+                }
+            })
+        })
+        .transpose()
+}
+
+fn string_at(array: Option<&StringArray>, row: usize) -> Option<String> {
+    array.and_then(|array| (!array.is_null(row)).then(|| array.value(row).to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::representation::PDataArrowTable;
+    use arrow::array::RecordBatch;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    fn batch(fields: Vec<Field>, columns: Vec<arrow::array::ArrayRef>) -> RecordBatch {
+        RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).unwrap()
+    }
+
+    fn records(tables: Vec<PDataArrowTable>) -> PDataArrowRecordSet {
+        PDataArrowRecordSet::new(
+            EXTENDED_LOGS_FORMAT_ID,
+            EXTENDED_LOGS_VERSION,
+            SignalType::Logs,
+            2,
+            tables,
+        )
+        .unwrap()
+    }
+
+    /// Scenario: two log rows refer to the same compact stack ID.
+    /// Guarantees: decoding preserves the complete ordered stack for both logs.
+    #[test]
+    fn shared_stack_is_available_to_every_log() {
+        let records = records(vec![
+            PDataArrowTable {
+                table_id: LOG_STACKS_TABLE_ID,
+                batch: batch(
+                    vec![
+                        Field::new("log_id", DataType::UInt16, false),
+                        Field::new("stack_id", DataType::UInt32, false),
+                    ],
+                    vec![
+                        Arc::new(UInt16Array::from(vec![4, 9])),
+                        Arc::new(UInt32Array::from(vec![7, 7])),
+                    ],
+                ),
+            },
+            PDataArrowTable {
+                table_id: STACK_FRAMES_TABLE_ID,
+                batch: batch(
+                    vec![
+                        Field::new("stack_id", DataType::UInt32, false),
+                        Field::new("ordinal", DataType::UInt16, false),
+                        Field::new("location_id", DataType::UInt32, false),
+                    ],
+                    vec![
+                        Arc::new(UInt32Array::from(vec![7, 7])),
+                        Arc::new(UInt16Array::from(vec![1, 0])),
+                        Arc::new(UInt32Array::from(vec![2, 1])),
+                    ],
+                ),
+            },
+            PDataArrowTable {
+                table_id: LOCATIONS_TABLE_ID,
+                batch: batch(
+                    vec![
+                        Field::new("id", DataType::UInt32, false),
+                        Field::new("address", DataType::UInt64, false),
+                    ],
+                    vec![
+                        Arc::new(UInt32Array::from(vec![1, 2])),
+                        Arc::new(UInt64Array::from(vec![0x10, 0x20])),
+                    ],
+                ),
+            },
+        ]);
+
+        let stacks = ExtendedLogsView::try_from(&records)
+            .unwrap()
+            .stacks()
+            .unwrap();
+        assert_eq!(
+            stacks[&4]
+                .iter()
+                .map(|frame| frame.address)
+                .collect::<Vec<_>>(),
+            vec![0x10, 0x20]
+        );
+        assert_eq!(stacks[&4], stacks[&9]);
+    }
+
+    /// Scenario: a representation declares log-to-stack rows without frame tables.
+    /// Guarantees: malformed stack extensions return an error instead of dropping stacks.
+    #[test]
+    fn partial_stack_extension_is_rejected() {
+        let records = records(vec![PDataArrowTable {
+            table_id: LOG_STACKS_TABLE_ID,
+            batch: batch(
+                vec![
+                    Field::new("log_id", DataType::UInt16, false),
+                    Field::new("stack_id", DataType::UInt32, false),
+                ],
+                vec![
+                    Arc::new(UInt16Array::from(vec![0])),
+                    Arc::new(UInt32Array::from(vec![0])),
+                ],
+            ),
+        }]);
+
+        let error = ExtendedLogsView::try_from(&records)
+            .unwrap()
+            .stacks()
+            .unwrap_err();
+        assert!(error.to_string().contains("stack frames table"));
+    }
+}

--- a/rust/otap-dataflow/crates/pdata/src/lib.rs
+++ b/rust/otap-dataflow/crates/pdata/src/lib.rs
@@ -14,7 +14,9 @@ pub mod proto;
 pub mod views;
 
 pub mod error;
+pub mod extended_logs;
 pub mod otap;
+pub mod representation;
 pub mod schema;
 
 pub mod arrays;
@@ -25,6 +27,9 @@ pub(crate) mod payload;
 pub use otap::OtapArrowRecords;
 pub use otlp::OtlpProtoBytes;
 pub use payload::{OtapPayload, OtapPayloadHelpers, PayloadData};
+pub use representation::{
+    PDataArrowRecordSet, PDataArrowTable, PDataBytes, RepresentationError, RepresentationVersion,
+};
 
 /// Testing support
 #[cfg(any(test, feature = "testing"))]

--- a/rust/otap-dataflow/crates/pdata/src/otap/memory.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/memory.rs
@@ -405,7 +405,9 @@ mod tests {
         assert_eq!(
             match arrow_payload.into_data() {
                 PayloadData::OtapArrowRecords(records) => records.root_payload_type(),
-                PayloadData::OtlpBytes(_) => unreachable!(),
+                PayloadData::OtlpBytes(_)
+                | PayloadData::PluggableArrowRecords(_)
+                | PayloadData::PluggableBytes(_) => unreachable!(),
             },
             ArrowPayloadType::Logs
         );

--- a/rust/otap-dataflow/crates/pdata/src/payload.rs
+++ b/rust/otap-dataflow/crates/pdata/src/payload.rs
@@ -90,6 +90,7 @@ use crate::otlp::metrics::MetricsProtoBytesEncoder;
 use crate::otlp::traces::TracesProtoBytesEncoder;
 use crate::otlp::{OtlpProtoBytes, ProtoBuffer, ProtoBytesEncoder};
 use crate::proto::OtlpProtoMessage;
+use crate::representation::{PDataArrowRecordSet, PDataBytes};
 use crate::views::otlp::bytes::logs::RawLogsData;
 use crate::views::otlp::bytes::metrics::RawMetricsData;
 use crate::views::otlp::bytes::traces::RawTraceData;
@@ -113,6 +114,12 @@ pub enum PayloadData {
     /// data is contained in `OtapBatch` which contains Arrow `RecordBatches` for OTAP payload type
     /// TODO: Remove "Arrow" from this case name, it stutters; follow SignalFormat.
     OtapArrowRecords(OtapArrowRecords),
+
+    /// Named and versioned set of format-local Arrow record batches.
+    PluggableArrowRecords(PDataArrowRecordSet),
+
+    /// Named and versioned encoded bytes carried without interpretation.
+    PluggableBytes(PDataBytes),
 }
 
 impl PayloadData {
@@ -120,6 +127,8 @@ impl PayloadData {
         match self {
             Self::OtlpBytes(value) => value.signal_type(),
             Self::OtapArrowRecords(value) => value.signal_type(),
+            Self::PluggableArrowRecords(value) => value.signal_type(),
+            Self::PluggableBytes(value) => value.signal_type(),
         }
     }
 
@@ -127,6 +136,8 @@ impl PayloadData {
         match self {
             Self::OtapArrowRecords(_) => SignalFormat::OtapRecords,
             Self::OtlpBytes(_) => SignalFormat::OtlpBytes,
+            Self::PluggableArrowRecords(_) => SignalFormat::OtapRecords,
+            Self::PluggableBytes(_) => SignalFormat::OtlpBytes,
         }
     }
 
@@ -134,6 +145,8 @@ impl PayloadData {
         match self {
             Self::OtlpBytes(value) => value.is_empty(),
             Self::OtapArrowRecords(value) => value.is_empty(),
+            Self::PluggableArrowRecords(value) => value.num_items() == 0,
+            Self::PluggableBytes(value) => value.num_items() == 0,
         }
     }
 
@@ -142,6 +155,8 @@ impl PayloadData {
         match self {
             Self::OtlpBytes(value) => Self::OtlpBytes(value.take_payload()),
             Self::OtapArrowRecords(value) => Self::OtapArrowRecords(value.take_payload()),
+            Self::PluggableArrowRecords(value) => Self::PluggableArrowRecords(value.take_payload()),
+            Self::PluggableBytes(value) => Self::PluggableBytes(value.take_payload()),
         }
     }
 
@@ -149,6 +164,8 @@ impl PayloadData {
         match self {
             Self::OtlpBytes(value) => value.num_items(),
             Self::OtapArrowRecords(value) => value.num_items(),
+            Self::PluggableArrowRecords(value) => value.num_items(),
+            Self::PluggableBytes(value) => value.num_items(),
         }
     }
 
@@ -156,6 +173,8 @@ impl PayloadData {
         match self {
             Self::OtlpBytes(value) => Some(value.num_bytes()),
             Self::OtapArrowRecords(value) => value.num_bytes(),
+            Self::PluggableArrowRecords(value) => value.logical_arrow_bytes().ok(),
+            Self::PluggableBytes(value) => Some(value.bytes().len()),
         }
     }
 
@@ -163,6 +182,8 @@ impl PayloadData {
         match self {
             Self::OtlpBytes(value) => value.retained_memory_bytes(),
             Self::OtapArrowRecords(value) => value.retained_memory_bytes(),
+            Self::PluggableArrowRecords(value) => value.retained_memory_bytes(),
+            Self::PluggableBytes(value) => value.bytes().len(),
         }
     }
 }
@@ -212,6 +233,18 @@ impl OtapPayload {
     #[must_use]
     pub fn from_otap(payload: OtapArrowRecords) -> Self {
         Self::from_data(PayloadData::OtapArrowRecords(payload))
+    }
+
+    /// Constructs a fresh payload from a pluggable Arrow representation.
+    #[must_use]
+    pub fn from_pluggable_arrow(payload: PDataArrowRecordSet) -> Self {
+        Self::from_data(PayloadData::PluggableArrowRecords(payload))
+    }
+
+    /// Constructs a fresh payload from a pluggable byte representation.
+    #[must_use]
+    pub fn from_pluggable_bytes(payload: PDataBytes) -> Self {
+        Self::from_data(PayloadData::PluggableBytes(payload))
     }
 
     /// Borrows the concrete payload data for pattern matching.
@@ -284,7 +317,10 @@ impl OtapPayload {
                 item_count
             }
             // Bypass the cache for OTAP because Arrow batches store row counts.
-            PayloadData::OtapArrowRecords(_) => self.data.num_items(),
+            PayloadData::OtapArrowRecords(_) | PayloadData::PluggableArrowRecords(_) => {
+                self.data.num_items()
+            }
+            PayloadData::PluggableBytes(_) => self.data.num_items(),
         }
     }
 
@@ -299,7 +335,7 @@ impl OtapPayload {
             // OTLP already stores the exact encoded length in Bytes metadata.
             PayloadData::OtlpBytes(_) => self.data.num_bytes(),
             // Cache OTAP sizing because it walks every Arrow array and buffer.
-            PayloadData::OtapArrowRecords(_) => {
+            PayloadData::OtapArrowRecords(_) | PayloadData::PluggableArrowRecords(_) => {
                 if let Some(size) = self.size {
                     return Some(size);
                 }
@@ -307,6 +343,7 @@ impl OtapPayload {
                 self.size = Some(size);
                 Some(size)
             }
+            PayloadData::PluggableBytes(_) => self.data.num_bytes(),
         }
     }
 
@@ -538,6 +575,18 @@ impl From<OtlpProtoBytes> for OtapPayload {
     }
 }
 
+impl From<PDataArrowRecordSet> for OtapPayload {
+    fn from(value: PDataArrowRecordSet) -> Self {
+        Self::from_pluggable_arrow(value)
+    }
+}
+
+impl From<PDataBytes> for OtapPayload {
+    fn from(value: PDataBytes) -> Self {
+        Self::from_pluggable_bytes(value)
+    }
+}
+
 impl From<PayloadData> for OtapPayload {
     fn from(value: PayloadData) -> Self {
         Self::from_data(value)
@@ -554,6 +603,14 @@ impl TryFromWithOptions<OtapPayload> for OtapArrowRecords {
         match value.into_data() {
             PayloadData::OtapArrowRecords(value) => Ok(value),
             PayloadData::OtlpBytes(value) => value.try_into_with_options(opts),
+            PayloadData::PluggableArrowRecords(value) => Err(Error::UnsupportedRepresentation {
+                format_id: value.format_id().to_owned(),
+            }
+            .into()),
+            PayloadData::PluggableBytes(value) => Err(Error::UnsupportedRepresentation {
+                format_id: value.format_id().to_owned(),
+            }
+            .into()),
         }
     }
 }
@@ -568,6 +625,12 @@ impl TryFromWithOptions<OtapPayload> for OtlpProtoBytes {
         match value.into_data() {
             PayloadData::OtapArrowRecords(value) => value.try_into_with_options(opts),
             PayloadData::OtlpBytes(value) => Ok(value),
+            PayloadData::PluggableArrowRecords(value) => Err(Error::UnsupportedRepresentation {
+                format_id: value.format_id().to_owned(),
+            }),
+            PayloadData::PluggableBytes(value) => Err(Error::UnsupportedRepresentation {
+                format_id: value.format_id().to_owned(),
+            }),
         }
     }
 }

--- a/rust/otap-dataflow/crates/pdata/src/representation.rs
+++ b/rust/otap-dataflow/crates/pdata/src/representation.rs
@@ -1,0 +1,331 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Named and versioned pluggable pdata representations.
+
+use crate::otap::memory;
+use arrow::array::RecordBatch;
+use bytes::Bytes;
+use otel_arrow_dfe_config::SignalType;
+use std::collections::BTreeMap;
+
+/// Version of a pluggable representation contract.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct RepresentationVersion {
+    /// Incompatible contract version.
+    pub major: u16,
+    /// Backward-compatible contract version.
+    pub minor: u16,
+}
+
+impl RepresentationVersion {
+    /// Creates a representation version.
+    #[must_use]
+    pub const fn new(major: u16, minor: u16) -> Self {
+        Self { major, minor }
+    }
+}
+
+/// Error constructing a pluggable representation.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum RepresentationError {
+    /// The format ID is empty.
+    #[error("pluggable representation format ID must not be empty")]
+    EmptyFormatId,
+    /// The media type is empty.
+    #[error("pluggable byte representation media type must not be empty")]
+    EmptyMediaType,
+    /// A format-local Arrow table ID occurs more than once.
+    #[error("duplicate pluggable Arrow table ID {table_id}")]
+    DuplicateTableId {
+        /// Duplicate format-local table ID.
+        table_id: u32,
+    },
+}
+
+/// One format-local table in a pluggable Arrow representation.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PDataArrowTable {
+    /// Identifier interpreted only by the named representation contract.
+    pub table_id: u32,
+    /// Arrow batch for this table.
+    pub batch: RecordBatch,
+}
+
+/// A named, versioned set of format-local Arrow tables.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PDataArrowRecordSet {
+    format_id: String,
+    version: RepresentationVersion,
+    signal: SignalType,
+    root_items: usize,
+    tables: BTreeMap<u32, RecordBatch>,
+}
+
+impl PDataArrowRecordSet {
+    /// Creates a validated pluggable Arrow record set.
+    pub fn new(
+        format_id: impl Into<String>,
+        version: RepresentationVersion,
+        signal: SignalType,
+        root_items: usize,
+        tables: impl IntoIterator<Item = PDataArrowTable>,
+    ) -> Result<Self, RepresentationError> {
+        let format_id = format_id.into();
+        if format_id.is_empty() {
+            return Err(RepresentationError::EmptyFormatId);
+        }
+
+        let mut table_map = BTreeMap::new();
+        for table in tables {
+            if table_map.insert(table.table_id, table.batch).is_some() {
+                return Err(RepresentationError::DuplicateTableId {
+                    table_id: table.table_id,
+                });
+            }
+        }
+
+        Ok(Self {
+            format_id,
+            version,
+            signal,
+            root_items,
+            tables: table_map,
+        })
+    }
+
+    /// Stable representation contract ID.
+    #[must_use]
+    pub fn format_id(&self) -> &str {
+        &self.format_id
+    }
+
+    /// Representation contract version.
+    #[must_use]
+    pub const fn version(&self) -> RepresentationVersion {
+        self.version
+    }
+
+    /// Semantic signal covered by this initial single-signal carrier.
+    #[must_use]
+    pub const fn signal_type(&self) -> SignalType {
+        self.signal
+    }
+
+    /// Format-defined number of root items.
+    #[must_use]
+    pub const fn num_items(&self) -> usize {
+        self.root_items
+    }
+
+    /// Returns a format-local table.
+    #[must_use]
+    pub fn table(&self, table_id: u32) -> Option<&RecordBatch> {
+        self.tables.get(&table_id)
+    }
+
+    /// Iterates over format-local tables in table-ID order.
+    #[must_use]
+    pub fn tables(&self) -> impl ExactSizeIterator<Item = (u32, &RecordBatch)> {
+        self.tables.iter().map(|(id, batch)| (*id, batch))
+    }
+
+    /// Logical Arrow bytes across all tables.
+    pub fn logical_arrow_bytes(&self) -> crate::error::Result<usize> {
+        self.tables.values().try_fold(0usize, |total, batch| {
+            let batch_bytes = memory::record_batch_logical_bytes(batch)
+                .map_err(|source| crate::error::Error::LogicalArrowSize { source })?;
+            total
+                .checked_add(batch_bytes)
+                .ok_or_else(|| crate::error::Error::LogicalArrowSize {
+                    source: arrow::error::ArrowError::ComputeError(
+                        "integer overflow computing pluggable Arrow byte size".to_owned(),
+                    ),
+                })
+        })
+    }
+
+    /// Deduplicated retained Arrow buffer capacity across all tables.
+    #[must_use]
+    pub fn retained_memory_bytes(&self) -> usize {
+        let mut seen = memory::CountedAllocations::default();
+        self.tables
+            .values()
+            .map(|batch| memory::record_batch_pinned_bytes(batch, &mut seen))
+            .sum()
+    }
+
+    pub(crate) fn take_payload(&mut self) -> Self {
+        Self {
+            format_id: self.format_id.clone(),
+            version: self.version,
+            signal: self.signal,
+            root_items: std::mem::take(&mut self.root_items),
+            tables: std::mem::take(&mut self.tables),
+        }
+    }
+}
+
+/// A named, versioned byte representation carried without interpretation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PDataBytes {
+    format_id: String,
+    version: RepresentationVersion,
+    media_type: String,
+    signal: SignalType,
+    num_items: usize,
+    bytes: Bytes,
+}
+
+impl PDataBytes {
+    /// Creates a validated pluggable byte representation.
+    pub fn new(
+        format_id: impl Into<String>,
+        version: RepresentationVersion,
+        media_type: impl Into<String>,
+        signal: SignalType,
+        num_items: usize,
+        bytes: Bytes,
+    ) -> Result<Self, RepresentationError> {
+        let format_id = format_id.into();
+        if format_id.is_empty() {
+            return Err(RepresentationError::EmptyFormatId);
+        }
+        let media_type = media_type.into();
+        if media_type.is_empty() {
+            return Err(RepresentationError::EmptyMediaType);
+        }
+        Ok(Self {
+            format_id,
+            version,
+            media_type,
+            signal,
+            num_items,
+            bytes,
+        })
+    }
+
+    /// Stable representation contract ID.
+    #[must_use]
+    pub fn format_id(&self) -> &str {
+        &self.format_id
+    }
+
+    /// Representation contract version.
+    #[must_use]
+    pub const fn version(&self) -> RepresentationVersion {
+        self.version
+    }
+
+    /// Media type of the encoded bytes.
+    #[must_use]
+    pub fn media_type(&self) -> &str {
+        &self.media_type
+    }
+
+    /// Semantic signal covered by this initial single-signal carrier.
+    #[must_use]
+    pub const fn signal_type(&self) -> SignalType {
+        self.signal
+    }
+
+    /// Format-defined item count.
+    #[must_use]
+    pub const fn num_items(&self) -> usize {
+        self.num_items
+    }
+
+    /// Encoded representation bytes.
+    #[must_use]
+    pub const fn bytes(&self) -> &Bytes {
+        &self.bytes
+    }
+
+    pub(crate) fn take_payload(&mut self) -> Self {
+        Self {
+            format_id: self.format_id.clone(),
+            version: self.version,
+            media_type: self.media_type.clone(),
+            signal: self.signal,
+            num_items: std::mem::take(&mut self.num_items),
+            bytes: std::mem::take(&mut self.bytes),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::UInt32Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    fn batch(values: Vec<u32>) -> RecordBatch {
+        RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "value",
+                DataType::UInt32,
+                false,
+            )])),
+            vec![Arc::new(UInt32Array::from(values))],
+        )
+        .unwrap()
+    }
+
+    /// Scenario: a pluggable Arrow record set contains two distinct local table IDs.
+    /// Guarantees: table lookup, root-item accounting, and memory accounting cover both tables.
+    #[test]
+    fn arrow_record_set_accounts_for_all_tables() {
+        let records = PDataArrowRecordSet::new(
+            "example.logs",
+            RepresentationVersion::new(1, 0),
+            SignalType::Logs,
+            3,
+            [
+                PDataArrowTable {
+                    table_id: 7,
+                    batch: batch(vec![1, 2, 3]),
+                },
+                PDataArrowTable {
+                    table_id: 42,
+                    batch: batch(vec![4]),
+                },
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(records.format_id(), "example.logs");
+        assert_eq!(records.num_items(), 3);
+        assert_eq!(records.tables().len(), 2);
+        assert_eq!(records.table(7).unwrap().num_rows(), 3);
+        assert!(records.logical_arrow_bytes().unwrap() > 0);
+        assert!(records.retained_memory_bytes() > 0);
+    }
+
+    /// Scenario: two Arrow tables use the same format-local table ID.
+    /// Guarantees: construction fails instead of replacing one table silently.
+    #[test]
+    fn arrow_record_set_rejects_duplicate_table_ids() {
+        let result = PDataArrowRecordSet::new(
+            "example.logs",
+            RepresentationVersion::new(1, 0),
+            SignalType::Logs,
+            1,
+            [
+                PDataArrowTable {
+                    table_id: 7,
+                    batch: batch(vec![1]),
+                },
+                PDataArrowTable {
+                    table_id: 7,
+                    batch: batch(vec![2]),
+                },
+            ],
+        );
+
+        assert_eq!(
+            result.unwrap_err(),
+            RepresentationError::DuplicateTableId { table_id: 7 }
+        );
+    }
+}

--- a/rust/otap-dataflow/crates/telemetry/Cargo.toml
+++ b/rust/otap-dataflow/crates/telemetry/Cargo.toml
@@ -26,6 +26,7 @@ otel-arrow-dfe-telemetry-macros = { workspace = true }
 otel-arrow-dfe-expohisto = { workspace = true }
 
 bytes = { workspace = true }
+backtrace = { workspace = true }
 chrono = { workspace = true }
 flume = { workspace = true }
 tokio = { workspace = true }

--- a/rust/otap-dataflow/crates/telemetry/src/event.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/event.rs
@@ -176,7 +176,62 @@ impl fmt::Display for LogEvent {
             f,
             "{}",
             format_log_record_to_string(Some(self.time), &self.record)
-        )
+        )?;
+        if let Some(stacktrace) = &self.record.stacktrace {
+            let callsite = self.record.callsite();
+            for (ordinal, address) in stacktrace.frames().iter().enumerate() {
+                let mut rendered = false;
+                let mut format_error = None;
+                backtrace::resolve(*address as *mut std::ffi::c_void, |symbol| {
+                    if rendered {
+                        return;
+                    }
+                    rendered = true;
+                    if let Err(error) = write!(f, "\n  at ") {
+                        format_error = Some(error);
+                        return;
+                    }
+                    if let Some(name) = symbol.name() {
+                        if let Err(error) = write!(f, "{name}") {
+                            format_error = Some(error);
+                            return;
+                        }
+                    } else {
+                        if let Err(error) = write!(f, "0x{address:x}") {
+                            format_error = Some(error);
+                            return;
+                        }
+                    }
+                    let filename = (ordinal == 0)
+                        .then(|| callsite.file())
+                        .flatten()
+                        .map(std::path::Path::new)
+                        .or_else(|| symbol.filename());
+                    if let Some(filename) = filename {
+                        if let Err(error) = write!(f, " ({})", filename.display()) {
+                            format_error = Some(error);
+                            return;
+                        }
+                    }
+                    let line = (ordinal == 0)
+                        .then(|| callsite.line())
+                        .flatten()
+                        .or_else(|| symbol.lineno());
+                    if let Some(line) = line {
+                        if let Err(error) = write!(f, ":{line}") {
+                            format_error = Some(error);
+                        }
+                    }
+                });
+                if let Some(error) = format_error {
+                    return Err(error);
+                }
+                if !rendered {
+                    write!(f, "\n  at 0x{address:x}")?;
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/rust/otap-dataflow/crates/telemetry/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/lib.rs
@@ -31,7 +31,9 @@ use crate::registry::TelemetryRegistryHandle;
 use log_filter::{RuntimeLogFilter, RuntimeLogFilterHandle};
 use otel_arrow_dfe_config::observed_state::SendPolicy;
 use otel_arrow_dfe_config::pipeline::telemetry::TelemetryConfig;
-use otel_arrow_dfe_config::settings::telemetry::logs::{LogLevel, LoggingProviders, ProviderMode};
+use otel_arrow_dfe_config::settings::telemetry::logs::{
+    LogLevel, LoggingProviders, ProviderMode, StackTraceConfig,
+};
 use self_tracing::LogContextFn;
 use std::sync::Arc;
 use tracing_init::ProviderSetup;
@@ -212,6 +214,9 @@ pub struct InternalTelemetrySystem {
     /// The logging providers.
     provider_modes: LoggingProviders,
 
+    /// Caller-thread stack capture policy for asynchronous providers.
+    stacktraces: StackTraceConfig,
+
     /// Entity key providers for associating log events with their source entity context.
     context_fn: LogContextFn,
 
@@ -294,6 +299,7 @@ impl InternalTelemetrySystem {
             log_filter,
             log_filter_handle,
             provider_modes: config.logs.providers.clone(),
+            stacktraces: config.logs.stacktraces,
             context_fn,
             console_async_reporter,
             its_reporter,
@@ -331,10 +337,12 @@ impl InternalTelemetrySystem {
                     .as_ref()
                     .expect("has provider")
                     .clone(),
+                stacktraces: self.stacktraces,
             },
 
             ProviderMode::ITS => ProviderSetup::InternalAsync {
                 reporter: self.its_reporter.clone(),
+                stacktraces: self.stacktraces,
             },
         };
 

--- a/rust/otap-dataflow/crates/telemetry/src/log_tap.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/log_tap.rs
@@ -7,7 +7,7 @@ use crate::event::LogEvent;
 use otel_arrow_dfe_config::settings::telemetry::logs::InternalLogTapConfig;
 use parking_lot::RwLock;
 use std::collections::VecDeque;
-use std::mem::size_of;
+use std::mem::{size_of, size_of_val};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::broadcast;
@@ -256,6 +256,11 @@ fn estimate_event_size(event: &LogEvent) -> usize {
     size_of::<RetainedLogEvent>()
         + event.record.body_attrs_bytes.len()
         + event.record.context.len() * size_of::<crate::registry::EntityKey>()
+        + event
+            .record
+            .stacktrace
+            .as_ref()
+            .map_or(0, |stacktrace| size_of_val(stacktrace.frames()))
 }
 
 #[cfg(test)]
@@ -275,7 +280,10 @@ mod tests {
         let (tx, rx) = flume::bounded(1);
         let reporter = ObservedEventReporter::new(SendPolicy::default(), tx);
         let setup = TracingSetup::new(
-            ProviderSetup::InternalAsync { reporter },
+            ProviderSetup::InternalAsync {
+                reporter,
+                stacktraces: Default::default(),
+            },
             level("info"),
             LogContext::new,
         );

--- a/rust/otap-dataflow/crates/telemetry/src/log_tap.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/log_tap.rs
@@ -7,7 +7,7 @@ use crate::event::LogEvent;
 use otel_arrow_dfe_config::settings::telemetry::logs::InternalLogTapConfig;
 use parking_lot::RwLock;
 use std::collections::VecDeque;
-use std::mem::{size_of, size_of_val};
+use std::mem::size_of;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::broadcast;
@@ -253,14 +253,19 @@ pub fn build(config: &InternalLogTapConfig) -> InternalLogTapHandle {
 }
 
 fn estimate_event_size(event: &LogEvent) -> usize {
+    let context_bytes = if event.record.context.spilled() {
+        event.record.context.capacity() * size_of::<crate::registry::EntityKey>()
+    } else {
+        0
+    };
     size_of::<RetainedLogEvent>()
         + event.record.body_attrs_bytes.len()
-        + event.record.context.len() * size_of::<crate::registry::EntityKey>()
+        + context_bytes
         + event
             .record
             .stacktrace
             .as_ref()
-            .map_or(0, |stacktrace| size_of_val(stacktrace.frames()))
+            .map_or(0, |stacktrace| stacktrace.retained_bytes())
 }
 
 #[cfg(test)]

--- a/rust/otap-dataflow/crates/telemetry/src/self_tracing.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/self_tracing.rs
@@ -58,6 +58,42 @@ pub struct LogRecord {
 
     /// The context of this log record, typically pipeline and node context keys.
     pub context: LogContext,
+
+    /// Unresolved caller instruction pointers captured on the emitting thread.
+    pub stacktrace: Option<Box<RawStackTrace>>,
+}
+
+/// Unresolved caller stack captured with bounded depth.
+#[derive(Debug, Clone)]
+pub struct RawStackTrace {
+    frames: SmallVec<[usize; 16]>,
+}
+
+impl RawStackTrace {
+    /// Captures current-thread instruction pointers without symbolization.
+    #[must_use]
+    pub fn capture(max_frames: usize) -> Self {
+        // Skip capture plus tracing-subscriber dispatch frames so the first
+        // retained address is the tracing macro expansion at the log callsite.
+        const INTERNAL_FRAMES: usize = 12;
+        let mut frames = SmallVec::new();
+        let mut skipped = 0;
+        backtrace::trace(|frame| {
+            if skipped < INTERNAL_FRAMES {
+                skipped += 1;
+                return true;
+            }
+            frames.push(frame.ip() as usize);
+            frames.len() < max_frames
+        });
+        Self { frames }
+    }
+
+    /// Captured instruction pointers in call order.
+    #[must_use]
+    pub fn frames(&self) -> &[usize] {
+        &self.frames
+    }
 }
 
 /// Borrowed view of a log record for zero-copy formatting.
@@ -179,6 +215,7 @@ impl StackLogRecord {
             body_attrs_bytes: self.buf.to_bytes(),
             callsite_id: self.callsite_id,
             context,
+            stacktrace: None,
         }
     }
 }
@@ -216,7 +253,15 @@ impl LogRecord {
             dropped_attributes_count: dropped_count as u16,
             body_attrs_bytes: buf.into_bytes(),
             context,
+            stacktrace: None,
         }
+    }
+
+    /// Attaches a bounded unresolved caller stack.
+    #[must_use]
+    pub fn with_stacktrace(mut self, max_frames: usize) -> Self {
+        self.stacktrace = Some(Box::new(RawStackTrace::capture(max_frames)));
+        self
     }
 
     /// The callsite.

--- a/rust/otap-dataflow/crates/telemetry/src/self_tracing.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/self_tracing.rs
@@ -17,12 +17,14 @@ use serde::Serialize;
 use serde::ser::Serializer;
 use smallvec::SmallVec;
 use std::fmt;
+use std::mem::size_of;
 use tracing::callsite::Identifier;
 use tracing::{Event, Level, Metadata};
 
 pub use encoder::DirectLogRecordEncoder;
 pub use encoder::ScopeToBytesMap;
 pub use encoder::encode_export_logs_request;
+pub use encoder::encode_export_logs_request_batch;
 pub use formatter::{
     AnsiCode, ColorMode, ConsoleWriter, RawLoggingLayer, StyledBufWriter,
     format_log_record_to_string,
@@ -93,6 +95,17 @@ impl RawStackTrace {
     #[must_use]
     pub fn frames(&self) -> &[usize] {
         &self.frames
+    }
+
+    /// Bytes retained by the boxed trace, including spilled frame storage.
+    #[must_use]
+    pub fn retained_bytes(&self) -> usize {
+        size_of::<Self>()
+            + if self.frames.spilled() {
+                self.frames.capacity() * size_of::<usize>()
+            } else {
+                0
+            }
     }
 }
 

--- a/rust/otap-dataflow/crates/telemetry/src/self_tracing/encoder.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/self_tracing/encoder.rs
@@ -15,7 +15,7 @@ use otel_arrow_dfe_pdata::otlp::common::{BoundedBuf, Dropped, EncodeResult, Prot
 use otel_arrow_dfe_pdata::proto::consts::{
     field_num::common::*, field_num::logs::*, field_num::resource::*, wire_types,
 };
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::time::SystemTime;
 use tracing::Level;
 
@@ -753,11 +753,36 @@ fn encode_any_value(
     Ok(())
 }
 
-/// Encode a LogEvent as a complete ExportLogsServiceRequest.
-///
-/// This version resolves entity keys from the log record's context to populate
-/// the InstrumentationScope.attributes field. The scope cache is used to avoid
-/// re-encoding entity attributes for each log event.
+fn encode_scope_logs(
+    buf: &mut ProtoBuffer,
+    target: &str,
+    context: &[EntityKey],
+    events: &[LogEvent],
+    indices: &[usize],
+    scope_cache: &mut ScopeToBytesMap,
+) -> EncodeResult {
+    buf.encode_len_delimited(RESOURCE_LOGS_SCOPE_LOGS, |buf| {
+        buf.encode_len_delimited(SCOPE_LOG_SCOPE, |buf| {
+            buf.encode_string(INSTRUMENTATION_SCOPE_NAME, target)?;
+            for entity_key in context {
+                let scope_bytes = scope_cache.get_or_encode(*entity_key);
+                buf.extend_from_slice(&scope_bytes)?;
+            }
+            Ok(())
+        })?;
+
+        for &index in indices {
+            buf.encode_len_delimited(SCOPE_LOGS_LOG_RECORDS, |buf| {
+                let mut encoder = DirectLogRecordEncoder::new(buf);
+                let _ = encoder.encode_log_record(events[index].time, &events[index].record);
+                Ok(())
+            })?;
+        }
+        Ok(())
+    })
+}
+
+/// Encode one log event as a complete `ExportLogsServiceRequest`.
 pub fn encode_export_logs_request(
     buf: &mut ProtoBuffer,
     event: &LogEvent,
@@ -765,39 +790,66 @@ pub fn encode_export_logs_request(
     scope_cache: &mut ScopeToBytesMap,
 ) {
     buf.clear();
-
-    // ExportLogsServiceRequest.resource_logs (field 1, repeated ResourceLogs)
     let _: EncodeResult = buf.encode_len_delimited(EXPORT_LOGS_REQUEST_RESOURCE_LOGS, |buf| {
-        // ResourceLogs.resource (field 1, Resource message)
-        // Copy pre-encoded resource bytes directly
         buf.extend_from_slice(resource_bytes)?;
-
-        // ResourceLogs.scope_logs (field 2, repeated ScopeLogs)
-        buf.encode_len_delimited(RESOURCE_LOGS_SCOPE_LOGS, |buf| {
-            // ScopeLogs.scope (field 1, InstrumentationScope message)
-            buf.encode_len_delimited(SCOPE_LOG_SCOPE, |buf| {
-                // InstrumentationScope.name (field 1, string) -- the tracing
-                // target identifying the static logical software unit that
-                // emitted the event. Component-owned events use a
-                // component-aware target; shared code uses its package target.
-                // Pairing scope.name with the bare `event.name` encoded below
-                // keeps `event.name` aligned with the semconv registry.
-                buf.encode_string(INSTRUMENTATION_SCOPE_NAME, event.record.callsite().target())?;
-                for entity_key in event.record.context.iter() {
-                    let scope_bytes = scope_cache.get_or_encode(*entity_key);
-                    buf.extend_from_slice(&scope_bytes)?;
-                }
-                Ok(())
-            })?;
-
-            // ScopeLogs.log_records (field 2, repeated LogRecord)
-            buf.encode_len_delimited(SCOPE_LOGS_LOG_RECORDS, |buf| {
-                let mut encoder = DirectLogRecordEncoder::new(buf);
-                let _ = encoder.encode_log_record(event.time, &event.record);
-                Ok(())
-            })
-        })
+        encode_scope_logs(
+            buf,
+            event.record.callsite().target(),
+            &event.record.context,
+            std::slice::from_ref(event),
+            &[0],
+            scope_cache,
+        )
     });
+}
+
+/// Encode logs in scope-grouped output order as one `ExportLogsServiceRequest`.
+///
+/// Returns the input event index for each encoded log row. Consumers that add
+/// side tables can use this mapping to preserve joins after scope grouping.
+pub fn encode_export_logs_request_batch(
+    buf: &mut ProtoBuffer,
+    events: &[LogEvent],
+    resource_bytes: &Bytes,
+    scope_cache: &mut ScopeToBytesMap,
+) -> Vec<usize> {
+    match events {
+        [] => {
+            buf.clear();
+            Vec::new()
+        }
+        [event] => {
+            encode_export_logs_request(buf, event, resource_bytes, scope_cache);
+            vec![0]
+        }
+        _ => {
+            let mut groups: BTreeMap<(&str, &[EntityKey]), Vec<usize>> = BTreeMap::new();
+            for (index, event) in events.iter().enumerate() {
+                groups
+                    .entry((
+                        event.record.callsite().target(),
+                        event.record.context.as_slice(),
+                    ))
+                    .or_default()
+                    .push(index);
+            }
+
+            let output_order = groups
+                .values()
+                .flat_map(|indices| indices.iter().copied())
+                .collect();
+            buf.clear();
+            let _: EncodeResult =
+                buf.encode_len_delimited(EXPORT_LOGS_REQUEST_RESOURCE_LOGS, |buf| {
+                    buf.extend_from_slice(resource_bytes)?;
+                    for (&(target, context), indices) in &groups {
+                        encode_scope_logs(buf, target, context, events, indices, scope_cache)?;
+                    }
+                    Ok(())
+                });
+            output_order
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1023,6 +1075,35 @@ mod tests {
             ),
         );
         assert_eq!(expected, decoded);
+    }
+
+    /// Scenario: a batch interleaves log events from two entity contexts.
+    /// Guarantees: one ScopeLogs is emitted per context and the returned order maps output rows.
+    #[test]
+    fn encode_export_logs_request_batch_groups_scopes_and_returns_order() {
+        let registry = TelemetryRegistryHandle::new();
+        let key_a = registry.register_entity(TestScopeAttributes::new("pipeline-a", 1));
+        let key_b = registry.register_entity(TestScopeAttributes::new("pipeline-b", 2));
+        let mut scope_cache = ScopeToBytesMap::new(registry);
+        let time = SystemTime::UNIX_EPOCH + Duration::from_secs(1);
+        let event_for = |key| LogEvent {
+            time,
+            record: __log_record_impl!(Level::INFO, "test.batch.encoding")
+                .into_record(LogContext::from_buf([key])),
+        };
+        let events = vec![event_for(key_a), event_for(key_b), event_for(key_a)];
+
+        let mut buf = ProtoBuffer::default();
+        let output_order =
+            encode_export_logs_request_batch(&mut buf, &events, &Bytes::new(), &mut scope_cache);
+        let decoded =
+            ExportLogsServiceRequest::decode(buf.into_bytes()).expect("valid logs request");
+        let scope_logs = &decoded.resource_logs[0].scope_logs;
+
+        assert_eq!(scope_logs.len(), 2);
+        assert_eq!(scope_logs[0].log_records.len(), 2);
+        assert_eq!(scope_logs[1].log_records.len(), 1);
+        assert_eq!(output_order, vec![0, 2, 1]);
     }
 
     // --- Test infrastructure for Map (kvlist) scope attributes ---

--- a/rust/otap-dataflow/crates/telemetry/src/self_tracing/formatter.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/self_tracing/formatter.rs
@@ -826,6 +826,7 @@ mod tests {
             body_attrs_bytes: Bytes::new(),
             dropped_attributes_count: 0,
             context: LogContext::new(),
+            stacktrace: None,
         };
 
         let output = format_log_record_to_string(Some(time), &record);
@@ -883,6 +884,7 @@ mod tests {
             body_attrs_bytes: Bytes::from(encoded),
             dropped_attributes_count: 0,
             context: LogContext::new(),
+            stacktrace: None,
         };
 
         let mut buf = [0u8; LOG_BUFFER_SIZE];

--- a/rust/otap-dataflow/crates/telemetry/src/tracing_init.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/tracing_init.rs
@@ -10,7 +10,7 @@
 use crate::event::{LogEvent, ObservedEventReporter};
 use crate::log_filter::RuntimeLogFilter;
 use crate::self_tracing::{ConsoleWriter, LogContextFn, LogRecord};
-use otel_arrow_dfe_config::settings::telemetry::logs::LogLevel;
+use otel_arrow_dfe_config::settings::telemetry::logs::{LogLevel, StackTraceConfig};
 use std::time::SystemTime;
 use tracing::{Dispatch, Event, Subscriber};
 #[cfg(test)]
@@ -105,6 +105,8 @@ pub enum ProviderSetup {
     InternalAsync {
         /// Reporter to send log events through.
         reporter: ObservedEventReporter,
+        /// Caller-thread stack capture policy.
+        stacktraces: StackTraceConfig,
     },
 }
 
@@ -118,13 +120,25 @@ impl ProviderSetup {
             ProviderSetup::Noop => Dispatch::new(tracing::subscriber::NoSubscriber::new()),
 
             ProviderSetup::ConsoleDirect => {
-                let layer =
-                    StructuredLoggingLayer::new(Some(ConsoleWriter::color()), None, context_fn);
+                let layer = StructuredLoggingLayer::new(
+                    Some(ConsoleWriter::color()),
+                    None,
+                    context_fn,
+                    StackTraceConfig::default(),
+                );
                 Dispatch::new(Registry::default().with(filter.layer()).with(layer))
             }
 
-            ProviderSetup::InternalAsync { reporter } => {
-                let layer = StructuredLoggingLayer::new(None, Some(reporter.clone()), context_fn);
+            ProviderSetup::InternalAsync {
+                reporter,
+                stacktraces,
+            } => {
+                let layer = StructuredLoggingLayer::new(
+                    None,
+                    Some(reporter.clone()),
+                    context_fn,
+                    *stacktraces,
+                );
                 Dispatch::new(Registry::default().with(filter.layer()).with(layer))
             }
         }
@@ -181,6 +195,7 @@ pub struct StructuredLoggingLayer {
     writer: Option<ConsoleWriter>,
     reporter: Option<ObservedEventReporter>,
     context_fn: LogContextFn,
+    stacktraces: StackTraceConfig,
 }
 
 impl StructuredLoggingLayer {
@@ -190,11 +205,13 @@ impl StructuredLoggingLayer {
         writer: Option<ConsoleWriter>,
         reporter: Option<ObservedEventReporter>,
         context_fn: LogContextFn,
+        stacktraces: StackTraceConfig,
     ) -> Self {
         Self {
             writer,
             reporter,
             context_fn,
+            stacktraces,
         }
     }
 }
@@ -206,7 +223,10 @@ where
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
         let time = SystemTime::now();
         let context = (self.context_fn)();
-        let record = LogRecord::new(event, context);
+        let mut record = LogRecord::new(event, context);
+        if self.stacktraces.enabled {
+            record = record.with_stacktrace(self.stacktraces.max_frames);
+        }
         if let Some(writer) = self.writer {
             writer.print_log_record(time, &record.as_view(), |w| {
                 w.format_entity_suffix_without_registry(&record.context);
@@ -242,7 +262,10 @@ mod tests {
     }
 
     fn internal_async_provider(reporter: ObservedEventReporter) -> ProviderSetup {
-        ProviderSetup::InternalAsync { reporter }
+        ProviderSetup::InternalAsync {
+            reporter,
+            stacktraces: StackTraceConfig::default(),
+        }
     }
 
     fn test_setup(p: ProviderSetup, l: LogLevel) -> TracingSetup {
@@ -377,6 +400,36 @@ mod tests {
                 matches!(event, ObservedEvent::Log(_)),
                 "event should be a log"
             );
+        });
+    }
+
+    /// Scenario: asynchronous logging has bounded caller stack capture enabled.
+    /// Guarantees: the queued log carries unresolved instruction pointers for later symbolization.
+    #[test]
+    fn internal_async_provider_captures_stacktrace_when_enabled() {
+        crate::with_cleared_rust_log(|| {
+            let (reporter, receiver) = test_reporter();
+            let setup = test_setup(
+                ProviderSetup::InternalAsync {
+                    reporter,
+                    stacktraces: StackTraceConfig {
+                        enabled: true,
+                        max_frames: 8,
+                    },
+                },
+                level("info"),
+            );
+
+            setup.with_subscriber_ignoring_env(|| {
+                otel_info!("stacktrace.capture");
+            });
+
+            let ObservedEvent::Log(event) = receiver.try_recv().expect("should receive log") else {
+                panic!("expected log event");
+            };
+            let stacktrace = event.record.stacktrace.expect("stacktrace");
+            assert!(!stacktrace.frames().is_empty());
+            assert!(stacktrace.frames().len() <= 8);
         });
     }
 

--- a/rust/otap-dataflow/docs/internal-log-otap-translation.md
+++ b/rust/otap-dataflow/docs/internal-log-otap-translation.md
@@ -1,0 +1,544 @@
+# Callsite-Planned Internal Log Translation to OTAP
+
+Status: experimental design note
+
+Related prototype: [#3882](https://github.com/open-telemetry/otel-arrow/pull/3882)
+
+## Purpose
+
+This note records a possible continuation of the internal-log stacktrace
+prototype. It is not an accepted design. Its purpose is to preserve the
+reasoning, constraints, staged implementation path, and open questions needed
+to resume the work later.
+
+The central idea is to apply a lesson from one-collect and similar event
+systems: separate static event metadata from dynamic event values, identify the
+metadata with a stable event or callsite ID, and compile translation work once
+per callsite instead of repeating it for every event.
+
+## Motivation
+
+Internal logging has two competing requirements:
+
+1. The caller thread must finish quickly and predictably.
+2. The Internal Telemetry Receiver (ITR) should produce canonical OTAP Arrow
+   tables efficiently.
+
+The existing self-tracing path favors the first requirement. On the caller
+thread it:
+
+- encodes log body and attribute fields as a bounded OTLP protobuf fragment;
+- captures a timestamp, callsite ID, and context IDs;
+- optionally captures a bounded sequence of instruction pointers;
+- sends the resulting `LogEvent` through a bounded channel.
+
+This has useful hot-path properties:
+
+- one bounded allocation for dynamic protobuf bytes;
+- sequential writes into a byte buffer;
+- no Arrow construction;
+- no symbolization;
+- no cross-thread synchronization beyond the channel operation.
+
+The stacktrace prototype in #3882 keeps that caller-side representation, but
+its ITR path is deliberately simple rather than optimized. ITR completes a
+protobuf `ExportLogsServiceRequest`, creates a zero-copy `RawLogsData` view over
+that request, invokes the generic OTLP-to-OTAP encoder, and then adds compact
+stacktrace tables.
+
+That path proves the representation and semantic conversion, but repeats work
+that is largely static for every event from the same tracing callsite.
+
+## Current Prototype Path
+
+```text
+caller thread
+  LogRecord {
+    callsite_id,
+    timestamp,
+    context,
+    body_attrs_bytes,
+    instruction_pointers
+  }
+        |
+        v
+bounded ITS channel
+        |
+        v
+ITR
+  complete ExportLogsServiceRequest
+        |
+        v
+RawLogsData protobuf view
+        |
+        v
+generic encode_logs_otap_batch
+        |
+        v
+four canonical OTAP log tables
+        |
+        v
+append compact stacktrace tables
+```
+
+The implementation is principally in:
+
+- `crates/telemetry/src/self_tracing.rs`
+- `crates/telemetry/src/self_tracing/encoder.rs`
+- `crates/core-nodes/src/receivers/internal_telemetry_receiver/mod.rs`
+- `crates/core-nodes/src/receivers/internal_telemetry_receiver/extended_logs.rs`
+- `crates/pdata/src/encode/mod.rs`
+
+The generic OTLP-to-OTAP path does not construct Prost message objects. It
+still has to traverse protobuf tags, lengths, keys, and nested messages before
+building Arrow records.
+
+The prototype also emits one pdata message per log. It therefore constructs
+and finishes Arrow builders and record batches for each individual event.
+
+## Key Observation
+
+A Tokio `tracing` callsite has stable metadata:
+
+- event name;
+- target or instrumentation scope;
+- source file and line;
+- severity;
+- declared field names;
+- declared field order;
+- formatting choices at the macro invocation.
+
+The values and encoded lengths vary from event to event, but the sequence of
+operations needed to interpret and append those values is normally stable.
+
+The current path repeatedly discovers that sequence from protobuf bytes.
+Instead, ITR could cache a validated translation plan keyed by callsite ID.
+
+This follows the same broad model used by one-collect-style event systems:
+
+```text
+static metadata + event identity + compact dynamic payload
+```
+
+The important distinction is that this proposal initially retains the current
+OTLP protobuf fragment as the dynamic payload. A new custom wire format is not
+required to test the optimization.
+
+## Goals
+
+- Preserve the bounded, allocation-minimal, synchronization-free caller path.
+- Keep Arrow construction and symbolization off the caller thread.
+- Produce the same canonical OTAP log tables as the generic converter.
+- Avoid constructing a complete OTLP export request inside ITR.
+- Avoid rediscovering static field layout for every event.
+- Amortize Arrow allocation and record-batch construction across multiple logs.
+- Bound all caches, builders, queues, and flush latency.
+- Detect layout mismatches rather than silently interpreting bytes using an
+  incorrect cached plan.
+- Retain an explicit general path for cache misses and new event shapes.
+
+## Non-Goals
+
+- Defining a process-independent internal-log wire protocol in the first
+  optimization phase.
+- Moving Arrow builders or symbolization onto the caller thread.
+- Removing backpressure or bounded-drop behavior from ITS.
+- Making process-local callsite IDs stable across restarts.
+- Replacing the canonical OTAP log schemas.
+- Standardizing the compact stacktrace extension as part of this note.
+
+## Proposed Steady-State Path
+
+```text
+caller thread                         ITR thread
+-------------                         ----------
+callsite ID                  -------> callsite plan cache
+timestamp                    -------> reusable OTAP builders
+OTLP field fragment          -------> planned value decoder
+context IDs                  -------> resource and scope caches
+instruction pointers         -------> symbol cache
+```
+
+ITR would consume `LogEvent` directly instead of first serializing its fields
+into a complete OTLP request:
+
+```text
+LogEvent
+  |
+  +-- static callsite metadata
+  +-- timestamp
+  +-- resource and scope context IDs
+  +-- body and attribute protobuf fragment
+  +-- stack addresses
+  |
+  v
+CallsitePlan::append(event, OtapLogsBatchBuilder)
+```
+
+Only the body and attribute fragment requires protobuf interpretation.
+Timestamp, severity, event name, scope name, source location, and context are
+already available without encoding and decoding them again.
+
+## Receiver-Local Translation Plans
+
+ITR should own a bounded cache conceptually shaped like:
+
+```rust
+CallsiteId -> LogToOtapPlan
+```
+
+A plan could contain:
+
+```rust
+struct LogToOtapPlan {
+    event_name: InternedString,
+    scope_name: InternedString,
+    severity: SeverityNumber,
+    source: SourceLocation,
+    fields: Box<[FieldPlan]>,
+    shape_fingerprint: ShapeFingerprint,
+}
+```
+
+Each `FieldPlan` would describe a validated sequence such as:
+
+```text
+expect LogRecord body tag
+decode string AnyValue
+append to the OTAP body column
+
+expect attribute key "pipeline_id"
+decode string AnyValue
+append log ID, cached key identity, and value
+```
+
+The plan is not a cache of absolute byte offsets. Protobuf varint lengths cause
+following offsets to move. It is a compiled sequence of parser and Arrow
+append operations.
+
+### Cache Miss
+
+The first event for a callsite would:
+
+1. Use the general fragment decoder.
+2. Validate the complete fragment.
+3. Discover its ordered field layout and wire types.
+4. Compile a translation plan.
+5. Store the plan in the receiver-local bounded cache.
+6. Append the event to the active OTAP batch.
+
+### Cache Hit
+
+Subsequent events would:
+
+1. Look up the plan using the callsite ID.
+2. Validate expected tags, wire types, field order, and complete consumption.
+3. Decode only dynamic lengths and values.
+4. Append directly to known Arrow builders.
+
+The cache remains receiver-local. The caller performs no cache lookup and
+acquires no new lock.
+
+### Shape Variants
+
+A callsite usually has one stable shape, but this must be verified rather than
+assumed. Dynamic `tracing::field::Value` implementations, optional fields, or
+future encoder changes could alter the wire representation.
+
+A plan must validate:
+
+- protobuf field tags;
+- protobuf wire types;
+- declared field order;
+- required and optional fields;
+- nested message boundaries;
+- complete input consumption.
+
+If validation fails, ITR must surface the mismatch and use a defined recovery
+policy. Possible policies include compiling a second plan keyed by
+`(callsite_id, shape_fingerprint)` or rejecting the event. It must not silently
+decode the event using the wrong plan.
+
+## Reusable Batched OTAP Builders
+
+Callsite planning reduces parsing work, but batching may provide the larger
+immediate improvement.
+
+The prototype finishes four canonical and four stack-related Arrow tables for
+each log. A future ITR should maintain reusable builders:
+
+```rust
+struct InternalLogsBatchBuilder {
+    resource_attrs: ResourceAttrsBuilder,
+    scope_attrs: ScopeAttrsBuilder,
+    logs: LogsBuilder,
+    log_attrs: LogAttrsBuilder,
+    log_stacks: LogStacksBuilder,
+    stack_frames: StackFramesBuilder,
+    locations: LocationsBuilder,
+    symbols: SymbolsBuilder,
+}
+```
+
+ITR would drain multiple queued events into one batch and flush on explicit,
+bounded conditions:
+
+- maximum number of logs;
+- maximum estimated retained bytes;
+- maximum elapsed latency;
+- downstream or memory pressure;
+- shutdown.
+
+The exact bounds require measurement. Example values such as 256 logs,
+256 KiB, or 10 ms are hypotheses, not recommendations.
+
+Batching enables:
+
+- amortized Arrow allocation and schema handling;
+- real batch-local log and stack IDs;
+- resource and scope deduplication;
+- symbol and location deduplication;
+- fewer pdata channel messages;
+- more useful Arrow buffer sizes.
+
+Builder reuse must not retain unbounded high-water-mark allocations after an
+unusually large batch.
+
+## Shared Canonical OTAP Builder API
+
+The direct path should not create a second, subtly different implementation of
+OTLP log semantics.
+
+The preferred refactoring is to expose a reusable canonical OTAP log builder or
+appender below `encode_logs_otap_batch`. Both the generic `LogsDataView`
+converter and the optimized internal-log path should append through that
+shared implementation.
+
+Conceptually:
+
+```text
+RawLogsData -----------+
+                       |
+                       v
+              CanonicalLogsAppender -> canonical OTAP tables
+                       ^
+                       |
+Callsite-planned view -+
+```
+
+This preserves one implementation for:
+
+- OTLP attribute and `AnyValue` semantics;
+- IDs and parent relationships;
+- dropped-attribute counts;
+- schema URLs;
+- canonical table schemas;
+- null and absent field handling.
+
+## Static-Key Optimization Stages
+
+The caller currently writes attribute key strings into every protobuf fragment.
+The optimization should proceed in stages.
+
+### Stage 1: Receiver-Only Plan
+
+Make no caller changes. A plan can compare expected key bytes directly and
+avoid allocating, hashing, or rediscovering their Arrow destination.
+
+The fragment remains valid protobuf and existing fallback tooling continues to
+work.
+
+### Stage 2: Pre-Encoded Protobuf Template
+
+If caller-side key encoding is measurable, cache static protobuf fragments for:
+
+- field tags;
+- attribute keys;
+- nested message tags;
+- static formatting choices.
+
+The caller would copy static fragments and insert dynamic values. This must not
+introduce shared mutable state or synchronization on the caller path.
+
+### Stage 3: Callsite-Native Dynamic Payload
+
+Only if measurement justifies it, consider a process-local representation such
+as:
+
+```text
+otap.internal.logs.callsite.v1
+```
+
+It could carry:
+
+```text
+callsite ID
+timestamp
+presence bitmap
+ordered dynamic values
+context IDs
+stack addresses
+```
+
+ITR would obtain field names and types from separately cached callsite
+metadata. This most closely resembles a one-collect metadata-plus-payload
+model, but it introduces ordering, cache-miss, versioning, and diagnostics
+requirements. It should not be the first optimization.
+
+## Resource and Scope Caching
+
+ITR already receives process resource bytes and entity context IDs separately
+from the dynamic log fields. A direct builder should map these identities to
+batch-local resource and scope IDs without serializing them into OTLP.
+
+The design must define:
+
+- cache keys and ownership;
+- behavior when entity metadata changes;
+- batch-local versus cross-batch dictionaries;
+- retained-memory bounds;
+- invalidation on configuration or registry changes.
+
+## Stacktrace Integration
+
+The stacktrace path is naturally compatible with batching and callsite plans:
+
+- instruction pointers remain caller-captured dynamic values;
+- frame zero remains the log callsite;
+- ITR owns bounded symbol and location caches;
+- repeated locations can be deduplicated within a batch;
+- repeated stacks may share a stack ID;
+- symbolization remains outside the caller thread.
+
+Module mappings and build IDs remain separate design work. They are not
+required to evaluate callsite-planned log translation.
+
+## Backpressure and Failure Behavior
+
+Optimization must not weaken the existing ITS safety model.
+
+- The caller still uses a bounded channel and configured send policy.
+- ITR must not grow a queue or batch indefinitely while downstream is blocked.
+- Cache and builder limits must be explicit and observable.
+- Shape mismatches and conversion failures must be reported.
+- Unsupported pluggable representations must continue to fail closed.
+- Shutdown must flush or explicitly account for remaining events within the
+  configured deadline.
+
+Plan compilation and first-touch symbolization can create latency spikes on the
+ITR thread. Measurements should distinguish cache-miss and steady-state costs.
+
+## Measurement Plan
+
+Optimization should be driven by an end-to-end benchmark rather than parser
+microbenchmarks alone.
+
+Measure at least:
+
+- caller-thread nanoseconds per enabled event;
+- caller-thread allocations and allocated bytes;
+- maximum caller latency under channel pressure;
+- ITR events per second;
+- ITR CPU time per event;
+- ITR allocations and retained bytes per event;
+- callsite-plan cache hit rate;
+- first-event plan compilation latency;
+- Arrow rows and bytes per emitted batch;
+- flush latency distribution;
+- symbol cache hit rate and first-resolution latency;
+- dropped events and conversion failures.
+
+Compare these paths:
+
+1. Current complete-OTLP-request prototype.
+2. Direct general fragment-to-OTAP append.
+3. Direct append with batching.
+4. Batched append with callsite translation plans.
+5. Optional static caller templates, only if earlier results justify them.
+
+Use workloads with:
+
+- one hot callsite;
+- many callsites;
+- mixed attribute types;
+- optional fields;
+- small and large dynamic strings;
+- stack capture disabled and enabled;
+- cold and warm caches;
+- downstream backpressure.
+
+## Suggested Implementation Sequence
+
+1. Extract a reusable canonical OTAP log appender from
+   `encode_logs_otap_batch`.
+2. Add a direct `LogEvent` adapter that uses the general decoder only for the
+   existing body and attribute fragment.
+3. Remove complete `ExportLogsServiceRequest` construction from the extended
+   ITR path.
+4. Add bounded multi-log batching and flush policies.
+5. Establish correctness and performance baselines.
+6. Add a bounded receiver-local callsite translation-plan cache.
+7. Add shape validation, mismatch tests, and cache observability.
+8. Measure caller-side static-key encoding.
+9. Consider static protobuf templates or a callsite-native payload only if
+   measured costs justify the added protocol complexity.
+
+Each stage should preserve a correctness oracle against the generic
+OTLP-to-OTAP converter.
+
+## Correctness Testing
+
+For the same generated `LogEvent`, compare the canonical four OTAP tables from:
+
+- the current complete-OTLP-request conversion;
+- the direct general fragment path;
+- the planned fast path.
+
+Tests should cover:
+
+- every supported OTLP `AnyValue` type;
+- absent and optional fields;
+- dropped-attribute counts;
+- resource and scope attributes;
+- repeated callsites and multiple shape variants;
+- malformed or truncated fragments;
+- cache eviction;
+- batch flush limits;
+- shared stack IDs;
+- shutdown with a partially filled batch.
+
+Property-based or generated differential tests would provide more confidence
+than hand-selected examples alone.
+
+## Open Questions
+
+1. Does `tracing` guarantee enough callsite field stability for one plan, or
+   must shape fingerprints always participate in the cache key?
+2. What canonical builder API can be shared without exposing Arrow
+   implementation details throughout the telemetry crate?
+3. Should plans append values directly, or produce a lightweight internal view
+   consumed by a shared appender?
+4. Which batching limits provide useful Arrow batches without adding
+   unacceptable internal-log latency?
+5. Should resource and scope dictionaries survive across batches?
+6. How should a plan mismatch affect the event: recompile, maintain variants,
+   reject, or use the general path with an explicit diagnostic?
+7. Can callsite registration safely install immutable caller-side protobuf
+   templates without adding synchronization?
+8. Is repeated caller-side key encoding measurable after receiver-side
+   batching and planning?
+9. What metrics are required to make cache behavior and fallback use visible?
+10. Should the optimized internal fragment eventually become a named
+    pluggable byte representation?
+
+## Pickup Checklist
+
+Before resuming implementation:
+
+1. Rebase or reproduce the #3882 prototype against current `main`.
+2. Confirm the current `LogRecord`, ITR, and canonical OTAP builder APIs.
+3. Capture baseline caller and ITR profiles.
+4. Verify the one-log-per-pdata and complete-OTLP-request costs independently.
+5. Start with the shared canonical builder and batching work.
+6. Retain the generic converter as a differential correctness oracle.
+7. Treat callsite planning as a measured optimization, not an assumed win.

--- a/rust/otap-dataflow/docs/internal-log-otap-translation.md
+++ b/rust/otap-dataflow/docs/internal-log-otap-translation.md
@@ -93,8 +93,11 @@ The generic OTLP-to-OTAP path does not construct Prost message objects. It
 still has to traverse protobuf tags, lengths, keys, and nested messages before
 building Arrow records.
 
-The prototype also emits one pdata message per log. It therefore constructs
-and finishes Arrow builders and record batches for each individual event.
+The prototype initially emitted one pdata message per log. It now incorporates
+the receiver-side batching design contributed in #3374: ITR groups logs by
+scope and flushes on bounded size, latency, and lifecycle conditions. For
+extended logs, one OTLP-to-OTAP conversion now produces a multi-log Arrow batch
+and the stack side tables preserve joins across scope-based row reordering.
 
 ## Key Observation
 
@@ -475,7 +478,7 @@ Use workloads with:
    existing body and attribute fragment.
 3. Remove complete `ExportLogsServiceRequest` construction from the extended
    ITR path.
-4. Add bounded multi-log batching and flush policies.
+4. Refine the existing bounded multi-log batching and flush policies.
 5. Establish correctness and performance baselines.
 6. Add a bounded receiver-local callsite translation-plan cache.
 7. Add shape validation, mismatch tests, and cache observability.
@@ -538,7 +541,7 @@ Before resuming implementation:
 1. Rebase or reproduce the #3882 prototype against current `main`.
 2. Confirm the current `LogRecord`, ITR, and canonical OTAP builder APIs.
 3. Capture baseline caller and ITR profiles.
-4. Verify the one-log-per-pdata and complete-OTLP-request costs independently.
+4. Verify batching and complete-OTLP-request costs independently.
 5. Start with the shared canonical builder and batching work.
 6. Retain the generic converter as a differential correctness oracle.
 7. Treat callsite planning as a measured optimization, not an assumed win.

--- a/rust/otap-dataflow/docs/self_tracing_architecture.md
+++ b/rust/otap-dataflow/docs/self_tracing_architecture.md
@@ -65,6 +65,12 @@ to consume internal telemetry. To obtain the partial bytes encoding
 needed, we have a custom [Tokio `tracing` Event][TOKIOEVENT] handler
 based on `otel_arrow_dfe_pdata::otlp::common::ProtoBuffer`.
 
+The experimental
+[callsite-planned OTAP translation design note](internal-log-otap-translation.md)
+records a possible path for retaining this low-cost caller representation while
+avoiding repeated protobuf-to-Arrow discovery and per-log Arrow batch
+construction in ITR.
+
 [TOKIOEVENT]: https://docs.rs/tracing/latest/tracing/struct.Event.html
 
 ## Raw logging


### PR DESCRIPTION
## Prototype status

This draft is an end-to-end proof of concept for carrying symbolized
internal-log stacktraces in a pluggable Arrow pdata representation. It uses a
small compact stack model rather than the complete NetTraceV6 table set from
RFCs 0005 and 0006.

See #3875.

## What this demonstrates

- Adds named and versioned pluggable Arrow-record and byte pdata carriers.
- Captures a bounded list of instruction pointers on the log caller thread.
- Passes unresolved stacks through the Internal Telemetry System.
- Batches internal logs in ITR with configurable retained-size and latency
  thresholds, a non-configurable 2 MiB maximum, and lifecycle flushes.
- Groups records sharing a target and entity context into one OTLP
  `ScopeLogs`.
- Symbolizes addresses in `internal_telemetry_receiver` using a bounded
  receiver-local cache.
- Emits `otap.logs.extended` version 1: the four canonical OTAP log tables plus
  log-to-stack, ordered-frame, location, and symbol tables.
- Preserves stack-to-log joins when scope grouping reorders rows and shares
  duplicate stacks and locations within a batch.
- Renders extended stacks in the console exporter and deferred
  `console_async` output.
- Rejects unsupported pluggable representations explicitly rather than
  silently converting or dropping their format-specific data.

Frame 0 is the source callsite of the log event; SDK capture, subscriber, and
tracing dispatcher frames are stripped.

## Demonstrated output

Using:

```powershell
cd rust\otap-dataflow
.\target\debug\df_engine.exe `
  --config configs\internal-telemetry-logs.yaml `
  --num-cores 1
```

ITR emitted multiple logs in one extended Arrow batch. The console exporter
decoded both stack relations, including:

```text
STACKTRACE log_id=1
  at otel_arrow_dfe_controller::...::run_with_mode::closure
     (crates\controller\src\lib.rs:1687)
  at otel_arrow_dfe_controller::Controller::run_with_mode
     (crates\controller\src\lib.rs:128)
  at otel_arrow_dfe_controller::Controller::run_forever_with_options
     (crates\controller\src\lib.rs:553)
  at df_engine::main
     (src\main.rs:308)
```

`crates/controller/src/lib.rs:1687` is the actual
`otel_info!("pipeline.core_allocation", ...)` invocation.

## Configuration

```yaml
engine:
  telemetry:
    logs:
      stacktraces:
        enabled: true
        max_frames: 32
```

```yaml
nodes:
  telemetry:
    type: receiver:internal_telemetry
    config:
      signals: [logs]
      logs:
        representation: arrow_extended
        min_size: 65536
        max_size: 2097152
        max_batch_duration: 200ms
```

`min_size` is the normal flush threshold. `max_size` prevents adding an event
to a partial batch when their estimated retained size would exceed the
configured limit; one individually bounded event is still sent whole.

## Design notes

The caller still performs one allocation-free bounded OTLP field-fragment
encoding and no Arrow construction or symbolization. ITR completes a
multi-record OTLP request, then the extended path uses the generic OTLP-to-OTAP
converter before appending compact stack tables.

The follow-up design in
[`docs/internal-log-otap-translation.md`](rust/otap-dataflow/docs/internal-log-otap-translation.md)
describes how callsite translation plans and reusable OTAP builders could
remove repeated structural work without adding synchronization to the caller
thread.

## Contributor credit

The receiver-side batching design and its test strategy were contributed by
@AvinashDevX in #3374. This branch ports that work onto the current ITR
metrics, shutdown, and pluggable-representation architecture, adds bounded
retained-size accounting, and extends batching to `arrow_extended`. The
integration commit retains Avinash Sharma as a co-author.

## Deliberate prototype constraints

- The carrier remains single-signal rather than implementing the complete
  mixed-signal/content-manifest envelope proposed by RFC 0006.
- The stack extension has four compact tables and does not yet include module
  mappings or build IDs.
- `log_id` in the stack extension is the zero-based row position in the
  canonical OTAP Logs table, not the nullable OTAP `Logs.id` attribute-parent
  key.
- Symbolization uses the `backtrace` crate. One-collect's currently exposed
  stack APIs consume ETW/perf-collected stacks and do not capture the current
  Rust caller stack.
- OTLP exporters and durable buffering NACK plugin representations because no
  durable/wire encoding has been defined for them.

## Validation

- `cargo xtask quick-check`
- `cargo xtask check`
- Focused batching, timer, shutdown-deadline, scope grouping, stack join,
  stack deduplication, configuration, and log-tap tests
- Markdown lint, diff whitespace, and Rust ASCII checks
- Live `df_engine` demonstration with multiple logs in one extended batch

Related to #3452.
