### PR TITLE
chore(docs): clarify telemetry metric availability

### DIFF
--- a/rust/otap-dataflow/crates/engine/telemetry.md
+++ b/rust/otap-dataflow/crates/engine/telemetry.md
@@ -6,65 +6,123 @@ emitted via `otel_*` log macros.
 
 ## Metrics
 
-| Metric name | Description | Produced in file |
+The admin server exposes the live metric registry at `GET /api/v1/metrics`
+(an alias of `GET /api/v1/telemetry/metrics`). The default response uses
+Prometheus text format. In that format, the metric-set name appears in the
+`otel_scope_name` label and the instrument name becomes the sample name. For
+example, `node.input.messages` appears as
+`messages_total{otel_scope_name="node.input", ...}`. Use `?format=json` to see
+the metric-set and instrument names separately.
+
+A metric is visible only after all of these conditions are met:
+
+- its configuration and platform conditions in the table below are satisfied;
+- the event it measures has occurred (for counters and histograms); and
+- the engine has completed a telemetry reporting interval.
+
+The endpoint omits zero-valued metric sets by default. For JSON responses, add
+`keep_all_zeroes=true` when investigating whether an instrument is registered
+but has not yet recorded a value.
+
+### Runtime metric levels
+
+`policies.telemetry.runtime_metrics` controls channel, node, and shared
+control-plane metrics. Its default value is `basic`.
+
+| Level | Data-path metrics enabled |
+| --- | --- |
+| `none` | No channel or node input/output metrics. |
+| `basic` | `channel.*` metrics. |
+| `normal` | `basic`, plus `node.input.messages` and `node.output.messages`. A node can also opt into item and size metrics. |
+| `detailed` | `normal`, plus node duration, item, and size metrics for every node. |
+
+At `normal`, enable the optional measurements on an individual node with
+`policies.telemetry.item_counts: true` and/or
+`policies.telemetry.size: true`. These node options do not enable node metrics
+when the pipeline level is `none` or `basic`.
+
+Node kind determines which side exists:
+
+| Node kind | `node.input.*` | `node.output.*` |
 | --- | --- | --- |
