### PR TITLE
refactor(metrics): Migrate topic_receiver telemetry to enum attributes

### DIFF
--- a/rust/otap-dataflow/.chloggen/topic-receiver-metrics.yaml
+++ b/rust/otap-dataflow/.chloggen/topic-receiver-metrics.yaml
@@ -1,0 +1,8 @@
+change_type: breaking
+component: pipeline
+note: >-
+  Migrated topic receiver telemetry from flat counters to dimensioned metric populations with enum attributes.
+issues: [3530]
+subtext: |
+  Migration: Update dashboards and queries to use dimensioned metrics:
+  - Topic receiver: forward metrics -> `forward{outcome}`, lag metrics -> `lag{event_type}`, bridge metrics -> `bridge{control, result}`.

--- a/rust/otap-dataflow/.chloggen/topic-receiver-metrics.yaml
+++ b/rust/otap-dataflow/.chloggen/topic-receiver-metrics.yaml
@@ -5,4 +5,5 @@ note: >-
 issues: [3530]
 subtext: |
   Migration: Update dashboards and queries to use dimensioned metrics:
-  - Topic receiver: forward metrics -> `forward{outcome}`, lag metrics -> `lag{event_type}`, bridge metrics -> `bridge{control, result}`.
+  - Topic receiver: forward metrics -> `forward.messages{outcome}`, lag metrics -> `lag.events{event.type}`, bridge metrics -> `bridge.controls{control, result}`.
+  - Also changed the unit of lagged_messages and forward metrics from `{item}` to `{message}`.

--- a/rust/otap-dataflow/.chloggen/topic-receiver-metrics.yaml
+++ b/rust/otap-dataflow/.chloggen/topic-receiver-metrics.yaml
@@ -4,6 +4,4 @@ note: >-
   Migrated topic receiver telemetry from flat counters to dimensioned metric populations with enum attributes.
 issues: [3530]
 subtext: |
-  Migration: Update dashboards and queries to use dimensioned metrics:
-  - Topic receiver: forward metrics -> `forward.messages{outcome}`, lag metrics -> `lag.events{event.type}`, bridge metrics -> `bridge.controls{control, result}`.
-  - Also changed the unit of lagged_messages and forward metrics from `{item}` to `{message}`.
+  Migration: Update queries for dimensioned metrics: forward -> `forward.messages{outcome}`, lag -> `lag.events{event.type}`, bridge -> `bridge.controls{control, result}`. Units for forward metrics and lagged_messages changed from `{item}` to `{message}`.

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/README.md
@@ -75,21 +75,14 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 #### `receiver.topic`
 
-| Metric | Unit | Description |
-| --- | --- | --- |
-| `receiver.topic.forwarded_messages` | `{item}` | Number of messages forwarded to downstream. |
-| `receiver.topic.forward_failures` | `{item}` | Number of forward failures to downstream channel. |
-| `receiver.topic.lagged_notifications` | `{event}` | Number of lag notifications emitted by broadcast subscriptions. |
-| `receiver.topic.lagged_messages` | `{item}` | Total messages missed across lag notifications. |
-| `receiver.topic.lag_disconnects` | `{event}` | Number of broadcast subscriptions disconnected because of lag. |
-| `receiver.topic.downstream_backpressure_events` | `{event}` | Number of downstream backpressure events (>= 500ms blocked). |
-| `receiver.topic.downstream_blocked_ms` | `ms` | Total milliseconds blocked while forwarding to downstream. |
-| `receiver.topic.bridged_downstream_acks` | `{item}` | Number of downstream ACK controls successfully bridged to topic ack. |
-| `receiver.topic.bridged_downstream_nacks` | `{item}` | Number of downstream NACK controls successfully bridged to topic nack. |
-| `receiver.topic.bridge_controls_ignored_propagation_disabled` | `{event}` | Number of downstream ACK/NACK controls ignored because topic Ack/Nack propagation is disabled for this receiver. |
-| `receiver.topic.bridge_missing_calldata` | `{event}` | Number of downstream ACK/NACK controls missing the bridged topic message id in calldata. |
-| `receiver.topic.bridge_invalid_or_untracked_id` | `{event}` | Number of downstream ACK/NACK controls carrying an id that is not currently tracked by the topic runtime. With the current raw `message_id` bridge this also includes invalid or forged ids; those causes are not distinguishable yet. |
-| `receiver.topic.bridge_runtime_failures` | `{event}` | Number of downstream ACK/NACK controls that failed to bridge for some runtime reason other than an unknown message id. |
+| Metric | Unit | Attributes | Description |
+| --- | --- | --- | --- |
+| `receiver.topic.forward` | `{message}` | `outcome` | Number of messages forwarded dimensionalized by `outcome` (`Success`, `Failed`). |
+| `receiver.topic.lag` | `{event}` | `event_type` | Number of lag events emitted by broadcast subscriptions, dimensionalized by `event_type` (`Notification`, `Disconnect`). |
+| `receiver.topic.bridge` | `{control}` | `outcome` | Number of downstream ACK/NACK bridge controls, dimensionalized by `outcome` (`Ack`, `Nack`, `IgnoredPropagationDisabled`, `MissingCalldata`, `InvalidOrUntrackedId`, `RuntimeFailure`). |
+| `receiver.topic.other.lagged_messages` | `{message}` | | Total messages missed across lag notifications. |
+| `receiver.topic.other.downstream_backpressure_events` | `{event}` | | Number of downstream backpressure events (>= 500ms blocked). |
+| `receiver.topic.other.downstream_blocked_ms` | `ms` | | Total milliseconds blocked while forwarding to downstream. |
 
 ### Events
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/README.md
@@ -77,12 +77,12 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 | Metric | Unit | Attributes | Description |
 | --- | --- | --- | --- |
