### PR TITLE
fix(quiver): Fix semantics of loss metrics and introduce contrasting reclaimed metrics

### DIFF
--- a/rust/otap-dataflow/.chloggen/durable-buffer-unresolved-loss-accounting.yaml
+++ b/rust/otap-dataflow/.chloggen/durable-buffer-unresolved-loss-accounting.yaml
@@ -1,0 +1,6 @@
+change_type: breaking
+component: pipeline
+note: "Correct durable-buffer retention metrics to report only unresolved logical loss."
+issues: [3892]
+subtext: |
+  Migration: replace processor.durable_buffer.loss.segments with processor.durable_buffer.reclaimed.segments, and use reclaimed.bytes for physical storage. loss.bytes now reports logical payload bytes.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/README.md
@@ -110,8 +110,16 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 | `processor.durable_buffer.bundles` | `resolved` | `outcome=acked\|deferred\|permanently_rejected` |
 | `processor.durable_buffer.ingest` | `failures` | `failure=error\|backpressure` |
 | `processor.durable_buffer.items` | `rejected`, `consumed`, `produced`, `requeued`, `queued` | `signal=traces\|metrics\|logs` |
-| `processor.durable_buffer.loss` | `segments`, `bundles`, `bytes` | `reason=drop_oldest\|expired` |
+| `processor.durable_buffer.reclaimed` | `segments`, `bytes` | `reason=drop_oldest\|expired` |
+| `processor.durable_buffer.loss` | `bundles`, `bytes` | `reason=drop_oldest\|expired` |
 | `processor.durable_buffer.loss` | `items` | `signal=traces\|metrics\|logs`, `reason=drop_oldest\|expired` |
+
+Reclaimed `segments` and `bytes` describe physical segment files and persisted
+storage removed by retention. Loss `bundles`, `bytes`, and `items` describe only
+unresolved logical telemetry in those files. Logical bytes use the payload's
+current representation: active Arrow ranges for OTAP and protobuf wire length
+for OTLP pass-through. Expiry excludes bundles that every subscriber had already
+resolved.
 
 ### Events
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/bundle_adapter.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/bundle_adapter.rs
@@ -370,6 +370,12 @@ impl RecordBundle for OtapRecordBundleAdapter {
     fn item_count(&self) -> u64 {
         self.records.num_items() as u64
     }
+
+    fn byte_count(&self) -> Option<u64> {
+        self.records
+            .num_bytes()
+            .and_then(|bytes| u64::try_from(bytes).ok())
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -500,6 +506,10 @@ impl RecordBundle for OtlpBytesAdapter {
     fn item_count(&self) -> u64 {
         self.cached_item_count
     }
+
+    fn byte_count(&self) -> Option<u64> {
+        u64::try_from(self.bytes.num_bytes()).ok()
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -605,6 +615,39 @@ pub fn recover_item_count(bundle: &dyn RecordBundle) -> Option<u64> {
         SignalType::Metrics => create_records::<Metrics>(&payloads).ok()?,
     };
     Some(records.num_items() as u64)
+}
+
+/// Recovers the logical byte count from a decoded Quiver bundle.
+///
+/// This is used for WAL entries because the WAL format does not persist
+/// [`RecordBundle::byte_count`].
+pub fn recover_byte_count(bundle: &dyn RecordBundle) -> Option<u64> {
+    let payloads = bundle
+        .descriptor()
+        .slots
+        .iter()
+        .filter_map(|slot| {
+            bundle
+                .payload(slot.id)
+                .map(|payload| (slot.id, payload.batch.clone()))
+        })
+        .collect::<HashMap<_, _>>();
+
+    if let Some((signal_type, batch)) = find_otlp_slot(&payloads) {
+        return extract_otlp_bytes(signal_type, batch)
+            .ok()
+            .and_then(|bytes| u64::try_from(bytes.num_bytes()).ok());
+    }
+
+    let signal_type = determine_signal_type(&payloads).ok()?;
+    let records = match signal_type {
+        SignalType::Logs => create_records::<Logs>(&payloads).ok()?,
+        SignalType::Traces => create_records::<Traces>(&payloads).ok()?,
+        SignalType::Metrics => create_records::<Metrics>(&payloads).ok()?,
+    };
+    records
+        .num_bytes()
+        .and_then(|bytes| u64::try_from(bytes).ok())
 }
 
 /// Convert a ReconstructedBundle back to OtapPdata.
@@ -907,6 +950,20 @@ mod tests {
         assert_eq!(recover_item_count(&adapter), Some(3));
     }
 
+    /// Scenario: An OTAP bundle is measured live and reconstructed from WAL slots.
+    /// Guarantees: Both paths use the payload's canonical logical byte measurement.
+    #[test]
+    fn byte_count_from_arrow_bundle_uses_payload_num_bytes() {
+        let records = OtapArrowRecords::Logs(logs!((Logs, ("id", UInt16, vec![1u16, 2, 3]))));
+        let expected = records
+            .num_bytes()
+            .and_then(|bytes| u64::try_from(bytes).ok());
+        let adapter = OtapRecordBundleAdapter::new(records);
+
+        assert_eq!(adapter.byte_count(), expected);
+        assert_eq!(recover_byte_count(&adapter), expected);
+    }
+
     /// Scenario: A decoded OTLP pass-through bundle is inspected during WAL expiry.
     /// Guarantees: The counter uses the same protobuf item scan as live ingestion.
     #[test]
@@ -919,6 +976,19 @@ mod tests {
             recover_item_count(&adapter),
             Some(adapter.cached_item_count())
         );
+    }
+
+    /// Scenario: An OTLP pass-through bundle is measured live and reconstructed from WAL slots.
+    /// Guarantees: Both paths report the protobuf wire length.
+    #[test]
+    fn byte_count_from_otlp_bundle_uses_wire_length() {
+        let payload = b"test OTLP protobuf data".to_vec();
+        let expected = payload.len() as u64;
+        let otlp = OtlpProtoBytes::new_from_bytes(SignalType::Logs, payload);
+        let adapter = OtlpBytesAdapter::new(otlp).map_err(|(e, _)| e).unwrap();
+
+        assert_eq!(adapter.byte_count(), Some(expected));
+        assert_eq!(recover_byte_count(&adapter), Some(expected));
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/metrics.rs
@@ -124,20 +124,34 @@ pub(super) struct LossAttributes {
     pub(super) reason: LossReason,
 }
 
-/// Loss metrics partitioned by retention reason.
+/// Physical storage reclaimed by retention.
+#[metric_set(
+    name = "processor.durable_buffer.reclaimed",
+    measurement_attributes = LossAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub(super) struct DurableBufferReclaimedMetrics {
+    /// Number of physical segment files removed.
+    #[metric(unit = "{segment}")]
+    pub(super) segments: Counter<u64>,
+    /// Full persisted bytes reclaimed from removed segment files.
+    #[metric(unit = "By")]
+    pub(super) bytes: Counter<u64>,
+}
+
+/// Logical loss metrics partitioned by retention reason.
 #[metric_set(
     name = "processor.durable_buffer.loss",
     measurement_attributes = LossAttributes
 )]
 #[derive(Debug, Default, Clone)]
 pub(super) struct DurableBufferLossMetrics {
-    /// Number of segments lost.
-    #[metric(unit = "{segment}")]
-    pub(super) segments: Counter<u64>,
-    /// Number of bundles lost.
+    /// Number of bundles attributed to retention loss.
+    ///
+    /// This may be only the unresolved subset of a removed segment.
     #[metric(unit = "{bundle}")]
     pub(super) bundles: Counter<u64>,
-    /// Persisted segment bytes lost.
+    /// Logical payload bytes attributed to retention loss.
     #[metric(unit = "By")]
     pub(super) bytes: Counter<u64>,
 }
@@ -156,7 +170,7 @@ pub(super) struct SignalLossAttributes {
 )]
 #[derive(Debug, Default, Clone)]
 pub(super) struct DurableBufferLossItemMetrics {
-    /// Number of items lost.
+    /// Number of items in bundles attributed to retention loss.
     #[metric(unit = "{item}")]
     pub(super) items: Counter<u64>,
 }
@@ -167,6 +181,7 @@ pub(super) struct DurableBufferMetrics {
     pub(super) bundle_metrics: MeasurementMetricSet<DurableBufferBundleMetrics>,
     pub(super) ingest_metrics: MeasurementMetricSet<DurableBufferIngestMetrics>,
     pub(super) item_metrics: MeasurementMetricSet<DurableBufferItemMetrics>,
+    pub(super) reclaimed_metrics: MeasurementMetricSet<DurableBufferReclaimedMetrics>,
     pub(super) loss_metrics: MeasurementMetricSet<DurableBufferLossMetrics>,
     pub(super) loss_item_metrics: MeasurementMetricSet<DurableBufferLossItemMetrics>,
 }
@@ -178,6 +193,7 @@ impl DurableBufferMetrics {
             bundle_metrics: DurableBufferBundleMetrics::register(pipeline_ctx),
             ingest_metrics: DurableBufferIngestMetrics::register(pipeline_ctx),
             item_metrics: DurableBufferItemMetrics::register(pipeline_ctx),
+            reclaimed_metrics: DurableBufferReclaimedMetrics::register(pipeline_ctx),
             loss_metrics: DurableBufferLossMetrics::register(pipeline_ctx),
             loss_item_metrics: DurableBufferLossItemMetrics::register(pipeline_ctx),
         }
@@ -189,6 +205,7 @@ impl DurableBufferMetrics {
             .and_then(|()| reporter.report_measurement(&mut self.bundle_metrics))
             .and_then(|()| reporter.report_measurement(&mut self.ingest_metrics))
             .and_then(|()| reporter.report_measurement(&mut self.item_metrics))
+            .and_then(|()| reporter.report_measurement(&mut self.reclaimed_metrics))
             .and_then(|()| reporter.report_measurement(&mut self.loss_metrics))
             .and_then(|()| reporter.report_measurement(&mut self.loss_item_metrics))
     }