-| `engine.memory_rss` | Process resident memory (RSS) in bytes. | `crates/engine/src/engine_metrics.rs` |
-| `engine.cpu_utilization` | Process-wide CPU utilization as a ratio in `[0, 1]`, normalized across all logical CPU cores on the system. Aligned with the OTel semantic convention `process.cpu.utilization`. | `crates/engine/src/engine_metrics.rs` |
-| `channel.sender.messages` | Number of immediate send attempts, grouped by `outcome` and, for PData channels, `signal`. | `crates/engine/src/channel_metrics.rs` |
-| `channel.sender.failures` | Number of unsuccessful send attempts, grouped by `error.type` and, for PData channels, `signal`. | `crates/engine/src/channel_metrics.rs` |
-| `channel.receiver.messages` | Number of messages successfully dequeued, grouped by `signal` for PData channels. | `crates/engine/src/channel_metrics.rs` |
-| `channel.receiver.queue.depth` | Current number of messages buffered in the channel. | `crates/engine/src/channel_metrics.rs` |
-| `channel.receiver.capacity` | Configured channel buffer capacity. | `crates/engine/src/channel_metrics.rs` |
-| `node.input.duration` | Duration from entry until the corresponding ack or nack is routed, in seconds (histogram). | `crates/engine/src/channel_metrics.rs` |
-| `node.input.messages` | Messages received by the node, grouped by the `signal` and `outcome` datapoint attributes. | `crates/engine/src/channel_metrics.rs` |
-| `node.input.items` | Signal items received by an item-count-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | `crates/engine/src/channel_metrics.rs` |
-| `node.input.size` | Logical payload bytes received by a size-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | `crates/engine/src/channel_metrics.rs` |
-| `node.output.duration` | Duration from output until the corresponding ack or nack is routed, in seconds (histogram). | `crates/engine/src/channel_metrics.rs` |
-| `node.output.messages` | Messages emitted by the node, grouped by the `signal` and `outcome` datapoint attributes. | `crates/engine/src/channel_metrics.rs` |
-| `node.output.items` | Signal items emitted by an item-count-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | `crates/engine/src/channel_metrics.rs` |
-| `node.output.size` | Logical payload bytes emitted by a size-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | `crates/engine/src/channel_metrics.rs` |
-| `flow.input.messages` | PData messages entering an opted-in processor flow, grouped by the `signal` datapoint attribute. | `crates/engine/src/flow_metrics.rs` |
-| `flow.input.items` | Signal items entering an opted-in processor flow, grouped by the `signal` datapoint attribute. | `crates/engine/src/flow_metrics.rs` |
-| `flow.input.size` | Logical payload bytes entering an opted-in processor flow, grouped by the `signal` datapoint attribute. | `crates/engine/src/flow_metrics.rs` |
-| `flow.output.messages` | PData messages leaving an opted-in processor flow, grouped by the `signal` datapoint attribute. | `crates/engine/src/flow_metrics.rs` |
-| `flow.output.items` | Signal items leaving an opted-in processor flow, grouped by the `signal` datapoint attribute. | `crates/engine/src/flow_metrics.rs` |
-| `flow.output.size` | Logical payload bytes leaving an opted-in processor flow, grouped by the `signal` datapoint attribute. | `crates/engine/src/flow_metrics.rs` |
-| `flow.compute.duration` | Histogram of processor compute duration within an opted-in flow, in seconds and grouped by the `signal` datapoint attribute. | `crates/engine/src/flow_metrics.rs` |
-| `flow.dropped.items` | Signal items dropped at a decision node in an opted-in flow, grouped by the `signal` datapoint attribute. | `crates/engine/src/flow_metrics.rs` |
-| `pipeline.uptime` | Time since pipeline instance start. | `crates/engine/src/pipeline_metrics.rs` |
-| `pipeline.memory_usage` | Current heap memory in use by the pipeline thread (jemalloc only). | `crates/engine/src/pipeline_metrics.rs` |
-| `pipeline.memory_allocated` | Cumulative bytes allocated by the pipeline thread (jemalloc only). | `crates/engine/src/pipeline_metrics.rs` |
-| `pipeline.memory_freed` | Cumulative bytes freed by the pipeline thread (jemalloc only). | `crates/engine/src/pipeline_metrics.rs` |
-| `pipeline.memory_allocated_delta` | Bytes allocated during the latest sampling interval (jemalloc only). | `crates/engine/src/pipeline_metrics.rs` |
-| `pipeline.memory_freed_delta` | Bytes freed during the latest sampling interval (jemalloc only). | `crates/engine/src/pipeline_metrics.rs` |
-| `pipeline.cpu_time` | Cumulative CPU seconds consumed by the pipeline thread. | `crates/engine/src/pipeline_metrics.rs` |
-| `pipeline.cpu_utilization` | Ratio of CPU time to wall time over the latest interval. | `crates/engine/src/pipeline_metrics.rs` |
-| `pipeline.context_switches_voluntary` | Cumulative voluntary thread context switches. | `crates/engine/src/pipeline_metrics.rs` |
-| `pipeline.context_switches_involuntary` | Cumulative involuntary thread context switches (preemption). | `crates/engine/src/pipeline_metrics.rs` |
-| `pipeline.page_faults_minor` | Cumulative minor page faults for the pipeline thread. | `crates/engine/src/pipeline_metrics.rs` |
-| `pipeline.page_faults_major` | Cumulative major page faults for the pipeline thread. | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.worker_count` | Number of Tokio worker threads in the runtime. | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.task_active_count` | Current count of alive tasks in the runtime. | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.global_task_queue_size` | Current count of tasks in Tokio global/injection queue. | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.worker_busy_time` | Total worker busy time summed across workers (`target_has_atomic = "64"`). | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.worker_park_count` | Total worker park operations (`target_has_atomic = "64"`). | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.worker_park_unpark_count` | Total worker park/unpark transitions (`target_has_atomic = "64"`). | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.blocking_task_queue_size` | Current tasks pending in Tokio blocking queue (`tokio_unstable`). | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.blocking_thread_count` | Current number of Tokio blocking pool threads (`tokio_unstable`). | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.blocking_thread_idle_count` | Current number of idle Tokio blocking pool threads (`tokio_unstable`). | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.worker_local_queue_size` | Current tasks in all worker-local queues (`tokio_unstable`). | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.spawned_tasks_count` | Total tasks spawned since runtime creation (`tokio_unstable`, `target_has_atomic = "64"`). | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.remote_schedule_count` | Total schedules from outside runtime (`tokio_unstable`, `target_has_atomic = "64"`). | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.budget_forced_yield_count` | Total forced cooperative yields (`tokio_unstable`, `target_has_atomic = "64"`). | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.worker_noop_count` | Total noop unpark events summed across workers (`tokio_unstable`, `target_has_atomic = "64"`). | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.worker_steal_success_count` | Total successful worker steal operations (`tokio_unstable`, `target_has_atomic = "64"`). | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.worker_steal_attempt_count` | Total worker steal attempts (`tokio_unstable`, `target_has_atomic = "64"`). | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.worker_poll_count` | Total task poll operations across workers (`tokio_unstable`, `target_has_atomic = "64"`). | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.worker_local_schedule_count` | Total schedules into worker-local queues (`tokio_unstable`, `target_has_atomic = "64"`). | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.worker_overflow_count` | Total worker local-queue overflow events (`tokio_unstable`, `target_has_atomic = "64"`). | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.io_driver_fd_registered_count` | Total file descriptors registered in Tokio I/O driver (`tokio_unstable`, `target_has_atomic = "64"`). | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.io_driver_fd_deregistered_count` | Total file descriptors deregistered in Tokio I/O driver (`tokio_unstable`, `target_has_atomic = "64"`). | `crates/engine/src/pipeline_metrics.rs` |
-| `tokio.runtime.io_driver_ready_count` | Total ready events processed by Tokio I/O driver (`tokio_unstable`, `target_has_atomic = "64"`). | `crates/engine/src/pipeline_metrics.rs` |
+| Receiver | Not produced; a receiver has no pipeline input channel. | Produced for messages sent into the pipeline. |
+| Processor | Produced for messages consumed by the processor. | Produced only for messages the processor sends. |
+| Exporter | Produced for messages consumed by the exporter. | Not produced; an exporter has no pipeline output channel. |
+
+Flow metrics are independent of `runtime_metrics`. They are produced only for
+ranges explicitly declared in `policies.telemetry.flow_metrics`. Omitting the
+`metrics` list from a flow enables every flow metric; specifying the list
+enables only the selected entries. If `flow_metrics` is omitted or empty, no
+`flow.*` metrics are produced.
+
+For configuration examples and guidance on interpreting flow attributes and
+counts, see [Node and Flow Metrics](../../docs/node-and-flow-metrics.md#flow-metrics).
+
+### Metric reference
+
+| Metric name | Description | Produced when |
+| --- | --- | --- |
+| `engine.memory_rss` | Process resident memory (RSS) in bytes. | The engine is running; sampled once per engine about every five seconds. |
+| `engine.cpu_utilization` | Process-wide CPU utilization as a ratio in `[0, 1]`, normalized across all logical CPU cores on the system. Aligned with the OTel semantic convention `process.cpu.utilization`. | The engine is running; sampled once per engine about every five seconds. |
+| `engine.memory_pressure_state` | Memory limiter state: `0` for normal, `1` for soft pressure, and `2` for hard pressure. | The engine is running. The value remains `0` while no memory pressure is detected. |
+| `engine.process_memory_usage_bytes` | Most recent process memory usage sample in bytes. | The engine is running and the memory limiter has sampled process memory. |
+| `engine.process_memory_soft_limit_bytes` | Effective process-wide soft memory limit in bytes. | The engine is running. The value is `0` when no soft limit is configured. |
+| `engine.process_memory_hard_limit_bytes` | Effective process-wide hard memory limit in bytes. | The engine is running. The value is `0` when no hard limit is configured. |
+| `channel.sender.messages` | Number of immediate send attempts, grouped by `outcome` and, for PData channels, `signal`. | `runtime_metrics` is `basic` or higher and a data or control channel send is attempted. |
+| `channel.sender.failures` | Number of unsuccessful send attempts, grouped by `error.type` and, for PData channels, `signal`. | `runtime_metrics` is `basic` or higher and a send finds a full or closed channel. Healthy pipelines may not produce this metric. |
+| `channel.receiver.messages` | Number of messages successfully dequeued, grouped by `signal` for PData channels. | `runtime_metrics` is `basic` or higher and a data or control message is dequeued. Empty polls and channel closure are not counted. |
+| `channel.receiver.queue.depth` | Current number of messages buffered in the channel. | `runtime_metrics` is `basic` or higher and the channel exists; sampled on the reporting interval. |
+| `channel.receiver.capacity` | Configured channel buffer capacity. | `runtime_metrics` is `basic` or higher and the channel exists; sampled on the reporting interval. |
+| `node.input.duration` | Duration from entry until the corresponding ack or nack is routed, in seconds (histogram). | `runtime_metrics` is `detailed`, a processor or exporter consumes PData, and its terminal ack or nack unwinds. |
+| `node.input.messages` | Messages received by the node, grouped by the `signal` and `outcome` datapoint attributes. | `runtime_metrics` is `normal` or `detailed`, a processor or exporter consumes PData, and its terminal ack or nack unwinds. |
+| `node.input.items` | Signal items received by an item-count-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | Input message conditions are met and either the level is `detailed` or that processor/exporter sets `policies.telemetry.item_counts: true`. |
+| `node.input.size` | Logical payload bytes received by a size-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | Input message conditions are met and either the level is `detailed` or that processor/exporter sets `policies.telemetry.size: true`. |
+| `node.output.duration` | Duration from output until the corresponding ack or nack is routed, in seconds (histogram). | `runtime_metrics` is `detailed`, a receiver emits PData, and its terminal ack or nack unwinds. Processor latency is recorded in `node.input.duration`. |
+| `node.output.messages` | Messages emitted by the node, grouped by the `signal` and `outcome` datapoint attributes. | `runtime_metrics` is `normal` or `detailed`, a receiver or processor sends PData, and its terminal ack or nack unwinds. A processor that drops a whole message produces no output datapoint for it. |
+| `node.output.items` | Signal items emitted by an item-count-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | Output message conditions are met and either the level is `detailed` or that receiver/processor sets `policies.telemetry.item_counts: true`. |
+| `node.output.size` | Logical payload bytes emitted by a size-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | Output message conditions are met and either the level is `detailed` or that receiver/processor sets `policies.telemetry.size: true`. |
+| `flow.input.messages` | PData messages entering an opted-in processor flow, grouped by the `signal` datapoint attribute. | A configured flow enables `input_messages` and a message enters its start processor. |
+| `flow.input.items` | Signal items entering an opted-in processor flow, grouped by the `signal` datapoint attribute. | A configured flow enables `input_items` and a message enters its start processor. |
+| `flow.input.size` | Logical payload bytes entering an opted-in processor flow, grouped by the `signal` datapoint attribute. | A configured flow enables `input_size` and a message enters its start processor. |
+| `flow.output.messages` | PData messages leaving an opted-in processor flow, grouped by the `signal` datapoint attribute. | A configured flow enables `output_messages` and a message leaves its end processor. |
+| `flow.output.items` | Signal items leaving an opted-in processor flow, grouped by the `signal` datapoint attribute. | A configured flow enables `output_items` and a message leaves its end processor. |
+| `flow.output.size` | Logical payload bytes leaving an opted-in processor flow, grouped by the `signal` datapoint attribute. | A configured flow enables `output_size` and a message leaves its end processor. |
+| `flow.compute.duration` | Histogram of processor compute duration within an opted-in flow, in seconds and grouped by the `signal` datapoint attribute. | A configured flow enables `compute_duration` and a message is processed within the declared processor range. |
+| `flow.dropped.items` | Signal items dropped at a decision node in an opted-in flow, grouped by the `signal` datapoint attribute. | A configured flow enables `dropped_items` and a drop-capable decision processor inside the range drops one or more items. |
+| `pipeline.uptime` | Time since pipeline instance start. | The pipeline sets `policies.telemetry.pipeline_metrics: true` (the default). |
+| `pipeline.memory_usage` | Current heap memory in use by the pipeline thread. | `pipeline_metrics` is `true` and the non-Windows build uses jemalloc with working thread-local statistics; otherwise it remains zero and is normally omitted. |
+| `pipeline.memory_allocated` | Cumulative bytes allocated by the pipeline thread. | Same conditions as `pipeline.memory_usage`. |
+| `pipeline.memory_freed` | Cumulative bytes freed by the pipeline thread. | Same conditions as `pipeline.memory_usage`. |
+| `pipeline.memory_allocated_delta` | Bytes allocated during the latest sampling interval. | Same conditions as `pipeline.memory_usage`. |
+| `pipeline.memory_freed_delta` | Bytes freed during the latest sampling interval. | Same conditions as `pipeline.memory_usage`. |
+| `pipeline.cpu_time` | Cumulative CPU seconds consumed by the pipeline thread. | The pipeline sets `pipeline_metrics: true`. |
+| `pipeline.cpu_utilization` | Ratio of CPU time to wall time over the latest interval. | The pipeline sets `pipeline_metrics: true`. |
+| `pipeline.context_switches_voluntary` | Cumulative voluntary thread context switches. | `pipeline_metrics` is `true`, the OS is Linux, FreeBSD, or OpenBSD, and per-thread `getrusage` succeeds. |
+| `pipeline.context_switches_involuntary` | Cumulative involuntary thread context switches (preemption). | Same conditions as `pipeline.context_switches_voluntary`. |
+| `pipeline.page_faults_minor` | Cumulative minor page faults for the pipeline thread. | Same conditions as `pipeline.context_switches_voluntary`. |
+| `pipeline.page_faults_major` | Cumulative major page faults for the pipeline thread. | Same conditions as `pipeline.context_switches_voluntary`. |
+| `tokio.runtime.worker_count` | Number of Tokio worker threads in the runtime. | The pipeline sets `policies.telemetry.tokio_metrics: true` (the default) and runs inside a Tokio runtime. |
+| `tokio.runtime.task_active_count` | Current count of alive tasks in the runtime. | Same conditions as `tokio.runtime.worker_count`. |
+| `tokio.runtime.global_task_queue_size` | Current count of tasks in Tokio global/injection queue. | Same conditions as `tokio.runtime.worker_count`. |
+| `tokio.runtime.worker_busy_time` | Total worker busy time summed across workers. | Same conditions as `tokio.runtime.worker_count`, on a target with 64-bit atomics. |
+| `tokio.runtime.worker_park_count` | Total worker park operations. | Same conditions as `tokio.runtime.worker_count`, on a target with 64-bit atomics. |
+| `tokio.runtime.worker_park_unpark_count` | Total worker park/unpark transitions. | Same conditions as `tokio.runtime.worker_count`, on a target with 64-bit atomics. |
+| `tokio.runtime.blocking_task_queue_size` | Current tasks pending in Tokio blocking queue. | Same conditions as `tokio.runtime.worker_count`, in a build compiled with `tokio_unstable`. |
+| `tokio.runtime.blocking_thread_count` | Current number of Tokio blocking pool threads. | Same conditions as `tokio.runtime.worker_count`, in a build compiled with `tokio_unstable`. |
+| `tokio.runtime.blocking_thread_idle_count` | Current number of idle Tokio blocking pool threads. | Same conditions as `tokio.runtime.worker_count`, in a build compiled with `tokio_unstable`. |
+| `tokio.runtime.worker_local_queue_size` | Current tasks in all worker-local queues. | Same conditions as `tokio.runtime.worker_count`, in a build compiled with `tokio_unstable`. |
+| `tokio.runtime.spawned_tasks_count` | Total tasks spawned since runtime creation. | Same conditions as `tokio.runtime.worker_count`, with `tokio_unstable` and 64-bit atomics. |
+| `tokio.runtime.remote_schedule_count` | Total schedules from outside runtime. | Same conditions as `tokio.runtime.worker_count`, with `tokio_unstable` and 64-bit atomics. |
+| `tokio.runtime.budget_forced_yield_count` | Total forced cooperative yields. | Same conditions as `tokio.runtime.worker_count`, with `tokio_unstable` and 64-bit atomics. |
+| `tokio.runtime.worker_noop_count` | Total noop unpark events summed across workers. | Same conditions as `tokio.runtime.worker_count`, with `tokio_unstable` and 64-bit atomics. |
+| `tokio.runtime.worker_steal_success_count` | Total successful worker steal operations. | Same conditions as `tokio.runtime.worker_count`, with `tokio_unstable` and 64-bit atomics. |
+| `tokio.runtime.worker_steal_attempt_count` | Total worker steal attempts. | Same conditions as `tokio.runtime.worker_count`, with `tokio_unstable` and 64-bit atomics. |
+| `tokio.runtime.worker_poll_count` | Total task poll operations across workers. | Same conditions as `tokio.runtime.worker_count`, with `tokio_unstable` and 64-bit atomics. |
+| `tokio.runtime.worker_local_schedule_count` | Total schedules into worker-local queues. | Same conditions as `tokio.runtime.worker_count`, with `tokio_unstable` and 64-bit atomics. |
+| `tokio.runtime.worker_overflow_count` | Total worker local-queue overflow events. | Same conditions as `tokio.runtime.worker_count`, with `tokio_unstable` and 64-bit atomics. |
+| `tokio.runtime.io_driver_fd_registered_count` | Total file descriptors registered in Tokio I/O driver. | Same conditions as `tokio.runtime.worker_count`, with `tokio_unstable` and 64-bit atomics. |
+| `tokio.runtime.io_driver_fd_deregistered_count` | Total file descriptors deregistered in Tokio I/O driver. | Same conditions as `tokio.runtime.worker_count`, with `tokio_unstable` and 64-bit atomics. |
+| `tokio.runtime.io_driver_ready_count` | Total ready events processed by Tokio I/O driver. | Same conditions as `tokio.runtime.worker_count`, with `tokio_unstable` and 64-bit atomics. |
 
 ### Channel metric semantics
 


### PR DESCRIPTION
# Change summary

Improve the engine telemetry documentation by describing when each metric is emitted, clarifying runtime and flow metric configuration, and linking to the detailed node and flow metrics guide.

## Related issue

None.

## Validation

- Verified `node.input.*` and `node.output.*` using a live basic pipeline at the admin metrics endpoint.
- Confirmed their behavior at `basic`, `normal`, and `detailed` runtime metric levels.

## User-facing changes

Documentation-only. No changelog entry required.