-| `receiver.topic.forward` | `{message}` | `outcome` | Number of messages forwarded dimensionalized by `outcome` (`Success`, `Failed`). |
-| `receiver.topic.lag` | `{event}` | `event_type` | Number of lag events emitted by broadcast subscriptions, dimensionalized by `event_type` (`Notification`, `Disconnect`). |
-| `receiver.topic.bridge` | `{control}` | `outcome` | Number of downstream ACK/NACK bridge controls, dimensionalized by `outcome` (`Ack`, `Nack`, `IgnoredPropagationDisabled`, `MissingCalldata`, `InvalidOrUntrackedId`, `RuntimeFailure`). |
-| `receiver.topic.other.lagged_messages` | `{message}` | | Total messages missed across lag notifications. |
-| `receiver.topic.other.downstream_backpressure_events` | `{event}` | | Number of downstream backpressure events (>= 500ms blocked). |
-| `receiver.topic.other.downstream_blocked_ms` | `ms` | | Total milliseconds blocked while forwarding to downstream. |
+| `receiver.topic.forward.messages` | `{message}` | `outcome` | Number of messages forwarded dimensionalized by `outcome` (`success`, `failure`). |
+| `receiver.topic.lag.events` | `{event}` | `event.type` | Number of lag events emitted by broadcast subscriptions, dimensionalized by `event.type` (`notification`, `disconnect`). |
+| `receiver.topic.bridge.controls` | `{control}` | `control`, `result` | Number of downstream ACK/NACK bridge controls, dimensionalized by `control` (`ack`, `nack`) and `result` (`success`, `ignored_propagation_disabled`, `missing_calldata`, `invalid_or_untracked_id`, `runtime_failure`). |
+| `receiver.topic.lagged_messages` | `{message}` | | Total messages missed across lag notifications. |
+| `receiver.topic.downstream_backpressure_events` | `{event}` | | Number of downstream backpressure events (>= 500ms blocked). |
+| `receiver.topic.downstream_blocked_ms` | `ms` | | Total milliseconds blocked while forwarding to downstream. |
 
 ### Events
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/metrics.rs
@@ -1,0 +1,333 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Metrics for the topic receiver node.
+
+use otel_arrow_dfe_engine::context::PipelineContext;
+use otel_arrow_dfe_telemetry::instrument::Counter;
+use otel_arrow_dfe_telemetry::metrics::{MeasurementMetricSet, MetricSet, MetricSetSnapshot};
+use otel_arrow_dfe_telemetry_macros::{AttributeEnum, attribute_set, metric_set};
+
+use otel_arrow_dfe_telemetry::common_attributes::OutcomeAttributes;
+
+/// Forward metrics for the topic receiver.
+#[metric_set(
+    name = "receiver.topic.forward",
+    measurement_attributes = OutcomeAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub struct TopicForwardMetrics {
+    /// Number of messages forwarded.
+    #[metric(unit = "{message}")]
+    pub messages: Counter<u64>,
+}
+
+/// Lag events for topic receiver broadcast subscriptions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, AttributeEnum)]
+pub enum LagEventType {
+    /// Lag notification emitted.
+    Notification,
+    /// Subscription disconnected because of lag.
+    Disconnect,
+}
+
+/// Attributes for lag events.
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+pub struct LagEventAttributes {
+    /// Type of the lag event.
+    pub event_type: LagEventType,
+}
+
+/// Lag event metrics for the topic receiver.
+#[metric_set(
+    name = "receiver.topic.lag",
+    measurement_attributes = LagEventAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub struct TopicLagEventMetrics {
+    /// Number of lag events.
+    #[metric(unit = "{event}")]
+    pub events: Counter<u64>,
+}
+
+/// Downstream control type bridged to topic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, AttributeEnum)]
+pub enum BridgeControl {
+    /// Downstream ACK.
+    Ack,
+    /// Downstream NACK.
+    Nack,
+}
+
+/// Bridge result for topic Ack/Nack controls.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, AttributeEnum)]
+pub enum BridgeResult {
+    /// Control successfully bridged.
+    Success,
+    /// Control ignored because Ack/Nack propagation is disabled.
+    IgnoredPropagationDisabled,
+    /// Control missing the bridged topic message id in calldata.
+    MissingCalldata,
+    /// Control carrying an id not tracked by the topic runtime.
+    InvalidOrUntrackedId,
+    /// Failed to bridge for some runtime reason other than an unknown id.
+    RuntimeFailure,
+}
+
+/// Attributes for bridge controls.
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+pub struct BridgeAttributes {
+    /// The type of downstream control.
+    pub control: BridgeControl,
+    /// Result of the bridge control.
+    pub result: BridgeResult,
+}
+
+/// Bridge control metrics for the topic receiver.
+#[metric_set(
+    name = "receiver.topic.bridge",
+    measurement_attributes = BridgeAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub struct TopicBridgeMetrics {
+    /// Number of bridge controls.
+    #[metric(unit = "{control}")]
+    pub controls: Counter<u64>,
+}
+
+/// Other un-dimensioned metrics for the topic receiver.
+#[metric_set(name = "receiver.topic.other")]
+#[derive(Debug, Default, Clone)]
+pub struct TopicOtherMetrics {
+    /// Total messages missed across lag notifications.
+    #[metric(unit = "{message}")]
+    pub lagged_messages: Counter<u64>,
+    /// Number of downstream backpressure events (>= 500ms blocked).
+    #[metric(unit = "{event}")]
+    pub downstream_backpressure_events: Counter<u64>,
+    /// Total milliseconds blocked while forwarding to downstream.
+    #[metric(unit = "ms")]
+    pub downstream_blocked_ms: Counter<u64>,
+}
+
+/// Topic receiver metrics collection.
+pub struct TopicReceiverMetrics {
+    /// Forward metrics.
+    pub forward: MeasurementMetricSet<TopicForwardMetrics>,
+    /// Lag event metrics.
+    pub lag_events: MeasurementMetricSet<TopicLagEventMetrics>,
+    /// Bridge control metrics.
+    pub bridge: MeasurementMetricSet<TopicBridgeMetrics>,
+    /// Other un-dimensioned metrics.
+    pub other: MetricSet<TopicOtherMetrics>,
+}
+
+impl TopicReceiverMetrics {
+    /// Registers topic receiver metric sets for a pipeline node.
+    #[must_use]
+    pub fn register(pipeline_ctx: &PipelineContext, topic_name: String) -> Self {
+        Self {
+            forward: pipeline_ctx.register_measurement_metrics_with_topic::<TopicForwardMetrics>(
+                topic_name.clone().into(),
+            ),
+            lag_events: pipeline_ctx
+                .register_measurement_metrics_with_topic::<TopicLagEventMetrics>(
+                    topic_name.clone().into(),
+                ),
+            bridge: pipeline_ctx.register_measurement_metrics_with_topic::<TopicBridgeMetrics>(
+                topic_name.clone().into(),
+            ),
+            other: pipeline_ctx.register_metrics_with_topic::<TopicOtherMetrics>(topic_name.into()),
+        }
+    }
+
+    /// Takes every touched metric bucket for terminal handoff.
+    pub fn terminal_snapshots(&mut self) -> Vec<MetricSetSnapshot> {
+        let mut snapshots = self.forward.terminal_snapshots();
+        snapshots.extend(self.lag_events.terminal_snapshots());
+        snapshots.extend(self.bridge.terminal_snapshots());
+        snapshots.extend(self.other.terminal_snapshots());
+        snapshots
+    }
+
+    /// Reports touched metric buckets.
+    pub fn report(
+        &mut self,
+        reporter: &mut otel_arrow_dfe_telemetry::reporter::MetricsReporter,
+    ) -> Result<(), otel_arrow_dfe_telemetry::error::Error> {
+        reporter.report_measurement(&mut self.forward)?;
+        reporter.report_measurement(&mut self.lag_events)?;
+        reporter.report_measurement(&mut self.bridge)?;
+        reporter.report(&mut self.other)?;
+        Ok(())
+    }
+
+    /// Records a bridge operation metric.
+    #[inline]
+    pub fn record_bridge(&mut self, control: BridgeControl, result: BridgeResult) {
+        self.bridge
+            .with(BridgeAttributes { control, result })
+            .controls
+            .add(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use otel_arrow_dfe_engine::context::ControllerContext;
+    use otel_arrow_dfe_telemetry::common_attributes::Outcome;
+    use otel_arrow_dfe_telemetry::registry::TelemetryRegistryHandle;
+
+    fn new_test_metrics() -> TopicReceiverMetrics {
+        let handle = TelemetryRegistryHandle::new();
+        let controller = ControllerContext::new(handle);
+        let pipeline_ctx =
+            controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        TopicReceiverMetrics::register(&pipeline_ctx, "test-topic".into())
+    }
+
+    #[test]
+    fn receiver_metrics_are_partitioned_by_context() {
+        let mut metrics = new_test_metrics();
+
+        metrics
+            .forward
+            .with(OutcomeAttributes {
+                outcome: Outcome::Success,
+            })
+            .messages
+            .add(1);
+        metrics
+            .forward
+            .with(OutcomeAttributes {
+                outcome: Outcome::Failure,
+            })
+            .messages
+            .add(2);
+
+        metrics
+            .bridge
+            .with(BridgeAttributes {
+                control: BridgeControl::Ack,
+                result: BridgeResult::Success,
+            })
+            .controls
+            .add(3);
+        metrics
+            .bridge
+            .with(BridgeAttributes {
+                control: BridgeControl::Nack,
+                result: BridgeResult::InvalidOrUntrackedId,
+            })
+            .controls
+            .add(4);
+
+        assert_eq!(
+            metrics
+                .forward
+                .get(OutcomeAttributes {
+                    outcome: Outcome::Success
+                })
+                .messages
+                .get(),
+            1
+        );
+        assert_eq!(
+            metrics
+                .forward
+                .get(OutcomeAttributes {
+                    outcome: Outcome::Failure
+                })
+                .messages
+                .get(),
+            2
+        );
+
+        assert_eq!(
+            metrics
+                .bridge
+                .get(BridgeAttributes {
+                    control: BridgeControl::Ack,
+                    result: BridgeResult::Success
+                })
+                .controls
+                .get(),
+            3
+        );
+        assert_eq!(
+            metrics
+                .bridge
+                .get(BridgeAttributes {
+                    control: BridgeControl::Nack,
+                    result: BridgeResult::InvalidOrUntrackedId
+                })
+                .controls
+                .get(),
+            4
+        );
+    }
+
+    #[test]
+    fn terminal_snapshots_preserve_enum_attribute_values_once() {
+        let mut metrics = new_test_metrics();
+        metrics
+            .forward
+            .with(OutcomeAttributes {
+                outcome: Outcome::Success,
+            })
+            .messages
+            .add(1);
+        metrics
+            .bridge
+            .with(BridgeAttributes {
+                control: BridgeControl::Ack,
+                result: BridgeResult::Success,
+            })
+            .controls
+            .add(1);
+        metrics
+            .lag_events
+            .with(LagEventAttributes {
+                event_type: LagEventType::Disconnect,
+            })
+            .events
+            .add(1);
+        metrics.other.lagged_messages.add(42);
+
+        let snapshots = metrics.terminal_snapshots();
+        assert_eq!(snapshots.len(), 4);
+
+        for snapshot in &snapshots {
+            println!("Metric name: {}", snapshot.descriptor().name);
+            for attr in snapshot.measurement_attributes() {
+                println!("  Attribute: {} = {:?}", attr.0, attr.1);
+            }
+        }
+
+        assert!(snapshots.iter().any(|snapshot| {
+            snapshot.descriptor().name == "receiver.topic.forward"
+                && snapshot.measurement_attribute_value("outcome") == Some("success")
+        }));
+        assert!(snapshots.iter().any(|snapshot| {
+            snapshot.descriptor().name == "receiver.topic.bridge"
+                && snapshot.measurement_attribute_value("control") == Some("ack")
+                && snapshot.measurement_attribute_value("result") == Some("success")
+        }));
+        assert!(snapshots.iter().any(|snapshot| {
+            snapshot.descriptor().name == "receiver.topic.lag"
+                && snapshot.measurement_attribute_value("event.type") == Some("disconnect")
+        }));
+        assert!(
+            snapshots
+                .iter()
+                .any(|snapshot| { snapshot.descriptor().name == "receiver.topic.other" })
+        );
+
+        let second = metrics.terminal_snapshots();
+        assert_eq!(second.len(), 1);
+        assert_eq!(second[0].descriptor().name, "receiver.topic.other");
+    }
+}

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/metrics.rs
@@ -97,10 +97,10 @@ pub struct TopicBridgeMetrics {
     pub controls: Counter<u64>,
 }
 
-/// Other un-dimensioned metrics for the topic receiver.
-#[metric_set(name = "receiver.topic.other")]
+/// General un-dimensioned metrics for the topic receiver.
+#[metric_set(name = "receiver.topic")]
 #[derive(Debug, Default, Clone)]
-pub struct TopicOtherMetrics {
+pub struct TopicGeneralMetrics {
     /// Total messages missed across lag notifications.
     #[metric(unit = "{message}")]
     pub lagged_messages: Counter<u64>,
@@ -120,8 +120,8 @@ pub struct TopicReceiverMetrics {
     pub lag_events: MeasurementMetricSet<TopicLagEventMetrics>,
     /// Bridge control metrics.
     pub bridge: MeasurementMetricSet<TopicBridgeMetrics>,
-    /// Other un-dimensioned metrics.
-    pub other: MetricSet<TopicOtherMetrics>,
+    /// General un-dimensioned metrics.
+    pub general: MetricSet<TopicGeneralMetrics>,
 }
 
 impl TopicReceiverMetrics {
@@ -139,7 +139,7 @@ impl TopicReceiverMetrics {
             bridge: pipeline_ctx.register_measurement_metrics_with_topic::<TopicBridgeMetrics>(
                 topic_name.clone().into(),
             ),
-            other: pipeline_ctx.register_metrics_with_topic::<TopicOtherMetrics>(topic_name.into()),
+            general: pipeline_ctx.register_metrics_with_topic::<TopicGeneralMetrics>(topic_name.into()),
         }
     }
 
@@ -148,7 +148,7 @@ impl TopicReceiverMetrics {
         let mut snapshots = self.forward.terminal_snapshots();
         snapshots.extend(self.lag_events.terminal_snapshots());
         snapshots.extend(self.bridge.terminal_snapshots());
-        snapshots.extend(self.other.terminal_snapshots());
+        snapshots.extend(self.general.terminal_snapshots());
         snapshots
     }
 
@@ -160,7 +160,7 @@ impl TopicReceiverMetrics {
         reporter.report_measurement(&mut self.forward)?;
         reporter.report_measurement(&mut self.lag_events)?;
         reporter.report_measurement(&mut self.bridge)?;
-        reporter.report(&mut self.other)?;
+        reporter.report(&mut self.general)?;
         Ok(())
     }
 
@@ -189,6 +189,8 @@ mod tests {
         TopicReceiverMetrics::register(&pipeline_ctx, "test-topic".into())
     }
 
+    /// Scenario: A topic receiver is instantiated and produces metrics for various events.
+    /// Guarantees: Metrics are properly grouped by their enum attributes into the right dimensions.
     #[test]
     fn receiver_metrics_are_partitioned_by_context() {
         let mut metrics = new_test_metrics();
@@ -270,6 +272,8 @@ mod tests {
         );
     }
 
+    /// Scenario: A terminal snapshot is taken from the topic receiver.
+    /// Guarantees: Terminal snapshots capture the measurement attributes properly and clear the buffers so subsequent snapshots are empty.
     #[test]
     fn terminal_snapshots_preserve_enum_attribute_values_once() {
         let mut metrics = new_test_metrics();
@@ -295,17 +299,10 @@ mod tests {
             })
             .events
             .add(1);
-        metrics.other.lagged_messages.add(42);
+        metrics.general.lagged_messages.add(42);
 
         let snapshots = metrics.terminal_snapshots();
         assert_eq!(snapshots.len(), 4);
-
-        for snapshot in &snapshots {
-            println!("Metric name: {}", snapshot.descriptor().name);
-            for attr in snapshot.measurement_attributes() {
-                println!("  Attribute: {} = {:?}", attr.0, attr.1);
-            }
-        }
 
         assert!(snapshots.iter().any(|snapshot| {
             snapshot.descriptor().name == "receiver.topic.forward"
@@ -323,11 +320,11 @@ mod tests {
         assert!(
             snapshots
                 .iter()
-                .any(|snapshot| { snapshot.descriptor().name == "receiver.topic.other" })
+                .any(|snapshot| { snapshot.descriptor().name == "receiver.topic" })
         );
 
         let second = metrics.terminal_snapshots();
         assert_eq!(second.len(), 1);
-        assert_eq!(second[0].descriptor().name, "receiver.topic.other");
+        assert_eq!(second[0].descriptor().name, "receiver.topic");
     }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/metrics.rs
@@ -139,7 +139,8 @@ impl TopicReceiverMetrics {
             bridge: pipeline_ctx.register_measurement_metrics_with_topic::<TopicBridgeMetrics>(
                 topic_name.clone().into(),
             ),
-            general: pipeline_ctx.register_metrics_with_topic::<TopicGeneralMetrics>(topic_name.into()),
+            general: pipeline_ctx
+                .register_metrics_with_topic::<TopicGeneralMetrics>(topic_name.into()),
         }
     }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/mod.rs
@@ -8,6 +8,7 @@ otel_arrow_dfe_telemetry::otel_component_scope!(
     target = "otel.receiver.topic",
 );
 
+pub mod metrics;
 use async_trait::async_trait;
 use linkme::distributed_slice;
 use otel_arrow_dfe_channel::error::SendError;
@@ -34,9 +35,11 @@ use otel_arrow_dfe_engine::{
 };
 use otel_arrow_dfe_otap::OTAP_RECEIVER_FACTORIES;
 use otel_arrow_dfe_otap::pdata::OtapPdata;
-use otel_arrow_dfe_telemetry::instrument::Counter;
-use otel_arrow_dfe_telemetry::metrics::MetricSet;
-use otel_arrow_dfe_telemetry_macros::metric_set;
+
+use metrics::{
+    BridgeControl, BridgeResult, LagEventAttributes, LagEventType, TopicReceiverMetrics,
+};
+use otel_arrow_dfe_telemetry::common_attributes::{Outcome, OutcomeAttributes};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use smallvec::smallvec;
@@ -48,58 +51,6 @@ use std::time::Instant;
 
 /// URN for the topic receiver.
 pub const TOPIC_RECEIVER_URN: &str = "urn:otel:receiver:topic";
-
-/// Telemetry metrics for the topic receiver.
-#[metric_set(name = "receiver.topic")]
-#[derive(Debug, Default, Clone)]
-pub struct TopicReceiverMetrics {
-    /// Number of messages forwarded to downstream.
-    #[metric(unit = "{item}")]
-    pub forwarded_messages: Counter<u64>,
-    /// Number of forward failures to downstream channel.
-    #[metric(unit = "{item}")]
-    pub forward_failures: Counter<u64>,
-    /// Number of lag notifications emitted by broadcast subscriptions.
-    #[metric(unit = "{event}")]
-    pub lagged_notifications: Counter<u64>,
-    /// Total messages missed across lag notifications.
-    #[metric(unit = "{item}")]
-    pub lagged_messages: Counter<u64>,
-    /// Number of broadcast subscriptions disconnected because of lag.
-    #[metric(unit = "{event}")]
-    pub lag_disconnects: Counter<u64>,
-    /// Number of downstream backpressure events (>= 500ms blocked).
-    #[metric(unit = "{event}")]
-    pub downstream_backpressure_events: Counter<u64>,
-    /// Total milliseconds blocked while forwarding to downstream.
-    #[metric(unit = "ms")]
-    pub downstream_blocked_ms: Counter<u64>,
-    /// Number of downstream ACK controls successfully bridged to topic ack.
-    #[metric(unit = "{item}")]
-    pub bridged_downstream_acks: Counter<u64>,
-    /// Number of downstream NACK controls successfully bridged to topic nack.
-    #[metric(unit = "{item}")]
-    pub bridged_downstream_nacks: Counter<u64>,
-    /// Number of downstream ACK/NACK controls ignored because topic Ack/Nack
-    /// propagation is disabled for this receiver.
-    #[metric(unit = "{event}")]
-    pub bridge_controls_ignored_propagation_disabled: Counter<u64>,
-    /// Number of downstream ACK/NACK controls missing the bridged topic
-    /// message id in calldata.
-    #[metric(unit = "{event}")]
-    pub bridge_missing_calldata: Counter<u64>,
-    /// Number of downstream ACK/NACK controls carrying an id that is not
-    /// currently tracked by the topic runtime.
-    ///
-    /// With the current raw `message_id` bridge this also includes invalid or
-    /// forged ids; those causes are not distinguishable yet.
-    #[metric(unit = "{event}")]
-    pub bridge_invalid_or_untracked_id: Counter<u64>,
-    /// Number of downstream ACK/NACK controls that failed to bridge for some
-    /// runtime reason other than an unknown message id.
-    #[metric(unit = "{event}")]
-    pub bridge_runtime_failures: Counter<u64>,
-}
 
 /// Topic receiver configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -137,7 +88,7 @@ pub struct TopicReceiver {
     subscription: Subscription<OtapPdata>,
     ack_propagation_mode: TopicAckPropagationMode,
     broadcast_on_lag: Option<TopicBroadcastOnLagPolicy>,
-    metrics: MetricSet<TopicReceiverMetrics>,
+    metrics: TopicReceiverMetrics,
 }
 
 /// Message received from the topic runtime but not yet admitted to the
@@ -197,8 +148,8 @@ pub static TOPIC_RECEIVER: ReceiverFactory<OtapPdata> = ReceiverFactory {
             let broadcast_on_lag =
                 matches!(&config.subscription, TopicSubscriptionConfig::Broadcast {})
                     .then(|| topic_binding.broadcast_on_lag_policy());
-            let metrics = pipeline
-                .register_metrics_with_topic::<TopicReceiverMetrics>(topic_binding.name().into());
+            let metrics =
+                TopicReceiverMetrics::register(&pipeline, topic_binding.name().to_string());
             Ok(ReceiverWrapper::local(
                 TopicReceiver {
                     config,
@@ -275,12 +226,12 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                         if let Some(reason) = draining_reason.as_deref() {
                             if let Some(message_id) = pending.tracked_message_id {
                                 match subscription.nack(message_id, reason) {
-                                    Ok(()) => metrics.bridged_downstream_nacks.add(1),
+                                    Ok(()) => metrics.record_bridge(BridgeControl::Nack, BridgeResult::Success),
                                     Err(Error::MessageNotTracked) => {
-                                        metrics.bridge_invalid_or_untracked_id.add(1);
+                                        metrics.record_bridge(BridgeControl::Nack, BridgeResult::InvalidOrUntrackedId);
                                     }
                                     Err(e) => {
-                                        metrics.bridge_runtime_failures.add(1);
+                                        metrics.record_bridge(BridgeControl::Nack, BridgeResult::RuntimeFailure);
                                         otel_warn!(
                                             "topic_receiver.drain_ingress_pending_forward_nack_failed",
                                             node = receiver_id.name.as_ref(),
@@ -304,7 +255,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
 
                     if pending_tracked_message_ids.is_empty() {
                         effect_handler.notify_receiver_drained().await?;
-                        return Ok(TerminalState::new(deadline, [metrics.snapshot()]));
+                        return Ok(TerminalState::new(deadline, metrics.terminal_snapshots()));
                     }
 
                     if Instant::now() >= deadline {
@@ -318,12 +269,12 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                             );
                             for message_id in pending_tracked_message_ids.drain() {
                                 match subscription.nack(message_id, reason) {
-                                    Ok(()) => metrics.bridged_downstream_nacks.add(1),
+                                    Ok(()) => metrics.record_bridge(BridgeControl::Nack, BridgeResult::Success),
                                     Err(Error::MessageNotTracked) => {
-                                        metrics.bridge_invalid_or_untracked_id.add(1);
+                                        metrics.record_bridge(BridgeControl::Nack, BridgeResult::InvalidOrUntrackedId);
                                     }
                                     Err(e) => {
-                                        metrics.bridge_runtime_failures.add(1);
+                                        metrics.record_bridge(BridgeControl::Nack, BridgeResult::RuntimeFailure);
                                         otel_warn!(
                                             "topic_receiver.drain_ingress_force_nack_failed",
                                             node = receiver_id.name.as_ref(),
@@ -336,7 +287,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                             }
                         }
                         effect_handler.notify_receiver_drained().await?;
-                        return Ok(TerminalState::new(deadline, [metrics.snapshot()]));
+                        return Ok(TerminalState::new(deadline, metrics.terminal_snapshots()));
                     }
                 }
 
@@ -359,21 +310,19 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                 Ok(NodeControlMsg::CollectTelemetry {
                                     mut metrics_reporter,
                                 }) => {
-                                    _ = metrics_reporter.report(&mut metrics);
+                                    _ = metrics.report(&mut metrics_reporter);
                                 }
                                 Ok(NodeControlMsg::Ack(ack)) => {
                                     if ack_propagation_mode != TopicAckPropagationMode::Auto {
-                                        metrics
-                                            .bridge_controls_ignored_propagation_disabled
-                                            .add(1);
+                                        metrics.record_bridge(BridgeControl::Ack, BridgeResult::IgnoredPropagationDisabled);
                                     } else if let Some(message_id) =
                                         Self::decode_topic_message_id(&ack.unwind.route.calldata)
                                     {
                                         let _ = pending_tracked_message_ids.remove(&message_id);
                                         match subscription.ack(message_id) {
-                                            Ok(()) => metrics.bridged_downstream_acks.add(1),
+                                            Ok(()) => metrics.record_bridge(BridgeControl::Ack, BridgeResult::Success),
                                             Err(Error::MessageNotTracked) => {
-                                                metrics.bridge_invalid_or_untracked_id.add(1);
+                                                metrics.record_bridge(BridgeControl::Ack, BridgeResult::InvalidOrUntrackedId);
                                                 otel_warn!(
                                                     "topic_receiver.bridge_ack_untracked_or_invalid_id",
                                                     node = receiver_id.name.as_ref(),
@@ -383,7 +332,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                                 );
                                             }
                                             Err(e) => {
-                                                metrics.bridge_runtime_failures.add(1);
+                                                metrics.record_bridge(BridgeControl::Ack, BridgeResult::RuntimeFailure);
                                                 otel_warn!(
                                                     "topic_receiver.bridge_ack_failed",
                                                     node = receiver_id.name.as_ref(),
@@ -394,7 +343,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                             }
                                         }
                                     } else {
-                                        metrics.bridge_missing_calldata.add(1);
+                                        metrics.record_bridge(BridgeControl::Ack, BridgeResult::MissingCalldata);
                                         otel_warn!(
                                             "topic_receiver.bridge_ack_missing_calldata",
                                             node = receiver_id.name.as_ref(),
@@ -416,17 +365,15 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                 }
                                 Ok(NodeControlMsg::Nack(nack)) => {
                                     if ack_propagation_mode != TopicAckPropagationMode::Auto {
-                                        metrics
-                                            .bridge_controls_ignored_propagation_disabled
-                                            .add(1);
+                                        metrics.record_bridge(BridgeControl::Nack, BridgeResult::IgnoredPropagationDisabled);
                                     } else if let Some(message_id) =
                                         Self::decode_topic_message_id(&nack.unwind.route.calldata)
                                     {
                                         let _ = pending_tracked_message_ids.remove(&message_id);
                                         match subscription.nack(message_id, nack.reason.as_str()) {
-                                            Ok(()) => metrics.bridged_downstream_nacks.add(1),
+                                            Ok(()) => metrics.record_bridge(BridgeControl::Nack, BridgeResult::Success),
                                             Err(Error::MessageNotTracked) => {
-                                                metrics.bridge_invalid_or_untracked_id.add(1);
+                                                metrics.record_bridge(BridgeControl::Nack, BridgeResult::InvalidOrUntrackedId);
                                                 otel_warn!(
                                                     "topic_receiver.bridge_nack_untracked_or_invalid_id",
                                                     node = receiver_id.name.as_ref(),
@@ -436,7 +383,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                                 );
                                             }
                                             Err(e) => {
-                                                metrics.bridge_runtime_failures.add(1);
+                                                metrics.record_bridge(BridgeControl::Nack, BridgeResult::RuntimeFailure);
                                                 otel_warn!(
                                                     "topic_receiver.bridge_nack_failed",
                                                     node = receiver_id.name.as_ref(),
@@ -447,7 +394,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                             }
                                         }
                                     } else {
-                                        metrics.bridge_missing_calldata.add(1);
+                                        metrics.record_bridge(BridgeControl::Nack, BridgeResult::MissingCalldata);
                                         otel_warn!(
                                             "topic_receiver.bridge_nack_missing_calldata",
                                             node = receiver_id.name.as_ref(),
@@ -457,7 +404,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                     }
                                 }
                                 Ok(NodeControlMsg::Shutdown { deadline, .. }) => {
-                                    return Ok(TerminalState::new(deadline, [metrics.snapshot()]));
+                                    return Ok(TerminalState::new(deadline, metrics.terminal_snapshots()));
                                 }
                                 Ok(_) => {}
                                 Err(e) => return Err(Error::ChannelRecvError(e)),
@@ -474,11 +421,11 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                     if let Some(message_id) = pending.tracked_message_id {
                                         _ = pending_tracked_message_ids.insert(message_id);
                                     }
-                                    metrics.forwarded_messages.add(1);
+                                    metrics.forward.with(OutcomeAttributes { outcome: Outcome::Success }).messages.add(1);
                                     let blocked_for = pending.send_started_at.elapsed();
                                     if blocked_for.as_millis() >= 500 {
-                                        metrics.downstream_backpressure_events.add(1);
-                                        metrics
+                                        metrics.other.downstream_backpressure_events.add(1);
+                                        metrics.other
                                             .downstream_blocked_ms
                                             .add(blocked_for.as_millis() as u64);
                                         otel_warn!(
@@ -492,7 +439,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                     tokio::task::consume_budget().await;
                                 }
                                 Err(e) => {
-                                    metrics.forward_failures.add(1);
+                                    metrics.forward.with(OutcomeAttributes { outcome: Outcome::Failure }).messages.add(1);
                                     otel_warn!(
                                         "topic_receiver.forward_failed",
                                         node = receiver_id.name.as_ref(),
@@ -527,21 +474,19 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                             Ok(NodeControlMsg::CollectTelemetry {
                                 mut metrics_reporter,
                             }) => {
-                                _ = metrics_reporter.report(&mut metrics);
+                                _ = metrics.report(&mut metrics_reporter);
                             }
                             Ok(NodeControlMsg::Ack(ack)) => {
                                 if ack_propagation_mode != TopicAckPropagationMode::Auto {
-                                    metrics
-                                        .bridge_controls_ignored_propagation_disabled
-                                        .add(1);
+                                    metrics.record_bridge(BridgeControl::Ack, BridgeResult::IgnoredPropagationDisabled);
                                 } else if let Some(message_id) =
                                     Self::decode_topic_message_id(&ack.unwind.route.calldata)
                                 {
                                     let _ = pending_tracked_message_ids.remove(&message_id);
                                     match subscription.ack(message_id) {
-                                        Ok(()) => metrics.bridged_downstream_acks.add(1),
+                                        Ok(()) => metrics.record_bridge(BridgeControl::Ack, BridgeResult::Success),
                                         Err(Error::MessageNotTracked) => {
-                                            metrics.bridge_invalid_or_untracked_id.add(1);
+                                            metrics.record_bridge(BridgeControl::Ack, BridgeResult::InvalidOrUntrackedId);
                                             otel_warn!(
                                                 "topic_receiver.bridge_ack_untracked_or_invalid_id",
                                                 node = receiver_id.name.as_ref(),
@@ -551,7 +496,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                             );
                                         }
                                         Err(e) => {
-                                            metrics.bridge_runtime_failures.add(1);
+                                            metrics.record_bridge(BridgeControl::Ack, BridgeResult::RuntimeFailure);
                                             otel_warn!(
                                                 "topic_receiver.bridge_ack_failed",
                                                 node = receiver_id.name.as_ref(),
@@ -562,7 +507,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                         }
                                     }
                                 } else {
-                                    metrics.bridge_missing_calldata.add(1);
+                                    metrics.record_bridge(BridgeControl::Ack, BridgeResult::MissingCalldata);
                                     otel_warn!(
                                         "topic_receiver.bridge_ack_missing_calldata",
                                         node = receiver_id.name.as_ref(),
@@ -584,17 +529,15 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                             }
                             Ok(NodeControlMsg::Nack(nack)) => {
                                 if ack_propagation_mode != TopicAckPropagationMode::Auto {
-                                    metrics
-                                        .bridge_controls_ignored_propagation_disabled
-                                        .add(1);
+                                    metrics.record_bridge(BridgeControl::Nack, BridgeResult::IgnoredPropagationDisabled);
                                 } else if let Some(message_id) =
                                     Self::decode_topic_message_id(&nack.unwind.route.calldata)
                                 {
                                     let _ = pending_tracked_message_ids.remove(&message_id);
                                     match subscription.nack(message_id, nack.reason.as_str()) {
-                                        Ok(()) => metrics.bridged_downstream_nacks.add(1),
+                                        Ok(()) => metrics.record_bridge(BridgeControl::Nack, BridgeResult::Success),
                                         Err(Error::MessageNotTracked) => {
-                                            metrics.bridge_invalid_or_untracked_id.add(1);
+                                            metrics.record_bridge(BridgeControl::Nack, BridgeResult::InvalidOrUntrackedId);
                                             otel_warn!(
                                                 "topic_receiver.bridge_nack_untracked_or_invalid_id",
                                                 node = receiver_id.name.as_ref(),
@@ -604,7 +547,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                             );
                                         }
                                         Err(e) => {
-                                            metrics.bridge_runtime_failures.add(1);
+                                            metrics.record_bridge(BridgeControl::Nack, BridgeResult::RuntimeFailure);
                                             otel_warn!(
                                                 "topic_receiver.bridge_nack_failed",
                                                 node = receiver_id.name.as_ref(),
@@ -615,7 +558,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                         }
                                     }
                                 } else {
-                                    metrics.bridge_missing_calldata.add(1);
+                                    metrics.record_bridge(BridgeControl::Nack, BridgeResult::MissingCalldata);
                                     otel_warn!(
                                         "topic_receiver.bridge_nack_missing_calldata",
                                         node = receiver_id.name.as_ref(),
@@ -625,7 +568,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                 }
                             }
                             Ok(NodeControlMsg::Shutdown { deadline, .. }) => {
-                                return Ok(TerminalState::new(deadline, [metrics.snapshot()]));
+                                return Ok(TerminalState::new(deadline, metrics.terminal_snapshots()));
                             }
                             Ok(_) => {}
                             Err(e) => return Err(Error::ChannelRecvError(e)),
@@ -667,7 +610,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                         if let Some(message_id) = tracked_message_id {
                                             _ = pending_tracked_message_ids.insert(message_id);
                                         }
-                                        metrics.forwarded_messages.add(1);
+                                        metrics.forward.with(OutcomeAttributes { outcome: Outcome::Success }).messages.add(1);
                                         tokio::task::consume_budget().await;
                                     }
                                     Err(otel_arrow_dfe_engine::error::TypedError::ChannelSendError(
@@ -684,7 +627,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                         });
                                     }
                                     Err(e) => {
-                                        metrics.forward_failures.add(1);
+                                        metrics.forward.with(OutcomeAttributes { outcome: Outcome::Failure }).messages.add(1);
                                         otel_warn!(
                                             "topic_receiver.forward_failed",
                                             node = receiver_id.name.as_ref(),
@@ -697,10 +640,10 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                 }
                             }
                             Ok(RecvDelivery::Lagged { missed }) => {
-                                metrics.lagged_notifications.add(1);
-                                metrics.lagged_messages.add(missed);
+                                metrics.lag_events.with(LagEventAttributes { event_type: LagEventType::Notification }).events.add(1);
+                                metrics.other.lagged_messages.add(missed);
                                 if broadcast_on_lag == Some(TopicBroadcastOnLagPolicy::Disconnect) {
-                                    metrics.lag_disconnects.add(1);
+                                    metrics.lag_events.with(LagEventAttributes { event_type: LagEventType::Disconnect }).events.add(1);
                                     otel_warn!(
                                         "topic_receiver.lag_disconnect",
                                         topic = config.topic.as_ref(),

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/mod.rs
@@ -424,8 +424,8 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                     metrics.forward.with(OutcomeAttributes { outcome: Outcome::Success }).messages.add(1);
                                     let blocked_for = pending.send_started_at.elapsed();
                                     if blocked_for.as_millis() >= 500 {
-                                        metrics.other.downstream_backpressure_events.add(1);
-                                        metrics.other
+                                        metrics.general.downstream_backpressure_events.add(1);
+                                        metrics.general
                                             .downstream_blocked_ms
                                             .add(blocked_for.as_millis() as u64);
                                         otel_warn!(
@@ -641,7 +641,7 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                             }
                             Ok(RecvDelivery::Lagged { missed }) => {
                                 metrics.lag_events.with(LagEventAttributes { event_type: LagEventType::Notification }).events.add(1);
-                                metrics.other.lagged_messages.add(missed);
+                                metrics.general.lagged_messages.add(missed);
                                 if broadcast_on_lag == Some(TopicBroadcastOnLagPolicy::Disconnect) {
                                     metrics.lag_events.with(LagEventAttributes { event_type: LagEventType::Disconnect }).events.add(1);
                                     otel_warn!(

--- a/rust/otap-dataflow/crates/engine/src/context.rs
+++ b/rust/otap-dataflow/crates/engine/src/context.rs
@@ -561,15 +561,8 @@ impl PipelineContext {
         )
     }
 
-    /// Registers a metric set for the current node entity, scoped by an additional `topic` attribute.
-    ///
-    /// This is used by topic-aware nodes so their metric series can be filtered by `topic`.
-    #[must_use]
-    pub fn register_metrics_with_topic<T: MetricSetHandler + Default + Debug + Send + Sync>(
-        &self,
-        topic: Cow<'static, str>,
-    ) -> MetricSet<T> {
-        let entity_key = if self.node_telemetry_attrs.is_empty() {
+    fn register_topic_entity(&self, topic: Cow<'static, str>) -> EntityKey {
+        if self.node_telemetry_attrs.is_empty() {
             self.controller_context
                 .telemetry_registry_handle
                 .register_entity(NodeWithTopicAttributeSet {
@@ -583,12 +576,45 @@ impl PipelineContext {
                     node_custom_attrs: self.node_with_custom_attribute_set(),
                     topic,
                 })
-        };
+        }
+    }
+
+    /// Registers a metric set for the current node entity, scoped by an additional `topic` attribute.
+    ///
+    /// This is used by topic-aware nodes so their metric series can be filtered by `topic`.
+    #[must_use]
+    pub fn register_metrics_with_topic<T: MetricSetHandler + Default + Debug + Send + Sync>(
+        &self,
+        topic: Cow<'static, str>,
+    ) -> MetricSet<T> {
+        let entity_key = self.register_topic_entity(topic);
 
         let metrics = self
             .controller_context
             .telemetry_registry_handle
             .register_metric_set_for_entity::<T>(entity_key);
+
+        if let Some(telemetry) = current_node_telemetry_handle() {
+            telemetry.track_metric_set(metrics.metric_set_key());
+            telemetry.track_entity(entity_key);
+        }
+
+        metrics
+    }
+
+    /// Registers measurement metrics sets with a topic dimension for the given entity.
+    pub fn register_measurement_metrics_with_topic<
+        T: MeasurementMetricSetHandler + Debug + Send + Sync,
+    >(
+        &self,
+        topic: Cow<'static, str>,
+    ) -> MeasurementMetricSet<T> {
+        let entity_key = self.register_topic_entity(topic);
+
+        let metrics = self
+            .controller_context
+            .telemetry_registry_handle
+            .register_metric_set_with_measurement_attributes_for_entity::<T>(entity_key);
 
         if let Some(telemetry) = current_node_telemetry_handle() {
             telemetry.track_metric_set(metrics.metric_set_key());
@@ -1215,6 +1241,58 @@ mod tests {
             .expect("channel entity registered");
 
         assert_eq!(schema, "node.channel.attrs");
+        assert!(
+            !rendered.contains("custom="),
+            "nodes without custom attributes must not emit a custom attribute: {rendered}"
+        );
+    }
+
+    fn register_test_topic(ctx: &PipelineContext) -> EntityKey {
+        ctx.register_topic_entity(Cow::Borrowed("test-topic"))
+    }
+
+    /// Scenario: a node configured with `entity.extend.identity_attributes` registers a topic entity.
+    /// Guarantees: the topic entity carries the configured custom attributes along with the topic name.
+    #[test]
+    fn register_topic_entity_includes_custom_attributes() {
+        let registry = TelemetryRegistryHandle::new();
+        let mut custom = HashMap::new();
+        let _ = custom.insert(
+            "custom.identity.foo".to_string(),
+            TelemetryAttribute::new(AttributeValue::String("bar".to_string())),
+        );
+        let ctx = pipeline_ctx_with_custom_attrs(registry.clone(), custom);
+        let key = register_test_topic(&ctx);
+
+        let (schema, rendered) = registry
+            .visit_entity(key, |a| (a.schema_name(), a.attributes_to_string()))
+            .expect("topic entity registered");
+
+        assert_eq!(schema, "node.custom.topic.attrs");
+        assert!(
+            rendered.contains("custom={custom.identity.foo=bar}"),
+            "custom identity attributes missing from topic entity: {rendered}"
+        );
+        assert!(
+            rendered.contains("topic=test-topic") && rendered.contains("node.id=test-node"),
+            "base topic attributes must be preserved: {rendered}"
+        );
+    }
+
+    /// Scenario: a node with no `entity.extend.identity_attributes` registers a topic entity.
+    /// Guarantees: the entity stays on the plain topic schema and emits no empty
+    /// `custom={}` attribute.
+    #[test]
+    fn register_topic_entity_omits_empty_custom_attributes() {
+        let registry = TelemetryRegistryHandle::new();
+        let ctx = pipeline_ctx_with_custom_attrs(registry.clone(), HashMap::new());
+        let key = register_test_topic(&ctx);
+
+        let (schema, rendered) = registry
+            .visit_entity(key, |a| (a.schema_name(), a.attributes_to_string()))
+            .expect("topic entity registered");
+
+        assert_eq!(schema, "node.topic.attrs");
         assert!(
             !rendered.contains("custom="),
             "nodes without custom attributes must not emit a custom attribute: {rendered}"

--- a/rust/otap-dataflow/crates/engine/src/context.rs
+++ b/rust/otap-dataflow/crates/engine/src/context.rs
@@ -602,7 +602,10 @@ impl PipelineContext {
         metrics
     }
 
-    /// Registers measurement metrics sets with a topic dimension for the given entity.
+    /// Registers a measurement metric set for the current node entity, scoped by an additional `topic` attribute.
+    ///
+    /// This is used by topic-aware nodes so their measurement metric series can be filtered by `topic`.
+    #[must_use]
     pub fn register_measurement_metrics_with_topic<
         T: MeasurementMetricSetHandler + Debug + Send + Sync,
     >(


### PR DESCRIPTION
## Description

Migrate `topic_receiver` telemetry to modern dimensioned metric populations with enum attributes, aligning with the project's telemetry guidelines.

### Changes:
- **`receiver.topic.forward`**: Dimensionalized by `outcome` (`success`, `failure`) with unit `{message}`.
- **`receiver.topic.lag`**: Dimensionalized by `event.type` (`notification`, `disconnect`) with unit `{event}`.
- **`receiver.topic.bridge`**: Dimensionalized by orthogonal dimensions `control` (`ack`, `nack`) and `result` (`success`, `ignored_propagation_disabled`, `missing_calldata`, `invalid_or_untracked_id`, `runtime_failure`) with unit `{control}`.
- **`receiver.topic`**: General un-dimensioned metrics (`receiver.topic.lagged.messages`, `receiver.topic.downstream.backpressure.events`, `receiver.topic.downstream.blocked.ms`).
- **Engine Context**: Added `register_measurement_metrics_with_topic` on `PipelineContext` to link metric sets to topic entities with support for custom identity attributes.
- Added comprehensive unit tests for metric partitioning, single-handoff terminal snapshots, and topic entity linking.
- Updated `README.md` and added chloggen breaking-change entry.