### PR TITLE
chore(toolchain): include rust-analyzer component

### DIFF
--- a/rust/otap-dataflow/rust-toolchain.toml
+++ b/rust/otap-dataflow/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.98.0"
-components = [ "rustfmt", "clippy" ]
+components = [ "rustfmt", "clippy", "rust-analyzer" ]


### PR DESCRIPTION
Keep rust-analyzer available when the repository's pinned Rust toolchain is installed or refreshed.