@@ -212,6 +229,13 @@ impl DurableBufferMetrics {
 
     pub(super) fn loss_for(&mut self, reason: LossReason) -> &mut DurableBufferLossMetrics {
         self.loss_metrics.with(LossAttributes { reason })
+    }
+
+    pub(super) fn reclaimed_for(
+        &mut self,
+        reason: LossReason,
+    ) -> &mut DurableBufferReclaimedMetrics {
+        self.reclaimed_metrics.with(LossAttributes { reason })
     }
 
     pub(super) fn loss_items_for(

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -104,8 +104,8 @@ use otel_arrow_dfe_otap::pdata::OtapPdata;
 use otel_arrow_dfe_pdata::TryIntoWithOptions;
 
 use bundle_adapter::{
-    OtapRecordBundleAdapter, OtlpBytesAdapter, convert_bundle_to_pdata, recover_item_count,
-    signal_type_from_slot_id,
+    OtapRecordBundleAdapter, OtlpBytesAdapter, convert_bundle_to_pdata, recover_byte_count,
+    recover_item_count, signal_type_from_slot_id,
 };
 pub use config::{DurableBufferConfig, OtlpHandling, SizeCapPolicy};
 use deferred_retry_state::DeferredRetryState;
@@ -271,6 +271,9 @@ fn retention_loss_delta(
             bundles: current.bundles.saturating_sub(previous.bundles),
             items: current.items.saturating_sub(previous.items),
             bytes: current.bytes.saturating_sub(previous.bytes),
+            reclaimed_bytes: current
+                .reclaimed_bytes
+                .saturating_sub(previous.reclaimed_bytes),
         }
     }
 
@@ -802,13 +805,23 @@ impl DurableBuffer {
         let loss_delta = retention_loss_delta(current_loss_snapshot, self.last_loss_snapshot);
         self.last_loss_snapshot = current_loss_snapshot;
 
+        let dropped_reclaimed = self.metrics.reclaimed_for(LossReason::DropOldest);
+        dropped_reclaimed
+            .segments
+            .add(loss_delta.drop_oldest.segments);
+        dropped_reclaimed
+            .bytes
+            .add(loss_delta.drop_oldest.reclaimed_bytes);
         let dropped = self.metrics.loss_for(LossReason::DropOldest);
-        dropped.segments.add(loss_delta.drop_oldest.segments);
         dropped.bundles.add(loss_delta.drop_oldest.bundles);
         dropped.bytes.add(loss_delta.drop_oldest.bytes);
 
+        let expired_reclaimed = self.metrics.reclaimed_for(LossReason::Expired);
+        expired_reclaimed.segments.add(loss_delta.expired.segments);
+        expired_reclaimed
+            .bytes
+            .add(loss_delta.expired.reclaimed_bytes);
         let expired = self.metrics.loss_for(LossReason::Expired);
-        expired.segments.add(loss_delta.expired.segments);
         expired.bundles.add(loss_delta.expired.bundles);
         expired.bytes.add(loss_delta.expired.bytes);
 
@@ -896,6 +909,7 @@ impl DurableBuffer {
         let engine = QuiverEngine::builder(quiver_config)
             .with_budget(budget)
             .with_wal_item_counter(Arc::new(recover_item_count))
+            .with_wal_byte_counter(Arc::new(recover_byte_count))
             .build()
             .await
             .map_err(|e| Error::InternalError {
@@ -1895,6 +1909,7 @@ mod tests {
         fingerprint: SchemaFingerprint,
         primary_slot: SlotId,
         item_count: u64,
+        byte_count: u64,
     }
 
     impl RecordBundle for SimpleBundle {
@@ -1919,6 +1934,10 @@ mod tests {
 
         fn item_count(&self) -> u64 {
             self.item_count
+        }
+
+        fn byte_count(&self) -> Option<u64> {
+            Some(self.byte_count)
         }
     }
 
@@ -1962,6 +1981,7 @@ mod tests {
             vec![Arc::new(Int32Array::from(vec![1]))],
         )
         .expect("valid batch");
+        let byte_count = batch.get_array_memory_size() as u64;
 
         // Include shared slots (ResourceAttrs=1, ScopeAttrs=2) alongside the
         // primary signal slot, mirroring real OTAP bundles. This ensures
@@ -1977,6 +1997,7 @@ mod tests {
             fingerprint: [0x11u8; 32],
             primary_slot,
             item_count,
+            byte_count,
         }
     }
 
@@ -2882,7 +2903,7 @@ mod tests {
         assert_eq!(
             processor
                 .metrics
-                .loss_metrics
+                .reclaimed_metrics
                 .get(LossAttributes {
                     reason: LossReason::Expired,
                 })
@@ -2902,8 +2923,8 @@ mod tests {
         assert_eq!(sample(&mut processor), (4, 0));
     }
 
-    /// Scenario: Segment, bundle, and byte loss occur in separate reporting intervals.
-    /// Guarantees: Each reason-only aggregate counter reports its delta and resets after export.
+    /// Scenario: Physical reclamation and logical loss occur in separate reporting intervals.
+    /// Guarantees: Each reason-only counter reports its delta and resets after export.
     #[tokio::test]
     async fn test_aggregate_loss_metrics_are_delta_counters() {
         let (mut processor, engine, subscriber_id, _temp_dir) =
@@ -2915,16 +2936,24 @@ mod tests {
             let dropped = processor.metrics.loss_metrics.get(LossAttributes {
                 reason: LossReason::DropOldest,
             });
+            let dropped_reclaimed = processor.metrics.reclaimed_metrics.get(LossAttributes {
+                reason: LossReason::DropOldest,
+            });
             let dropped_values = (
-                dropped.segments.get(),
+                dropped_reclaimed.segments.get(),
+                dropped_reclaimed.bytes.get(),
                 dropped.bundles.get(),
                 dropped.bytes.get(),
             );
             let expired = processor.metrics.loss_metrics.get(LossAttributes {
                 reason: LossReason::Expired,
             });
+            let expired_reclaimed = processor.metrics.reclaimed_metrics.get(LossAttributes {
+                reason: LossReason::Expired,
+            });
             let expired_values = (
-                expired.segments.get(),
+                expired_reclaimed.segments.get(),
+                expired_reclaimed.bytes.get(),
                 expired.bundles.get(),
                 expired.bytes.get(),
             );
@@ -2932,13 +2961,18 @@ mod tests {
             reporter
                 .report_measurement(&mut processor.metrics.loss_metrics)
                 .expect("report loss metrics");
+            reporter
+                .report_measurement(&mut processor.metrics.reclaimed_metrics)
+                .expect("report reclaimed metrics");
             while metrics_rx.try_recv().is_ok() {}
 
             (dropped_values, expired_values)
         };
 
+        let dropped_bundle = make_simple_bundle(SlotId::new(30), 5);
+        let dropped_logical_bytes = dropped_bundle.byte_count().expect("logical byte count");
         engine
-            .ingest(&make_simple_bundle(SlotId::new(30), 5))
+            .ingest(&dropped_bundle)
             .await
             .expect("ingest dropped bundle");
         engine.flush().await.expect("flush dropped bundle");
@@ -2955,10 +2989,15 @@ mod tests {
             })
             .expect("oldest segment");
         assert_eq!(engine.force_drop_oldest_pending_segments(), 1);
-        assert_eq!(sample(&mut processor), ((1, 1, dropped_bytes), (0, 0, 0)));
+        assert_eq!(
+            sample(&mut processor),
+            ((1, dropped_bytes, 1, dropped_logical_bytes), (0, 0, 0, 0))
+        );
 
+        let expired_bundle = make_simple_bundle(SlotId::new(30), 3);
+        let expired_logical_bytes = expired_bundle.byte_count().expect("logical byte count");
         engine
-            .ingest(&make_simple_bundle(SlotId::new(30), 3))
+            .ingest(&expired_bundle)
             .await
             .expect("ingest expired bundle");
         engine.flush().await.expect("flush expired bundle");
@@ -2978,9 +3017,12 @@ mod tests {
             engine.cleanup_expired_segments().expect("expire segment"),
             1
         );
-        assert_eq!(sample(&mut processor), ((0, 0, 0), (1, 1, expired_bytes)));
+        assert_eq!(
+            sample(&mut processor),
+            ((0, 0, 0, 0), (1, expired_bytes, 1, expired_logical_bytes))
+        );
 
-        assert_eq!(sample(&mut processor), ((0, 0, 0), (0, 0, 0)));
+        assert_eq!(sample(&mut processor), ((0, 0, 0, 0), (0, 0, 0, 0)));
     }
 
     /// Scenario: DropOldest removes a metrics bundle containing 42 items.

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/telemetry.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/telemetry.md
@@ -18,8 +18,9 @@ OpenTelemetry attributes rather than encoded in instrument names.
 | `processor.durable_buffer.bundles` | `resolved` | `outcome=acked\|deferred\|permanently_rejected` | Bundle resolution by downstream outcome. |
 | `processor.durable_buffer.ingest` | `failures` | `failure=error\|backpressure` | Failed ingest attempts by failure kind. |
 | `processor.durable_buffer.items` | `rejected`, `consumed`, `produced`, `requeued`, `queued` | `signal=traces\|metrics\|logs` | Item operations and queued gauges by OpenTelemetry signal. |
-| `processor.durable_buffer.loss` | `segments`, `bundles`, `bytes` | `reason=drop_oldest\|expired` | Runtime retention loss, including full persisted segment-file bytes. |
-| `processor.durable_buffer.loss` | `items` | `signal=traces\|metrics\|logs`, `reason=drop_oldest\|expired` | Item retention loss. |
+| `processor.durable_buffer.reclaimed` | `segments`, `bytes` | `reason=drop_oldest\|expired` | Physical segment files and persisted storage removed by retention. |
+| `processor.durable_buffer.loss` | `bundles`, `bytes` | `reason=drop_oldest\|expired` | Unresolved logical telemetry attributed to retention loss. |
+| `processor.durable_buffer.loss` | `items` | `signal=traces\|metrics\|logs`, `reason=drop_oldest\|expired` | Items in bundles attributed to retention loss; for expiry, already-resolved bundles are excluded. |
 
 ## Logs
 

--- a/rust/otap-dataflow/crates/quiver/src/engine.rs
+++ b/rust/otap-dataflow/crates/quiver/src/engine.rs
@@ -5596,6 +5596,78 @@ mod tests {
         );
     }
 
+    /// Scenario: An expired segment finalized after the subscriber's last progress flush.
+    /// Guarantees: Startup recovery counts the unrecorded segment as logical loss while excluding the persisted ACKed segment.
+    #[tokio::test]
+    async fn startup_expiry_reconciles_segment_finalized_after_progress_flush() {
+        let dir = tempdir().expect("tempdir");
+        let sub_id = SubscriberId::new("test-sub").expect("valid id");
+        let segment_config = SegmentConfig {
+            target_size_bytes: NonZeroU64::new(100).unwrap(),
+            ..Default::default()
+        };
+
+        {
+            let config = QuiverConfig::builder()
+                .data_dir(dir.path())
+                .segment(segment_config.clone())
+                .build()
+                .expect("config");
+            let engine = QuiverEngine::open(config, test_budget())
+                .await
+                .expect("engine");
+
+            engine
+                .register_subscriber(sub_id.clone())
+                .expect("register");
+            engine.activate_subscriber(&sub_id).expect("activate");
+
+            engine
+                .ingest(&DummyBundle::with_rows(25).with_byte_count(100))
+                .await
+                .expect("ingest persisted bundle");
+            engine.flush().await.expect("flush persisted segment");
+
+            let handle = engine
+                .poll_next_bundle(&sub_id)
+                .expect("poll")
+                .expect("persisted bundle");
+            handle.ack();
+            assert_eq!(
+                engine.flush_progress().await.expect("flush progress"),
+                1,
+                "ACKed progress should be persisted"
+            );
+
+            engine
+                .ingest(&DummyBundle::with_rows(75).with_byte_count(300))
+                .await
+                .expect("ingest unrecorded bundle");
+            engine.flush().await.expect("flush unrecorded segment");
+        }
+
+        backdate_segment_files(dir.path(), Duration::from_secs(1));
+
+        let config = QuiverConfig::builder()
+            .data_dir(dir.path())
+            .segment(segment_config)
+            .retention(RetentionConfig {
+                max_age: Some(Duration::from_millis(10)),
+            })
+            .build()
+            .expect("config");
+        let engine = QuiverEngine::open(config, test_budget())
+            .await
+            .expect("engine");
+
+        let expired = engine.retention_loss_snapshot().expired;
+        assert_eq!(
+            (expired.bundles, expired.items, expired.bytes),
+            (1, 75, 300),
+            "only the segment finalized after the progress snapshot should be lost"
+        );
+    }
+
     /// Test that next_segment_seq is monotonic even when all segments are deleted.
     ///
     /// If scan_existing_with_max_age deletes ALL segments, the sequence counter

--- a/rust/otap-dataflow/crates/quiver/src/engine.rs
+++ b/rust/otap-dataflow/crates/quiver/src/engine.rs
@@ -67,17 +67,23 @@ pub struct MaintenanceStats {
     pub pending_deletes_cleared: usize,
 }
 
-/// Cumulative loss totals for one retention reason.
+/// Cumulative physical retention and logical loss totals for one reason.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct RetentionLossCounts {
-    /// Number of segments removed by retention.
+    /// Number of physical segments removed by retention.
+    ///
+    /// A removed segment may contain both resolved and unresolved bundles.
     pub segments: u64,
-    /// Number of bundles stored in the removed segments.
+    /// Number of bundles attributed to retention loss.
+    ///
+    /// This may be only the unresolved subset of bundles in removed segments.
     pub bundles: u64,
-    /// Number of logical items stored in the removed segments.
+    /// Number of logical items attributed to retention loss.
     pub items: u64,
-    /// Persisted bytes stored in the removed segment files.
+    /// Logical payload bytes attributed to retention loss.
     pub bytes: u64,
+    /// Full size of the persisted segment files removed by retention.
+    pub reclaimed_bytes: u64,
 }
 
 /// Cumulative retention-loss totals for the current engine lifetime.
@@ -93,8 +99,17 @@ pub struct RetentionLossSnapshot {
     pub expired: RetentionLossCounts,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum ReclamationReason {
+    DropOldest,
+    Expired,
+}
+
 /// Counts the logical items in a decoded WAL bundle during startup expiry.
 pub type WalItemCounter = Arc<dyn Fn(&dyn RecordBundle) -> Option<u64> + Send + Sync + 'static>;
+
+/// Counts logical payload bytes in a decoded WAL bundle during startup expiry.
+pub type WalByteCounter = Arc<dyn Fn(&dyn RecordBundle) -> Option<u64> + Send + Sync + 'static>;
 
 /// Primary entry point for the persistence engine.
 ///
@@ -138,8 +153,10 @@ pub struct QuiverEngine {
     force_dropped_bundles: AtomicU64,
     /// Count of individual data items lost due to force-dropped segments.
     force_dropped_items: AtomicU64,
-    /// Count of persisted bytes lost due to force-dropped segments.
+    /// Count of logical payload bytes lost due to force-dropped segments.
     force_dropped_bytes: AtomicU64,
+    /// Count of physical segment-file bytes reclaimed by DropOldest.
+    force_reclaimed_bytes: AtomicU64,
     /// Pending dropped items grouped by slot shape, for per-signal tracking.
     /// Keyed by sorted slot_ids to bound memory by unique bundle shapes.
     dropped_items_by_shape: RwLock<HashMap<Vec<crate::record_bundle::SlotId>, u64>>,
@@ -149,8 +166,12 @@ pub struct QuiverEngine {
     expired_bundles: AtomicU64,
     /// Count of individual data items lost due to expired segments.
     expired_items: AtomicU64,
-    /// Count of persisted bytes lost due to expired segments.
+    /// Count of logical payload bytes lost due to expired segments.
     expired_bytes: AtomicU64,
+    /// Count of physical segment-file bytes reclaimed by max-age expiry.
+    expired_reclaimed_bytes: AtomicU64,
+    /// Retention reason for files whose physical deletion was deferred.
+    pending_reclaimed: Mutex<HashMap<SegmentSeq, ReclamationReason>>,
     /// Pending expired items grouped by slot shape, for per-signal tracking.
     /// Keyed by sorted slot_ids to bound memory by unique bundle shapes.
     expired_items_by_shape: RwLock<HashMap<Vec<crate::record_bundle::SlotId>, u64>>,
@@ -204,6 +225,7 @@ pub struct QuiverEngineBuilder {
     config: QuiverConfig,
     budget: Option<Arc<crate::budget::DiskBudget>>,
     wal_item_counter: Option<WalItemCounter>,
+    wal_byte_counter: Option<WalByteCounter>,
 }
 
 impl std::fmt::Debug for QuiverEngineBuilder {
@@ -214,6 +236,10 @@ impl std::fmt::Debug for QuiverEngineBuilder {
             .field(
                 "wal_item_counter",
                 &self.wal_item_counter.as_ref().map(|_| "<counter>"),
+            )
+            .field(
+                "wal_byte_counter",
+                &self.wal_byte_counter.as_ref().map(|_| "<counter>"),
             )
             .finish()
     }
@@ -229,6 +255,7 @@ impl QuiverEngineBuilder {
             config,
             budget: None,
             wal_item_counter: None,
+            wal_byte_counter: None,
         }
     }
 
@@ -250,6 +277,13 @@ impl QuiverEngineBuilder {
         self
     }
 
+    /// Sets the counter used to recover logical byte counts for WAL bundles.
+    #[must_use]
+    pub fn with_wal_byte_counter(mut self, counter: WalByteCounter) -> Self {
+        self.wal_byte_counter = Some(counter);
+        self
+    }
+
     /// Builds the engine asynchronously, returning an `Arc<QuiverEngine>`.
     ///
     /// # Errors
@@ -260,7 +294,13 @@ impl QuiverEngineBuilder {
         let budget = self
             .budget
             .unwrap_or_else(|| Arc::new(crate::budget::DiskBudget::unlimited()));
-        QuiverEngine::open_with_wal_item_counter(self.config, budget, self.wal_item_counter).await
+        QuiverEngine::open_with_wal_counters(
+            self.config,
+            budget,
+            self.wal_item_counter,
+            self.wal_byte_counter,
+        )
+        .await
     }
 }
 
@@ -307,13 +347,14 @@ impl QuiverEngine {
         config: QuiverConfig,
         budget: Arc<crate::budget::DiskBudget>,
     ) -> Result<Arc<Self>> {
-        Self::open_with_wal_item_counter(config, budget, None).await
+        Self::open_with_wal_counters(config, budget, None, None).await
     }
 
-    async fn open_with_wal_item_counter(
+    async fn open_with_wal_counters(
         config: QuiverConfig,
         budget: Arc<crate::budget::DiskBudget>,
         wal_item_counter: Option<WalItemCounter>,
+        wal_byte_counter: Option<WalByteCounter>,
     ) -> Result<Arc<Self>> {
         config.validate()?;
 
@@ -399,7 +440,7 @@ impl QuiverEngine {
         let mut next_segment_seq = 0u64;
         let mut deleted_during_scan = Vec::new();
         let mut startup_expired = RetentionLossCounts::default();
-        let mut startup_expired_items_by_shape = HashMap::new();
+        let startup_expired_items_by_shape = HashMap::new();
         match segment_store.scan_existing_with_max_age(config.retention.max_age) {
             Ok(scan_result) => {
                 if let Some(highest) = scan_result.highest_seen {
@@ -421,16 +462,9 @@ impl QuiverEngine {
                         next_segment_seq,
                     );
                 }
-                for (seq, bytes, summary) in scan_result.deleted {
+                for (seq, bytes) in scan_result.deleted {
                     startup_expired.segments += 1;
-                    startup_expired.bytes += bytes;
-                    if let Some(summary) = summary {
-                        startup_expired.bundles += summary.bundles;
-                        startup_expired.items += summary.items;
-                        for (shape, items) in summary.items_by_shape {
-                            *startup_expired_items_by_shape.entry(shape).or_insert(0) += items;
-                        }
-                    }
+                    startup_expired.reclaimed_bytes += bytes;
                     deleted_during_scan.push(seq);
                 }
             }
@@ -479,11 +513,14 @@ impl QuiverEngine {
             force_dropped_bundles: AtomicU64::new(0),
             force_dropped_items: AtomicU64::new(0),
             force_dropped_bytes: AtomicU64::new(0),
+            force_reclaimed_bytes: AtomicU64::new(0),
             dropped_items_by_shape: RwLock::new(HashMap::new()),
             expired_segments: AtomicU64::new(startup_expired.segments),
             expired_bundles: AtomicU64::new(startup_expired.bundles),
             expired_items: AtomicU64::new(startup_expired.items),
             expired_bytes: AtomicU64::new(startup_expired.bytes),
+            expired_reclaimed_bytes: AtomicU64::new(startup_expired.reclaimed_bytes),
+            pending_reclaimed: Mutex::new(HashMap::new()),
             expired_items_by_shape: RwLock::new(startup_expired_items_by_shape),
             segment_store,
             registry: registry.clone(),
@@ -499,9 +536,17 @@ impl QuiverEngine {
                 registry_for_callback.on_segment_finalized(seq, bundle_count);
             });
 
+        // Apply startup max-age retention only after persisted subscriber
+        // progress is loaded, so logical loss excludes already-resolved bundles.
+        let _ = engine.cleanup_expired_segments().map_err(|e| {
+            SegmentError::io(engine.config.data_dir.clone(), std::io::Error::other(e))
+        })?;
+
         // Replay WAL entries that weren't finalized to segments before shutdown/crash
         // This uses the same ingest path as live ingestion (minus WAL writes)
-        let replayed = engine.replay_wal(wal_item_counter.as_ref()).await?;
+        let replayed = engine
+            .replay_wal(wal_item_counter.as_ref(), wal_byte_counter.as_ref())
+            .await?;
         if replayed > 0 {
             otel_info!("quiver.wal.replay", replayed,);
         }
@@ -590,12 +635,14 @@ impl QuiverEngine {
                 bundles: self.force_dropped_bundles(),
                 items: self.force_dropped_items(),
                 bytes: self.force_dropped_bytes.load(Ordering::Relaxed),
+                reclaimed_bytes: self.force_reclaimed_bytes.load(Ordering::Relaxed),
             },
             expired: RetentionLossCounts {
                 segments: self.expired_segments(),
                 bundles: self.expired_bundles(),
                 items: self.expired_items(),
                 bytes: self.expired_bytes.load(Ordering::Relaxed),
+                reclaimed_bytes: self.expired_reclaimed_bytes.load(Ordering::Relaxed),
             },
         }
     }
@@ -813,7 +860,11 @@ impl QuiverEngine {
     ///
     /// The number of WAL entries replayed.
     #[must_use = "the replay count indicates recovery status and should be logged"]
-    async fn replay_wal(&self, wal_item_counter: Option<&WalItemCounter>) -> Result<usize> {
+    async fn replay_wal(
+        &self,
+        wal_item_counter: Option<&WalItemCounter>,
+        wal_byte_counter: Option<&WalByteCounter>,
+    ) -> Result<usize> {
         let wal_path = wal_path(&self.config);
 
         // Load cursor sidecar to find where we left off
@@ -972,36 +1023,59 @@ impl QuiverEngine {
                 };
                 if entry_time < cutoff {
                     skipped_expired += 1;
-                    if let Some(counter) = wal_item_counter {
+                    if wal_item_counter.is_some() || wal_byte_counter.is_some() {
                         match ReplayBundle::from_wal_entry(&entry) {
-                            Some(bundle) => match counter(&bundle) {
-                                Some(item_count) => {
-                                    let _ =
-                                        self.expired_items.fetch_add(item_count, Ordering::Relaxed);
-                                    if item_count > 0 {
-                                        let mut slot_ids = entry
-                                            .slots
-                                            .iter()
-                                            .map(|slot| slot.slot_id)
-                                            .collect::<Vec<_>>();
-                                        slot_ids.sort_unstable();
-                                        *self
-                                            .expired_items_by_shape
-                                            .write()
-                                            .entry(slot_ids)
-                                            .or_insert(0) += item_count;
+                            Some(bundle) => {
+                                if let Some(counter) = wal_item_counter {
+                                    match counter(&bundle) {
+                                        Some(item_count) => {
+                                            let _ = self
+                                                .expired_items
+                                                .fetch_add(item_count, Ordering::Relaxed);
+                                            if item_count > 0 {
+                                                let mut slot_ids = entry
+                                                    .slots
+                                                    .iter()
+                                                    .map(|slot| slot.slot_id)
+                                                    .collect::<Vec<_>>();
+                                                slot_ids.sort_unstable();
+                                                *self
+                                                    .expired_items_by_shape
+                                                    .write()
+                                                    .entry(slot_ids)
+                                                    .or_insert(0) += item_count;
+                                            }
+                                        }
+                                        None => {
+                                            otel_warn!(
+                                                "quiver.wal.expiry.accounting",
+                                                sequence = entry.sequence,
+                                                slot_count = entry.slots.len(),
+                                                reason = "item_count_unavailable",
+                                                message = "deleting expired WAL entry without item loss accounting because the item counter returned no count",
+                                            );
+                                        }
                                     }
                                 }
-                                None => {
-                                    otel_warn!(
-                                        "quiver.wal.expiry.accounting",
-                                        sequence = entry.sequence,
-                                        slot_count = entry.slots.len(),
-                                        reason = "item_count_unavailable",
-                                        message = "deleting expired WAL entry without item loss accounting because the item counter returned no count",
-                                    );
+                                if let Some(counter) = wal_byte_counter {
+                                    match counter(&bundle) {
+                                        Some(byte_count) => {
+                                            let _ = self
+                                                .expired_bytes
+                                                .fetch_add(byte_count, Ordering::Relaxed);
+                                        }
+                                        None => {
+                                            otel_warn!(
+                                                "quiver.wal.expiry.accounting",
+                                                sequence = entry.sequence,
+                                                slot_count = entry.slots.len(),
+                                                reason = "byte_count_unavailable",
+                                                message = "deleting expired WAL entry without byte loss accounting because the byte counter returned no count",
+                                            );
+                                        }
+                                    }
                                 }
-                            },
+                            }
                             None => {
                                 otel_warn!(
                                     "quiver.wal.expiry.accounting",
@@ -1054,6 +1128,20 @@ impl QuiverEngine {
                             slot_count = entry.slots.len(),
                             reason = "item_count_unavailable",
                             message = "replaying WAL entry without an item count; future segment loss accounting may be incomplete",
+                        );
+                    }
+                }
+            }
+            if let Some(counter) = wal_byte_counter {
+                match counter(&bundle) {
+                    Some(byte_count) => bundle.set_byte_count(byte_count),
+                    None => {
+                        otel_warn!(
+                            "quiver.wal.replay.accounting",
+                            sequence = entry.sequence,
+                            slot_count = entry.slots.len(),
+                            reason = "byte_count_unavailable",
+                            message = "replaying WAL entry without a byte count; future segment loss accounting may be incomplete",
                         );
                     }
                 }
@@ -1509,44 +1597,65 @@ impl QuiverEngine {
     ///
     /// Returns the number of segments force-dropped.
     pub fn force_drop_oldest_pending_segments(&self) -> usize {
-        // Get list of segments to drop from the registry
-        let to_drop = self.registry.force_drop_oldest_pending_segments();
+        let (to_drop, unresolved_by_segment) = self
+            .registry
+            .force_drop_oldest_pending_segments_with_unresolved();
 
         if to_drop.is_empty() {
             return 0;
         }
 
-        // Delete the segment files, counting bundles and items before deletion
         let mut deleted = 0;
         let mut bundles_dropped: u64 = 0;
         let mut items_dropped: u64 = 0;
-        let mut bytes_dropped: u64 = 0;
+        let mut bytes_dropped = Some(0u64);
+        let mut reclaimed_segments = 0u64;
+        let mut reclaimed_bytes = 0u64;
         for seq in &to_drop {
-            // Count bundles and items before deleting (single lock acquisition)
-            let has_exact_item_counts =
-                if let Ok((bundles, items)) = self.segment_store.retention_drop_counts(*seq) {
-                    bundles_dropped += bundles as u64;
-                    if let Some(items) = items {
-                        items_dropped += items;
-                        true
-                    } else {
-                        false
-                    }
-                } else {
-                    false
-                };
-            let file_size = self.segment_store.segment_file_size(*seq);
-            if has_exact_item_counts {
-                match self.segment_store.bundle_metadata(*seq) {
-                    Ok(metadata) => {
+            let unresolved = unresolved_by_segment
+                .get(seq)
+                .expect("the selected segment has an unresolved set");
+            bundles_dropped += unresolved.len() as u64;
+
+            if !unresolved.is_empty() {
+                match (
+                    self.segment_store.retention_drop_counts(*seq),
+                    self.segment_store.bundle_metadata(*seq),
+                ) {
+                    (Ok((_, exact_items, _)), Ok(metadata)) => {
+                        let mut selected_bytes = Some(0u64);
                         let mut map = self.dropped_items_by_shape.write();
-                        for bundle in metadata {
-                            let mut key = bundle.slot_ids;
-                            key.sort_unstable();
-                            *map.entry(key).or_insert(0) += bundle.item_count;
+                        for &bundle_index in unresolved {
+                            let Some(bundle) = metadata.get(bundle_index.raw() as usize) else {
+                                selected_bytes = None;
+                                otel_warn!(
+                                    "quiver.segment.drop_metadata_missing_bundle",
+                                    segment = seq.raw(),
+                                    bundle = bundle_index.raw(),
+                                    error_type = "invalid_data",
+                                    reason = "force_drop"
+                                );
+                                continue;
+                            };
+                            if exact_items.is_some() {
+                                items_dropped += bundle.item_count;
+                                let mut key = bundle.slot_ids.clone();
+                                key.sort_unstable();
+                                *map.entry(key).or_insert(0) += bundle.item_count;
+                            }
+                            selected_bytes = selected_bytes.and_then(|total| {
+                                bundle.byte_count.and_then(|count| total.checked_add(count))
+                            });
+                        }
+                        if let Some(bytes) = selected_bytes {
+                            bytes_dropped =
+                                bytes_dropped.and_then(|total| total.checked_add(bytes));
+                        } else {
+                            bytes_dropped = None;
                         }
                     }
-                    Err(e) => {
+                    (_, Err(e)) => {
+                        bytes_dropped = None;
                         otel_warn!(
                             "quiver.segment.drop_metadata_failed",
                             segment = seq.raw(),
@@ -1555,13 +1664,24 @@ impl QuiverEngine {
                             reason = "force_drop"
                         );
                     }
+                    (Err(_), Ok(_)) => {
+                        bytes_dropped = None;
+                    }
                 }
             }
-            self.segment_store
+
+            let deletion = self
+                .segment_store
                 .delete_segment(*seq)
                 .expect("physical deletion failures are deferred");
-            if let Ok(bytes) = file_size {
-                bytes_dropped += bytes;
+            if let Some(file_size) = deletion {
+                reclaimed_segments += 1;
+                reclaimed_bytes = reclaimed_bytes.saturating_add(file_size);
+            } else {
+                let _ = self
+                    .pending_reclaimed
+                    .lock()
+                    .insert(*seq, ReclamationReason::DropOldest);
             }
             otel_info!(
                 "quiver.segment.drop",
@@ -1574,16 +1694,21 @@ impl QuiverEngine {
         // Update the force-dropped counters
         let _ = self
             .force_dropped_segments
-            .fetch_add(deleted as u64, Ordering::Relaxed);
+            .fetch_add(reclaimed_segments, Ordering::Relaxed);
         let _ = self
             .force_dropped_bundles
             .fetch_add(bundles_dropped, Ordering::Relaxed);
         let _ = self
             .force_dropped_items
             .fetch_add(items_dropped, Ordering::Relaxed);
+        if let Some(bytes_dropped) = bytes_dropped {
+            let _ = self
+                .force_dropped_bytes
+                .fetch_add(bytes_dropped, Ordering::Relaxed);
+        }
         let _ = self
-            .force_dropped_bytes
-            .fetch_add(bytes_dropped, Ordering::Relaxed);
+            .force_reclaimed_bytes
+            .fetch_add(reclaimed_bytes, Ordering::Relaxed);
 
         // Clean up registry internal state
         if let Some(&max_dropped) = to_drop.iter().max() {
@@ -1617,57 +1742,110 @@ impl QuiverEngine {
             return Ok(0);
         }
 
-        // Force-complete these segments in the registry BEFORE deleting files.
-        // This ensures subscribers don't try to read from segments we're about to delete.
-        // Any claimed but unresolved bundles will be abandoned.
-        self.registry.force_complete_segments(&expired_segments);
+        // Snapshot logical loss while force-completing the segments, before
+        // deleting the physical files. The union prevents multiple subscribers
+        // from charging the same stored bundle more than once.
+        let unresolved_by_segment = self
+            .registry
+            .force_complete_segments_with_unresolved(&expired_segments);
 
         let mut deleted = 0;
         let mut bundles_expired: u64 = 0;
         let mut items_expired: u64 = 0;
-        let mut bytes_expired: u64 = 0;
+        let mut bytes_expired = Some(0u64);
+        let mut reclaimed_segments = 0u64;
+        let mut reclaimed_bytes: u64 = 0;
         for seq in &expired_segments {
-            // Count bundles and items before deleting (single lock acquisition)
-            let has_exact_item_counts =
-                if let Ok((bundles, items)) = self.segment_store.retention_drop_counts(*seq) {
-                    bundles_expired += bundles as u64;
-                    if let Some(items) = items {
-                        items_expired += items;
-                        true
-                    } else {
-                        false
-                    }
-                } else {
-                    false
-                };
-            let file_size = self.segment_store.segment_file_size(*seq);
-            if has_exact_item_counts {
-                match self.segment_store.bundle_metadata(*seq) {
-                    Ok(metadata) => {
-                        let mut map = self.expired_items_by_shape.write();
-                        for bundle in metadata {
-                            let mut key = bundle.slot_ids;
-                            key.sort_unstable();
-                            *map.entry(key).or_insert(0) += bundle.item_count;
+            let unresolved = unresolved_by_segment
+                .as_ref()
+                .and_then(|by_segment| by_segment.get(seq));
+            let drop_counts = self.segment_store.retention_drop_counts(*seq);
+
+            if let Ok((stored_bundles, exact_items, exact_bytes)) = drop_counts {
+                bundles_expired +=
+                    unresolved.map_or(stored_bundles as u64, |indices| indices.len() as u64);
+
+                if unresolved.is_none() {
+                    items_expired += exact_items.unwrap_or(0);
+                    bytes_expired = bytes_expired
+                        .and_then(|total| exact_bytes.and_then(|bytes| total.checked_add(bytes)));
+                }
+
+                let needs_metadata = unresolved.is_some_and(|indices| !indices.is_empty())
+                    || (unresolved.is_none() && exact_items.is_some());
+                if needs_metadata {
+                    let metadata = self.segment_store.bundle_metadata(*seq);
+                    match (unresolved, metadata) {
+                        (Some(indices), Ok(metadata)) => {
+                            let mut selected_bytes = Some(0u64);
+                            let mut map = self.expired_items_by_shape.write();
+                            for &bundle_index in indices {
+                                let Some(bundle) = metadata.get(bundle_index.raw() as usize) else {
+                                    selected_bytes = None;
+                                    otel_warn!(
+                                        "quiver.segment.drop_metadata_missing_bundle",
+                                        segment = seq.raw(),
+                                        bundle = bundle_index.raw(),
+                                        error_type = "invalid_data",
+                                        reason = "expired"
+                                    );
+                                    continue;
+                                };
+                                if exact_items.is_some() {
+                                    items_expired += bundle.item_count;
+                                    let mut key = bundle.slot_ids.clone();
+                                    key.sort_unstable();
+                                    *map.entry(key).or_insert(0) += bundle.item_count;
+                                }
+                                selected_bytes = selected_bytes.and_then(|total| {
+                                    bundle.byte_count.and_then(|count| total.checked_add(count))
+                                });
+                            }
+                            if let Some(bytes) = selected_bytes {
+                                bytes_expired =
+                                    bytes_expired.and_then(|total| total.checked_add(bytes));
+                            } else {
+                                bytes_expired = None;
+                            }
+                        }
+                        (None, Ok(metadata)) => {
+                            let mut map = self.expired_items_by_shape.write();
+                            for bundle in metadata {
+                                let mut key = bundle.slot_ids;
+                                key.sort_unstable();
+                                *map.entry(key).or_insert(0) += bundle.item_count;
+                            }
+                        }
+                        (_, Err(e)) => {
+                            if unresolved.is_some_and(|indices| !indices.is_empty()) {
+                                bytes_expired = None;
+                            }
+                            otel_warn!(
+                                "quiver.segment.drop_metadata_failed",
+                                segment = seq.raw(),
+                                error = %e,
+                                error_type = "io",
+                                reason = "expired"
+                            );
                         }
                     }
-                    Err(e) => {
-                        otel_warn!(
-                            "quiver.segment.drop_metadata_failed",
-                            segment = seq.raw(),
-                            error = %e,
-                            error_type = "io",
-                            reason = "expired"
-                        );
-                    }
+                } else if unresolved.is_none_or(|indices| !indices.is_empty()) {
+                    bytes_expired = None;
                 }
             }
 
-            self.segment_store
+            let deletion = self
+                .segment_store
                 .delete_segment(*seq)
                 .expect("physical deletion failures are deferred");
-            if let Ok(bytes) = file_size {
-                bytes_expired += bytes;
+            if let Some(file_size) = deletion {
+                reclaimed_segments += 1;
+                reclaimed_bytes = reclaimed_bytes.saturating_add(file_size);
+            } else {
+                let _ = self
+                    .pending_reclaimed
+                    .lock()
+                    .insert(*seq, ReclamationReason::Expired);
             }
             otel_info!(
                 "quiver.segment.drop",
@@ -1686,7 +1864,7 @@ impl QuiverEngine {
         // Track expired segments, bundles, and items in the dedicated counters.
         let _ = self
             .expired_segments
-            .fetch_add(expired_segments.len() as u64, Ordering::Relaxed);
+            .fetch_add(reclaimed_segments, Ordering::Relaxed);
         if bundles_expired > 0 {
             let _ = self
                 .expired_bundles
@@ -1697,10 +1875,15 @@ impl QuiverEngine {
                 .expired_items
                 .fetch_add(items_expired, Ordering::Relaxed);
         }
-        if bytes_expired > 0 {
+        if let Some(bytes_expired) = bytes_expired.filter(|bytes| *bytes > 0) {
             let _ = self
                 .expired_bytes
                 .fetch_add(bytes_expired, Ordering::Relaxed);
+        }
+        if reclaimed_bytes > 0 {
+            let _ = self
+                .expired_reclaimed_bytes
+                .fetch_add(reclaimed_bytes, Ordering::Relaxed);
         }
 
         Ok(deleted)
@@ -1732,7 +1915,31 @@ impl QuiverEngine {
         let flushed = self.flush_progress().await?;
         let deleted = self.cleanup_completed_segments()?;
         let expired = self.cleanup_expired_segments()?;
-        let pending_deletes_cleared = self.segment_store.retry_pending_deletes();
+        let pending_results = self.segment_store.retry_pending_deletes_with_results();
+        let pending_deletes_cleared = pending_results.cleared();
+        if pending_deletes_cleared > 0 {
+            let mut pending_reclaimed = self.pending_reclaimed.lock();
+            for (seq, bytes) in pending_results.removed {
+                match pending_reclaimed.remove(&seq) {
+                    Some(ReclamationReason::DropOldest) => {
+                        let _ = self.force_dropped_segments.fetch_add(1, Ordering::Relaxed);
+                        let _ = self
+                            .force_reclaimed_bytes
+                            .fetch_add(bytes, Ordering::Relaxed);
+                    }
+                    Some(ReclamationReason::Expired) => {
+                        let _ = self.expired_segments.fetch_add(1, Ordering::Relaxed);
+                        let _ = self
+                            .expired_reclaimed_bytes
+                            .fetch_add(bytes, Ordering::Relaxed);
+                    }
+                    None => {}
+                }
+            }
+            for seq in pending_results.abandoned {
+                let _ = pending_reclaimed.remove(&seq);
+            }
+        }
 
         if flushed > 0 || deleted > 0 || expired > 0 || pending_deletes_cleared > 0 {
             otel_debug!(
@@ -1974,6 +2181,7 @@ mod tests {
     struct DummyBundle {
         descriptor: BundleDescriptor,
         batch: arrow_array::RecordBatch,
+        byte_count: Option<u64>,
     }
 
     impl DummyBundle {
@@ -1989,6 +2197,7 @@ mod tests {
                     "Logs",
                 )]),
                 batch: arrow_array::RecordBatch::new_empty(schema),
+                byte_count: None,
             }
         }
 
@@ -2015,7 +2224,13 @@ mod tests {
                     "Logs",
                 )]),
                 batch,
+                byte_count: None,
             }
+        }
+
+        fn with_byte_count(mut self, byte_count: u64) -> Self {
+            self.byte_count = Some(byte_count);
+            self
         }
     }
 
@@ -2041,6 +2256,10 @@ mod tests {
 
         fn item_count(&self) -> u64 {
             self.batch.num_rows() as u64
+        }
+
+        fn byte_count(&self) -> Option<u64> {
+            self.byte_count
         }
     }
 
@@ -3716,7 +3935,8 @@ mod tests {
         let loss = engine.retention_loss_snapshot();
         assert_eq!(loss.drop_oldest.segments, 1);
         assert!(loss.drop_oldest.bundles > 0);
-        assert_eq!(loss.drop_oldest.bytes, oldest_file_size);
+        assert_eq!(loss.drop_oldest.bytes, 0);
+        assert_eq!(loss.drop_oldest.reclaimed_bytes, oldest_file_size);
         assert_eq!(loss.expired, RetentionLossCounts::default());
 
         // Segment count should decrease
@@ -4537,7 +4757,8 @@ mod tests {
         let loss = engine.retention_loss_snapshot();
         assert_eq!(loss.expired.segments, initial_segment_count as u64);
         assert_eq!(loss.expired.bundles, 5);
-        assert_eq!(loss.expired.bytes, expected_bytes);
+        assert_eq!(loss.expired.bytes, 0);
+        assert_eq!(loss.expired.reclaimed_bytes, expected_bytes);
         assert_eq!(loss.drop_oldest, RetentionLossCounts::default());
     }
 
@@ -4631,6 +4852,149 @@ mod tests {
         assert!(
             result.is_none(),
             "no bundles should remain after all segments expired"
+        );
+    }
+
+    /// Scenario: An expired segment contains one unresolved empty bundle and one ACKed item.
+    /// Guarantees: Logical loss excludes the ACKed bundle and is smaller than physical reclamation.
+    #[tokio::test]
+    async fn cleanup_expired_segments_counts_only_unresolved_bundles_and_items() {
+        let temp_dir = tempdir().expect("tempdir");
+        let config = QuiverConfig::builder()
+            .data_dir(temp_dir.path())
+            .segment(SegmentConfig {
+                target_size_bytes: NonZeroU64::new(100 * 1024 * 1024).unwrap(),
+                ..Default::default()
+            })
+            .retention(RetentionConfig {
+                max_age: Some(Duration::from_secs(1)),
+            })
+            .build()
+            .expect("config");
+
+        let engine = QuiverEngine::open(config, test_budget())
+            .await
+            .expect("engine");
+        let sub_id = SubscriberId::new("partial-ack").expect("valid id");
+        engine
+            .register_subscriber(sub_id.clone())
+            .expect("register");
+        engine.activate_subscriber(&sub_id).expect("activate");
+
+        let unresolved_logical_bytes = 64;
+        engine
+            .ingest(&DummyBundle::new().with_byte_count(unresolved_logical_bytes))
+            .await
+            .expect("ingest empty bundle");
+        engine
+            .ingest(&DummyBundle::with_rows(1).with_byte_count(512))
+            .await
+            .expect("ingest non-empty bundle");
+        engine.flush().await.expect("flush");
+        assert_eq!(
+            engine.segment_store().segment_count(),
+            1,
+            "both bundles must share one segment"
+        );
+
+        let unresolved = engine
+            .poll_next_bundle(&sub_id)
+            .expect("poll empty bundle")
+            .expect("empty bundle available");
+        assert_eq!(unresolved.item_count(), 0);
+
+        let resolved = engine
+            .poll_next_bundle(&sub_id)
+            .expect("poll non-empty bundle")
+            .expect("non-empty bundle available");
+        assert_eq!(resolved.item_count(), 1);
+        resolved.ack();
+
+        engine
+            .segment_store()
+            .backdate_all_segments(Duration::from_secs(2));
+        assert_eq!(engine.cleanup_expired_segments().expect("cleanup"), 1);
+
+        let expired = engine.retention_loss_snapshot().expired;
+        unresolved.ack();
+        assert_eq!(expired.segments, 1);
+        assert_eq!(
+            (expired.bundles, expired.items, expired.bytes),
+            (1, 0, unresolved_logical_bytes),
+            "only the unresolved empty bundle should be counted as expired"
+        );
+        assert!(
+            expired.reclaimed_bytes > expired.bytes,
+            "physical segment reclamation must exceed the unresolved bundle's logical bytes"
+        );
+    }
+
+    /// Scenario: A completed segment remains behind an older incomplete cleanup boundary until both expire.
+    /// Guarantees: The completed segment contributes physical segment bytes but no logical bundle or item loss.
+    #[tokio::test]
+    async fn cleanup_expired_segments_excludes_completed_segment_behind_incomplete_gap() {
+        let temp_dir = tempdir().expect("tempdir");
+        let config = QuiverConfig::builder()
+            .data_dir(temp_dir.path())
+            .segment(SegmentConfig {
+                target_size_bytes: NonZeroU64::new(100 * 1024 * 1024).unwrap(),
+                ..Default::default()
+            })
+            .retention(RetentionConfig {
+                max_age: Some(Duration::from_secs(1)),
+            })
+            .build()
+            .expect("config");
+
+        let engine = QuiverEngine::open(config, test_budget())
+            .await
+            .expect("engine");
+        let sub_id = SubscriberId::new("completed-behind-gap").expect("valid id");
+        engine
+            .register_subscriber(sub_id.clone())
+            .expect("register");
+        engine.activate_subscriber(&sub_id).expect("activate");
+
+        engine
+            .ingest(&DummyBundle::new())
+            .await
+            .expect("ingest unresolved bundle");
+        engine.flush().await.expect("flush first segment");
+        let unresolved = engine
+            .poll_next_bundle(&sub_id)
+            .expect("poll unresolved bundle")
+            .expect("unresolved bundle available");
+
+        engine
+            .ingest(&DummyBundle::with_rows(1))
+            .await
+            .expect("ingest resolved bundle");
+        engine.flush().await.expect("flush second segment");
+        let resolved = engine
+            .poll_next_bundle(&sub_id)
+            .expect("poll resolved bundle")
+            .expect("resolved bundle available");
+        resolved.ack();
+
+        assert_eq!(engine.segment_store().segment_count(), 2);
+        assert_eq!(
+            engine.cleanup_completed_segments().expect("cleanup"),
+            0,
+            "the older incomplete segment must retain the completed successor"
+        );
+
+        engine
+            .segment_store()
+            .backdate_all_segments(Duration::from_secs(2));
+        assert_eq!(engine.cleanup_expired_segments().expect("cleanup"), 2);
+
+        let expired = engine.retention_loss_snapshot().expired;
+        unresolved.ack();
+        assert_eq!(expired.segments, 2);
+        assert_eq!(
+            (expired.bundles, expired.items),
+            (1, 0),
+            "the completed successor must not contribute logical expiry loss"
         );
     }
 
@@ -4870,7 +5234,8 @@ mod tests {
                     segments: segments_created as u64,
                     bundles: 5,
                     items: 250,
-                    bytes: expired_bytes,
+                    bytes: 0,
+                    reclaimed_bytes: expired_bytes,
                 },
                 vec![(vec![SlotId::new(0)], 250)],
             ),
@@ -4949,7 +5314,8 @@ mod tests {
                 segments: 1,
                 bundles: 0,
                 items: 0,
-                bytes: segment_bytes,
+                bytes: 0,
+                reclaimed_bytes: segment_bytes,
             }
         );
     }
@@ -5124,14 +5490,10 @@ mod tests {
         );
     }
 
-    /// Test that subscribers restored from progress.json don't fail when
-    /// expired segments are deleted during startup scan.
+    /// Test that startup expiry restores subscriber progress before accounting.
     ///
-    /// If scan_existing_with_max_age deletes segments on disk, but
-    /// SubscriberRegistry::open restores subscriber state from progress.json
-    /// which references those deleted segments, ensure that the deleted
-    /// segments are force-completed in the registry to avoid
-    /// segment_not_found errors.
+    /// Resolved bundles must not be charged as logical loss, and restored
+    /// subscribers must not retain references to deleted segments.
     #[tokio::test]
     async fn startup_expired_segments_force_completed_in_registry() {
         let dir = tempdir().expect("tempdir");
@@ -5209,6 +5571,12 @@ mod tests {
             engine.segment_store().segment_count(),
             0,
             "all segments should be deleted"
+        );
+        let expired = engine.retention_loss_snapshot().expired;
+        assert_eq!(
+            (expired.bundles, expired.items),
+            (4, 200),
+            "startup expiry must exclude the persisted ACKed bundle"
         );
 
         // Re-register the subscriber (loads from progress.json)
@@ -5676,7 +6044,8 @@ mod tests {
                     segments: finalized_segment_count as u64,
                     bundles: bundles_to_ingest as u64,
                     items: (bundles_to_ingest * rows_per_bundle) as u64,
-                    bytes: finalized_segment_bytes,
+                    bytes: 0,
+                    reclaimed_bytes: finalized_segment_bytes,
                 },
                 vec![(
                     vec![SlotId::new(0)],
@@ -5759,7 +6128,8 @@ mod tests {
                 segments: 1,
                 bundles: 1,
                 items: 0,
-                bytes: finalized_segment_bytes,
+                bytes: 0,
+                reclaimed_bytes: finalized_segment_bytes,
             }
         );
         assert!(engine.drain_expired_items_by_shape().is_empty());
@@ -5828,7 +6198,8 @@ mod tests {
                 segments: 1,
                 bundles: 1,
                 items: 0,
-                bytes: finalized_segment_bytes,
+                bytes: 0,
+                reclaimed_bytes: finalized_segment_bytes,
             }
         );
         assert!(engine.drain_expired_items_by_shape().is_empty());
@@ -6294,6 +6665,7 @@ mod tests {
                         bundles: old_bundles as u64,
                         items: (old_bundles * 10) as u64,
                         bytes: 0,
+                        reclaimed_bytes: 0,
                     },
                     vec![(vec![SlotId::new(0)], (old_bundles * 10) as u64)],
                 ),

--- a/rust/otap-dataflow/crates/quiver/src/lib.rs
+++ b/rust/otap-dataflow/crates/quiver/src/lib.rs
@@ -134,7 +134,7 @@ pub use config::{
 };
 pub use engine::{
     MaintenanceStats, QuiverEngine, QuiverEngineBuilder, RetentionLossCounts,
-    RetentionLossSnapshot, WalItemCounter,
+    RetentionLossSnapshot, WalByteCounter, WalItemCounter,
 };
 pub use error::{QuiverError, Result};
 

--- a/rust/otap-dataflow/crates/quiver/src/record_bundle.rs
+++ b/rust/otap-dataflow/crates/quiver/src/record_bundle.rs
@@ -240,6 +240,16 @@ pub trait RecordBundle {
     fn item_count_is_known(&self) -> bool {
         true
     }
+
+    /// Returns the authoritative logical byte size of this bundle.
+    ///
+    /// This describes the current logical payload representation, not its
+    /// encoded WAL size, finalized segment-file size, or retained allocation
+    /// capacity. Returns `None` when the adapter cannot measure it exactly.
+    #[must_use]
+    fn byte_count(&self) -> Option<u64> {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/rust/otap-dataflow/crates/quiver/src/segment/mod.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment/mod.rs
@@ -85,7 +85,7 @@ mod writer;
 
 pub use error::SegmentError;
 pub use open_segment::{OpenSegment, OpenSegmentBundleSummary};
-pub use reader::{ReconstructedBundle, SegmentLossSummary, SegmentReader};
+pub use reader::{ReconstructedBundle, SegmentReader};
 pub use stream_accumulator::StreamAccumulator;
 pub use types::{
     ChunkIndex, ManifestEntry, SegmentSeq, SlotChunkRef, StreamId, StreamKey, StreamMetadata,

--- a/rust/otap-dataflow/crates/quiver/src/segment/open_segment.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment/open_segment.rs
@@ -164,7 +164,8 @@ impl OpenSegment {
 
         let bundle_index = self.manifest.len() as u32;
         let item_count = bundle.item_count_is_known().then(|| bundle.item_count());
-        let mut entry = ManifestEntry::new_with_item_count(bundle_index, item_count);
+        let mut entry =
+            ManifestEntry::new_with_counts(bundle_index, item_count, bundle.byte_count());
 
         // Iterate over all slots defined in the bundle's descriptor
         for slot_desc in &bundle.descriptor().slots {

--- a/rust/otap-dataflow/crates/quiver/src/segment/reader.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment/reader.rs
@@ -59,17 +59,6 @@ use super::types::{
 };
 use crate::record_bundle::{ArrowPrimitive, SlotId};
 
-/// Trusted logical loss metadata represented by one finalized segment.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct SegmentLossSummary {
-    /// Number of bundles stored in the segment.
-    pub bundles: u64,
-    /// Number of logical telemetry items, or 0 when exact counts are unavailable.
-    pub items: u64,
-    /// Logical item totals grouped by each bundle's sorted slot IDs.
-    pub items_by_shape: Vec<(Vec<SlotId>, u64)>,
-}
-
 // -----------------------------------------------------------------------------
 // ReconstructedBundle
 // -----------------------------------------------------------------------------
@@ -334,8 +323,6 @@ pub struct SegmentReader {
     stream_by_id: HashMap<StreamId, usize>,
     /// Batch manifest (parsed on open).
     manifest: Vec<ManifestEntry>,
-    /// Whether the manifest persisted authoritative logical item counts.
-    manifest_has_item_count: bool,
     /// Cached stream decoders for efficient repeated reads.
     /// Lazily populated on first access to each stream.
     stream_decoders: RwLock<HashMap<StreamId, StreamDecoder>>,
@@ -355,102 +342,6 @@ impl std::fmt::Debug for SegmentReader {
 }
 
 impl SegmentReader {
-    /// Opens and validates a segment, then recovers its trusted logical loss metadata.
-    pub(crate) fn read_loss_summary(
-        path: impl AsRef<Path>,
-    ) -> Result<SegmentLossSummary, SegmentError> {
-        let reader = Self::open(path)?;
-        Self::loss_summary_from_reader(&reader)
-    }
-
-    /// Memory-maps and validates a segment, then recovers its trusted logical loss metadata.
-    #[cfg(feature = "mmap")]
-    pub(crate) fn read_loss_summary_mmap(
-        path: impl AsRef<Path>,
-    ) -> Result<SegmentLossSummary, SegmentError> {
-        let reader = Self::open_mmap(path)?;
-        Self::loss_summary_from_reader(&reader)
-    }
-
-    fn loss_summary_from_reader(reader: &Self) -> Result<SegmentLossSummary, SegmentError> {
-        if !reader.manifest_has_item_count {
-            return Ok(SegmentLossSummary {
-                bundles: reader.manifest().len() as u64,
-                ..Default::default()
-            });
-        }
-        Self::summarize_loss(&reader.streams, reader.manifest())
-    }
-
-    fn summarize_loss(
-        streams: &[StreamMetadata],
-        manifest: &[ManifestEntry],
-    ) -> Result<SegmentLossSummary, SegmentError> {
-        let streams_by_id = streams
-            .iter()
-            .map(|stream| (stream.id, stream))
-            .collect::<HashMap<_, _>>();
-        if streams_by_id.len() != streams.len() {
-            return Err(SegmentError::InvalidFormat {
-                message: "stream directory contains duplicate stream IDs".to_string(),
-            });
-        }
-
-        let mut items = 0u64;
-        let mut items_by_shape = HashMap::<Vec<SlotId>, u64>::new();
-        for (expected_index, entry) in manifest.iter().enumerate() {
-            if entry.bundle_index != expected_index as u32 {
-                return Err(SegmentError::InvalidFormat {
-                    message: "manifest bundle indices are not contiguous".to_string(),
-                });
-            }
-
-            let mut shape = Vec::with_capacity(entry.slot_count());
-            for (slot_id, chunk_ref) in entry.slots() {
-                let stream = streams_by_id.get(&chunk_ref.stream_id).ok_or_else(|| {
-                    SegmentError::InvalidFormat {
-                        message: "manifest references an unknown stream".to_string(),
-                    }
-                })?;
-                if stream.slot_id != slot_id || chunk_ref.chunk_index.raw() >= stream.chunk_count {
-                    return Err(SegmentError::InvalidFormat {
-                        message: "manifest slot reference does not match the stream directory"
-                            .to_string(),
-                    });
-                }
-                shape.push(slot_id);
-            }
-            shape.sort_unstable();
-
-            let item_count =
-                entry
-                    .exact_item_count()
-                    .ok_or_else(|| SegmentError::InvalidFormat {
-                        message: "segment manifest has no exact item counts".to_string(),
-                    })?;
-            items = items
-                .checked_add(item_count)
-                .ok_or_else(|| SegmentError::InvalidFormat {
-                    message: "segment item count overflow".to_string(),
-                })?;
-            let shape_items = items_by_shape.entry(shape).or_insert(0);
-            *shape_items =
-                shape_items
-                    .checked_add(item_count)
-                    .ok_or_else(|| SegmentError::InvalidFormat {
-                        message: "segment shape item count overflow".to_string(),
-                    })?;
-        }
-
-        let mut items_by_shape = items_by_shape.into_iter().collect::<Vec<_>>();
-        items_by_shape.sort_by(|left, right| left.0.cmp(&right.0));
-        Ok(SegmentLossSummary {
-            bundles: manifest.len() as u64,
-            items,
-            items_by_shape,
-        })
-    }
-
     /// Opens a segment file by reading it into memory.
     ///
     /// This allocates a buffer and reads the entire file.
@@ -623,7 +514,7 @@ impl SegmentReader {
             streams.iter().enumerate().map(|(i, s)| (s.id, i)).collect();
 
         // 6. Read batch manifest
-        let (manifest, manifest_has_item_count) = Self::read_manifest(
+        let manifest = Self::read_manifest(
             &buffer,
             footer.manifest_offset as usize,
             footer.manifest_length as usize,
@@ -635,7 +526,6 @@ impl SegmentReader {
             streams,
             stream_by_id,
             manifest,
-            manifest_has_item_count,
             stream_decoders: RwLock::new(HashMap::new()),
         })
     }
@@ -1011,6 +901,7 @@ impl SegmentReader {
     ///
     /// - `bundle_index`: UInt32
     /// - `item_count`: nullable UInt64 (optional for legacy segments)
+    /// - `byte_count`: nullable UInt64 (optional for legacy segments)
     /// - `slot_refs`: List<Struct<slot_id: UInt16, stream_id: UInt32, chunk_index: UInt32>>
     ///
     /// Each row represents one [`ManifestEntry`] describing which stream chunks
@@ -1021,7 +912,7 @@ impl SegmentReader {
         buffer: &Buffer,
         offset: usize,
         length: usize,
-    ) -> Result<(Vec<ManifestEntry>, bool), SegmentError> {
+    ) -> Result<Vec<ManifestEntry>, SegmentError> {
         let ipc_buffer = buffer.slice_with_length(offset, length);
         let decoder = StreamDecoder::new(ipc_buffer)?;
 
@@ -1045,6 +936,20 @@ impl SegmentReader {
         // Null values preserve bundles replayed without an authoritative count.
         let item_counts = batch
             .column_by_name("item_count")
+            .and_then(|column| column.as_primitive_opt::<arrow_array::types::UInt64Type>())
+            .map(|array| {
+                (0..array.len())
+                    .map(|index| {
+                        if array.is_null(index) {
+                            None
+                        } else {
+                            Some(array.value(index))
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            });
+        let byte_counts = batch
+            .column_by_name("byte_count")
             .and_then(|column| column.as_primitive_opt::<arrow_array::types::UInt64Type>())
             .map(|array| {
                 (0..array.len())
@@ -1089,7 +994,8 @@ impl SegmentReader {
         let mut entries = Vec::with_capacity(batch.num_rows());
         for (i, &bundle_index) in bundle_indices.iter().enumerate() {
             let item_count = item_counts.as_ref().and_then(|counts| counts[i]);
-            let mut entry = ManifestEntry::new_with_item_count(bundle_index, item_count);
+            let byte_count = byte_counts.as_ref().and_then(|counts| counts[i]);
+            let mut entry = ManifestEntry::new_with_counts(bundle_index, item_count, byte_count);
 
             // Get the struct array for this bundle's slot refs
             let slot_refs_for_bundle = slot_refs_list.value(i);
@@ -1145,10 +1051,7 @@ impl SegmentReader {
             entries.push(entry);
         }
 
-        let manifest_has_item_count = item_counts
-            .as_ref()
-            .is_some_and(|counts| counts.iter().all(Option::is_some));
-        Ok((entries, manifest_has_item_count))
+        Ok(entries)
     }
 
     /// Extracts a primitive column from a RecordBatch as a Vec.
@@ -1600,7 +1503,7 @@ mod tests {
         std::fs::write(&seg.path, bytes).expect("write");
 
         assert!(matches!(
-            SegmentReader::read_loss_summary(&seg.path),
+            SegmentReader::open(&seg.path),
             Err(SegmentError::ChecksumMismatch { .. })
         ));
     }
@@ -1674,6 +1577,75 @@ mod tests {
         assert_eq!(
             bundle.payload(SlotId::new(1)).map(|b| b.num_rows()),
             Some(3)
+        );
+    }
+
+    /// Scenario: A manifest mixes known-zero, known-nonzero, and unknown byte counts.
+    /// Guarantees: Byte-count presence and nullability survive segment round-trip.
+    #[tokio::test]
+    async fn roundtrip_optional_manifest_byte_counts() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("byte_counts.qseg");
+        let schema = test_schema();
+        let fingerprint = [0x33; 32];
+
+        let bundles = [
+            TestBundle::new(slot_descriptors())
+                .with_payload(SlotId::new(0), fingerprint, make_batch(&schema, &[], &[]))
+                .with_byte_count(0),
+            TestBundle::new(slot_descriptors())
+                .with_payload(
+                    SlotId::new(0),
+                    fingerprint,
+                    make_batch(&schema, &[1], &["one"]),
+                )
+                .with_byte_count(123),
+            TestBundle::new(slot_descriptors()).with_payload(
+                SlotId::new(0),
+                fingerprint,
+                make_batch(&schema, &[2], &["unknown"]),
+            ),
+        ];
+
+        let mut open_segment = OpenSegment::new();
+        for bundle in &bundles {
+            let _ = open_segment.append(bundle);
+        }
+        let _ = SegmentWriter::new(SegmentSeq::new(1), true)
+            .write_segment(&path, open_segment)
+            .await
+            .expect("write");
+
+        let reader = SegmentReader::open(&path).expect("open");
+        assert_eq!(
+            reader
+                .manifest()
+                .iter()
+                .map(ManifestEntry::exact_byte_count)
+                .collect::<Vec<_>>(),
+            vec![Some(0), Some(123), None]
+        );
+        assert!(
+            reader
+                .manifest()
+                .iter()
+                .any(|entry| entry.exact_byte_count().is_none()),
+            "a partial byte-count column must not be treated as an exact segment total"
+        );
+    }
+
+    /// Scenario: A legacy manifest contains no byte-count column.
+    /// Guarantees: The new reader accepts it without inventing logical bytes.
+    #[tokio::test]
+    async fn reads_manifest_without_byte_count_column() {
+        let seg = TestSegment::new().await;
+        let reader = SegmentReader::open(&seg.path).expect("open");
+
+        assert!(
+            reader
+                .manifest()
+                .iter()
+                .all(|entry| entry.exact_byte_count().is_none())
         );
     }
 

--- a/rust/otap-dataflow/crates/quiver/src/segment/test_utils.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment/test_utils.rs
@@ -92,6 +92,7 @@ pub fn slot_descriptors() -> Vec<SlotDescriptor> {
 pub struct TestBundle {
     descriptor: BundleDescriptor,
     payloads: HashMap<SlotId, (SchemaFingerprint, RecordBatch)>,
+    byte_count: Option<u64>,
 }
 
 impl TestBundle {
@@ -101,6 +102,7 @@ impl TestBundle {
         Self {
             descriptor: BundleDescriptor::new(slots),
             payloads: HashMap::new(),
+            byte_count: None,
         }
     }
 
@@ -113,6 +115,13 @@ impl TestBundle {
         batch: RecordBatch,
     ) -> Self {
         let _ = self.payloads.insert(slot_id, (fingerprint, batch));
+        self
+    }
+
+    /// Sets the authoritative logical payload byte count.
+    #[must_use]
+    pub const fn with_byte_count(mut self, byte_count: u64) -> Self {
+        self.byte_count = Some(byte_count);
         self
     }
 }
@@ -139,5 +148,9 @@ impl RecordBundle for TestBundle {
             .next()
             .map(|(_, batch)| batch.num_rows() as u64)
             .unwrap_or(0)
+    }
+
+    fn byte_count(&self) -> Option<u64> {
+        self.byte_count
     }
 }

--- a/rust/otap-dataflow/crates/quiver/src/segment/types.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment/types.rs
@@ -305,6 +305,11 @@ pub struct ManifestEntry {
     /// bundles this is the count of log records, metric data points,
     /// or spans. `None` means the count is unknown.
     item_count: Option<u64>,
+    /// Logical bytes in this bundle's original payload representation.
+    ///
+    /// This excludes segment encoding and shared file overhead. `None` means
+    /// the count is unknown.
+    byte_count: Option<u64>,
     /// Mapping from slot to the stream/chunk containing that slot's data.
     slot_refs: HashMap<SlotId, SlotChunkRef>,
 }
@@ -318,9 +323,19 @@ impl ManifestEntry {
 
     /// Creates a manifest entry with an optional authoritative item count.
     pub(crate) fn new_with_item_count(bundle_index: u32, item_count: Option<u64>) -> Self {
+        Self::new_with_counts(bundle_index, item_count, None)
+    }
+
+    /// Creates a manifest entry with optional authoritative item and byte counts.
+    pub(crate) fn new_with_counts(
+        bundle_index: u32,
+        item_count: Option<u64>,
+        byte_count: Option<u64>,
+    ) -> Self {
         Self {
             bundle_index,
             item_count,
+            byte_count,
             slot_refs: HashMap::new(),
         }
     }
@@ -339,6 +354,11 @@ impl ManifestEntry {
     /// Returns the authoritative item count when available.
     pub(crate) const fn exact_item_count(&self) -> Option<u64> {
         self.item_count
+    }
+
+    /// Returns the authoritative logical byte count when available.
+    pub(crate) const fn exact_byte_count(&self) -> Option<u64> {
+        self.byte_count
     }
 
     /// Adds a slot reference to this manifest entry.

--- a/rust/otap-dataflow/crates/quiver/src/segment/writer.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment/writer.rs
@@ -477,9 +477,15 @@ impl SegmentWriter {
         let has_item_counts = entries
             .iter()
             .all(|entry| entry.exact_item_count().is_some());
+        let has_any_byte_counts = entries
+            .iter()
+            .any(|entry| entry.exact_byte_count().is_some());
         let mut fields = vec![Field::new("bundle_index", DataType::UInt32, false)];
         if has_item_counts {
             fields.push(Field::new("item_count", DataType::UInt64, false));
+        }
+        if has_any_byte_counts {
+            fields.push(Field::new("byte_count", DataType::UInt64, true));
         }
         // Note: The list item field must be nullable to match what ListBuilder produces.
         fields.push(Field::new(
@@ -495,6 +501,7 @@ impl SegmentWriter {
 
         let mut bundle_index_builder = UInt32Builder::with_capacity(entries.len());
         let mut item_count_builder = UInt64Builder::with_capacity(entries.len());
+        let mut byte_count_builder = UInt64Builder::with_capacity(entries.len());
 
         // Create the list builder with a struct builder inside
         let struct_builder = StructBuilder::from_fields(
@@ -508,6 +515,7 @@ impl SegmentWriter {
             if let Some(item_count) = entry.exact_item_count() {
                 item_count_builder.append_value(item_count);
             }
+            byte_count_builder.append_option(entry.exact_byte_count());
 
             // Get the struct builder from the list builder
             let struct_builder = slot_refs_builder.values();
@@ -537,6 +545,9 @@ impl SegmentWriter {
         let mut columns: Vec<ArrayRef> = vec![Arc::new(bundle_index_builder.finish())];
         if has_item_counts {
             columns.push(Arc::new(item_count_builder.finish()));
+        }
+        if has_any_byte_counts {
+            columns.push(Arc::new(byte_count_builder.finish()));
         }
         columns.push(Arc::new(slot_refs_builder.finish()));
         let batch = RecordBatch::try_new(schema.clone(), columns)

--- a/rust/otap-dataflow/crates/quiver/src/segment/writer.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment/writer.rs
@@ -501,7 +501,8 @@ impl SegmentWriter {
 
         let mut bundle_index_builder = UInt32Builder::with_capacity(entries.len());
         let mut item_count_builder = UInt64Builder::with_capacity(entries.len());
-        let mut byte_count_builder = UInt64Builder::with_capacity(entries.len());
+        let mut byte_count_builder =
+            has_any_byte_counts.then(|| UInt64Builder::with_capacity(entries.len()));
 
         // Create the list builder with a struct builder inside
         let struct_builder = StructBuilder::from_fields(
@@ -515,7 +516,9 @@ impl SegmentWriter {
             if let Some(item_count) = entry.exact_item_count() {
                 item_count_builder.append_value(item_count);
             }
-            byte_count_builder.append_option(entry.exact_byte_count());
+            if let Some(byte_count_builder) = &mut byte_count_builder {
+                byte_count_builder.append_option(entry.exact_byte_count());
+            }
 
             // Get the struct builder from the list builder
             let struct_builder = slot_refs_builder.values();
@@ -546,7 +549,7 @@ impl SegmentWriter {
         if has_item_counts {
             columns.push(Arc::new(item_count_builder.finish()));
         }
-        if has_any_byte_counts {
+        if let Some(mut byte_count_builder) = byte_count_builder {
             columns.push(Arc::new(byte_count_builder.finish()));
         }
         columns.push(Arc::new(slot_refs_builder.finish()));

--- a/rust/otap-dataflow/crates/quiver/src/segment_store.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment_store.rs
@@ -16,7 +16,7 @@ use parking_lot::{Mutex, RwLock};
 
 use crate::budget::DiskBudget;
 use crate::logging::{otel_debug, otel_error, otel_warn};
-use crate::segment::{ReconstructedBundle, SegmentLossSummary, SegmentReader, SegmentSeq};
+use crate::segment::{ReconstructedBundle, SegmentReader, SegmentSeq};
 use crate::subscriber::{BundleIndex, BundleRef, SegmentProvider, SubscriberError};
 
 /// Maximum number of maintenance cycles a pending delete is retried before
@@ -66,10 +66,22 @@ pub struct ScanResult {
     /// Segments that were found and registered, sorted by sequence number.
     /// Each entry contains the segment sequence and its bundle count.
     pub found: Vec<(SegmentSeq, u32)>,
-    /// Expired segments deleted during scan, their persisted bytes, and any exact loss summaries.
-    pub deleted: Vec<(SegmentSeq, u64, Option<SegmentLossSummary>)>,
+    /// Corrupt expired segments deleted during scan and their persisted bytes.
+    pub deleted: Vec<(SegmentSeq, u64)>,
     /// Highest valid segment sequence observed, including retained corrupt files.
     pub highest_seen: Option<SegmentSeq>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct PendingDeleteResults {
+    pub(crate) removed: Vec<(SegmentSeq, u64)>,
+    pub(crate) abandoned: Vec<SegmentSeq>,
+}
+
+impl PendingDeleteResults {
+    pub(crate) const fn cleared(&self) -> usize {
+        self.removed.len() + self.abandoned.len()
+    }
 }
 
 /// Type alias for subscriber-related results.
@@ -114,6 +126,8 @@ struct SegmentHandle {
     bundle_count: u32,
     /// Authoritative total number of logical data items across all bundles.
     total_item_count: Option<u64>,
+    /// Authoritative total logical payload bytes across all bundles.
+    total_byte_count: Option<u64>,
     /// Size of the segment file in bytes.
     file_size_bytes: u64,
     /// Time when the segment was finalized (from file modification time).
@@ -147,6 +161,11 @@ impl SegmentHandle {
                 .exact_item_count()
                 .and_then(|count| total.checked_add(count))
         });
+        let total_byte_count = reader.manifest().iter().try_fold(0u64, |total, entry| {
+            entry
+                .exact_byte_count()
+                .and_then(|count| total.checked_add(count))
+        });
 
         Ok(Self {
             seq,
@@ -154,6 +173,7 @@ impl SegmentHandle {
             reader,
             bundle_count,
             total_item_count,
+            total_byte_count,
             file_size_bytes,
             finalized_at,
         })
@@ -378,7 +398,7 @@ impl SegmentStore {
     /// fails (sharing violation, permission error, etc.), the segment is added
     /// to a pending-delete list and the budget is released later when
     /// [`retry_pending_deletes`](Self::retry_pending_deletes) succeeds.
-    pub fn delete_segment(&self, seq: SegmentSeq) -> std::io::Result<()> {
+    pub fn delete_segment(&self, seq: SegmentSeq) -> std::io::Result<Option<u64>> {
         // Remove from in-memory map and capture file size for budget accounting.
         let file_size = {
             let mut segments = self.segments.write();
@@ -394,12 +414,14 @@ impl SegmentStore {
                     if let (Some(budget), Some(size)) = (&self.budget, file_size) {
                         budget.remove(size);
                     }
+                    return Ok(file_size);
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     // Raced with external deletion -- file is gone, release budget.
                     if let (Some(budget), Some(size)) = (&self.budget, file_size) {
                         budget.remove(size);
                     }
+                    return Ok(file_size);
                 }
                 Err(e) => {
                     // File still on disk (sharing violation, permission error, etc.).
@@ -422,6 +444,7 @@ impl SegmentStore {
                         );
                     }
                     self.defer_delete(seq, file_size.unwrap_or(0));
+                    return Ok(None);
                 }
             }
         } else {
@@ -429,9 +452,8 @@ impl SegmentStore {
             if let (Some(budget), Some(size)) = (&self.budget, file_size) {
                 budget.remove(size);
             }
+            return Ok(file_size);
         }
-
-        Ok(())
     }
 
     /// Schedules deferred cleanup of an orphaned segment file.
@@ -497,7 +519,7 @@ impl SegmentStore {
     ///
     /// Returns the number of segments whose budget was released (successful
     /// deletes + abandoned entries).
-    pub fn retry_pending_deletes(&self) -> usize {
+    pub(crate) fn retry_pending_deletes_with_results(&self) -> PendingDeleteResults {
         let now = Instant::now();
         let pending: Vec<(SegmentSeq, PendingDelete)> = {
             let pending = self.pending_deletes.lock();
@@ -509,10 +531,10 @@ impl SegmentStore {
         };
 
         if pending.is_empty() {
-            return 0;
+            return PendingDeleteResults::default();
         }
 
-        let mut cleared = 0;
+        let mut results = PendingDeleteResults::default();
         for (seq, pd) in pending {
             let path = self.segment_path(seq);
             if !path.exists() {
@@ -521,7 +543,7 @@ impl SegmentStore {
                 if let Some(budget) = &self.budget {
                     budget.remove(pd.file_size);
                 }
-                cleared += 1;
+                results.removed.push((seq, pd.file_size));
                 continue;
             }
 
@@ -537,7 +559,7 @@ impl SegmentStore {
                         phase = "deferred",
                         message = "Successfully deleted deferred segment on retry",
                     );
-                    cleared += 1;
+                    results.removed.push((seq, pd.file_size));
                 }
                 Err(e) if Self::is_sharing_violation(&e) => {
                     // Still in use -- schedule next retry with backoff.
@@ -599,11 +621,16 @@ impl SegmentStore {
                     message = "Giving up on segment deletion after max retries; \
                                budget released but file may remain on disk",
                 );
-                cleared += 1;
+                results.abandoned.push(seq);
             }
         }
 
-        cleared
+        results
+    }
+
+    /// Retries deferred deletions and returns the number cleared or abandoned.
+    pub fn retry_pending_deletes(&self) -> usize {
+        self.retry_pending_deletes_with_results().cleared()
     }
 
     /// Returns the number of segments pending deletion.
@@ -631,8 +658,7 @@ impl SegmentStore {
         self.scan_existing_with_max_age(None)
     }
 
-    /// Scans the segment directory and loads existing segments, optionally
-    /// validating, accounting for, and deleting expired segments.
+    /// Scans the segment directory and loads existing segments.
     ///
     /// When `max_age` is provided, segment files whose modification time
     /// exceeds the age limit are validated using the configured read mode,
@@ -642,8 +668,9 @@ impl SegmentStore {
     ///
     /// # Arguments
     ///
-    /// * `max_age` - If provided, segments older than this duration are validated,
-    ///   accounted for, and deleted.
+    /// * `max_age` - If provided, corrupt expired segments are deleted during
+    ///   scanning. Valid expired segments are loaded so the engine can apply
+    ///   retention after restoring subscriber progress.
     ///
     /// # Errors
     ///
@@ -674,45 +701,22 @@ impl SegmentStore {
                 if let Some(seq) = Self::parse_segment_filename(&path) {
                     highest_seen =
                         Some(highest_seen.map_or(seq, |highest: SegmentSeq| highest.max(seq)));
-                    // Check if the segment is expired before registering it.
-                    if let Some(cutoff) = cutoff {
-                        if Self::is_file_before_cutoff(&path, cutoff) {
-                            let file_size = match std::fs::metadata(&path) {
-                                Ok(metadata) => metadata.len(),
-                                Err(e) => {
-                                    otel_warn!(
-                                        "quiver.segment.scan",
-                                        path = %path.display(),
-                                        error = %e,
-                                        error_type = "io",
-                                        message = "expired segment byte loss cannot be reported because file metadata could not be read",
-                                    );
-                                    0
-                                }
-                            };
-                            let summary_result = match self.read_mode {
-                                SegmentReadMode::Standard => {
-                                    SegmentReader::read_loss_summary(&path)
-                                }
-                                #[cfg(feature = "mmap")]
-                                SegmentReadMode::Mmap => {
-                                    SegmentReader::read_loss_summary_mmap(&path)
-                                }
-                            };
-                            let summary = match summary_result {
-                                Ok(summary) => Some(summary),
-                                Err(e) => {
-                                    otel_warn!(
-                                        "quiver.segment.scan",
-                                        path = %path.display(),
-                                        error = %e,
-                                        error_type = "invalid_metadata",
-                                        message = "deleting expired segment without bundle or item loss accounting because exact metadata could not be recovered",
-                                    );
-                                    None
-                                }
-                            };
-                            // No budget release is needed because the file was never registered.
+                    let is_expired =
+                        cutoff.is_some_and(|cutoff| Self::is_file_before_cutoff(&path, cutoff));
+
+                    match self.register_existing_segment(seq) {
+                        Ok(bundle_count) => found.push((seq, bundle_count)),
+                        Err(e) if is_expired => {
+                            let file_size = std::fs::metadata(&path)
+                                .map(|metadata| metadata.len())
+                                .unwrap_or(0);
+                            otel_warn!(
+                                "quiver.segment.scan",
+                                path = %path.display(),
+                                error = %e,
+                                error_type = "invalid_metadata",
+                                message = "deleting corrupt expired segment without logical loss accounting",
+                            );
                             if let Err(e) = Self::remove_readonly_file(&path) {
                                 otel_warn!(
                                     "quiver.segment.scan",
@@ -721,15 +725,9 @@ impl SegmentStore {
                                     error_type = "io",
                                 );
                             } else {
-                                otel_debug!("quiver.segment.scan", segment = seq.raw(),);
-                                deleted.push((seq, file_size, summary));
+                                deleted.push((seq, file_size));
                             }
-                            continue;
                         }
-                    }
-
-                    match self.register_existing_segment(seq) {
-                        Ok(bundle_count) => found.push((seq, bundle_count)),
                         Err(e) => {
                             otel_error!(
                                 "quiver.segment.scan",
@@ -746,7 +744,7 @@ impl SegmentStore {
 
         // Sort by sequence number
         found.sort_by_key(|(seq, _)| *seq);
-        deleted.sort_by_key(|(seq, _, _)| *seq);
+        deleted.sort_by_key(|(seq, _)| *seq);
 
         Ok(ScanResult {
             found,
@@ -831,12 +829,16 @@ impl SegmentStore {
     pub(crate) fn retention_drop_counts(
         &self,
         segment_seq: SegmentSeq,
-    ) -> Result<(u32, Option<u64>)> {
+    ) -> Result<(u32, Option<u64>, Option<u64>)> {
         let segments = self.segments.read();
         let handle = segments
             .get(&segment_seq)
             .ok_or_else(|| SubscriberError::segment_not_found(segment_seq.raw()))?;
-        Ok((handle.bundle_count, handle.total_item_count))
+        Ok((
+            handle.bundle_count,
+            handle.total_item_count,
+            handle.total_byte_count,
+        ))
     }
 
     /// Subtracts `offset` from every segment's `finalized_at` timestamp,
@@ -900,6 +902,7 @@ impl SegmentProvider for SegmentStore {
             .iter()
             .map(|entry| crate::subscriber::BundleMetadata {
                 item_count: entry.item_count(),
+                byte_count: entry.exact_byte_count(),
                 slot_ids: entry.slot_ids().collect(),
             })
             .collect())
@@ -1163,6 +1166,11 @@ mod tests {
             "delete_segment should not error on sharing violation"
         );
         assert_eq!(
+            result.expect("deferred deletion result"),
+            None,
+            "deferred deletion must not report reclaimed bytes"
+        );
+        assert_eq!(
             store.pending_delete_count(),
             1,
             "segment should be added to pending deletes"
@@ -1178,8 +1186,13 @@ mod tests {
         drop(_held_handle);
 
         // Now retry should succeed
-        let deleted = store.retry_pending_deletes();
-        assert_eq!(deleted, 1, "retry should successfully delete");
+        let deleted = store.retry_pending_deletes_with_results();
+        assert_eq!(
+            deleted.removed,
+            vec![(seq, 0)],
+            "retry should report the confirmed physical removal"
+        );
+        assert!(deleted.abandoned.is_empty());
         assert_eq!(store.pending_delete_count(), 0);
         assert!(!path.exists(), "file should be deleted after retry");
     }
@@ -1313,7 +1326,7 @@ mod tests {
         assert_eq!(budget.used(), file_size);
 
         // Delete the segment -- file should be removed and budget released.
-        store.delete_segment(seq).unwrap();
+        assert_eq!(store.delete_segment(seq).unwrap(), Some(file_size));
         assert_eq!(
             budget.used(),
             0,
@@ -1335,7 +1348,7 @@ mod tests {
         std::fs::remove_file(&path).unwrap();
 
         // delete_segment should still release budget (file doesn't exist on disk).
-        store.delete_segment(seq).unwrap();
+        assert_eq!(store.delete_segment(seq).unwrap(), Some(file_size));
         assert_eq!(
             budget.used(),
             0,
@@ -1449,7 +1462,7 @@ mod tests {
         std::fs::write(&path, "test data").unwrap();
 
         // delete_segment should succeed without a budget configured.
-        store.delete_segment(seq).unwrap();
+        let _ = store.delete_segment(seq).unwrap();
         assert!(!path.exists());
         assert_eq!(store.pending_delete_count(), 0);
     }

--- a/rust/otap-dataflow/crates/quiver/src/segment_store.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment_store.rs
@@ -414,14 +414,14 @@ impl SegmentStore {
                     if let (Some(budget), Some(size)) = (&self.budget, file_size) {
                         budget.remove(size);
                     }
-                    return Ok(file_size);
+                    Ok(file_size)
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     // Raced with external deletion -- file is gone, release budget.
                     if let (Some(budget), Some(size)) = (&self.budget, file_size) {
                         budget.remove(size);
                     }
-                    return Ok(file_size);
+                    Ok(file_size)
                 }
                 Err(e) => {
                     // File still on disk (sharing violation, permission error, etc.).
@@ -444,7 +444,7 @@ impl SegmentStore {
                         );
                     }
                     self.defer_delete(seq, file_size.unwrap_or(0));
-                    return Ok(None);
+                    Ok(None)
                 }
             }
         } else {
@@ -452,7 +452,7 @@ impl SegmentStore {
             if let (Some(budget), Some(size)) = (&self.budget, file_size) {
                 budget.remove(size);
             }
-            return Ok(file_size);
+            Ok(file_size)
         }
     }
 

--- a/rust/otap-dataflow/crates/quiver/src/subscriber/registry.rs
+++ b/rust/otap-dataflow/crates/quiver/src/subscriber/registry.rs
@@ -35,7 +35,7 @@
 //! layer should call `flush_progress()` periodically (e.g., every 25ms) to
 //! write dirty subscribers to disk.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -70,6 +70,8 @@ use crate::record_bundle::SlotId;
 pub struct BundleMetadata {
     /// Number of logical data items in this bundle.
     pub item_count: u64,
+    /// Authoritative logical payload bytes in this bundle, when available.
+    pub byte_count: Option<u64>,
     /// All populated slot IDs for this bundle.
     ///
     /// The consumer is responsible for interpreting these IDs.  For
@@ -897,12 +899,18 @@ impl<P: SegmentProvider> SubscriberRegistry<P> {
     /// Returns the list of segment sequences that were force-completed and
     /// can be safely deleted from disk.
     pub fn force_drop_oldest_pending_segments(&self) -> Vec<SegmentSeq> {
+        self.force_drop_oldest_pending_segments_with_unresolved().0
+    }
+
+    /// Force-drops the oldest eligible segment and returns its logical loss set.
+    pub(crate) fn force_drop_oldest_pending_segments_with_unresolved(
+        &self,
+    ) -> (Vec<SegmentSeq>, BTreeMap<SegmentSeq, BTreeSet<BundleIndex>>) {
         let subscribers = self.subscribers.read();
 
         // Build a set of all pending (incomplete) segments across all subscribers
         // and track which segments have claimed bundles
-        let mut pending_segments: std::collections::BTreeSet<SegmentSeq> =
-            std::collections::BTreeSet::new();
+        let mut pending_segments: BTreeSet<SegmentSeq> = BTreeSet::new();
         let mut segments_with_readers: HashSet<SegmentSeq> = HashSet::new();
 
         for state_lock in subscribers.values() {
@@ -930,11 +938,12 @@ impl<P: SegmentProvider> SubscriberRegistry<P> {
             .collect();
 
         if droppable.is_empty() {
-            return Vec::new();
+            return (Vec::new(), BTreeMap::new());
         }
 
         // Take only the oldest segment to drop (be conservative)
         let to_drop = vec![droppable[0]];
+        let mut unresolved = BTreeMap::from([(droppable[0], BTreeSet::new())]);
 
         // Force-complete these segments for all subscribers
         for state_lock in subscribers.values() {
@@ -943,6 +952,17 @@ impl<P: SegmentProvider> SubscriberRegistry<P> {
 
             // Process all segments before releasing the lock
             for &segment_seq in &to_drop {
+                if let Some(progress) = state.segments().get(&segment_seq) {
+                    let unresolved_for_segment = unresolved
+                        .get_mut(&segment_seq)
+                        .expect("the selected segment has an unresolved set");
+                    for bundle_index in 0..progress.bundle_count() {
+                        let bundle_index = BundleIndex::new(bundle_index);
+                        if !progress.is_resolved(bundle_index) {
+                            let _ = unresolved_for_segment.insert(bundle_index);
+                        }
+                    }
+                }
                 if state.force_complete_segment(segment_seq) {
                     any_completed = true;
                 }
@@ -957,7 +977,7 @@ impl<P: SegmentProvider> SubscriberRegistry<P> {
             }
         }
 
-        to_drop
+        (to_drop, unresolved)
     }
 
     /// Force-completes the specified segments for all subscribers.
@@ -969,17 +989,54 @@ impl<P: SegmentProvider> SubscriberRegistry<P> {
     /// Any bundles that were claimed but not yet resolved will be abandoned.
     /// Subscribers will see these segments as completed and move on.
     pub fn force_complete_segments(&self, segments: &[SegmentSeq]) {
+        let _ = self.force_complete_segments_with_unresolved(segments);
+    }
+
+    /// Snapshots unresolved bundles, then force-completes the specified segments.
+    ///
+    /// The returned set is the union of bundles unresolved by any subscriber.
+    /// A bundle needed by multiple subscribers appears only once because loss
+    /// accounting describes the stored data, not per-subscriber deliveries.
+    ///
+    /// Returns `None` when no subscribers are registered. Callers can use this
+    /// distinction to preserve physical-segment accounting when there is no
+    /// subscriber progress from which to derive logical loss.
+    pub(crate) fn force_complete_segments_with_unresolved(
+        &self,
+        segments: &[SegmentSeq],
+    ) -> Option<BTreeMap<SegmentSeq, BTreeSet<BundleIndex>>> {
         if segments.is_empty() {
-            return;
+            return Some(BTreeMap::new());
         }
 
         let subscribers = self.subscribers.read();
+        if subscribers.is_empty() {
+            return None;
+        }
+
+        let mut unresolved = segments
+            .iter()
+            .copied()
+            .map(|segment_seq| (segment_seq, BTreeSet::new()))
+            .collect::<BTreeMap<_, _>>();
 
         for state_lock in subscribers.values() {
             let mut state = state_lock.write();
             let mut any_completed = false;
 
             for &segment_seq in segments {
+                if let Some(progress) = state.segments().get(&segment_seq) {
+                    let unresolved_for_segment = unresolved
+                        .get_mut(&segment_seq)
+                        .expect("all requested segments have an unresolved set");
+                    for bundle_index in 0..progress.bundle_count() {
+                        let bundle_index = BundleIndex::new(bundle_index);
+                        if !progress.is_resolved(bundle_index) {
+                            let _ = unresolved_for_segment.insert(bundle_index);
+                        }
+                    }
+                }
+
                 if state.force_complete_segment(segment_seq) {
                     any_completed = true;
                 }
@@ -992,6 +1049,8 @@ impl<P: SegmentProvider> SubscriberRegistry<P> {
                 let _ = dirty_set.insert(id);
             }
         }
+
+        Some(unresolved)
     }
 }
 
@@ -1106,6 +1165,7 @@ mod tests {
             Ok((0..info.bundle_count)
                 .map(|_| BundleMetadata {
                     item_count: info.items_per_bundle,
+                    byte_count: None,
                     slot_ids: Vec::new(),
                 })
                 .collect())
@@ -1902,6 +1962,40 @@ mod tests {
         handle2.ack();
         next1.ack();
         next2.ack();
+    }
+
+    #[test]
+    fn force_complete_segments_with_unresolved_unions_subscriber_progress() {
+        let (registry, _dir) = setup_registry();
+        let provider = registry.segment_provider.clone();
+        provider.add_segment(1, 2);
+
+        let id1 = SubscriberId::new("sub-1").unwrap();
+        let id2 = SubscriberId::new("sub-2").unwrap();
+        for id in [&id1, &id2] {
+            registry.register(id.clone()).unwrap();
+            registry.activate(id).unwrap();
+        }
+
+        let sub1_bundle0 = registry.poll_next_bundle(&id1).unwrap().unwrap();
+        sub1_bundle0.ack();
+        let sub1_bundle1 = registry.poll_next_bundle(&id1).unwrap().unwrap();
+
+        let sub2_bundle0 = registry.poll_next_bundle(&id2).unwrap().unwrap();
+        let sub2_bundle1 = registry.poll_next_bundle(&id2).unwrap().unwrap();
+        sub2_bundle1.ack();
+
+        let unresolved = registry
+            .force_complete_segments_with_unresolved(&[SegmentSeq::new(1)])
+            .expect("registered subscribers");
+        assert_eq!(
+            unresolved[&SegmentSeq::new(1)],
+            BTreeSet::from([BundleIndex::new(0), BundleIndex::new(1)]),
+            "each stored bundle should be counted once when any subscriber still needs it"
+        );
+
+        sub1_bundle1.ack();
+        sub2_bundle0.ack();
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/quiver/src/subscriber/registry.rs
+++ b/rust/otap-dataflow/crates/quiver/src/subscriber/registry.rs
@@ -1964,6 +1964,8 @@ mod tests {
         next2.ack();
     }
 
+    /// Scenario: Force-completing a segment snapshots the union of unresolved bundles across subscribers.
+    /// Guarantees: Each stored bundle index appears once if any subscriber has not resolved it.
     #[test]
     fn force_complete_segments_with_unresolved_unions_subscriber_progress() {
         let (registry, _dir) = setup_registry();

--- a/rust/otap-dataflow/crates/quiver/src/subscriber/registry.rs
+++ b/rust/otap-dataflow/crates/quiver/src/subscriber/registry.rs
@@ -177,12 +177,26 @@ impl<P: SegmentProvider> SubscriberRegistry<P> {
         // Scan for existing progress files
         if config.data_dir.exists() {
             let subscriber_ids = scan_progress_files(&config.data_dir)?;
+            let available_segments = if subscriber_ids.is_empty() {
+                Vec::new()
+            } else {
+                segment_provider
+                    .available_segments()
+                    .into_iter()
+                    .map(|segment_seq| {
+                        segment_provider
+                            .bundle_count(segment_seq)
+                            .map(|bundle_count| (segment_seq, bundle_count))
+                    })
+                    .collect::<Result<Vec<_>>>()?
+            };
 
             for sub_id in subscriber_ids {
                 let path = progress_file_path(&config.data_dir, &sub_id);
                 match read_progress_file(&path) {
-                    Ok((_oldest_incomplete, entries)) => {
+                    Ok((oldest_incomplete, entries)) => {
                         let mut state = SubscriberState::new(sub_id.clone());
+                        let highest_persisted = entries.iter().map(|entry| entry.seg_seq).max();
 
                         // Restore segment progress from entries
                         for entry in entries {
@@ -194,6 +208,26 @@ impl<P: SegmentProvider> SubscriberRegistry<P> {
                                         BundleRef::new(entry.seg_seq, BundleIndex::new(bundle_idx));
                                     let _ = state.record_outcome(bundle_ref, AckOutcome::Acked);
                                 }
+                            }
+                        }
+
+                        // Segments may finalize after the last progress flush. Restore
+                        // those as unresolved before startup retention runs. Missing
+                        // segments below the persisted boundary were already completed.
+                        for &(segment_seq, bundle_count) in &available_segments {
+                            if state.segments().contains_key(&segment_seq) {
+                                continue;
+                            }
+
+                            // Zero also represents a real segment. Persisted entries
+                            // define the covered range when the boundary is ambiguous.
+                            let completed_before_snapshot = if oldest_incomplete.raw() == 0 {
+                                highest_persisted.is_some_and(|highest| segment_seq <= highest)
+                            } else {
+                                segment_seq < oldest_incomplete
+                            };
+                            if !completed_before_snapshot {
+                                state.add_segment(segment_seq, bundle_count);
                             }
                         }
 
@@ -1087,6 +1121,7 @@ mod tests {
     use std::sync::Mutex;
     use tempfile::tempdir;
 
+    use crate::subscriber::progress::SegmentProgressEntry;
     use crate::subscriber::types::BundleIndex;
 
     /// Per-segment metadata stored in the mock.
@@ -1371,6 +1406,81 @@ mod tests {
             assert_eq!(handle.bundle_ref().bundle_index, BundleIndex::new(1));
             handle.ack();
         }
+    }
+
+    /// Scenario: A segment finalizes after a subscriber's last progress snapshot.
+    /// Guarantees: Recovery tracks the later segment as unresolved without restoring completed segments below the persisted boundary.
+    #[tokio::test]
+    async fn recovery_reconciles_segments_missing_from_progress_snapshot() {
+        let dir = tempdir().unwrap();
+        let config = RegistryConfig::new(dir.path());
+        let provider = Arc::new(MockSegmentProvider::new());
+        provider.add_segment(1, 1);
+        provider.add_segment(2, 1);
+        provider.add_segment(3, 2);
+
+        let id = SubscriberId::new("test-sub").unwrap();
+        let persisted = SegmentProgressEntry::new(SegmentSeq::new(2), 1);
+        write_progress_file(
+            dir.path(),
+            &id,
+            SegmentSeq::new(2),
+            std::slice::from_ref(&persisted),
+        )
+        .await
+        .unwrap();
+
+        let registry = SubscriberRegistry::open(config, provider).unwrap();
+        let progress = registry.pending_segment_progress(&id).unwrap();
+
+        assert!(
+            !progress.contains_key(&SegmentSeq::new(1)),
+            "segments below the persisted boundary were already completed"
+        );
+        assert_eq!(
+            progress[&SegmentSeq::new(2)].bundle_count(),
+            1,
+            "persisted progress should be restored"
+        );
+        assert_eq!(
+            progress[&SegmentSeq::new(3)].resolved_count(),
+            0,
+            "segments absent beyond the persisted snapshot should be unresolved"
+        );
+        assert_eq!(progress[&SegmentSeq::new(3)].bundle_count(), 2);
+    }
+
+    /// Scenario: Segment zero is genuinely incomplete in a persisted progress snapshot.
+    /// Guarantees: Recovery preserves segment zero and treats only later unrecorded segments as unresolved.
+    #[tokio::test]
+    async fn recovery_reconciles_with_real_segment_zero_boundary() {
+        let dir = tempdir().unwrap();
+        let config = RegistryConfig::new(dir.path());
+        let provider = Arc::new(MockSegmentProvider::new());
+        provider.add_segment(0, 1);
+        provider.add_segment(1, 1);
+        provider.add_segment(2, 2);
+
+        let id = SubscriberId::new("test-sub").unwrap();
+        let segment_zero = SegmentProgressEntry::new(SegmentSeq::new(0), 1);
+        let mut segment_one = SegmentProgressEntry::new(SegmentSeq::new(1), 1);
+        segment_one.mark_acked(0);
+        write_progress_file(
+            dir.path(),
+            &id,
+            SegmentSeq::new(0),
+            &[segment_zero, segment_one],
+        )
+        .await
+        .unwrap();
+
+        let registry = SubscriberRegistry::open(config, provider).unwrap();
+        let progress = registry.pending_segment_progress(&id).unwrap();
+
+        assert_eq!(progress[&SegmentSeq::new(0)].resolved_count(), 0);
+        assert_eq!(progress[&SegmentSeq::new(1)].resolved_count(), 1);
+        assert_eq!(progress[&SegmentSeq::new(2)].resolved_count(), 0);
+        assert_eq!(progress[&SegmentSeq::new(2)].bundle_count(), 2);
     }
 
     #[tokio::test]

--- a/rust/otap-dataflow/crates/quiver/src/wal/replay.rs
+++ b/rust/otap-dataflow/crates/quiver/src/wal/replay.rs
@@ -30,6 +30,8 @@ pub(crate) struct ReplayBundle {
     ingestion_time: SystemTime,
     /// Logical item count recovered by the caller's WAL item counter.
     item_count: Option<u64>,
+    /// Logical byte count recovered by the caller's WAL byte counter.
+    byte_count: Option<u64>,
     /// Decoded slots with their Arrow RecordBatch data.
     slots: Vec<ReplaySlot>,
 }
@@ -107,6 +109,7 @@ impl ReplayBundle {
             descriptor: BundleDescriptor::new(descriptors),
             ingestion_time,
             item_count: None,
+            byte_count: None,
             slots,
         })
     }
@@ -114,6 +117,11 @@ impl ReplayBundle {
     /// Sets the logical item count recovered by the caller's WAL item counter.
     pub(crate) const fn set_item_count(&mut self, item_count: u64) {
         self.item_count = Some(item_count);
+    }
+
+    /// Sets the logical byte count recovered by the caller's WAL byte counter.
+    pub(crate) const fn set_byte_count(&mut self, byte_count: u64) {
+        self.byte_count = Some(byte_count);
     }
 }
 
@@ -142,6 +150,10 @@ impl RecordBundle for ReplayBundle {
 
     fn item_count_is_known(&self) -> bool {
         self.item_count.is_some()
+    }
+
+    fn byte_count(&self) -> Option<u64> {
+        self.byte_count
     }
 }
 


### PR DESCRIPTION
# Change summary

- report durable-buffer retention loss from only the bundles that remain unresolved when a segment is removed
- persist optional logical byte counts per bundle so loss bytes reflect the original OTAP or OTLP payload rather than the containing segment file
- separate physical storage reclamation into `processor.durable_buffer.reclaimed`
- restore subscriber progress before startup expiry accounting and report deferred file deletion only after removal is confirmed

### Details

Quiver stores multiple bundles in each physical segment. Previously, if one unresolved bundle kept a segment until retention expiry, the entire segment was reported as lost—including bundles that downstream exporters had already ACKed.

```text
segment selected by retention
├── bundle 0: unresolved  -> logical loss
└── bundle 1: ACKed       -> excluded from logical loss

physical segment removal  -> reclaimed storage
```

Retention now snapshots the union of unresolved bundle indices across subscribers while force-completing the segment under the same subscriber-state lock. Each stored bundle is counted once when any subscriber still needs it, avoiding both ACK races and per-subscriber double counting.

The segment manifest now includes an optional nullable `byte_count` for each bundle:

- OTAP records use their active-range Arrow logical size
- OTLP pass-through records use encoded protobuf wire length
- known zero remains distinct from an unavailable count
- loss bytes are emitted only when the selected unresolved bundles all have exact counts

The manifest change is additive. New readers treat a missing `byte_count` column as unavailable, while existing readers continue locating known fields by name and ignore the additional column.

## Related issue

* Closes #3892 

## Validation

Regression coverage exercises:

- a partially ACKed segment, verifying only its unresolved bundle contributes bundles, items, and logical bytes to expiry loss
- a fully ACKed later segment retained behind an incomplete predecessor, verifying resolved data is excluded from expiry loss
- multiple subscribers with overlapping unresolved bundles, verifying union semantics count each stored bundle once
- startup expiry after subscriber progress restoration, verifying persisted ACKs remain excluded
- immediate, deferred, retried, and abandoned physical deletion, verifying reclaimed counters advance only after confirmed removal
- nullable manifest byte counts, including known zero, known nonzero, unavailable counts, and legacy manifests without the new column
- canonical OTAP active-range and OTLP protobuf-wire byte measurements

A standalone mixed-segment repro sends one log bundle and one metric bundle through the same durable buffer, ACKs one downstream, transiently NACKs the other, and waits for the segment to expire.

### Single-item batches

| Unresolved bundle | `reclaimed.segments` | `reclaimed.bytes` | `loss.bundles` | `loss.bytes` | `loss.items` |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1 log | 1 `reason=expired` | 7,344 `reason=expired` | 1 `reason=expired` | 359 `reason=expired` | 1 `signal=logs, reason=expired` |
| 1 metric datapoint | 1 `reason=expired` | 7,344 `reason=expired` | 1 `reason=expired` | 329 `reason=expired` | 1 `signal=metrics, reason=expired` |

### 100-item batches

| Unresolved bundle | `reclaimed.segments` | `reclaimed.bytes` | `loss.bundles` | `loss.bytes` | `loss.items` |
| --- | ---: | ---: | ---: | ---: | ---: |
| 100 logs | 1 `reason=expired` | 57,840 `reason=expired` | 1 `reason=expired` | 24,248 `reason=expired` | 100 `signal=logs, reason=expired` |
| 100 metric datapoints | 1 `reason=expired` | 57,840 `reason=expired` | 1 `reason=expired` | 26,952 `reason=expired` | 100 `signal=metrics, reason=expired` |

For the 100-item run, the segment contained 51,200 logical payload bytes and 6,640 bytes of Arrow IPC and Quiver segment overhead:

```text
57,840 physical bytes reclaimed
├── 24,248 logical log bytes
├── 26,952 logical metric bytes
└──  6,640 segment encoding overhead
```

In every permutation, the physical segment size remained constant while `loss.bytes` changed to match only the unresolved bundle. The ACKed neighboring bundle was excluded from logical loss.

## User-facing changes

| Previous metric | Replacement | Meaning |
| --- | --- | --- |
| `processor.durable_buffer.loss.segments` | `processor.durable_buffer.reclaimed.segments` | Physical segment files removed |
| `processor.durable_buffer.loss.bytes` | `processor.durable_buffer.reclaimed.bytes` | Physical persisted bytes removed |
| N/A | `processor.durable_buffer.loss.bytes` | Logical bytes in unresolved bundles |
| `processor.durable_buffer.loss.bundles` | unchanged | Unresolved bundles removed by retention |
| `processor.durable_buffer.loss.items` | unchanged | Items in unresolved bundles, partitioned by signal |

Physical reclamation advances only after a segment file is confirmed removed. Deferred or abandoned deletion attempts are not reported as reclaimed.
