### PR TITLE
feat(config-translators): add AMCS to pipeline config translator

### DIFF
--- a/rust/otap-dataflow/.chloggen/amcs-config-translator.yaml
+++ b/rust/otap-dataflow/.chloggen/amcs-config-translator.yaml
@@ -1,0 +1,12 @@
+change_type: new_component
+
+component: pipeline
+
+note: Add an AMCS config translator that turns Azure Monitor Data Collection Rules into a pipeline configuration.
+
+issues: [3911]
+
+subtext: |
+  Reads the AMCS configuration payload delivered to the agent and generates the equivalent
+  receiver, filter, batch and exporter pipeline. Supports multiple Data Collection Rules on one
+  host, per-signal resource attribute routing, and the AgentSettings rule for OTLP listener ports.

--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -7349,6 +7349,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "otel-arrow-dfe-contrib-config-translators"
+version = "0.52.0"
+dependencies = [
+ "clap",
+ "otel-arrow-dfe-config",
+ "otel-arrow-dfe-telemetry",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.20",
+ "urlencoding",
+]
+
+[[package]]
 name = "otel-arrow-dfe-contrib-extensions"
 version = "0.52.0"
 dependencies = [

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -75,6 +75,7 @@ otel-arrow-dfe-pdata = { path = "crates/pdata" }
 otel-arrow-dfe-pdata-views = { path = "crates/pdata-views" }
 otel-arrow-dfe-telemetry = { path = "crates/telemetry" }
 otel-arrow-dfe-quiver = { path = "crates/quiver" }
+otel-arrow-dfe-contrib-config-translators = { path = "crates/contrib-config-translators" }
 data_engine_expressions = { path = "../experimental/query_engine/expressions" }
 data_engine_kql_parser = { path = "../experimental/query_engine/kql-parser" }
 data_engine_parser_abstractions = { path = "../experimental/query_engine/parser-abstractions"}

--- a/rust/otap-dataflow/crates/contrib-config-translators/Cargo.toml
+++ b/rust/otap-dataflow/crates/contrib-config-translators/Cargo.toml
@@ -12,6 +12,9 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[[bin]]
+name = "config-translator"
+path = "src/cli.rs"
 
 [dependencies]
 otel-arrow-dfe-config = { workspace = true }

--- a/rust/otap-dataflow/crates/contrib-config-translators/Cargo.toml
+++ b/rust/otap-dataflow/crates/contrib-config-translators/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "otel-arrow-dfe-contrib-config-translators"
+description = "Vendor-specific configuration translators that produce OTAP dataflow pipeline specs"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+
+[dependencies]
+otel-arrow-dfe-config = { workspace = true }
+otel-arrow-dfe-telemetry = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+thiserror = { workspace = true }
+clap = { workspace = true }
+urlencoding = { workspace = true }

--- a/rust/otap-dataflow/crates/contrib-config-translators/README.md
+++ b/rust/otap-dataflow/crates/contrib-config-translators/README.md
@@ -1,0 +1,254 @@
+# Contrib Config Translators
+
+Vendor-specific configuration translators that produce OTAP dataflow pipeline
+specifications.
+
+A *translator* converts a vendor's own configuration document into an
+`OtelDataflowSpec` the engine can run. This sits one stage after
+`ConfigProvider`, which resolves a URI to raw content:
+
+```text
+  vendor config (JSON)  --ConfigTranslator-->  OtelDataflowSpec  -->  pipeline YAML
+```
+
+## Available translators
+
+- `amcs` (`src/amcs/mod.rs`) -- Azure Monitor Configuration Service, third-party
+  (3P) Data Collection Rules.
+
+A first-party (1P) Geneva/GigLA translator can be added as a sibling module
+implementing the same `ConfigTranslator` trait.
+
+## Library usage
+
+```rust,no_run
+use otap_df_contrib_config_translators::ConfigTranslator;
+use otap_df_contrib_config_translators::amcs::AmcsTranslator;
+
+let payload = std::fs::read_to_string("amcs-config.json")?;
+let yaml = AmcsTranslator::new().translate_to_yaml(&payload)?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## CLI usage
+
+A development binary is provided for inspecting translator output:
+
+```bash
+cargo run -p otap-df-contrib-config-translators --bin config-translator -- \
+  --input tests/fixtures/AMCSConfig.json \
+  --validate
+```
+
+- `--input <path>` -- vendor configuration document to translate.
+- `--output <path>` -- where to write the YAML; defaults to stdout.
+- `--dialect <name>` -- configuration dialect; defaults to `amcs`.
+- `--validate` -- check the YAML parses back through the engine loader.
+
+The binary source lives at `src/cli.rs` rather than the conventional `src/bin/`,
+because the repository's top-level `.gitignore` matches `bin/` and would make the
+file invisible to git.
+
+The generated file can be handed straight to the engine:
+
+```bash
+cargo run --bin df_engine -- --config generated.yaml --num-cores 1
+```
+
+## The AMCS translator
+
+AMCS delivers the Azure Monitor Agent every customer-authored Data Collection
+Rule (DCR) that applies to a host, as a single JSON document. This crate is a
+port of `AMCSParser.ExtractConfiguration` from the .NET `AMCSConfiguration`
+project: the input is byte-for-byte the same payload the .NET agent consumes,
+and only the output differs -- a pipeline specification instead of an in-memory
+list of endpoint bindings.
+
+### Stages
+
+- `schema` -- serde model of the AMCS JSON payload.
+- `listener` -- OTLP listener discovery from environment variables.
+- `extract` -- payload plus listeners to routable endpoint bindings.
+- `emit` -- endpoint bindings to a pipeline specification.
+
+### Translation rules
+
+- A configuration whose `content.kind` is `AgentSettings` carries listener
+  settings, not telemetry routing. It is consumed for its ports and never
+  becomes a pipeline branch. Unknown kinds are skipped rather than rejected, so
+  a newer control plane can add rule kinds without breaking existing agents.
+- `dataSource.kind` is matched case-insensitively: `otelLogs` becomes logs and
+  `otelTraces` becomes traces. Every other kind (`perfCounter`, `extension`,
+  and so on) is skipped.
+- Only channels with `protocol: gig` carry OTLP endpoint templates. `ods`
+  channels are legacy and are ignored.
+- The literal `<STREAM>` token in an endpoint template is replaced with each of
+  the data source's stream names.
+- Each export path is identified by `{configurationId}.{channelId}`.
+- `resourceAttributeRouting` is optional and tracked **per signal**, because a
+  rule may filter its logs while broadcasting its traces. A missing filter
+  means broadcast, and is logged.
+- `otelLogsEndpointUriTemplate` and `otelTracesEndpointUriTemplate` are
+  independently optional.
+
+### Listener configuration
+
+Listeners are global to the host, not per rule, which is why the generated
+pipeline has a single OTLP receiver. Ports come from the environment or from an
+Agent Settings DCR; the host is environment-only.
+
+Port values resolve in this order, highest priority first, per
+`Telemetry-Collection-Spec/AMACoreAgent/otel-port-configuration.md`:
+
+1. **Environment variable** -- `OTLP_GRPC_LOGS_TRACES_PORT` and
+   `OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT`. If set, the Agent Settings value is
+   ignored, so AKS deployments driven by environment variables are never
+   disrupted by a DCR.
+2. **Agent Settings DCR** -- the `OtlpGrpcLogsTracesPort` and
+   `OtlpHttpProtobufLogsTracesPort` settings.
+3. **Built-in default** -- `4319` for gRPC and `4320` for HTTP/protobuf.
+
+Value handling:
+
+- `-1` disables that listener outright, overriding any Agent Settings value.
+- Any other invalid value -- unparseable, or outside `[1, 65535]` -- is treated
+  as **unset**, so resolution falls through to the next source.
+- `OTLP_GRPC_LOGS_TRACES_HOST` and `OTLP_HTTP_PROTOBUF_LOGS_TRACES_HOST`
+  override the default host `localhost`. There is no Agent Settings equivalent.
+
+A listener being configured does not by itself open a port: an OTel data-source
+rule must also be present. An Agent Settings DCR on its own produces no
+pipeline, which surfaces as an `EmptyPipeline` error.
+
+### Agent Settings DCR shape
+
+The Agent Settings DCR is a separate configuration entry alongside the
+data-source rules, and a host has at most one:
+
+```json
+{
+  "configurationId": "dcr-00000000000000000000000000000003",
+  "content": {
+    "kind": "AgentSettings",
+    "settings": [
+      { "name": "MaxDiskQuotaInMB", "value": "10240" },
+      { "name": "OtlpGrpcLogsTracesPort", "value": "4319" },
+      { "name": "OtlpHttpProtobufLogsTracesPort", "value": "4320" }
+    ]
+  }
+}
+```
+
+Settings not related to listeners, such as `MaxDiskQuotaInMB`, are parsed and
+ignored. `agentSettings` is accepted as an alias for `settings` because the
+specification writes it that way.
+
+### Generated topologies
+
+With a single export path the result is one pipeline:
+
+```text
+  receiver:otlp -> [filter] -> batch -> exporter:otlp_http
+```
+
+With several export paths the receiver's single output port cannot fan out --
+the engine rejects broadcast to more than one target -- so a `processor:fanout`
+clones each message to one named output port per rule. Every path therefore
+sees every message and decides for itself, matching the .NET publisher.
+
+```text
+                    +-- port_a --> [filter] -> batch -> exporter
+  receiver -> fanout+
+                    +-- port_b --> [filter] -> batch -> exporter
+```
+
+Each path carries its own batch node. A batch shared across rules would merge
+their telemetry with no way to separate it again before the exporters, because
+the batch processor has no partition key or per-key queueing.
+
+The `filter` node is omitted when a path neither routes on a resource attribute
+nor needs to drop a signal, so a rule that accepts everything connects straight
+to its batch node.
+
+### Where each generated value comes from
+
+- Receiver `listening_addr` -- environment variables, with defaults.
+- Filter `resource_attributes` -- AMCS `resourceAttributeRouting`.
+- Exporter `logs_endpoint` and `traces_endpoint` -- AMCS channel templates, with
+  `<STREAM>` substituted.
+- Exporter `user_agent` and the `azure-monitor-source-resourceId` /
+  `x-ms-AzureRegion` headers -- the embedding host, not the AMCS payload. The
+  resource id is percent-encoded, matching the .NET agent.
+- Receiver `max_decoding_message_size` / `max_request_body_size` -- fixed at
+  64 MiB. Without this the engine's own 4 MiB default silently rejects larger
+  payloads before they reach the pipeline.
+- `batch`, `policies`, `version` and `engine` -- fixed defaults. Batches
+  flush at 1043333 bytes or after 20 seconds, in `otlp` format so payloads are
+  not converted to OTAP and back on a path that is OTLP end to end.
+
+### Dropping a signal that has no endpoint
+
+When a path has an endpoint for only one signal, the other must be discarded.
+Leaving the filter's section empty would not work: the filter processor treats
+an empty match list as "match everything". Instead the absent signal is given a
+match list containing a sentinel value that cannot occur in real telemetry,
+producing an all-false mask.
+
+Without this the exporter would fall back to `endpoint + "/v1/<signal>"` and
+misroute the signal.
+
+### Intentional divergence from the .NET reference
+
+`AMCSParser.cs:235-242` selects the endpoint template with:
+
+```csharp
+if (eventName == Log && otelLogsEndpointUriTemplate != null) { ...logs... }
+else if (otelTracesEndpointUriTemplate != null)              { ...traces... }
+```
+
+When the signal is `Log` but `otelLogsEndpointUriTemplate` is null, control
+falls into the `else if` and a **traces** URL is emitted for a **logs** data
+source. Since both templates are independently optional, that path is reachable
+with real customer configuration and would silently misroute logs.
+
+This port selects each signal's own template only, so a data source whose
+template is absent produces no endpoint at all. See `endpoint_template` in
+`src/amcs/extract.rs`.
+
+## Testing
+
+```bash
+cargo test -p otap-df-contrib-config-translators
+```
+
+The fixtures in `tests/fixtures/` are verbatim copies of
+`PipelineAgentTests/TestData/ConfigPackage/AMCSConfig*` from the
+`PipelineAgent` repository.
+
+- `AMCSConfig` -- one rule; logs, traces and `perfCounter`; `gig` and `ods`
+  channels.
+- `AMCSConfig2` -- as above, but the traces source has no routing attribute.
+- `AMCSConfig3` -- two rules sharing one channel id, with different routing
+  values.
+- `AMCSConfig4` -- no data sources at all.
+- `AMCSConfig5` -- logs only; the `gig` channel has no traces template.
+- `AMCSConfigAgentSettings` -- an Agent Settings rule alongside a data-source
+  rule.
+- `AMCSConfigAgentSettingsOnly` -- an Agent Settings rule with no data-source
+  rule, which must open no ports.
+
+`tests/parity.rs` asserts values captured by invoking the real
+`AMCSParser.ExtractConfigurationByIdentifier` from the prebuilt
+`AMCSConfiguration.dll`, which is what makes this a port rather than a
+reimplementation. Note that the .NET parser does not read Agent Settings --
+`Content.kind` and `Content.settings` are commented out in `Configurations.cs` --
+so that behaviour is specified by
+`Telemetry-Collection-Spec/AMACoreAgent/otel-port-configuration.md` rather than
+by parity.
+
+## References
+
+- `Telemetry-Collection-Spec/AMACoreAgent/otel-port-configuration.md` -- the
+  approved specification for OTel port configuration via environment variables
+  and the Agent Settings DCR.
+- `PipelineAgent/AMCSConfiguration/AMCSParser.cs` -- the .NET reference parser.

--- a/rust/otap-dataflow/crates/contrib-config-translators/src/amcs/emit.rs
+++ b/rust/otap-dataflow/crates/contrib-config-translators/src/amcs/emit.rs
@@ -1,0 +1,1243 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Conversion of extracted AMCS endpoint bindings into an engine pipeline specification.
+//!
+//! # Topology
+//!
+//! Listeners are global to the host (see [`crate::amcs::listener`]), so the generated pipeline
+//! has a single OTLP receiver. Every Data Collection Rule then gets its own
+//! `filter -> batch -> exporter` chain.
+//!
+//! With one export path the chain hangs directly off the receiver:
+//!
+//! ```text
+//!   receiver -> filter -> batch -> exporter
+//! ```
+//!
+//! With several export paths a `processor:fanout` clones each message to one named output port
+//! per rule, so every rule sees every message and applies its own filter:
+//!
+//! ```text
+//!                       +-- port_a --> filter_a -> batch_a -> exporter_a
+//!   receiver -> fanout -+
+//!                       +-- port_b --> filter_b -> batch_b -> exporter_b
+//! ```
+//!
+//! A filter node is emitted for **every** rule, including one that declares no resource attribute
+//! routing. In that case the filter matches everything and is redundant, but keeping the shape
+//! uniform makes generation and review simpler; the redundant node can be optimised away later.
+//!
+//! Each path gets its **own** batch node. A batch shared across rules would merge their telemetry
+//! with no way to separate it again before the exporters, because the batch processor has no
+//! partition key or per-key queueing. Per-path batching also keeps one high-volume rule from
+//! driving flush behaviour for the others.
+//!
+//! # Values and their origins
+//!
+//! | Generated field | Source |
+//! |---|---|
+//! | receiver `listening_addr` | environment variables and the agent settings rule |
+//! | receiver size limits | fixed constants ([`MAX_DECODING_MESSAGE_SIZE`]) |
+//! | filter `resource_attributes` | AMCS `resourceAttributeRouting` |
+//! | exporter `logs_endpoint` / `traces_endpoint` | AMCS channel templates, `<STREAM>` substituted |
+//! | exporter headers and user agent | the embedding host, via [`HostContext`] |
+//! | `batch`, `policies`, `version`, `engine` | fixed defaults |
+
+use crate::amcs::extract::{OtlpAttributeRouting, OtlpEventInfo, OtlpEventName};
+use crate::amcs::listener::{OtlpEventListenerInfo, OtlpProtocol};
+use otel_arrow_dfe_config::engine::{EngineConfig, OtelDataflowSpec};
+use otel_arrow_dfe_config::pipeline::{PipelineConfigBuilder, PipelineType};
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use std::collections::HashSet;
+
+/// Node type URN for the OTLP receiver.
+const OTLP_RECEIVER_URN: &str = "urn:otel:receiver:otlp";
+
+/// Node type URN for the fan-out processor.
+const FANOUT_PROCESSOR_URN: &str = "urn:otel:processor:fanout";
+
+/// Node type URN for the filter processor.
+const FILTER_PROCESSOR_URN: &str = "urn:otel:processor:filter";
+
+/// Node type URN for the batch processor.
+const BATCH_PROCESSOR_URN: &str = "urn:otel:processor:batch";
+
+/// Node type URN for the OTLP/HTTP exporter.
+const OTLP_HTTP_EXPORTER_URN: &str = "urn:otel:exporter:otlp_http";
+
+/// Name of the fan-out node used when there is more than one export path.
+const FANOUT_NODE: &str = "fanout";
+
+/// Pipeline group the generated pipeline is placed in.
+const PIPELINE_GROUP_ID: &str = "default";
+
+/// Pipeline name within the group.
+const PIPELINE_ID: &str = "main";
+
+/// Maximum decompressed OTLP/gRPC message the receiver will accept.
+///
+/// The agent accepts a much larger payload than the engine's own 4 MiB default, so without this
+/// every request above 4 MiB is rejected before it reaches the pipeline.
+const MAX_DECODING_MESSAGE_SIZE: &str = "64MiB";
+
+/// Maximum OTLP/HTTP request body the receiver will accept, for the same reason.
+const MAX_REQUEST_BODY_SIZE: &str = "64MiB";
+
+/// Batch size in bytes. The minimum and maximum are deliberately identical so a batch is emitted
+/// at a predictable size rather than anywhere within a range.
+const BATCH_SIZE_BYTES: u64 = 1_043_333;
+
+/// Longest a batch may wait before being flushed.
+const BATCH_MAX_DURATION: &str = "20000ms";
+
+/// Batching format. `otlp` keeps payloads in OTLP form end to end rather than converting to OTAP.
+const BATCH_FORMAT: &str = "otlp";
+
+/// Whether outbound OTLP/HTTP requests are gzip compressed.
+///
+/// Disabled for now. When enabled the exporter's `http.compression` setting is emitted; keeping
+/// the decision in a constant means the parser logic does not change if it is revisited.
+const ENABLE_COMPRESSION: bool = false;
+
+/// Compression algorithm used when [`ENABLE_COMPRESSION`] is set.
+const COMPRESSION_ALGORITHM: &str = "gzip";
+
+/// Number of pooled HTTP clients per exporter.
+const EXPORTER_CLIENT_POOL_SIZE: u64 = 1;
+
+/// Header carrying the Azure resource id of the host, matching the .NET agent.
+const HEADER_RESOURCE_ID: &str = "azure-monitor-source-resourceId";
+
+/// Header carrying the Azure region of the host, matching the .NET agent.
+const HEADER_REGION: &str = "x-ms-AzureRegion";
+
+/// Capability binding name for the credential provider the embedding host supplies.
+///
+/// `urn:otel:exporter:otlp_http` accepts two mutually exclusive credential capabilities:
+/// `bearer_token_provider`, and `agent_fed_credential_provider` for host-managed rotating
+/// credentials (added by open-telemetry/otel-arrow#3836). The exporter rejects a configuration
+/// that binds both.
+///
+/// Agent-fed is the one that applies here: the Monitoring Agent owns the token and rotates it, and
+/// the exporter re-reads the snapshot on every export attempt rather than holding a static token.
+const CAPABILITY_AGENT_FED_CREDENTIAL_PROVIDER: &str = "agent_fed_credential_provider";
+
+/// Sentinel used to build a filter that matches nothing.
+///
+/// The filter processor treats an empty match list as "match everything", so a signal cannot be
+/// dropped by leaving its section empty. A non-empty list of names that cannot occur in real
+/// telemetry yields an all-false mask instead, which is how a path discards a signal it has no
+/// endpoint for.
+const NEVER_MATCHES: &str = "__otap_amcs_signal_disabled__";
+
+/// Values supplied by the embedding host rather than by the AMCS payload.
+///
+/// The agent knows its own identity, region and version; none of that appears in a Data
+/// Collection Rule. The .NET agent sends the same three values as request headers, so the
+/// generated configuration carries them on every exporter.
+#[derive(Debug, Clone, Default)]
+pub struct HostContext {
+    /// Azure resource id of the host, for example
+    /// `/subscriptions/<id>/resourceGroups/<rg>/providers/...`.
+    ///
+    /// Percent-encoded before it is emitted, matching `HttpUtility.UrlEncode` in the .NET agent.
+    pub agent_identity: Option<String>,
+
+    /// Azure region of the host, for example `westus2`. Emitted verbatim.
+    pub region: Option<String>,
+
+    /// Value for the outbound `User-Agent` header, for example `AMACoreAgent/1.2.3`.
+    ///
+    /// The host builds this from its own product name and version so the backend can tell which
+    /// agent flavour sent the request.
+    pub user_agent: Option<String>,
+}
+
+/// All bindings belonging to one `{configurationId}.{channelId}` identifier.
+#[derive(Debug, Default)]
+struct Branch {
+    /// Resolved logs endpoint URLs, in stable order.
+    logs_urls: Vec<String>,
+    /// Resolved traces endpoint URLs, in stable order.
+    traces_urls: Vec<String>,
+    /// Routing filter for logs, or `None` when logs are broadcast.
+    logs_routing: Option<OtlpAttributeRouting>,
+    /// Routing filter for traces, or `None` when traces are broadcast.
+    traces_routing: Option<OtlpAttributeRouting>,
+}
+
+/// One export path: a filter, a batch processor, and an exporter.
+#[derive(Debug)]
+struct SubBranch {
+    /// Node name suffix, unique within the generated configuration.
+    suffix: String,
+    /// The logs endpoint for this path, if any.
+    logs_url: Option<String>,
+    /// The traces endpoint for this path, if any.
+    traces_url: Option<String>,
+    /// Routing filter for logs, or `None` when logs are broadcast.
+    logs_routing: Option<OtlpAttributeRouting>,
+    /// Routing filter for traces, or `None` when traces are broadcast.
+    traces_routing: Option<OtlpAttributeRouting>,
+}
+
+impl SubBranch {
+    /// Node name of this path's filter.
+    fn filter_node(&self) -> String {
+        format!("filter_{}", self.suffix)
+    }
+
+    /// Node name of this path's batch processor.
+    ///
+    /// The flush duration is part of the name so a reader can tell a node's batching behaviour
+    /// without cross-referencing its config.
+    fn batch_node(&self) -> String {
+        format!("batch_20k_ms_{}", self.suffix)
+    }
+
+    /// Node name of this path's exporter.
+    fn exporter_node(&self) -> String {
+        format!("exporter_{}", self.suffix)
+    }
+
+    /// Name of the fan-out output port feeding this path.
+    fn fanout_port(&self) -> String {
+        format!("port_{}", self.suffix)
+    }
+
+    /// Whether this path needs a filter node at all.
+    ///
+    /// A filter is required to apply a routing attribute, or to drop a signal this path has no
+    /// endpoint for. A rule that routes on nothing and exports both signals needs neither, so the
+    /// node is omitted and the path is one hop shorter; a filter that matches everything would
+    /// only cost a copy per message.
+    ///
+    /// # Metrics are not dropped
+    ///
+    /// AMCS describes only `otelLogs` and `otelTraces`, so no path ever carries a metrics
+    /// endpoint. The OTLP receiver still accepts metrics, and neither the filter nor the exporter
+    /// discards them: a filter section left absent means "match everything" (`MetricFilter` with
+    /// no include and no exclude returns the payload untouched), and the exporter has no way to
+    /// disable a signal -- an unset `metrics_endpoint` falls back to `endpoint + "/v1/metrics"`.
+    /// A client that sends OTLP metrics to the agent therefore has them posted to a synthesised
+    /// DCE URL that does not exist, producing 404s and retry churn rather than data loss.
+    ///
+    /// This is deliberate. Dropping metrics would mean emitting a filter on *every* path,
+    /// including the ones this method leaves filter-free for rules that route on nothing, which is
+    /// the shape the design calls for. Metrics are out of scope for the agent functionality being
+    /// shipped, so the extra node is not worth spending on a signal the product does not carry.
+    /// Revisit if metrics ever become part of the collected set.
+    const fn needs_filter(&self) -> bool {
+        self.logs_routing.is_some()
+            || self.traces_routing.is_some()
+            || self.logs_url.is_none()
+            || self.traces_url.is_none()
+    }
+}
+
+/// Build an engine pipeline specification from extracted AMCS bindings.
+///
+/// # Errors
+///
+/// Returns [`Error::EmptyPipeline`](crate::Error::EmptyPipeline) when `infos` is empty,
+/// [`Error::InvalidListenerAddress`](crate::Error::InvalidListenerAddress) when a listener host
+/// cannot be resolved, and [`Error::InvalidPipeline`](crate::Error::InvalidPipeline) when the
+/// assembled pipeline is rejected by the engine configuration model.
+pub fn build_pipeline(
+    infos: &[OtlpEventInfo],
+    host: &HostContext,
+) -> Result<OtelDataflowSpec, crate::Error> {
+    if infos.is_empty() {
+        return Err(crate::Error::EmptyPipeline {
+            details: "no OTLP endpoints were extracted from the AMCS configuration".to_string(),
+        });
+    }
+
+    let listeners = collect_listeners(infos);
+    let receiver_name = receiver_node_name(&listeners);
+    let receiver_config = build_receiver_config(&listeners)?;
+    let paths = collect_sub_branches(infos);
+
+    if paths.is_empty() {
+        return Err(crate::Error::EmptyPipeline {
+            details: "no export paths could be derived from the AMCS configuration".to_string(),
+        });
+    }
+
+    let mut builder = PipelineConfigBuilder::new().add_receiver(
+        receiver_name.clone(),
+        OTLP_RECEIVER_URN,
+        Some(receiver_config),
+    );
+
+    // A single path hangs directly off the receiver. Several paths need a fan-out, because the
+    // receiver's one output port cannot feed more than one target.
+    let needs_fanout = paths.len() > 1;
+    if needs_fanout {
+        builder = builder
+            .add_processor(
+                FANOUT_NODE,
+                FANOUT_PROCESSOR_URN,
+                Some(build_fanout_config(&paths)),
+            )
+            .to(receiver_name.clone(), FANOUT_NODE);
+    }
+
+    for path in &paths {
+        let batch_node = path.batch_node();
+        let exporter_node = path.exporter_node();
+
+        builder = builder
+            .add_processor(
+                batch_node.clone(),
+                BATCH_PROCESSOR_URN,
+                Some(build_batch_config()),
+            )
+            .add_exporter(
+                exporter_node.clone(),
+                OTLP_HTTP_EXPORTER_URN,
+                Some(build_exporter_config(path, host)?),
+            );
+
+        // A path that routes on nothing and exports both signals needs no filter, so telemetry
+        // goes straight to its batch node.
+        let filter_node = path.needs_filter().then(|| path.filter_node());
+        if let Some(filter_node) = &filter_node {
+            builder = builder.add_processor(
+                filter_node.clone(),
+                FILTER_PROCESSOR_URN,
+                Some(build_filter_config(path)),
+            );
+        }
+        let entry_node = filter_node.clone().unwrap_or_else(|| batch_node.clone());
+
+        // Connections are added in data-flow order so the generated document reads top to bottom:
+        // the list is a `Vec` and is serialized in insertion order.
+        builder = if needs_fanout {
+            builder.to_output(FANOUT_NODE, path.fanout_port(), entry_node)
+        } else {
+            builder.to(receiver_name.clone(), entry_node)
+        };
+
+        if let Some(filter_node) = filter_node {
+            builder = builder.to(filter_node, batch_node.clone());
+        }
+
+        builder = builder.to(batch_node, exporter_node);
+    }
+
+    let pipeline = builder.build(PipelineType::Otlp, PIPELINE_GROUP_ID, PIPELINE_ID)?;
+
+    Ok(OtelDataflowSpec::from_pipeline(
+        PIPELINE_GROUP_ID.into(),
+        PIPELINE_ID.into(),
+        pipeline,
+        EngineConfig::default(),
+    )?)
+}
+
+/// Collect the distinct listeners referenced by the extracted bindings, gRPC first.
+fn collect_listeners(infos: &[OtlpEventInfo]) -> Vec<OtlpEventListenerInfo> {
+    let mut grpc: Option<OtlpEventListenerInfo> = None;
+    let mut http: Option<OtlpEventListenerInfo> = None;
+
+    for info in infos {
+        match info.listener.protocol {
+            OtlpProtocol::Grpc => grpc = grpc.or_else(|| Some(info.listener.clone())),
+            OtlpProtocol::HttpProtobuf => http = http.or_else(|| Some(info.listener.clone())),
+        }
+    }
+
+    grpc.into_iter().chain(http).collect()
+}
+
+/// Derive the receiver node name from the ports it listens on, for example `receiver_4319_4320`.
+///
+/// Ports rather than addresses, because a node name cannot contain the dots in an IP address, and
+/// because the ports are what a reader wants when checking which listeners are live. A disabled
+/// protocol simply does not appear.
+fn receiver_node_name(listeners: &[OtlpEventListenerInfo]) -> String {
+    let mut name = String::from("receiver");
+    for listener in listeners {
+        name.push('_');
+        name.push_str(&listener.port.to_string());
+    }
+    name
+}
+
+/// Build the shared receiver configuration.
+///
+/// Listener hosts are resolved to literal socket addresses because the receiver deserializes
+/// `listening_addr` as a [`std::net::SocketAddr`], which cannot accept a hostname such as the
+/// default `localhost`.
+fn build_receiver_config(listeners: &[OtlpEventListenerInfo]) -> Result<Value, crate::Error> {
+    let mut protocols = serde_json::Map::new();
+
+    for listener in listeners {
+        let addr = listener.socket_addr()?.to_string();
+        match listener.protocol {
+            OtlpProtocol::Grpc => {
+                let _ = protocols.insert(
+                    "grpc".to_string(),
+                    json!({
+                        "listening_addr": addr,
+                        "max_decoding_message_size": MAX_DECODING_MESSAGE_SIZE,
+                    }),
+                );
+            }
+            OtlpProtocol::HttpProtobuf => {
+                let _ = protocols.insert(
+                    "http".to_string(),
+                    json!({
+                        "listening_addr": addr,
+                        "max_request_body_size": MAX_REQUEST_BODY_SIZE,
+                    }),
+                );
+            }
+        }
+    }
+
+    if protocols.is_empty() {
+        return Err(crate::Error::EmptyPipeline {
+            details: "no OTLP listeners are enabled".to_string(),
+        });
+    }
+
+    Ok(json!({ "protocols": Value::Object(protocols) }))
+}
+
+/// Build the fan-out configuration: one destination per export path.
+///
+/// `await_ack: none` keeps the receiver from blocking on downstream acknowledgement. Every rule
+/// that matches a message should receive it, so no destination is marked primary.
+fn build_fanout_config(paths: &[SubBranch]) -> Value {
+    let destinations: Vec<Value> = paths
+        .iter()
+        .map(|path| json!({ "port": path.fanout_port() }))
+        .collect();
+
+    json!({
+        "await_ack": "none",
+        "destinations": destinations,
+    })
+}
+
+/// Build the filter configuration for an export path.
+///
+/// Routing is applied per signal, because a rule may filter its logs while broadcasting its
+/// traces or the reverse; the .NET parser records routing on each endpoint binding rather than on
+/// the rule as a whole.
+///
+/// A signal this path has no endpoint for is dropped here. Without that the exporter would fall
+/// back to `endpoint + "/v1/<signal>"` and deliver it somewhere nobody asked for.
+fn build_filter_config(path: &SubBranch) -> Value {
+    let logs_attributes = resource_attributes(path.logs_routing.as_ref());
+    let traces_attributes = resource_attributes(path.traces_routing.as_ref());
+
+    let logs_include = if path.logs_url.is_some() {
+        json!({
+            "match_type": "strict",
+            "resource_attributes": logs_attributes,
+        })
+    } else {
+        json!({
+            "match_type": "strict",
+            "resource_attributes": logs_attributes,
+            "severity_texts": [NEVER_MATCHES],
+        })
+    };
+
+    // `span_names` has no serde default, so it must always be present.
+    let traces_include = if path.traces_url.is_some() {
+        json!({
+            "match_type": "strict",
+            "resource_attributes": traces_attributes,
+            "span_names": [],
+        })
+    } else {
+        json!({
+            "match_type": "strict",
+            "resource_attributes": traces_attributes,
+            "span_names": [NEVER_MATCHES],
+        })
+    };
+
+    json!({
+        "logs": { "include": logs_include },
+        "traces": { "include": traces_include },
+    })
+}
+
+/// Render a routing filter as the filter processor's `resource_attributes` list.
+///
+/// `None` yields an empty list, which the filter processor treats as "match everything" -- the
+/// broadcast behaviour applied when a rule declares no attribute routing.
+fn resource_attributes(routing: Option<&OtlpAttributeRouting>) -> Vec<Value> {
+    routing.map_or_else(Vec::new, |r| {
+        vec![json!({ "key": r.name, "value": r.value })]
+    })
+}
+
+/// Build the batch processor configuration.
+///
+/// None of these values come from AMCS; a Data Collection Rule says nothing about batching.
+fn build_batch_config() -> Value {
+    json!({
+        "otlp": {
+            "sizer": "bytes",
+            "min_size": BATCH_SIZE_BYTES,
+            "max_size": BATCH_SIZE_BYTES,
+        },
+        "max_batch_duration": BATCH_MAX_DURATION,
+        "format": BATCH_FORMAT,
+    })
+}
+
+/// Build the exporter configuration for one export path.
+fn build_exporter_config(path: &SubBranch, host: &HostContext) -> Result<Value, crate::Error> {
+    // `endpoint` is mandatory and must be a valid URL. It is only ever consulted for a signal
+    // with no explicit endpoint, which cannot happen here because such a signal is dropped by the
+    // filter, but it still has to be present and parseable.
+    let reference = path
+        .logs_url
+        .as_ref()
+        .or(path.traces_url.as_ref())
+        .ok_or_else(|| crate::Error::EmptyPipeline {
+            details: "export path has neither a logs nor a traces URL".to_string(),
+        })?;
+
+    let mut http = serde_json::Map::new();
+    if let Some(user_agent) = &host.user_agent {
+        let _ = http.insert("user_agent".to_string(), json!(user_agent));
+    }
+    if ENABLE_COMPRESSION {
+        let _ = http.insert("compression".to_string(), json!(COMPRESSION_ALGORITHM));
+    }
+
+    let mut headers = serde_json::Map::new();
+    if let Some(identity) = &host.agent_identity {
+        // Percent-encoded to match `HttpUtility.UrlEncode` in the .NET agent, because a resource
+        // id contains slashes that are not legal unencoded in a header value.
+        let _ = headers.insert(
+            HEADER_RESOURCE_ID.to_string(),
+            json!(urlencoding::encode(identity).into_owned()),
+        );
+    }
+    if let Some(region) = &host.region {
+        let _ = headers.insert(HEADER_REGION.to_string(), json!(region));
+    }
+    if !headers.is_empty() {
+        let _ = http.insert("headers".to_string(), Value::Object(headers));
+    }
+
+    let mut config = serde_json::Map::new();
+    let _ = config.insert("http".to_string(), Value::Object(http));
+    let _ = config.insert("endpoint".to_string(), json!(origin_of(reference)));
+    let _ = config.insert(
+        "client_pool_size".to_string(),
+        json!(EXPORTER_CLIENT_POOL_SIZE),
+    );
+    if let Some(url) = &path.logs_url {
+        let _ = config.insert("logs_endpoint".to_string(), json!(url));
+    }
+    if let Some(url) = &path.traces_url {
+        let _ = config.insert("traces_endpoint".to_string(), json!(url));
+    }
+
+    Ok(Value::Object(config))
+}
+
+/// Group bindings by identifier and flatten them into export paths.
+fn collect_sub_branches(infos: &[OtlpEventInfo]) -> Vec<SubBranch> {
+    // BTreeMap keeps identifiers in a stable order so generated output is deterministic.
+    let mut branches: BTreeMap<String, Branch> = BTreeMap::new();
+
+    for info in infos {
+        let branch = branches.entry(info.identifier.clone()).or_default();
+
+        let (target, routing) = match info.event_name {
+            OtlpEventName::Log => (&mut branch.logs_urls, &mut branch.logs_routing),
+            OtlpEventName::Span => (&mut branch.traces_urls, &mut branch.traces_routing),
+        };
+
+        if routing.is_none() {
+            *routing = info.routing_info.clone();
+        }
+
+        for url in &info.endpoint_urls {
+            // The same identifier appears once per listener, so URLs repeat; keep one copy.
+            if !target.contains(url) {
+                target.push(url.clone());
+            }
+        }
+    }
+
+    let mut used_names: HashSet<String> = HashSet::new();
+    let mut result = Vec::new();
+
+    for (identifier, branch) in &branches {
+        let slug = unique_slug(identifier, &mut used_names);
+
+        // A data source may declare several streams, giving several endpoint URLs for one signal.
+        // Each URL needs its own exporter, so emit as many paths as the widest signal requires
+        // and pair URLs by index.
+        let count = branch.logs_urls.len().max(branch.traces_urls.len());
+
+        for index in 0..count {
+            let suffix = if count > 1 {
+                format!("{slug}_{index}")
+            } else {
+                slug.clone()
+            };
+
+            result.push(SubBranch {
+                suffix,
+                logs_url: branch.logs_urls.get(index).cloned(),
+                traces_url: branch.traces_urls.get(index).cloned(),
+                logs_routing: branch.logs_routing.clone(),
+                traces_routing: branch.traces_routing.clone(),
+            });
+        }
+    }
+
+    result
+}
+
+/// Return the scheme and authority of `url`, for example `https://dce.example.com`.
+///
+/// Falls back to the whole string when the input has no path component, which keeps the value a
+/// parseable URL in every case the exporter will accept.
+fn origin_of(url: &str) -> String {
+    match url.find("://") {
+        Some(scheme_end) => {
+            let authority_start = scheme_end + "://".len();
+            match url[authority_start..].find('/') {
+                Some(path_start) => url[..authority_start + path_start].to_string(),
+                None => url.to_string(),
+            }
+        }
+        None => url.to_string(),
+    }
+}
+
+/// Derive a node-name-safe slug from an identifier, guaranteed unique within the pipeline.
+///
+/// Identifiers look like `dcr-00000002....gigl-dce-00000002...`; the `.` separator is replaced so
+/// generated node names stay readable. Because distinct identifiers can sanitize to the same
+/// string, a numeric suffix is appended on collision.
+fn unique_slug(identifier: &str, used: &mut HashSet<String>) -> String {
+    let base: String = identifier
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+
+    let base = if base.is_empty() {
+        "branch".to_string()
+    } else {
+        base
+    };
+
+    if used.insert(base.clone()) {
+        return base;
+    }
+
+    let mut suffix = 2u32;
+    loop {
+        let candidate = format!("{base}_{suffix}");
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+        suffix = suffix.saturating_add(1);
+    }
+}
+
+/// Name of the capability an exporter must bind to receive credentials from the embedding host.
+///
+/// This translator deliberately does **not** emit the binding itself. Attaching credentials takes
+/// two things that only the host can supply: an entry in the pipeline's `extensions` section
+/// declaring the provider instance, and a `capabilities` binding on each exporter. The generated
+/// specification carries neither, because the AMCS payload says nothing about how the agent
+/// authenticates, and because `PipelineConfigBuilder` currently exposes no way to set node
+/// capabilities (`PipelineConfig::nodes` is private and `add_exporter` always writes an empty
+/// capability map). Emitting a binding without the matching extension would also fail validation
+/// outright -- see `PipelineConfig` validation, "binds capability ... but no extension with that
+/// name exists".
+///
+/// The name is exported so the host binds the right one. `urn:otel:exporter:otlp_http` takes
+/// either this capability or `bearer_token_provider`, never both -- it rejects an ambiguous
+/// configuration. Agent-fed is correct for this agent because the Monitoring Agent owns the token
+/// and rotates it; the exporter reads a fresh snapshot per export instead of caching a static one.
+///
+/// Requires open-telemetry/otel-arrow#3836, which adds agent-fed support to the OTLP/HTTP
+/// exporter. Until it merges, binding this name resolves nothing: validation checks only that the
+/// *extension name* exists, never that the node consumes the capability, and the binding is
+/// optional -- so the exporter would send no `Authorization` header and report nothing.
+#[must_use]
+pub const fn credential_capability_name() -> &'static str {
+    CAPABILITY_AGENT_FED_CREDENTIAL_PROVIDER
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::amcs::listener::OtlpEventListenerInfo;
+
+    fn listener(protocol: OtlpProtocol, port: u16) -> OtlpEventListenerInfo {
+        OtlpEventListenerInfo {
+            host: "127.0.0.1".to_string(),
+            port,
+            protocol,
+        }
+    }
+
+    fn routing(value: &str) -> Option<OtlpAttributeRouting> {
+        Some(OtlpAttributeRouting {
+            name: "service.name".to_string(),
+            value: value.to_string(),
+        })
+    }
+
+    fn info(
+        identifier: &str,
+        event_name: OtlpEventName,
+        url: &str,
+        routing_info: Option<OtlpAttributeRouting>,
+    ) -> OtlpEventInfo {
+        OtlpEventInfo {
+            listener: listener(OtlpProtocol::Grpc, 4319),
+            identifier: identifier.to_string(),
+            endpoint_urls: vec![url.to_string()],
+            event_name,
+            routing_info,
+        }
+    }
+
+    /// Build a spec with no host context and render it as YAML.
+    fn to_yaml(infos: &[OtlpEventInfo]) -> String {
+        let spec = build_pipeline(infos, &HostContext::default()).expect("pipeline should build");
+        serde_yaml::to_string(&spec).expect("spec should serialize")
+    }
+
+    /// Scenario: `build_pipeline` is called with no extracted endpoint bindings.
+    /// Guarantees: an empty AMCS payload reports an error rather than producing a pipeline that
+    /// would start, bind ports and silently discard everything.
+    #[test]
+    fn empty_input_is_an_error() {
+        assert!(matches!(
+            build_pipeline(&[], &HostContext::default()),
+            Err(crate::Error::EmptyPipeline { .. })
+        ));
+    }
+
+    /// Scenario: one rule sends both logs and traces to a single channel.
+    /// Guarantees: a single export path produces the receiver, filter, batch and exporter chain
+    /// with no fan-out node, since fan-out is only needed for more than one path.
+    #[test]
+    fn single_path_has_no_fanout() {
+        let infos = vec![
+            info(
+                "dcr-1.gig-1",
+                OtlpEventName::Log,
+                "https://dce.example.com/a/logs",
+                routing("amcs"),
+            ),
+            info(
+                "dcr-1.gig-1",
+                OtlpEventName::Span,
+                "https://dce.example.com/a/traces",
+                routing("amcs"),
+            ),
+        ];
+
+        let yaml = to_yaml(&infos);
+
+        assert!(yaml.contains("urn:otel:receiver:otlp"));
+        assert!(yaml.contains("filter_dcr-1_gig-1"));
+        assert!(yaml.contains("batch_20k_ms_dcr-1_gig-1"));
+        assert!(yaml.contains("exporter_dcr-1_gig-1"));
+        assert!(
+            !yaml.contains("urn:otel:processor:fanout"),
+            "a single path needs no fan-out:\n{yaml}"
+        );
+    }
+
+    /// Scenario: two rules on one host route on different resource attribute values.
+    /// Guarantees: a fan-out node clones telemetry to one named port per rule, so each rule sees
+    /// every message and applies its own filter, and the receiver is not duplicated.
+    #[test]
+    fn multiple_paths_use_fanout() {
+        let infos = vec![
+            info(
+                "dcr-a.gig-a",
+                OtlpEventName::Log,
+                "https://a.example.com/logs",
+                routing("amcs_1"),
+            ),
+            info(
+                "dcr-b.gig-b",
+                OtlpEventName::Log,
+                "https://b.example.com/logs",
+                routing("amcs_2"),
+            ),
+        ];
+
+        let yaml = to_yaml(&infos);
+
+        assert_eq!(yaml.matches("urn:otel:receiver:otlp").count(), 1);
+        assert_eq!(yaml.matches("urn:otel:processor:fanout").count(), 1);
+        assert_eq!(yaml.matches("urn:otel:exporter:otlp_http").count(), 2);
+        assert!(yaml.contains("port_dcr-a_gig-a"));
+        assert!(yaml.contains("port_dcr-b_gig-b"));
+        assert!(yaml.contains("amcs_1"));
+        assert!(yaml.contains("amcs_2"));
+    }
+
+    /// Scenario: two rules each need their telemetry batched before export.
+    /// Guarantees: rules do not share a batch node, which would merge their telemetry with no way
+    /// to separate it again before the exporters, since the batch processor has no partition key.
+    #[test]
+    fn each_path_gets_its_own_batch() {
+        let infos = vec![
+            info(
+                "dcr-a.gig-a",
+                OtlpEventName::Log,
+                "https://a.example.com/logs",
+                routing("amcs_1"),
+            ),
+            info(
+                "dcr-b.gig-b",
+                OtlpEventName::Log,
+                "https://b.example.com/logs",
+                routing("amcs_2"),
+            ),
+        ];
+
+        let yaml = to_yaml(&infos);
+
+        assert_eq!(
+            yaml.matches("urn:otel:processor:batch").count(),
+            2,
+            "expected one batch per path:\n{yaml}"
+        );
+        assert!(yaml.contains("batch_20k_ms_dcr-a_gig-a"));
+        assert!(yaml.contains("batch_20k_ms_dcr-b_gig-b"));
+    }
+
+    /// Scenario: a rule declares no `resourceAttributeRouting` and exports both signals.
+    /// Guarantees: no filter node is emitted, matching Kennedy's optimised shape where a rule that
+    /// accepts everything connects straight to its batch node instead of paying for a
+    /// match-everything filter on every message.
+    #[test]
+    fn a_rule_that_routes_on_nothing_needs_no_filter() {
+        let infos = vec![
+            info(
+                "dcr-1.gig-1",
+                OtlpEventName::Log,
+                "https://x.example.com/logs",
+                None,
+            ),
+            info(
+                "dcr-1.gig-1",
+                OtlpEventName::Span,
+                "https://x.example.com/traces",
+                None,
+            ),
+        ];
+
+        let yaml = to_yaml(&infos);
+
+        assert!(
+            !yaml.contains("urn:otel:processor:filter"),
+            "a match-everything path should skip the filter:\n{yaml}"
+        );
+        assert!(yaml.contains("batch_20k_ms_dcr-1_gig-1"));
+        assert!(yaml.contains("exporter_dcr-1_gig-1"));
+    }
+
+    /// Scenario: Kennedy's three-rule matrix -- two rules routing on distinct `service.name`
+    /// values and a third accepting everything, each with its own destination.
+    /// Guarantees: the routed rules get filters, the accept-everything rule does not, and all
+    /// three still reach separate exporters, so a future change that misroutes the
+    /// accept-everything case fails here.
+    #[test]
+    fn three_rule_matrix_filters_only_where_routing_is_declared() {
+        let infos = vec![
+            info(
+                "dcr-a.gig-a",
+                OtlpEventName::Log,
+                "https://dce1.example.com/logs",
+                routing("amcs"),
+            ),
+            info(
+                "dcr-a.gig-a",
+                OtlpEventName::Span,
+                "https://dce1.example.com/traces",
+                routing("amcs"),
+            ),
+            info(
+                "dcr-b.gig-b",
+                OtlpEventName::Log,
+                "https://dce2.example.com/logs",
+                routing("backend"),
+            ),
+            info(
+                "dcr-b.gig-b",
+                OtlpEventName::Span,
+                "https://dce2.example.com/traces",
+                routing("backend"),
+            ),
+            info(
+                "dcr-c.gig-c",
+                OtlpEventName::Log,
+                "https://dce3.example.com/logs",
+                None,
+            ),
+            info(
+                "dcr-c.gig-c",
+                OtlpEventName::Span,
+                "https://dce3.example.com/traces",
+                None,
+            ),
+        ];
+
+        let yaml = to_yaml(&infos);
+
+        assert_eq!(yaml.matches("urn:otel:exporter:otlp_http").count(), 3);
+        assert_eq!(
+            yaml.matches("urn:otel:processor:filter").count(),
+            2,
+            "only the two routed rules need a filter:\n{yaml}"
+        );
+        assert!(yaml.contains("value: amcs"));
+        assert!(yaml.contains("value: backend"));
+        assert!(yaml.contains("dce1.example.com"));
+        assert!(yaml.contains("dce2.example.com"));
+        assert!(yaml.contains("dce3.example.com"));
+    }
+
+    /// Scenario: a channel supplies a logs endpoint but no traces endpoint.
+    /// Guarantees: traces are dropped by the filter rather than reaching the exporter, which would
+    /// otherwise fall back to `endpoint + "/v1/traces"` and deliver them to an unintended URL.
+    #[test]
+    fn a_signal_without_an_endpoint_is_dropped() {
+        let infos = vec![info(
+            "dcr-1.gig-1",
+            OtlpEventName::Log,
+            "https://x.example.com/logs",
+            None,
+        )];
+
+        let yaml = to_yaml(&infos);
+
+        assert!(yaml.contains(NEVER_MATCHES));
+        assert!(yaml.contains("logs_endpoint"));
+        assert!(!yaml.contains("traces_endpoint"));
+    }
+
+    /// Scenario: the receiver listens on a gRPC and an HTTP port.
+    /// Guarantees: the node is named after both ports with no address, since a node name cannot
+    /// contain the dots of an IP address, and both size limits are present so payloads above the
+    /// engine's 4 MiB default are not rejected before reaching the pipeline.
+    #[test]
+    fn receiver_is_named_after_its_ports_and_raises_size_limits() {
+        let mut grpc = info(
+            "dcr-1.gig-1",
+            OtlpEventName::Log,
+            "https://x.example.com/logs",
+            routing("amcs"),
+        );
+        grpc.listener = listener(OtlpProtocol::Grpc, 4319);
+        let mut http = grpc.clone();
+        http.listener = listener(OtlpProtocol::HttpProtobuf, 4320);
+
+        let yaml = to_yaml(&[grpc, http]);
+
+        assert!(yaml.contains("receiver_4319_4320"), "got:\n{yaml}");
+        assert!(!yaml.contains("receiver_127"));
+        assert!(yaml.contains(MAX_DECODING_MESSAGE_SIZE));
+        assert!(yaml.contains(MAX_REQUEST_BODY_SIZE));
+    }
+
+    /// Scenario: the batch processor configuration is generated.
+    /// Guarantees: the agreed batching values are emitted, including identical minimum and maximum
+    /// sizes so batches flush at a predictable size, and `otlp` format so payloads are not
+    /// converted to OTAP and back on a path that is OTLP end to end.
+    #[test]
+    fn batch_uses_the_agreed_values() {
+        let infos = vec![info(
+            "dcr-1.gig-1",
+            OtlpEventName::Log,
+            "https://x.example.com/logs",
+            routing("amcs"),
+        )];
+
+        let yaml = to_yaml(&infos);
+
+        assert!(yaml.contains("min_size: 1043333"));
+        assert!(yaml.contains("max_size: 1043333"));
+        assert!(yaml.contains("max_batch_duration: 20000ms"));
+        assert!(yaml.contains("format: otlp"));
+    }
+
+    /// Scenario: the embedding host supplies its identity, region and user agent.
+    /// Guarantees: those reach every exporter as request metadata, with the resource id
+    /// percent-encoded so its slashes remain a legal HTTP header value.
+    #[test]
+    fn host_context_reaches_the_exporter() {
+        let infos = vec![info(
+            "dcr-1.gig-1",
+            OtlpEventName::Log,
+            "https://x.example.com/logs",
+            routing("amcs"),
+        )];
+
+        let host = HostContext {
+            agent_identity: Some("/subscriptions/abc/resourceGroups/rg".to_string()),
+            region: Some("westus2".to_string()),
+            user_agent: Some("AMACoreAgent/1.2.3".to_string()),
+        };
+
+        let spec = build_pipeline(&infos, &host).expect("pipeline should build");
+        let yaml = serde_yaml::to_string(&spec).expect("serialize");
+
+        assert!(yaml.contains("AMACoreAgent/1.2.3"));
+        assert!(yaml.contains(HEADER_REGION));
+        assert!(yaml.contains("westus2"));
+        assert!(
+            yaml.contains("%2Fsubscriptions%2Fabc%2FresourceGroups%2Frg"),
+            "resource id should be percent-encoded:\n{yaml}"
+        );
+    }
+
+    /// Scenario: the exported credential capability name is checked, and a generated config is
+    /// checked for capability bindings.
+    /// Guarantees: the name is `agent_fed_credential_provider`, which suits a host that rotates
+    /// the token, and which `urn:otel:exporter:otlp_http` accepts as of
+    /// open-telemetry/otel-arrow#3836. The exporter takes this capability or
+    /// `bearer_token_provider` but never both, so the two must not be conflated. The translator
+    /// emits no binding of its own, since the matching `extensions` entry can only come from the
+    /// host and a binding without it would not validate.
+    #[test]
+    fn credential_capability_is_the_agent_fed_provider() {
+        assert_eq!(
+            credential_capability_name(),
+            "agent_fed_credential_provider",
+            "the host rotates the token, so the exporter must re-read a snapshot per export"
+        );
+
+        let infos = vec![info(
+            "dcr-1.gig-1",
+            OtlpEventName::Log,
+            "https://x.example.com/logs",
+            routing("amcs"),
+        )];
+        let yaml = to_yaml(&infos);
+
+        assert!(
+            !yaml.contains("capabilities:"),
+            "credential binding is the host's to add, together with the extension:\n{yaml}"
+        );
+    }
+
+    /// Scenario: one rule declares more log streams than trace streams, so the two signals yield
+    /// different numbers of endpoint URLs and are paired by index.
+    /// Guarantees: every URL is exported exactly once. The shorter signal is not repeated to fill
+    /// the gap, which would duplicate telemetry and bill a customer twice for the same data, and
+    /// the surplus path drops the signal it has no endpoint for rather than inventing one.
+    #[test]
+    fn asymmetric_url_counts_export_each_url_exactly_once() {
+        let infos = vec![
+            OtlpEventInfo {
+                identifier: "dcr-1.gig-1".to_string(),
+                endpoint_urls: vec![
+                    "https://x.example.com/s1/logs".to_string(),
+                    "https://x.example.com/s2/logs".to_string(),
+                ],
+                event_name: OtlpEventName::Log,
+                routing_info: routing("amcs"),
+                listener: listener(OtlpProtocol::Grpc, 4319),
+            },
+            OtlpEventInfo {
+                identifier: "dcr-1.gig-1".to_string(),
+                endpoint_urls: vec!["https://x.example.com/s1/traces".to_string()],
+                event_name: OtlpEventName::Span,
+                routing_info: routing("amcs"),
+                listener: listener(OtlpProtocol::Grpc, 4319),
+            },
+        ];
+
+        let yaml = to_yaml(&infos);
+
+        let occurrences = |needle: &str| -> usize { yaml.matches(needle).count() };
+
+        assert_eq!(
+            occurrences("https://x.example.com/s1/logs"),
+            1,
+            "first logs URL should be exported once:\n{yaml}"
+        );
+        assert_eq!(
+            occurrences("https://x.example.com/s2/logs"),
+            1,
+            "second logs URL should be exported once:\n{yaml}"
+        );
+        assert_eq!(
+            occurrences("https://x.example.com/s1/traces"),
+            1,
+            "the single traces URL must not be repeated onto the surplus path:\n{yaml}"
+        );
+
+        // The surplus path has no traces endpoint, so it must drop traces outright.
+        assert!(
+            yaml.contains(NEVER_MATCHES),
+            "the path without a traces URL should drop the signal:\n{yaml}"
+        );
+    }
+
+    /// Scenario: the host supplies no identity, region or user agent.
+    /// Guarantees: no header block is emitted, so a configuration generated without host context
+    /// stays valid rather than carrying blank metadata.
+    #[test]
+    fn absent_host_context_emits_no_headers() {
+        let infos = vec![info(
+            "dcr-1.gig-1",
+            OtlpEventName::Log,
+            "https://x.example.com/logs",
+            routing("amcs"),
+        )];
+
+        let yaml = to_yaml(&infos);
+
+        assert!(!yaml.contains(HEADER_REGION));
+        assert!(!yaml.contains(HEADER_RESOURCE_ID));
+        assert!(!yaml.contains("user_agent"));
+    }
+
+    /// Scenario: compression is disabled by the build-time constant.
+    /// Guarantees: no compression setting is emitted while the constant is false, so the default
+    /// deployment sends uncompressed requests and the decision lives in exactly one place.
+    #[test]
+    fn compression_is_absent_while_disabled() {
+        let infos = vec![info(
+            "dcr-1.gig-1",
+            OtlpEventName::Log,
+            "https://x.example.com/logs",
+            routing("amcs"),
+        )];
+
+        let yaml = to_yaml(&infos);
+
+        // Guard the current default without asserting on a constant directly, so flipping
+        // ENABLE_COMPRESSION fails this test loudly rather than silently changing behaviour.
+        if ENABLE_COMPRESSION {
+            assert!(yaml.contains(COMPRESSION_ALGORITHM));
+        } else {
+            assert!(!yaml.contains("compression"));
+        }
+    }
+
+    /// Scenario: several streams on one data source yield several endpoint URLs.
+    /// Guarantees: each URL gets its own export path, so no configured destination is dropped.
+    #[test]
+    fn multiple_urls_produce_multiple_paths() {
+        let infos = vec![OtlpEventInfo {
+            listener: listener(OtlpProtocol::Grpc, 4319),
+            identifier: "dcr-1.gig-1".to_string(),
+            endpoint_urls: vec![
+                "https://x.example.com/s1/logs".to_string(),
+                "https://x.example.com/s2/logs".to_string(),
+            ],
+            event_name: OtlpEventName::Log,
+            routing_info: routing("amcs"),
+        }];
+
+        let yaml = to_yaml(&infos);
+
+        assert_eq!(yaml.matches("urn:otel:exporter:otlp_http").count(), 2);
+        assert!(yaml.contains("exporter_dcr-1_gig-1_0"));
+        assert!(yaml.contains("exporter_dcr-1_gig-1_1"));
+    }
+
+    /// Scenario: one identifier is reported once per enabled listener.
+    /// Guarantees: repeated bindings collapse into a single export path, so the number of
+    /// exporters follows the number of destinations rather than the number of listeners.
+    #[test]
+    fn repeated_listeners_do_not_duplicate_paths() {
+        let mut grpc = info(
+            "dcr-1.gig-1",
+            OtlpEventName::Log,
+            "https://x.example.com/logs",
+            routing("amcs"),
+        );
+        grpc.listener = listener(OtlpProtocol::Grpc, 4319);
+        let mut http = grpc.clone();
+        http.listener = listener(OtlpProtocol::HttpProtobuf, 4320);
+
+        let yaml = to_yaml(&[grpc, http]);
+
+        assert_eq!(yaml.matches("urn:otel:exporter:otlp_http").count(), 1);
+        assert!(yaml.contains("127.0.0.1:4319"));
+        assert!(yaml.contains("127.0.0.1:4320"));
+    }
+
+    /// Scenario: a generated specification is serialized and read back.
+    /// Guarantees: the engine's own loader accepts it, so the translator cannot emit a
+    /// configuration the engine would refuse to start.
+    #[test]
+    fn generated_yaml_round_trips() {
+        let infos = vec![
+            info(
+                "dcr-a.gig-a",
+                OtlpEventName::Log,
+                "https://a.example.com/logs",
+                routing("amcs_1"),
+            ),
+            info(
+                "dcr-b.gig-b",
+                OtlpEventName::Log,
+                "https://b.example.com/logs",
+                routing("amcs_2"),
+            ),
+        ];
+
+        let yaml = to_yaml(&infos);
+        let reparsed = OtelDataflowSpec::from_yaml(&yaml);
+        assert!(reparsed.is_ok(), "round-trip failed: {reparsed:?}\n{yaml}");
+    }
+
+    /// Scenario: an endpoint URL is reduced to the value used for the exporter's `endpoint` field.
+    /// Guarantees: only the scheme and authority survive, which keeps the fallback endpoint a
+    /// parseable URL without pointing at any one signal's path.
+    #[test]
+    fn origin_is_extracted_from_a_url() {
+        assert_eq!(
+            origin_of("https://dce.example.com/dataCollectionRules/dcr-1/streams/S/otlp/v1/logs"),
+            "https://dce.example.com"
+        );
+        assert_eq!(
+            origin_of("https://dce.example.com"),
+            "https://dce.example.com"
+        );
+        assert_eq!(
+            origin_of("https://dce.example.com:443/x"),
+            "https://dce.example.com:443"
+        );
+    }
+
+    /// Scenario: two identifiers differ only in a character that is not name-safe.
+    /// Guarantees: the sanitized names stay distinct, so one rule's nodes cannot silently
+    /// overwrite another's.
+    #[test]
+    fn slugs_are_sanitized_and_unique() {
+        let mut used = HashSet::new();
+        assert_eq!(unique_slug("dcr-1.gig-1", &mut used), "dcr-1_gig-1");
+        assert_eq!(unique_slug("dcr-1_gig-1", &mut used), "dcr-1_gig-1_2");
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-config-translators/src/amcs/extract.rs
+++ b/rust/otap-dataflow/crates/contrib-config-translators/src/amcs/extract.rs
@@ -1,0 +1,731 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Extraction of routable OTLP endpoints from an AMCS configuration payload.
+//!
+//! Port of `AMCSParser.ExtractConfiguration` from the .NET `AMCSConfiguration` project.
+//!
+//! The algorithm, per Data Collection Rule:
+//!
+//! 1. Map `dataSource.kind` to an [`OtlpEventName`]; skip unrecognised kinds such as
+//!    `perfCounter`.
+//! 2. Read the optional `resourceAttributeRouting`. When absent, telemetry is broadcast to every
+//!    endpoint instead of filtered, and a warning is emitted.
+//! 3. Collect the data source's stream names.
+//! 4. Resolve `sendToChannels` against the rule's channels; only `gig` channels carry OTLP
+//!    endpoint templates.
+//! 5. Build the identifier `{configurationId}.{channelId}` and substitute each stream name into
+//!    the endpoint template in place of the `<STREAM>` token.
+//! 6. Emit one [`OtlpEventInfo`] per (channel x listener) pair.
+
+use crate::amcs::listener::{AgentSettings, OtlpEventListenerInfo, discover_listeners};
+use crate::amcs::schema::{Channel, Configurations, DataSource};
+use otel_arrow_dfe_telemetry::otel_warn;
+use std::collections::BTreeSet;
+
+/// The literal placeholder substituted with a stream name inside endpoint templates.
+pub const URL_STREAM_REPLACEMENT_VAL: &str = "<STREAM>";
+
+/// The channel protocol that carries OTLP endpoint templates. `ods` channels are legacy and
+/// carry no OTLP endpoints, so they are ignored.
+pub const GIG_PROTOCOL: &str = "gig";
+
+/// The AMCS data source kind for OTLP logs.
+pub const AMCS_KIND_OTEL_LOGS: &str = "otelLogs";
+
+/// The AMCS data source kind for OTLP traces.
+pub const AMCS_KIND_OTEL_TRACES: &str = "otelTraces";
+
+/// The OTLP signal a data source carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum OtlpEventName {
+    /// OTLP logs, from an `otelLogs` data source.
+    Log,
+    /// OTLP spans, from an `otelTraces` data source.
+    Span,
+}
+
+impl OtlpEventName {
+    /// Map an AMCS `kind` to a signal, case-insensitively.
+    ///
+    /// Returns `None` for every other kind (`perfCounter`, `syslog`, ...), which is how
+    /// non-OTLP data sources are skipped.
+    #[must_use]
+    pub fn from_amcs_kind(kind: &str) -> Option<Self> {
+        if kind.eq_ignore_ascii_case(AMCS_KIND_OTEL_LOGS) {
+            Some(Self::Log)
+        } else if kind.eq_ignore_ascii_case(AMCS_KIND_OTEL_TRACES) {
+            Some(Self::Span)
+        } else {
+            None
+        }
+    }
+
+    /// A stable lowercase name, used in diagnostics and generated node names.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Log => "logs",
+            Self::Span => "traces",
+        }
+    }
+}
+
+/// The resource attribute a branch routes on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OtlpAttributeRouting {
+    /// The resource attribute key, e.g. `service.name`.
+    pub name: String,
+    /// The value the key must equal, e.g. `amcs`.
+    pub value: String,
+}
+
+/// One routable OTLP endpoint binding: which listener receives the data, which rule and channel
+/// it belongs to, where it is forwarded, and how it is selected.
+///
+/// Equivalent to `OtlpEventInfo` in the .NET implementation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OtlpEventInfo {
+    /// The listener that accepts this telemetry.
+    pub listener: OtlpEventListenerInfo,
+
+    /// `{configurationId}.{channelId}` -- unique per rule and destination.
+    pub identifier: String,
+
+    /// Fully-resolved destination URLs, with `<STREAM>` substituted.
+    pub endpoint_urls: Vec<String>,
+
+    /// The signal this binding carries.
+    pub event_name: OtlpEventName,
+
+    /// The routing filter, or `None` when telemetry should be broadcast to every endpoint.
+    pub routing_info: Option<OtlpAttributeRouting>,
+}
+
+/// Extract every routable OTLP endpoint from an AMCS payload.
+///
+/// A payload carries all Data Collection Rules that apply to the host, so this iterates every
+/// rule, every data source, and every channel in a single pass. Listener ports are resolved from
+/// the environment and from the payload's agent settings rule, in that order of precedence.
+///
+/// Returns an empty vector when OTLP ingestion is disabled, when no rule declares an OTLP data
+/// source, or when no data source resolves to a usable endpoint. Per
+/// `Telemetry-Collection-Spec/AMACoreAgent/otel-port-configuration.md`, an agent settings rule on
+/// its own is **not** sufficient to open a port: an OTel data-source rule must also be present,
+/// which an empty result correctly expresses.
+#[must_use]
+pub fn extract_configuration<E: crate::amcs::listener::EnvironmentProvider + ?Sized>(
+    env: &E,
+    config: &Configurations,
+) -> Vec<OtlpEventInfo> {
+    let settings = AgentSettings::from_configurations(config);
+    let listeners = discover_listeners(env, &settings);
+    if listeners.is_empty() {
+        otel_warn!(
+            "amcs.extract.no_listeners",
+            message = "no OTLP listeners are enabled; the generated pipeline will be empty"
+        );
+        return Vec::new();
+    }
+
+    let mut result = Vec::new();
+
+    for configuration in &config.configurations {
+        let Some(content) = configuration.content.as_ref() else {
+            continue;
+        };
+
+        // An agent settings rule carries listener configuration, not telemetry routing. It has
+        // already been consumed above, and must never become a pipeline branch.
+        if content.is_agent_settings() {
+            continue;
+        }
+
+        for data_source in &content.data_sources {
+            // Non-OTLP kinds (perfCounter, etc.) are skipped outright.
+            let Some(event_name) = OtlpEventName::from_amcs_kind(&data_source.kind) else {
+                continue;
+            };
+
+            let routing_info =
+                resolve_routing(data_source, &configuration.configuration_id, event_name);
+
+            // A BTreeSet both de-duplicates (as the .NET HashSet does) and gives a stable
+            // ordering, so generated output is deterministic across runs.
+            let streams: BTreeSet<&str> = data_source
+                .streams
+                .iter()
+                .map(|s| s.stream.as_str())
+                .filter(|s| !s.is_empty())
+                .collect();
+
+            if streams.is_empty() {
+                otel_warn!(
+                    "amcs.extract.no_streams",
+                    configuration_id = configuration.configuration_id.as_str(),
+                    kind = data_source.kind.as_str(),
+                    message = "data source declares no streams; no endpoint can be built for it"
+                );
+                continue;
+            }
+
+            for channel_id in &data_source.send_to_channels {
+                let Some(channel) = content.channels.iter().find(|c| c.id == *channel_id) else {
+                    otel_warn!(
+                        "amcs.extract.channel_not_found",
+                        configuration_id = configuration.configuration_id.as_str(),
+                        channel_id = channel_id.as_str(),
+                        message = "data source references a channel that the rule does not declare"
+                    );
+                    continue;
+                };
+
+                // Only `gig` channels carry OTLP endpoint templates; `ods` channels are legacy.
+                if !is_gig_channel(channel) {
+                    continue;
+                }
+
+                let Some(template) = endpoint_template(channel, event_name) else {
+                    // Entirely expected: a customer may configure logs only, or traces only.
+                    continue;
+                };
+
+                let endpoint_urls: Vec<String> = streams
+                    .iter()
+                    .map(|stream| template.replace(URL_STREAM_REPLACEMENT_VAL, stream))
+                    .collect();
+
+                let identifier = format!("{}.{}", configuration.configuration_id, channel_id);
+
+                for listener in &listeners {
+                    result.push(OtlpEventInfo {
+                        listener: listener.clone(),
+                        identifier: identifier.clone(),
+                        endpoint_urls: endpoint_urls.clone(),
+                        event_name,
+                        routing_info: routing_info.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    result
+}
+
+/// Read the optional routing filter, warning when it is absent.
+///
+/// A missing filter is legal but unusual: it means telemetry is broadcast to every endpoint
+/// rather than routed to this one, so it is worth surfacing.
+fn resolve_routing(
+    data_source: &DataSource,
+    configuration_id: &str,
+    event_name: OtlpEventName,
+) -> Option<OtlpAttributeRouting> {
+    let routing = data_source
+        .configuration
+        .as_ref()
+        .and_then(|c| c.resource_attribute_routing.as_ref());
+
+    let name = routing
+        .and_then(|r| r.attribute_name.as_deref())
+        .filter(|v| !v.is_empty());
+    let value = routing
+        .and_then(|r| r.attribute_value.as_deref())
+        .filter(|v| !v.is_empty());
+
+    match (name, value) {
+        (Some(name), Some(value)) => Some(OtlpAttributeRouting {
+            name: name.to_string(),
+            value: value.to_string(),
+        }),
+        _ => {
+            otel_warn!(
+                "amcs.extract.missing_attribute_routing",
+                configuration_id = configuration_id,
+                signal = event_name.as_str(),
+                message = "data collection rule has no resource attribute routing; telemetry will be broadcast to all endpoints"
+            );
+            None
+        }
+    }
+}
+
+/// Whether a channel is a `gig` channel, and therefore carries OTLP endpoint templates.
+fn is_gig_channel(channel: &Channel) -> bool {
+    channel
+        .protocol
+        .as_deref()
+        .is_some_and(|p| p.eq_ignore_ascii_case(GIG_PROTOCOL))
+}
+
+/// Select the endpoint template matching the signal.
+///
+/// This deliberately diverges from the .NET implementation. `AMCSParser.cs` uses:
+///
+/// ```csharp
+/// if (eventName == OtlpEventName.Log && otelLogsEndpointUriTemplate != null) { ...logs... }
+/// else if (otelTracesEndpointUriTemplate != null)                            { ...traces... }
+/// ```
+///
+/// When the signal is `Log` but `otelLogsEndpointUriTemplate` is null, control falls into the
+/// `else if` and a **traces** URL is emitted for a **logs** data source. Because both templates
+/// are independently optional, that path is reachable with real customer configuration and would
+/// silently misroute logs into the traces endpoint.
+///
+/// Here each signal only ever selects its own template, and a data source whose template is
+/// absent produces no endpoint at all.
+fn endpoint_template(channel: &Channel, event_name: OtlpEventName) -> Option<&str> {
+    match event_name {
+        OtlpEventName::Log => channel.otel_logs_endpoint_uri_template.as_deref(),
+        OtlpEventName::Span => channel.otel_traces_endpoint_uri_template.as_deref(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::amcs::listener::{
+        ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, OtlpProtocol, StaticEnvironment,
+    };
+
+    /// An environment with a single gRPC listener, so each binding appears exactly once.
+    fn single_listener_env() -> StaticEnvironment {
+        StaticEnvironment::new().with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "-1")
+    }
+
+    fn parse(json: &str) -> Configurations {
+        Configurations::from_json(json).expect("fixture should parse")
+    }
+
+    /// The canonical single-rule payload: one logs and one traces data source, both routed on
+    /// `service.name = amcs`, plus a `perfCounter` data source that must be ignored.
+    fn canonical_payload() -> &'static str {
+        r#"{
+          "configurations": [{
+            "configurationId": "dcr-1",
+            "content": {
+              "dataSources": [
+                {
+                  "id": "perf",
+                  "kind": "perfCounter",
+                  "streams": [{ "stream": "GENERIC_PERF_BLOB" }],
+                  "sendToChannels": ["ods-1"]
+                },
+                {
+                  "configuration": {
+                    "resourceAttributeRouting": {
+                      "attributeName": "service.name",
+                      "attributeValue": "amcs"
+                    }
+                  },
+                  "id": "logs",
+                  "kind": "otelLogs",
+                  "streams": [{ "stream": "OPENTELEMETRY_LOGS_AGENT" }],
+                  "sendToChannels": ["gig-1"]
+                },
+                {
+                  "configuration": {
+                    "resourceAttributeRouting": {
+                      "attributeName": "service.name",
+                      "attributeValue": "amcs"
+                    }
+                  },
+                  "id": "traces",
+                  "kind": "otelTraces",
+                  "streams": [{ "stream": "OPENTELEMETRY_TRACES_AGENT" }],
+                  "sendToChannels": ["gig-1"]
+                }
+              ],
+              "channels": [
+                { "id": "ods-1", "protocol": "ods" },
+                {
+                  "id": "gig-1",
+                  "protocol": "gig",
+                  "otelLogsEndpointUriTemplate": "https://dce.example.com/dataCollectionRules/dcr-1/streams/<STREAM>/otlp/v1/logs?api-version=2021-11-01-preview",
+                  "otelTracesEndpointUriTemplate": "https://dce.example.com/dataCollectionRules/dcr-1/streams/<STREAM>/otlp/v1/traces?api-version=2021-11-01-preview"
+                }
+              ]
+            }
+          }]
+        }"#
+    }
+
+    #[test]
+    fn extracts_logs_and_traces_and_skips_perf_counter() {
+        let infos = extract_configuration(&single_listener_env(), &parse(canonical_payload()));
+
+        assert_eq!(infos.len(), 2, "expected one logs and one traces binding");
+
+        let logs = infos
+            .iter()
+            .find(|i| i.event_name == OtlpEventName::Log)
+            .expect("logs binding present");
+        assert_eq!(logs.identifier, "dcr-1.gig-1");
+        assert_eq!(
+            logs.endpoint_urls,
+            vec![
+                "https://dce.example.com/dataCollectionRules/dcr-1/streams/OPENTELEMETRY_LOGS_AGENT/otlp/v1/logs?api-version=2021-11-01-preview"
+            ]
+        );
+        assert_eq!(
+            logs.routing_info,
+            Some(OtlpAttributeRouting {
+                name: "service.name".to_string(),
+                value: "amcs".to_string(),
+            })
+        );
+        assert_eq!(logs.listener.protocol, OtlpProtocol::Grpc);
+
+        let traces = infos
+            .iter()
+            .find(|i| i.event_name == OtlpEventName::Span)
+            .expect("traces binding present");
+        assert_eq!(
+            traces.endpoint_urls,
+            vec![
+                "https://dce.example.com/dataCollectionRules/dcr-1/streams/OPENTELEMETRY_TRACES_AGENT/otlp/v1/traces?api-version=2021-11-01-preview"
+            ]
+        );
+    }
+
+    /// No `<STREAM>` token may survive into a resolved endpoint URL.
+    #[test]
+    fn stream_placeholder_is_always_substituted() {
+        let infos = extract_configuration(&single_listener_env(), &parse(canonical_payload()));
+
+        assert!(!infos.is_empty());
+        for info in &infos {
+            for url in &info.endpoint_urls {
+                assert!(
+                    !url.contains(URL_STREAM_REPLACEMENT_VAL),
+                    "unsubstituted placeholder in {url}"
+                );
+            }
+        }
+    }
+
+    /// Each enabled listener produces its own binding for the same channel.
+    #[test]
+    fn each_listener_produces_a_binding() {
+        // Default environment enables both gRPC and HTTP.
+        let infos = extract_configuration(&StaticEnvironment::new(), &parse(canonical_payload()));
+
+        assert_eq!(infos.len(), 4, "2 signals x 2 listeners");
+        assert_eq!(
+            infos
+                .iter()
+                .filter(|i| i.listener.protocol == OtlpProtocol::Grpc)
+                .count(),
+            2
+        );
+        assert_eq!(
+            infos
+                .iter()
+                .filter(|i| i.listener.protocol == OtlpProtocol::HttpProtobuf)
+                .count(),
+            2
+        );
+    }
+
+    /// Ragu's multi-DCR case: several rules arrive in one payload and all must be processed.
+    #[test]
+    fn handles_multiple_data_collection_rules() {
+        let json = r#"{
+          "configurations": [
+            {
+              "configurationId": "dcr-a",
+              "content": {
+                "dataSources": [{
+                  "configuration": { "resourceAttributeRouting": { "attributeName": "service.name", "attributeValue": "a" } },
+                  "id": "logs", "kind": "otelLogs",
+                  "streams": [{ "stream": "S_A" }],
+                  "sendToChannels": ["gig-a"]
+                }],
+                "channels": [{ "id": "gig-a", "protocol": "gig", "otelLogsEndpointUriTemplate": "https://a/<STREAM>/logs" }]
+              }
+            },
+            {
+              "configurationId": "dcr-b",
+              "content": {
+                "dataSources": [{
+                  "configuration": { "resourceAttributeRouting": { "attributeName": "service.name", "attributeValue": "b" } },
+                  "id": "logs", "kind": "otelLogs",
+                  "streams": [{ "stream": "S_B" }],
+                  "sendToChannels": ["gig-b"]
+                }],
+                "channels": [{ "id": "gig-b", "protocol": "gig", "otelLogsEndpointUriTemplate": "https://b/<STREAM>/logs" }]
+              }
+            }
+          ]
+        }"#;
+
+        let infos = extract_configuration(&single_listener_env(), &parse(json));
+
+        assert_eq!(infos.len(), 2);
+        let mut identifiers: Vec<&str> = infos.iter().map(|i| i.identifier.as_str()).collect();
+        identifiers.sort_unstable();
+        assert_eq!(identifiers, vec!["dcr-a.gig-a", "dcr-b.gig-b"]);
+    }
+
+    /// A rule with only a traces endpoint yields only a traces binding.
+    #[test]
+    fn traces_only_configuration() {
+        let json = r#"{
+          "configurations": [{
+            "configurationId": "dcr-1",
+            "content": {
+              "dataSources": [{
+                "configuration": { "resourceAttributeRouting": { "attributeName": "service.name", "attributeValue": "amcs" } },
+                "id": "traces", "kind": "otelTraces",
+                "streams": [{ "stream": "T" }],
+                "sendToChannels": ["gig-1"]
+              }],
+              "channels": [{ "id": "gig-1", "protocol": "gig", "otelTracesEndpointUriTemplate": "https://x/<STREAM>/traces" }]
+            }
+          }]
+        }"#;
+
+        let infos = extract_configuration(&single_listener_env(), &parse(json));
+
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0].event_name, OtlpEventName::Span);
+        assert_eq!(infos[0].endpoint_urls, vec!["https://x/T/traces"]);
+    }
+
+    /// Regression guard for the .NET fall-through bug: a logs data source whose channel has only
+    /// a **traces** template must produce nothing, never a traces URL labelled as logs.
+    #[test]
+    fn logs_source_without_logs_template_emits_nothing() {
+        let json = r#"{
+          "configurations": [{
+            "configurationId": "dcr-1",
+            "content": {
+              "dataSources": [{
+                "configuration": { "resourceAttributeRouting": { "attributeName": "service.name", "attributeValue": "amcs" } },
+                "id": "logs", "kind": "otelLogs",
+                "streams": [{ "stream": "S" }],
+                "sendToChannels": ["gig-1"]
+              }],
+              "channels": [{ "id": "gig-1", "protocol": "gig", "otelTracesEndpointUriTemplate": "https://x/<STREAM>/traces" }]
+            }
+          }]
+        }"#;
+
+        let infos = extract_configuration(&single_listener_env(), &parse(json));
+
+        assert!(
+            infos.is_empty(),
+            "a logs data source must never fall through to the traces endpoint, got {infos:?}"
+        );
+    }
+
+    /// A channel with neither template yields nothing.
+    #[test]
+    fn channel_without_any_template_emits_nothing() {
+        let json = r#"{
+          "configurations": [{
+            "configurationId": "dcr-1",
+            "content": {
+              "dataSources": [{
+                "id": "logs", "kind": "otelLogs",
+                "streams": [{ "stream": "S" }],
+                "sendToChannels": ["gig-1"]
+              }],
+              "channels": [{ "id": "gig-1", "protocol": "gig" }]
+            }
+          }]
+        }"#;
+
+        assert!(extract_configuration(&single_listener_env(), &parse(json)).is_empty());
+    }
+
+    /// Missing routing is legal: the binding is produced with `routing_info: None`, meaning
+    /// broadcast.
+    #[test]
+    fn missing_attribute_routing_yields_broadcast_binding() {
+        let json = r#"{
+          "configurations": [{
+            "configurationId": "dcr-1",
+            "content": {
+              "dataSources": [{
+                "id": "logs", "kind": "otelLogs",
+                "streams": [{ "stream": "S" }],
+                "sendToChannels": ["gig-1"]
+              }],
+              "channels": [{ "id": "gig-1", "protocol": "gig", "otelLogsEndpointUriTemplate": "https://x/<STREAM>/logs" }]
+            }
+          }]
+        }"#;
+
+        let infos = extract_configuration(&single_listener_env(), &parse(json));
+
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0].routing_info, None);
+    }
+
+    /// A partially-specified routing block (value missing) is treated as absent.
+    #[test]
+    fn partial_attribute_routing_is_treated_as_absent() {
+        let json = r#"{
+          "configurations": [{
+            "configurationId": "dcr-1",
+            "content": {
+              "dataSources": [{
+                "configuration": { "resourceAttributeRouting": { "attributeName": "service.name" } },
+                "id": "logs", "kind": "otelLogs",
+                "streams": [{ "stream": "S" }],
+                "sendToChannels": ["gig-1"]
+              }],
+              "channels": [{ "id": "gig-1", "protocol": "gig", "otelLogsEndpointUriTemplate": "https://x/<STREAM>/logs" }]
+            }
+          }]
+        }"#;
+
+        let infos = extract_configuration(&single_listener_env(), &parse(json));
+
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0].routing_info, None);
+    }
+
+    /// `ods` channels carry no OTLP endpoints and must be ignored.
+    #[test]
+    fn ods_channels_are_ignored() {
+        let json = r#"{
+          "configurations": [{
+            "configurationId": "dcr-1",
+            "content": {
+              "dataSources": [{
+                "id": "logs", "kind": "otelLogs",
+                "streams": [{ "stream": "S" }],
+                "sendToChannels": ["ods-1"]
+              }],
+              "channels": [{ "id": "ods-1", "protocol": "ods", "otelLogsEndpointUriTemplate": "https://x/<STREAM>/logs" }]
+            }
+          }]
+        }"#;
+
+        assert!(extract_configuration(&single_listener_env(), &parse(json)).is_empty());
+    }
+
+    /// An unresolvable `sendToChannels` reference is skipped rather than fatal.
+    #[test]
+    fn unresolvable_channel_reference_is_skipped() {
+        let json = r#"{
+          "configurations": [{
+            "configurationId": "dcr-1",
+            "content": {
+              "dataSources": [{
+                "id": "logs", "kind": "otelLogs",
+                "streams": [{ "stream": "S" }],
+                "sendToChannels": ["does-not-exist"]
+              }],
+              "channels": [{ "id": "gig-1", "protocol": "gig", "otelLogsEndpointUriTemplate": "https://x/<STREAM>/logs" }]
+            }
+          }]
+        }"#;
+
+        assert!(extract_configuration(&single_listener_env(), &parse(json)).is_empty());
+    }
+
+    /// A data source fanning out to several channels yields one binding per channel.
+    #[test]
+    fn multiple_channels_per_data_source() {
+        let json = r#"{
+          "configurations": [{
+            "configurationId": "dcr-1",
+            "content": {
+              "dataSources": [{
+                "configuration": { "resourceAttributeRouting": { "attributeName": "service.name", "attributeValue": "amcs" } },
+                "id": "logs", "kind": "otelLogs",
+                "streams": [{ "stream": "S" }],
+                "sendToChannels": ["gig-1", "gig-2"]
+              }],
+              "channels": [
+                { "id": "gig-1", "protocol": "gig", "otelLogsEndpointUriTemplate": "https://one/<STREAM>/logs" },
+                { "id": "gig-2", "protocol": "gig", "otelLogsEndpointUriTemplate": "https://two/<STREAM>/logs" }
+              ]
+            }
+          }]
+        }"#;
+
+        let infos = extract_configuration(&single_listener_env(), &parse(json));
+
+        assert_eq!(infos.len(), 2);
+        let mut identifiers: Vec<&str> = infos.iter().map(|i| i.identifier.as_str()).collect();
+        identifiers.sort_unstable();
+        assert_eq!(identifiers, vec!["dcr-1.gig-1", "dcr-1.gig-2"]);
+    }
+
+    /// Several streams on one data source produce several endpoint URLs, in stable order.
+    #[test]
+    fn multiple_streams_produce_multiple_urls() {
+        let json = r#"{
+          "configurations": [{
+            "configurationId": "dcr-1",
+            "content": {
+              "dataSources": [{
+                "id": "logs", "kind": "otelLogs",
+                "streams": [{ "stream": "B_STREAM" }, { "stream": "A_STREAM" }],
+                "sendToChannels": ["gig-1"]
+              }],
+              "channels": [{ "id": "gig-1", "protocol": "gig", "otelLogsEndpointUriTemplate": "https://x/<STREAM>/logs" }]
+            }
+          }]
+        }"#;
+
+        let infos = extract_configuration(&single_listener_env(), &parse(json));
+
+        assert_eq!(infos.len(), 1);
+        assert_eq!(
+            infos[0].endpoint_urls,
+            vec!["https://x/A_STREAM/logs", "https://x/B_STREAM/logs"],
+            "stream order must be deterministic"
+        );
+    }
+
+    /// The `kind` match is case-insensitive, as in the .NET frozen dictionary.
+    #[test]
+    fn kind_matching_is_case_insensitive() {
+        assert_eq!(
+            OtlpEventName::from_amcs_kind("OTELLOGS"),
+            Some(OtlpEventName::Log)
+        );
+        assert_eq!(
+            OtlpEventName::from_amcs_kind("otelTRACES"),
+            Some(OtlpEventName::Span)
+        );
+        assert_eq!(OtlpEventName::from_amcs_kind("perfCounter"), None);
+        assert_eq!(OtlpEventName::from_amcs_kind(""), None);
+    }
+
+    /// With every listener disabled there is nothing to build.
+    #[test]
+    fn no_listeners_yields_no_bindings() {
+        let env = StaticEnvironment::new()
+            .with(crate::amcs::listener::ENV_OTLP_GRPC_LOGS_TRACES_PORT, "-1")
+            .with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "-1");
+
+        assert!(extract_configuration(&env, &parse(canonical_payload())).is_empty());
+    }
+
+    /// A data source with no streams cannot produce an endpoint.
+    #[test]
+    fn data_source_without_streams_emits_nothing() {
+        let json = r#"{
+          "configurations": [{
+            "configurationId": "dcr-1",
+            "content": {
+              "dataSources": [{
+                "id": "logs", "kind": "otelLogs",
+                "streams": [],
+                "sendToChannels": ["gig-1"]
+              }],
+              "channels": [{ "id": "gig-1", "protocol": "gig", "otelLogsEndpointUriTemplate": "https://x/<STREAM>/logs" }]
+            }
+          }]
+        }"#;
+
+        assert!(extract_configuration(&single_listener_env(), &parse(json)).is_empty());
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-config-translators/src/amcs/listener.rs
+++ b/rust/otap-dataflow/crates/contrib-config-translators/src/amcs/listener.rs
@@ -1,0 +1,759 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! OTLP listener discovery.
+//!
+//! Port of `AMCSParser.GetOtlpEventListenerInfo` / `AMCSParser.TryAddListener` from the .NET
+//! `AMCSConfiguration` project, extended with Agent Settings support per
+//! `Telemetry-Collection-Spec/AMACoreAgent/otel-port-configuration.md` (owner: Ragu Marimuthu).
+//!
+//! Listeners are **global to the host**: they come from environment variables and the agent
+//! settings rule, not from a data-source rule. Every Data Collection Rule on the machine shares
+//! the same listening sockets, which is why the generated pipeline has a single receiver.
+//!
+//! # Port precedence
+//!
+//! Highest to lowest, per the specification:
+//!
+//! 1. **Environment variable** -- always wins. If set, the agent settings value is ignored.
+//! 2. **Agent Settings DCR** -- `OtlpGrpcLogsTracesPort` / `OtlpHttpProtobufLogsTracesPort`.
+//! 3. **Hardcoded default** -- 4319 (gRPC) and 4320 (HTTP/protobuf).
+//!
+//! | Source | Variable / setting | Default |
+//! |---|---|---|
+//! | env | `OTLP_GRPC_LOGS_TRACES_PORT` | -- |
+//! | agent settings | `OtlpGrpcLogsTracesPort` | -- |
+//! | built in | -- | `4319` |
+//! | env | `OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT` | -- |
+//! | agent settings | `OtlpHttpProtobufLogsTracesPort` | -- |
+//! | built in | -- | `4320` |
+//!
+//! Value handling, also per the specification:
+//!
+//! - `-1` ([`PORT_IGNORE`]) disables that listener outright, overriding any agent settings value.
+//! - Any other invalid value -- unparseable, or outside `[1, 65535]` -- is treated as **unset**, so
+//!   resolution falls through to the next source. With no agent settings rule present this is
+//!   indistinguishable from the .NET behaviour of falling back to the default.
+//! - A blank or unset host falls back to [`DEFAULT_HOST`]. Host has **no** agent settings
+//!   equivalent; `OTLP_GRPC_LOGS_TRACES_HOST` and `OTLP_HTTP_PROTOBUF_LOGS_TRACES_HOST` are the
+//!   only way to override it.
+//!
+//! Note that discovering a listener here does not by itself open a port: the specification
+//! requires an OTel data-source rule to be present, which in this crate means
+//! [`extract_configuration`](crate::amcs::extract::extract_configuration) produced at least one
+//! binding.
+
+use otel_arrow_dfe_telemetry::otel_warn;
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs};
+
+/// Host used when the host environment variable is unset or blank.
+pub const DEFAULT_HOST: &str = "localhost";
+
+/// Sentinel port value that disables a listener.
+pub const PORT_IGNORE: i64 = -1;
+
+/// Default port for the OTLP/gRPC logs and traces listener.
+pub const DEFAULT_OTLP_GRPC_LOGS_TRACES_PORT: u16 = 4319;
+
+/// Default port for the OTLP/HTTP-protobuf logs and traces listener.
+pub const DEFAULT_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT: u16 = 4320;
+
+/// Environment variable naming the host for the OTLP/gRPC listener.
+pub const ENV_OTLP_GRPC_LOGS_TRACES_HOST: &str = "OTLP_GRPC_LOGS_TRACES_HOST";
+
+/// Environment variable naming the host for the OTLP/HTTP-protobuf listener.
+pub const ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_HOST: &str = "OTLP_HTTP_PROTOBUF_LOGS_TRACES_HOST";
+
+/// Environment variable naming the port for the OTLP/gRPC listener.
+pub const ENV_OTLP_GRPC_LOGS_TRACES_PORT: &str = "OTLP_GRPC_LOGS_TRACES_PORT";
+
+/// Environment variable naming the port for the OTLP/HTTP-protobuf listener.
+pub const ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT: &str = "OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT";
+
+/// Agent settings name carrying the OTLP/gRPC listener port.
+pub const SETTING_OTLP_GRPC_LOGS_TRACES_PORT: &str = "OtlpGrpcLogsTracesPort";
+
+/// Agent settings name carrying the OTLP/HTTP-protobuf listener port.
+pub const SETTING_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT: &str = "OtlpHttpProtobufLogsTracesPort";
+
+/// Lowest valid TCP port.
+const MIN_PORT: i64 = 1;
+
+/// Highest valid TCP port.
+const MAX_PORT: i64 = 65535;
+
+/// Supplies environment variables to the translator.
+///
+/// Injected rather than read directly from the process so that tests can vary the environment
+/// without `unsafe` calls to [`std::env::set_var`], which is neither sound nor race-free when
+/// tests run in parallel. This mirrors the .NET `IEnvironmentVariableProvider` abstraction and its
+/// `UnitTestEnvironmentVariableProvider` implementation.
+pub trait EnvironmentProvider {
+    /// Return the value of `key`, or `None` when it is not set.
+    fn get(&self, key: &str) -> Option<String>;
+}
+
+/// Reads environment variables from the current process.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ProcessEnvironment;
+
+impl EnvironmentProvider for ProcessEnvironment {
+    fn get(&self, key: &str) -> Option<String> {
+        std::env::var(key).ok()
+    }
+}
+
+/// An in-memory [`EnvironmentProvider`] for tests and for callers that already hold the values.
+#[derive(Debug, Clone, Default)]
+pub struct StaticEnvironment {
+    vars: HashMap<String, String>,
+}
+
+impl StaticEnvironment {
+    /// Create an empty environment, in which every lookup misses and defaults apply.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set a variable, returning `self` so calls can be chained.
+    #[must_use]
+    pub fn with(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        let _ = self.vars.insert(key.into(), value.into());
+        self
+    }
+}
+
+impl EnvironmentProvider for StaticEnvironment {
+    fn get(&self, key: &str) -> Option<String> {
+        self.vars.get(key).cloned()
+    }
+}
+
+/// The wire protocol a listener accepts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OtlpProtocol {
+    /// OTLP over gRPC.
+    Grpc,
+    /// OTLP over HTTP with protobuf encoding.
+    HttpProtobuf,
+}
+
+impl OtlpProtocol {
+    /// A stable lowercase name, used in diagnostics.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Grpc => "grpc",
+            Self::HttpProtobuf => "http_protobuf",
+        }
+    }
+}
+
+/// A resolved OTLP listener.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OtlpEventListenerInfo {
+    /// The configured host, verbatim (for example `localhost` or `0.0.0.0`).
+    pub host: String,
+    /// The resolved port.
+    pub port: u16,
+    /// The protocol this listener accepts.
+    pub protocol: OtlpProtocol,
+}
+
+impl OtlpEventListenerInfo {
+    /// Resolve this listener to a [`SocketAddr`] suitable for the OTLP receiver's
+    /// `listening_addr` field.
+    ///
+    /// The receiver deserializes `listening_addr` as a [`SocketAddr`], which does **not** accept
+    /// hostnames -- so the default host `localhost` has to be resolved to a literal address before
+    /// it reaches the generated YAML. Resolution prefers IPv4 to match the .NET agent's binding
+    /// behaviour, falling back to IPv6 when no IPv4 address is available.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidListenerAddress`](crate::Error::InvalidListenerAddress) when the
+    /// host cannot be resolved.
+    pub fn socket_addr(&self) -> Result<SocketAddr, crate::Error> {
+        if let Ok(ip) = self.host.parse::<IpAddr>() {
+            return Ok(SocketAddr::new(ip, self.port));
+        }
+
+        let resolved: Vec<SocketAddr> = (self.host.as_str(), self.port)
+            .to_socket_addrs()
+            .map_err(|e| crate::Error::InvalidListenerAddress {
+                host: self.host.clone(),
+                port: self.port,
+                details: e.to_string(),
+            })?
+            .collect();
+
+        resolved
+            .iter()
+            .find(|addr| addr.is_ipv4())
+            .or_else(|| resolved.first())
+            .copied()
+            .ok_or_else(|| crate::Error::InvalidListenerAddress {
+                host: self.host.clone(),
+                port: self.port,
+                details: "host resolved to no addresses".to_string(),
+            })
+    }
+}
+
+/// Agent settings values relevant to listener discovery.
+///
+/// Built from the payload's agent settings rule, if one is present. Values are kept as raw
+/// strings because that is how they arrive on the wire, and because an unparseable value must be
+/// treated as absent rather than rejected.
+#[derive(Debug, Clone, Default)]
+pub struct AgentSettings {
+    /// Value of the `OtlpGrpcLogsTracesPort` setting, if present.
+    pub grpc_port: Option<String>,
+    /// Value of the `OtlpHttpProtobufLogsTracesPort` setting, if present.
+    pub http_protobuf_port: Option<String>,
+}
+
+impl AgentSettings {
+    /// Extract the listener-relevant settings from a parsed AMCS payload.
+    ///
+    /// Returns an empty set when the payload carries no agent settings rule.
+    #[must_use]
+    pub fn from_configurations(config: &crate::amcs::schema::Configurations) -> Self {
+        Self {
+            grpc_port: config
+                .agent_setting(SETTING_OTLP_GRPC_LOGS_TRACES_PORT)
+                .map(str::to_string),
+            http_protobuf_port: config
+                .agent_setting(SETTING_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT)
+                .map(str::to_string),
+        }
+    }
+}
+
+/// How a candidate port value was interpreted.
+enum PortValue {
+    /// A usable port.
+    Port(u16),
+    /// The sentinel `-1`, disabling the listener.
+    Disabled,
+    /// Absent, blank, unparseable, or out of range -- fall through to the next source.
+    Unset,
+}
+
+/// Interpret one raw port value.
+///
+/// Anything that is not a valid port and is not the disable sentinel counts as [`PortValue::Unset`],
+/// so resolution continues to the next source in the precedence chain. The specification is
+/// explicit about this: *"Any other invalid input is treated as an empty string (not `-1`) and the
+/// listener starts accordingly."*
+fn interpret_port(raw: Option<&str>) -> PortValue {
+    let Some(trimmed) = raw.map(str::trim).filter(|v| !v.is_empty()) else {
+        return PortValue::Unset;
+    };
+
+    let Ok(value) = trimmed.parse::<i64>() else {
+        return PortValue::Unset;
+    };
+
+    if value == PORT_IGNORE {
+        return PortValue::Disabled;
+    }
+
+    if (MIN_PORT..=MAX_PORT).contains(&value) {
+        // Range-checked immediately above, so this conversion cannot fail.
+        u16::try_from(value).map_or(PortValue::Unset, PortValue::Port)
+    } else {
+        PortValue::Unset
+    }
+}
+
+/// Discover the OTLP listeners configured for this host.
+///
+/// Returns at most two listeners (gRPC and HTTP/protobuf), in that order. Either or both may be
+/// absent when disabled via [`PORT_IGNORE`]. An empty result means OTLP ingestion is switched off
+/// entirely, which callers must treat as "no pipeline to build".
+///
+/// `settings` supplies the agent settings rule values; pass
+/// [`AgentSettings::default`] when the payload has no such rule.
+#[must_use]
+pub fn discover_listeners<E: EnvironmentProvider + ?Sized>(
+    env: &E,
+    settings: &AgentSettings,
+) -> Vec<OtlpEventListenerInfo> {
+    let mut listeners = Vec::with_capacity(2);
+
+    try_add_listener(
+        env,
+        ENV_OTLP_GRPC_LOGS_TRACES_HOST,
+        ENV_OTLP_GRPC_LOGS_TRACES_PORT,
+        SETTING_OTLP_GRPC_LOGS_TRACES_PORT,
+        settings.grpc_port.as_deref(),
+        DEFAULT_OTLP_GRPC_LOGS_TRACES_PORT,
+        OtlpProtocol::Grpc,
+        &mut listeners,
+    );
+
+    try_add_listener(
+        env,
+        ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_HOST,
+        ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT,
+        SETTING_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT,
+        settings.http_protobuf_port.as_deref(),
+        DEFAULT_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT,
+        OtlpProtocol::HttpProtobuf,
+        &mut listeners,
+    );
+
+    listeners
+}
+
+/// Resolve one listener and append it to `listeners`, unless it is disabled.
+#[allow(clippy::too_many_arguments)]
+fn try_add_listener<E: EnvironmentProvider + ?Sized>(
+    env: &E,
+    host_env_var: &str,
+    port_env_var: &str,
+    port_setting_name: &str,
+    setting_port: Option<&str>,
+    default_port: u16,
+    protocol: OtlpProtocol,
+    listeners: &mut Vec<OtlpEventListenerInfo>,
+) {
+    let env_port = env.get(port_env_var);
+
+    // 1. Environment variable always wins.
+    let port = match interpret_port(env_port.as_deref()) {
+        PortValue::Disabled => {
+            otel_warn!(
+                "amcs.listener.disabled",
+                protocol = protocol.as_str(),
+                env_var = port_env_var,
+                message = "OTLP listener disabled because its environment variable is set to -1"
+            );
+            return;
+        }
+        PortValue::Port(port) => port,
+        // 2. Fall through to the agent settings rule.
+        PortValue::Unset => match interpret_port(setting_port) {
+            PortValue::Disabled => {
+                otel_warn!(
+                    "amcs.listener.disabled",
+                    protocol = protocol.as_str(),
+                    setting = port_setting_name,
+                    message = "OTLP listener disabled because its agent setting is set to -1"
+                );
+                return;
+            }
+            PortValue::Port(port) => port,
+            // 3. Fall back to the built-in default.
+            PortValue::Unset => {
+                if setting_port.is_some() {
+                    otel_warn!(
+                        "amcs.listener.invalid_agent_setting",
+                        protocol = protocol.as_str(),
+                        setting = port_setting_name,
+                        default_port = i64::from(default_port),
+                        message =
+                            "agent setting port is not usable; falling back to the default port"
+                    );
+                }
+                default_port
+            }
+        },
+    };
+
+    // Host is environment-only; the agent settings rule has no equivalent.
+    let host = env
+        .get(host_env_var)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_HOST.to_string());
+
+    listeners.push(OtlpEventListenerInfo {
+        host,
+        port,
+        protocol,
+    });
+}
+
+/// The loopback address `localhost` resolves to when no resolver is available.
+#[allow(dead_code)]
+pub(crate) const LOOPBACK_V4: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// No agent settings rule present.
+    fn no_settings() -> AgentSettings {
+        AgentSettings::default()
+    }
+
+    /// An agent settings rule supplying both ports.
+    fn settings(grpc: &str, http: &str) -> AgentSettings {
+        AgentSettings {
+            grpc_port: Some(grpc.to_string()),
+            http_protobuf_port: Some(http.to_string()),
+        }
+    }
+
+    /// With no environment set at all, both listeners appear on their default ports.
+    #[test]
+    fn defaults_when_environment_is_empty() {
+        let env = StaticEnvironment::new();
+        let listeners = discover_listeners(&env, &no_settings());
+
+        assert_eq!(listeners.len(), 2);
+        assert_eq!(
+            listeners[0],
+            OtlpEventListenerInfo {
+                host: DEFAULT_HOST.to_string(),
+                port: DEFAULT_OTLP_GRPC_LOGS_TRACES_PORT,
+                protocol: OtlpProtocol::Grpc,
+            }
+        );
+        assert_eq!(
+            listeners[1],
+            OtlpEventListenerInfo {
+                host: DEFAULT_HOST.to_string(),
+                port: DEFAULT_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT,
+                protocol: OtlpProtocol::HttpProtobuf,
+            }
+        );
+    }
+
+    /// Mirrors `OtlpEventInfoTest` permutation 1: gRPC disabled, custom HTTP host and port.
+    #[test]
+    fn grpc_disabled_with_custom_http_endpoint() {
+        let env = StaticEnvironment::new()
+            .with(ENV_OTLP_GRPC_LOGS_TRACES_PORT, "-1")
+            .with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "12345")
+            .with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_HOST, "0.0.0.0");
+
+        let listeners = discover_listeners(&env, &no_settings());
+
+        assert_eq!(listeners.len(), 1);
+        assert_eq!(listeners[0].host, "0.0.0.0");
+        assert_eq!(listeners[0].port, 12345);
+        assert_eq!(listeners[0].protocol, OtlpProtocol::HttpProtobuf);
+    }
+
+    /// Mirrors permutation 2: port `0` is out of range so the default applies, and a blank host
+    /// falls back to `localhost`.
+    #[test]
+    fn zero_port_and_blank_host_fall_back_to_defaults() {
+        let env = StaticEnvironment::new()
+            .with(ENV_OTLP_GRPC_LOGS_TRACES_PORT, "-1")
+            .with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "0")
+            .with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_HOST, "");
+
+        let listeners = discover_listeners(&env, &no_settings());
+
+        assert_eq!(listeners.len(), 1);
+        assert_eq!(listeners[0].host, DEFAULT_HOST);
+        assert_eq!(
+            listeners[0].port,
+            DEFAULT_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT
+        );
+        assert_eq!(listeners[0].protocol, OtlpProtocol::HttpProtobuf);
+    }
+
+    /// Mirrors permutation 3: HTTP disabled, gRPC falls back to its default.
+    #[test]
+    fn http_disabled_leaves_grpc_on_default_port() {
+        let env = StaticEnvironment::new()
+            .with(ENV_OTLP_GRPC_LOGS_TRACES_HOST, "")
+            .with(ENV_OTLP_GRPC_LOGS_TRACES_PORT, "0")
+            .with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "-1");
+
+        let listeners = discover_listeners(&env, &no_settings());
+
+        assert_eq!(listeners.len(), 1);
+        assert_eq!(listeners[0].host, DEFAULT_HOST);
+        assert_eq!(listeners[0].port, DEFAULT_OTLP_GRPC_LOGS_TRACES_PORT);
+        assert_eq!(listeners[0].protocol, OtlpProtocol::Grpc);
+    }
+
+    /// Mirrors permutation 4: an unparseable port falls back to the default.
+    #[test]
+    fn unparseable_port_falls_back_to_default() {
+        let env = StaticEnvironment::new()
+            .with(ENV_OTLP_GRPC_LOGS_TRACES_HOST, "")
+            .with(ENV_OTLP_GRPC_LOGS_TRACES_PORT, "Junk")
+            .with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "-1");
+
+        let listeners = discover_listeners(&env, &no_settings());
+
+        assert_eq!(listeners.len(), 1);
+        assert_eq!(listeners[0].port, DEFAULT_OTLP_GRPC_LOGS_TRACES_PORT);
+        assert_eq!(listeners[0].protocol, OtlpProtocol::Grpc);
+    }
+
+    /// Both protocols disabled yields no listeners at all.
+    #[test]
+    fn both_protocols_disabled_yields_empty_list() {
+        let env = StaticEnvironment::new()
+            .with(ENV_OTLP_GRPC_LOGS_TRACES_PORT, "-1")
+            .with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "-1");
+
+        assert!(discover_listeners(&env, &no_settings()).is_empty());
+    }
+
+    /// A port above the valid range falls back to the default, as with `0`.
+    #[test]
+    fn port_above_range_falls_back_to_default() {
+        let env = StaticEnvironment::new()
+            .with(ENV_OTLP_GRPC_LOGS_TRACES_PORT, "70000")
+            .with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "-1");
+
+        let listeners = discover_listeners(&env, &no_settings());
+
+        assert_eq!(listeners.len(), 1);
+        assert_eq!(listeners[0].port, DEFAULT_OTLP_GRPC_LOGS_TRACES_PORT);
+    }
+
+    /// Custom hosts and ports are honoured on both protocols.
+    #[test]
+    fn custom_hosts_and_ports() {
+        let env = StaticEnvironment::new()
+            .with(ENV_OTLP_GRPC_LOGS_TRACES_HOST, "127.0.0.2")
+            .with(ENV_OTLP_GRPC_LOGS_TRACES_PORT, "5000")
+            .with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_HOST, "127.0.0.3")
+            .with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "5001");
+
+        let listeners = discover_listeners(&env, &no_settings());
+
+        assert_eq!(listeners.len(), 2);
+        assert_eq!(listeners[0].host, "127.0.0.2");
+        assert_eq!(listeners[0].port, 5000);
+        assert_eq!(listeners[1].host, "127.0.0.3");
+        assert_eq!(listeners[1].port, 5001);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Agent Settings precedence, per
+    // Telemetry-Collection-Spec/AMACoreAgent/otel-port-configuration.md.
+    // Scenario numbers below refer to that document's "Port opening behavior by scenario" table.
+    // Scenarios 1, 2, 5, 6, 9, 10, 13 and 14 concern the absence of an OTel data-source rule,
+    // which is enforced one level up in `extract_configuration`; they are covered in
+    // `tests/translate.rs`.
+    // ---------------------------------------------------------------------------------------
+
+    /// Scenario 4: both env vars set and agent settings present -- the environment wins.
+    #[test]
+    fn environment_overrides_agent_settings() {
+        let env = StaticEnvironment::new()
+            .with(ENV_OTLP_GRPC_LOGS_TRACES_PORT, "4319")
+            .with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "4320");
+
+        let listeners = discover_listeners(&env, &settings("4329", "4330"));
+
+        assert_eq!(listeners.len(), 2);
+        assert_eq!(listeners[0].port, 4319);
+        assert_eq!(listeners[1].port, 4320);
+    }
+
+    /// Scenario 8: no environment variables -- the agent settings values are used.
+    #[test]
+    fn agent_settings_used_when_environment_is_unset() {
+        let listeners = discover_listeners(&StaticEnvironment::new(), &settings("4329", "4330"));
+
+        assert_eq!(listeners.len(), 2);
+        assert_eq!(listeners[0].port, 4329);
+        assert_eq!(listeners[0].protocol, OtlpProtocol::Grpc);
+        assert_eq!(listeners[1].port, 4330);
+        assert_eq!(listeners[1].protocol, OtlpProtocol::HttpProtobuf);
+    }
+
+    /// Scenario 7: no environment variables and no agent settings -- defaults apply.
+    #[test]
+    fn defaults_when_neither_source_supplies_a_port() {
+        let listeners = discover_listeners(&StaticEnvironment::new(), &no_settings());
+
+        assert_eq!(listeners[0].port, DEFAULT_OTLP_GRPC_LOGS_TRACES_PORT);
+        assert_eq!(
+            listeners[1].port,
+            DEFAULT_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT
+        );
+    }
+
+    /// Scenario 12: only the HTTP env var is set, so gRPC comes from agent settings and HTTP from
+    /// the environment.
+    #[test]
+    fn per_protocol_precedence_is_independent() {
+        let env = StaticEnvironment::new().with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "4321");
+
+        let listeners = discover_listeners(&env, &settings("4329", "4330"));
+
+        assert_eq!(listeners.len(), 2);
+        assert_eq!(
+            listeners[0].port, 4329,
+            "gRPC should come from agent settings"
+        );
+        assert_eq!(
+            listeners[1].port, 4321,
+            "HTTP should come from the environment"
+        );
+    }
+
+    /// Scenario 11: only the HTTP env var is set and there are no agent settings, so gRPC falls
+    /// back to its default.
+    #[test]
+    fn partial_environment_without_agent_settings_uses_defaults() {
+        let env = StaticEnvironment::new().with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "4321");
+
+        let listeners = discover_listeners(&env, &no_settings());
+
+        assert_eq!(listeners.len(), 2);
+        assert_eq!(listeners[0].port, DEFAULT_OTLP_GRPC_LOGS_TRACES_PORT);
+        assert_eq!(listeners[1].port, 4321);
+    }
+
+    /// Scenario 16: `-1` in the environment disables the listener even when agent settings supply
+    /// a port.
+    #[test]
+    fn environment_disable_overrides_agent_settings() {
+        let env = StaticEnvironment::new()
+            .with(ENV_OTLP_GRPC_LOGS_TRACES_PORT, "-1")
+            .with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "-1");
+
+        assert!(discover_listeners(&env, &settings("4329", "4330")).is_empty());
+    }
+
+    /// An invalid environment value is treated as unset, so resolution falls through to the agent
+    /// settings rather than jumping straight to the default.
+    #[test]
+    fn invalid_environment_value_falls_through_to_agent_settings() {
+        let env = StaticEnvironment::new()
+            .with(ENV_OTLP_GRPC_LOGS_TRACES_PORT, "Junk")
+            .with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "0");
+
+        let listeners = discover_listeners(&env, &settings("4329", "4330"));
+
+        assert_eq!(listeners.len(), 2);
+        assert_eq!(listeners[0].port, 4329);
+        assert_eq!(listeners[1].port, 4330);
+    }
+
+    /// An invalid agent settings value falls through to the default.
+    #[test]
+    fn invalid_agent_setting_falls_through_to_default() {
+        let listeners = discover_listeners(&StaticEnvironment::new(), &settings("Junk", "99999"));
+
+        assert_eq!(listeners.len(), 2);
+        assert_eq!(listeners[0].port, DEFAULT_OTLP_GRPC_LOGS_TRACES_PORT);
+        assert_eq!(
+            listeners[1].port,
+            DEFAULT_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT
+        );
+    }
+
+    /// `-1` in the agent settings disables the listener when the environment says nothing.
+    #[test]
+    fn agent_setting_can_disable_a_listener() {
+        let listeners = discover_listeners(&StaticEnvironment::new(), &settings("-1", "4330"));
+
+        assert_eq!(listeners.len(), 1);
+        assert_eq!(listeners[0].port, 4330);
+        assert_eq!(listeners[0].protocol, OtlpProtocol::HttpProtobuf);
+    }
+
+    /// Host has no agent settings equivalent, so it is always environment or default.
+    #[test]
+    fn host_is_not_configurable_through_agent_settings() {
+        let env = StaticEnvironment::new().with(ENV_OTLP_GRPC_LOGS_TRACES_HOST, "0.0.0.0");
+
+        let listeners = discover_listeners(&env, &settings("4329", "4330"));
+
+        assert_eq!(listeners[0].host, "0.0.0.0");
+        assert_eq!(listeners[0].port, 4329);
+        assert_eq!(listeners[1].host, DEFAULT_HOST);
+    }
+
+    /// Agent settings are read out of the payload's agent settings rule.
+    #[test]
+    fn agent_settings_are_read_from_the_payload() {
+        let json = r#"{
+            "configurations": [{
+                "configurationId": "dcr-settings",
+                "content": {
+                    "kind": "AgentSettings",
+                    "settings": [
+                        { "name": "MaxDiskQuotaInMB", "value": "10240" },
+                        { "name": "OtlpGrpcLogsTracesPort", "value": "4329" },
+                        { "name": "OtlpHttpProtobufLogsTracesPort", "value": "4330" }
+                    ]
+                }
+            }]
+        }"#;
+
+        let config = crate::amcs::schema::Configurations::from_json(json).expect("should parse");
+        let extracted = AgentSettings::from_configurations(&config);
+
+        assert_eq!(extracted.grpc_port.as_deref(), Some("4329"));
+        assert_eq!(extracted.http_protobuf_port.as_deref(), Some("4330"));
+
+        let listeners = discover_listeners(&StaticEnvironment::new(), &extracted);
+        assert_eq!(listeners[0].port, 4329);
+        assert_eq!(listeners[1].port, 4330);
+    }
+
+    /// A payload with no agent settings rule yields empty settings and therefore defaults.
+    #[test]
+    fn payload_without_agent_settings_yields_defaults() {
+        let json = r#"{ "configurations": [{ "configurationId": "dcr-1", "content": {} }] }"#;
+
+        let config = crate::amcs::schema::Configurations::from_json(json).expect("should parse");
+        let extracted = AgentSettings::from_configurations(&config);
+
+        assert!(extracted.grpc_port.is_none());
+        assert!(extracted.http_protobuf_port.is_none());
+
+        let listeners = discover_listeners(&StaticEnvironment::new(), &extracted);
+        assert_eq!(listeners[0].port, DEFAULT_OTLP_GRPC_LOGS_TRACES_PORT);
+    }
+
+    /// A literal IP address is used directly, without going through name resolution.
+    #[test]
+    fn literal_ip_resolves_without_lookup() {
+        let listener = OtlpEventListenerInfo {
+            host: "0.0.0.0".to_string(),
+            port: 4319,
+            protocol: OtlpProtocol::Grpc,
+        };
+
+        let addr = listener.socket_addr().expect("literal IP should resolve");
+        assert_eq!(addr.to_string(), "0.0.0.0:4319");
+    }
+
+    /// `localhost` must resolve to a literal address, because the receiver's `listening_addr`
+    /// field is a `SocketAddr` and cannot accept a hostname.
+    #[test]
+    fn localhost_resolves_to_loopback() {
+        let listener = OtlpEventListenerInfo {
+            host: DEFAULT_HOST.to_string(),
+            port: 4319,
+            protocol: OtlpProtocol::Grpc,
+        };
+
+        let addr = listener.socket_addr().expect("localhost should resolve");
+        assert!(addr.ip().is_loopback(), "expected loopback, got {addr}");
+        assert_eq!(addr.port(), 4319);
+    }
+
+    /// An unresolvable host surfaces as an error rather than a panic.
+    #[test]
+    fn unresolvable_host_is_an_error() {
+        let listener = OtlpEventListenerInfo {
+            host: "host.invalid.".to_string(),
+            port: 4319,
+            protocol: OtlpProtocol::Grpc,
+        };
+
+        assert!(matches!(
+            listener.socket_addr(),
+            Err(crate::Error::InvalidListenerAddress { .. })
+        ));
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-config-translators/src/amcs/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-config-translators/src/amcs/mod.rs
@@ -25,7 +25,9 @@
 //! |---|---|
 //! | [`schema`] | Serde model of the AMCS JSON payload |
 //! | [`listener`] | OTLP listener discovery from the environment and Agent Settings |
+//! | [`extract`] | Payload plus listeners to routable endpoint bindings |
 
+pub mod extract;
 pub mod listener;
 pub mod schema;
 

--- a/rust/otap-dataflow/crates/contrib-config-translators/src/amcs/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-config-translators/src/amcs/mod.rs
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Translator for AMCS (Azure Monitor Configuration Service) third-party configuration.
+//!
+//! AMCS delivers the Azure Monitor Agent every customer-authored Data Collection Rule (DCR) that
+//! applies to a host, as a single JSON document. This module turns that document into an
+//! [`OtelDataflowSpec`] the OTAP dataflow engine can run.
+//!
+//! This is a port of `AMCSParser.ExtractConfiguration` from the .NET `AMCSConfiguration`
+//! project. The input is byte-for-byte the same payload the .NET agent consumes; only the output
+//! differs -- a pipeline specification rather than a list of in-memory endpoint bindings.
+//!
+//! It additionally supports the **Agent Settings DCR** (`content.kind: "AgentSettings"`), which
+//! the .NET parser does not read -- `Content.kind` and `Content.settings` are commented out in
+//! `Configurations.cs`. That behaviour follows
+//! `Telemetry-Collection-Spec/AMACoreAgent/otel-port-configuration.md` (owner: Ragu Marimuthu):
+//! listener ports resolve from the environment first, then the Agent Settings rule, then the
+//! built-in defaults. See [`listener`] for the full precedence chain.
+//!
+//!
+//! # Stages
+//!
+//! | Module | Responsibility |
+//! |---|---|
+//! | [`schema`] | Serde model of the AMCS JSON payload |
+
+pub mod schema;
+
+/// The dialect name reported by the AMCS translator.
+pub const AMCS_DIALECT: &str = "amcs";

--- a/rust/otap-dataflow/crates/contrib-config-translators/src/amcs/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-config-translators/src/amcs/mod.rs
@@ -24,7 +24,9 @@
 //! | Module | Responsibility |
 //! |---|---|
 //! | [`schema`] | Serde model of the AMCS JSON payload |
+//! | [`listener`] | OTLP listener discovery from the environment and Agent Settings |
 
+pub mod listener;
 pub mod schema;
 
 /// The dialect name reported by the AMCS translator.

--- a/rust/otap-dataflow/crates/contrib-config-translators/src/amcs/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-config-translators/src/amcs/mod.rs
@@ -18,7 +18,6 @@
 //! listener ports resolve from the environment first, then the Agent Settings rule, then the
 //! built-in defaults. See [`listener`] for the full precedence chain.
 //!
-//!
 //! # Stages
 //!
 //! | Module | Responsibility |
@@ -26,10 +25,236 @@
 //! | [`schema`] | Serde model of the AMCS JSON payload |
 //! | [`listener`] | OTLP listener discovery from the environment and Agent Settings |
 //! | [`extract`] | Payload plus listeners to routable endpoint bindings |
+//! | [`emit`] | Endpoint bindings to an engine pipeline specification |
+//!
+//! # Example
+//!
+//! ```no_run
+//! use otel_arrow_dfe_contrib_config_translators::ConfigTranslator;
+//! use otel_arrow_dfe_contrib_config_translators::amcs::AmcsTranslator;
+//!
+//! let payload = std::fs::read_to_string("amcs-config.json")?;
+//! let yaml = AmcsTranslator::new().translate_to_yaml(&payload)?;
+//! println!("{yaml}");
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
 
+pub mod emit;
 pub mod extract;
 pub mod listener;
 pub mod schema;
 
-/// The dialect name reported by the AMCS translator.
+use crate::amcs::emit::HostContext;
+use crate::amcs::listener::{EnvironmentProvider, ProcessEnvironment};
+use crate::{ConfigTranslator, Error};
+use otel_arrow_dfe_config::engine::OtelDataflowSpec;
+
+/// The dialect name reported by [`AmcsTranslator`].
 pub const AMCS_DIALECT: &str = "amcs";
+
+/// Translates AMCS configuration payloads into engine pipeline specifications.
+///
+/// Listener settings are read through an [`EnvironmentProvider`], which defaults to the process
+/// environment. Tests and callers that already hold the values can substitute
+/// [`StaticEnvironment`](listener::StaticEnvironment) via [`AmcsTranslator::with_environment`].
+///
+/// Values the agent knows about itself -- its Azure resource id, region and version -- do not
+/// appear in a Data Collection Rule, so the embedding host supplies them through a
+/// [`HostContext`] set with [`AmcsTranslator::with_host_context`]. Without one, the generated
+/// exporters carry no request metadata.
+#[derive(Debug, Clone, Default)]
+pub struct AmcsTranslator<E = ProcessEnvironment> {
+    environment: E,
+    host: HostContext,
+}
+
+impl AmcsTranslator<ProcessEnvironment> {
+    /// Create a translator that reads listener settings from the process environment.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            environment: ProcessEnvironment,
+            host: HostContext::default(),
+        }
+    }
+}
+
+impl<E: EnvironmentProvider> AmcsTranslator<E> {
+    /// Create a translator backed by a specific [`EnvironmentProvider`].
+    #[must_use]
+    pub fn with_environment(environment: E) -> Self {
+        Self {
+            environment,
+            host: HostContext::default(),
+        }
+    }
+
+    /// Attach the host-supplied values carried on every generated exporter.
+    #[must_use]
+    pub fn with_host_context(mut self, host: HostContext) -> Self {
+        self.host = host;
+        self
+    }
+
+    /// Access the environment provider backing this translator.
+    #[must_use]
+    pub const fn environment(&self) -> &E {
+        &self.environment
+    }
+
+    /// Access the host context backing this translator.
+    #[must_use]
+    pub const fn host_context(&self) -> &HostContext {
+        &self.host
+    }
+}
+
+impl<E: EnvironmentProvider> ConfigTranslator for AmcsTranslator<E> {
+    fn dialect(&self) -> &str {
+        AMCS_DIALECT
+    }
+
+    fn translate(&self, raw: &str) -> Result<OtelDataflowSpec, Error> {
+        let configurations = schema::Configurations::from_json(raw)?;
+        let infos = extract::extract_configuration(&self.environment, &configurations);
+        emit::build_pipeline(&infos, &self.host)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::amcs::listener::{ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, StaticEnvironment};
+
+    /// A payload mirroring the shape of `PipelineAgentTests/TestData/ConfigPackage/AMCSConfig`.
+    const CANONICAL: &str = r#"{
+      "configurations": [{
+        "configurationId": "dcr-00000000000000000000000000000002",
+        "eTag": "dcr-00000000000000000000000000000002/%22e1e1e1e1%22",
+        "op": "added",
+        "content": {
+          "dataSources": [
+            {
+              "configuration": { "scheduledTransferPeriod": "PT1M" },
+              "id": "myPerfCounterDataSource1",
+              "kind": "perfCounter",
+              "streams": [{ "stream": "GENERIC_PERF_BLOB", "solution": "LogManagement" }],
+              "sendToChannels": ["ods-aaaaaaaa"]
+            },
+            {
+              "configuration": {
+                "resourceAttributeRouting": { "attributeName": "service.name", "attributeValue": "amcs" }
+              },
+              "id": "myOtelLogs1DataSource",
+              "kind": "otelLogs",
+              "streams": [{ "stream": "OPENTELEMETRY_LOGS_AGENT" }],
+              "sendToChannels": ["gigl-dce-00000002"]
+            },
+            {
+              "configuration": {
+                "resourceAttributeRouting": { "attributeName": "service.name", "attributeValue": "amcs" }
+              },
+              "id": "myOtelTraces1DataSource",
+              "kind": "otelTraces",
+              "streams": [{ "stream": "OPENTELEMETRY_TRACES_AGENT" }],
+              "sendToChannels": ["gigl-dce-00000002"]
+            }
+          ],
+          "channels": [
+            {
+              "endpoint": "https://aaaaaaaa.ods.opinsights.azure.com",
+              "id": "ods-aaaaaaaa",
+              "protocol": "ods"
+            },
+            {
+              "endpointUriTemplate": "https://dce.example.com/dataCollectionRules/dcr-1/streams/<STREAM>?api-version=2021-11-01-preview",
+              "otelLogsEndpointUriTemplate": "https://dce.example.com/dataCollectionRules/dcr-1/streams/<STREAM>/otlp/v1/logs?api-version=2021-11-01-preview",
+              "otelTracesEndpointUriTemplate": "https://dce.example.com/dataCollectionRules/dcr-1/streams/<STREAM>/otlp/v1/traces?api-version=2021-11-01-preview",
+              "id": "gigl-dce-00000002",
+              "protocol": "gig"
+            }
+          ]
+        }
+      }]
+    }"#;
+
+    fn translator() -> AmcsTranslator<StaticEnvironment> {
+        AmcsTranslator::with_environment(
+            StaticEnvironment::new().with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "-1"),
+        )
+    }
+
+    #[test]
+    fn reports_its_dialect() {
+        assert_eq!(translator().dialect(), AMCS_DIALECT);
+    }
+
+    #[test]
+    fn translates_the_canonical_payload() {
+        let yaml = translator()
+            .translate_to_yaml(CANONICAL)
+            .expect("translation should succeed");
+
+        assert!(yaml.contains("urn:otel:receiver:otlp"));
+        assert!(yaml.contains("urn:otel:exporter:otlp_http"));
+        assert!(yaml.contains("OPENTELEMETRY_LOGS_AGENT"));
+        assert!(yaml.contains("OPENTELEMETRY_TRACES_AGENT"));
+        assert!(yaml.contains("service.name"));
+        // The `perfCounter` data source and the `ods` channel must not appear.
+        assert!(!yaml.contains("GENERIC_PERF_BLOB"));
+        assert!(!yaml.contains("opinsights"));
+    }
+
+    #[test]
+    fn generated_yaml_is_accepted_by_the_engine_loader() {
+        let yaml = translator()
+            .translate_to_yaml(CANONICAL)
+            .expect("translation should succeed");
+
+        let spec = OtelDataflowSpec::from_yaml(&yaml);
+        assert!(
+            spec.is_ok(),
+            "engine rejected generated config: {spec:?}\n{yaml}"
+        );
+    }
+
+    #[test]
+    fn translation_is_deterministic() {
+        // The engine stores nodes in a `HashMap`, so the *textual* order of the serialized YAML
+        // is not stable across runs. What must be stable is the specification itself, so compare
+        // the parsed values rather than the strings.
+        let first = translator().translate(CANONICAL).expect("first");
+        let second = translator().translate(CANONICAL).expect("second");
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn malformed_payload_is_a_deserialization_error() {
+        let err = translator()
+            .translate_to_yaml("{ not json")
+            .expect_err("should fail");
+        assert!(matches!(err, Error::Deserialization { .. }));
+    }
+
+    #[test]
+    fn payload_without_otlp_data_sources_yields_an_empty_pipeline_error() {
+        let json = r#"{
+          "configurations": [{
+            "configurationId": "dcr-1",
+            "content": {
+              "dataSources": [{
+                "id": "perf", "kind": "perfCounter",
+                "streams": [{ "stream": "GENERIC_PERF_BLOB" }],
+                "sendToChannels": ["ods-1"]
+              }],
+              "channels": [{ "id": "ods-1", "protocol": "ods" }]
+            }
+          }]
+        }"#;
+
+        let err = translator()
+            .translate_to_yaml(json)
+            .expect_err("should fail");
+        assert!(matches!(err, Error::EmptyPipeline { .. }));
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-config-translators/src/amcs/schema.rs
+++ b/rust/otap-dataflow/crates/contrib-config-translators/src/amcs/schema.rs
@@ -1,0 +1,448 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Serde model for the AMCS (Azure Monitor Configuration Service) configuration payload.
+//!
+//! This is a direct port of `Configurations.cs` from the .NET `AMCSConfiguration` project.
+//!
+//! The payload delivered to the agent contains substantially more than we consume -- `eTag`,
+//! `op`, `settings`, `tokenEndpointUri`, `endpoint`, `endpointUriTemplate`, per-stream
+//! `solution`, and entire data source kinds such as `perfCounter`. These structs therefore
+//! deliberately **do not** use `deny_unknown_fields`: unrecognised fields must be ignored rather
+//! than rejected, exactly as the .NET parser does.
+//!
+//! Field names use AMCS's lowerCamelCase spelling verbatim so the mapping stays obvious when
+//! comparing against a raw payload.
+
+use serde::Deserialize;
+
+/// Root of an AMCS configuration payload.
+///
+/// A single payload carries **every** Data Collection Rule (DCR) that applies to the host, so
+/// `configurations` commonly holds more than one entry.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct Configurations {
+    /// One entry per DCR.
+    #[serde(default)]
+    pub configurations: Vec<Configuration>,
+}
+
+/// A single Data Collection Rule.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Configuration {
+    /// The DCR identifier, e.g. `dcr-00000000000000000000000000000002`.
+    ///
+    /// Forms the first half of the per-branch identifier (see
+    /// [`OtlpEventInfo::identifier`](crate::amcs::extract::OtlpEventInfo::identifier)).
+    #[serde(rename = "configurationId")]
+    pub configuration_id: String,
+
+    /// The rule body: data sources and channels.
+    #[serde(default)]
+    pub content: Option<Content>,
+}
+
+/// The body of a Data Collection Rule.
+///
+/// A rule is either a **data-source rule** (carrying `dataSources` and `channels`) or an
+/// **agent settings rule** (`kind: "AgentSettings"`, carrying `settings`). The two never mix, and
+/// per the OTel port configuration specification a host has at most one agent settings rule.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct Content {
+    /// The rule kind. `AgentSettings` marks an agent settings rule; data-source rules leave this
+    /// unset.
+    ///
+    /// Unknown kinds must be skipped rather than rejected, so that a newer control plane can add
+    /// rule kinds without breaking existing agents.
+    #[serde(default)]
+    pub kind: Option<String>,
+
+    /// Agent settings key/value pairs, present only on an agent settings rule.
+    ///
+    /// The live AMCS payload nests these under `content.settings`. `agentSettings` is accepted as
+    /// an alias because the specification writes it that way.
+    #[serde(default, alias = "agentSettings")]
+    pub settings: Vec<AmcsSetting>,
+
+    /// Declared inputs. Only `otelLogs` and `otelTraces` kinds are relevant here.
+    #[serde(rename = "dataSources", default)]
+    pub data_sources: Vec<DataSource>,
+
+    /// Declared destinations, referenced by [`DataSource::send_to_channels`].
+    #[serde(default)]
+    pub channels: Vec<Channel>,
+}
+
+/// A single agent settings key/value pair.
+///
+/// Values arrive as strings even when they denote numbers, matching the AMCS wire format.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AmcsSetting {
+    /// The setting name, for example `OtlpGrpcLogsTracesPort`.
+    #[serde(default)]
+    pub name: String,
+
+    /// The setting value, always a string on the wire.
+    #[serde(default)]
+    pub value: Option<String>,
+}
+
+/// A telemetry input declared by a Data Collection Rule.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DataSource {
+    /// The data source identifier within the rule.
+    #[serde(default)]
+    pub id: String,
+
+    /// The data source kind, e.g. `otelLogs`, `otelTraces`, `perfCounter`.
+    ///
+    /// Matched case-insensitively against
+    /// [`OtlpEventName::from_amcs_kind`](crate::amcs::extract::OtlpEventName::from_amcs_kind);
+    /// anything unrecognised is skipped.
+    #[serde(default)]
+    pub kind: String,
+
+    /// Ids of the channels this data source sends to, resolved against [`Content::channels`].
+    #[serde(rename = "sendToChannels", default)]
+    pub send_to_channels: Vec<String>,
+
+    /// The streams (schemas) this data source produces. Each stream name is substituted into the
+    /// channel's endpoint template in place of the `<STREAM>` token.
+    #[serde(default)]
+    pub streams: Vec<AmcsStream>,
+
+    /// Optional kind-specific configuration. Only `resourceAttributeRouting` is consumed.
+    #[serde(default)]
+    pub configuration: Option<DataSourceConfiguration>,
+}
+
+/// A destination declared by a Data Collection Rule.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Channel {
+    /// The channel identifier, referenced by [`DataSource::send_to_channels`].
+    ///
+    /// Forms the second half of the per-branch identifier.
+    #[serde(default)]
+    pub id: String,
+
+    /// The channel protocol. Only `gig` channels carry OTLP endpoint templates; `ods` channels
+    /// are legacy and ignored.
+    #[serde(default)]
+    pub protocol: Option<String>,
+
+    /// Endpoint template for OTLP logs, containing the literal `<STREAM>` token.
+    ///
+    /// Optional: a customer may configure traces only, logs only, both, or neither.
+    #[serde(rename = "otelLogsEndpointUriTemplate", default)]
+    pub otel_logs_endpoint_uri_template: Option<String>,
+
+    /// Endpoint template for OTLP traces, containing the literal `<STREAM>` token.
+    ///
+    /// Optional, for the same reason as [`Channel::otel_logs_endpoint_uri_template`].
+    #[serde(rename = "otelTracesEndpointUriTemplate", default)]
+    pub otel_traces_endpoint_uri_template: Option<String>,
+}
+
+/// A named stream (schema) produced by a data source.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AmcsStream {
+    /// The stream name, e.g. `OPENTELEMETRY_LOGS_AGENT`.
+    #[serde(default)]
+    pub stream: String,
+}
+
+/// Kind-specific data source configuration.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct DataSourceConfiguration {
+    /// How telemetry is routed to this data source.
+    ///
+    /// When absent, telemetry is broadcast to every endpoint rather than filtered.
+    #[serde(rename = "resourceAttributeRouting", default)]
+    pub resource_attribute_routing: Option<ResourceAttributeRouting>,
+}
+
+/// The resource attribute used to route telemetry to a specific data source.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ResourceAttributeRouting {
+    /// The resource attribute key, e.g. `service.name`.
+    #[serde(rename = "attributeName", default)]
+    pub attribute_name: Option<String>,
+
+    /// The resource attribute value the key must equal, e.g. `amcs`.
+    #[serde(rename = "attributeValue", default)]
+    pub attribute_value: Option<String>,
+}
+
+/// The `content.kind` value marking an agent settings rule.
+pub const AGENT_SETTINGS_KIND: &str = "AgentSettings";
+
+impl Content {
+    /// Whether this rule is an agent settings rule rather than a data-source rule.
+    #[must_use]
+    pub fn is_agent_settings(&self) -> bool {
+        self.kind
+            .as_deref()
+            .is_some_and(|k| k.eq_ignore_ascii_case(AGENT_SETTINGS_KIND))
+    }
+}
+
+impl Configurations {
+    /// Parse an AMCS configuration payload from JSON.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Deserialization`](crate::Error::Deserialization) if the payload is not
+    /// valid JSON or does not match the expected shape.
+    pub fn from_json(json: &str) -> Result<Self, crate::Error> {
+        serde_json::from_str(json).map_err(|e| crate::Error::Deserialization {
+            format: "JSON",
+            details: e.to_string(),
+        })
+    }
+
+    /// Look up an agent setting by name, matched case-insensitively.
+    ///
+    /// Returns `None` when no agent settings rule is present, or when the named setting is absent
+    /// or has no value. A host has at most one agent settings rule, but if several were somehow
+    /// delivered the first match wins.
+    #[must_use]
+    pub fn agent_setting(&self, name: &str) -> Option<&str> {
+        self.configurations
+            .iter()
+            .filter_map(|c| c.content.as_ref())
+            .filter(|content| content.is_agent_settings())
+            .flat_map(|content| content.settings.iter())
+            .find(|setting| setting.name.eq_ignore_ascii_case(name))
+            .and_then(|setting| setting.value.as_deref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Unknown fields such as `eTag`, `op` and `perfCounter` configuration blocks must be
+    /// ignored, not rejected.
+    #[test]
+    fn ignores_unknown_fields() {
+        let json = r#"{
+            "configurations": [{
+                "configurationId": "dcr-1",
+                "eTag": "dcr-1/%22abc%22",
+                "op": "added",
+                "content": {
+                    "dataSources": [{
+                        "configuration": {
+                            "scheduledTransferPeriod": "PT1M",
+                            "counters": [{ "samplingFrequencyInSeconds": 30 }]
+                        },
+                        "id": "perf",
+                        "kind": "perfCounter",
+                        "streams": [{ "stream": "GENERIC_PERF_BLOB", "solution": "LogManagement" }],
+                        "sendToChannels": ["ods-1"]
+                    }],
+                    "channels": [{
+                        "endpoint": "https://example.ods.opinsights.azure.com",
+                        "tokenEndpointUri": "https://example/issueIngestionToken",
+                        "id": "ods-1",
+                        "protocol": "ods"
+                    }]
+                }
+            }]
+        }"#;
+
+        let parsed = Configurations::from_json(json).expect("payload should parse");
+        assert_eq!(parsed.configurations.len(), 1);
+        assert_eq!(parsed.configurations[0].configuration_id, "dcr-1");
+
+        let content = parsed.configurations[0]
+            .content
+            .as_ref()
+            .expect("content present");
+        assert_eq!(content.data_sources.len(), 1);
+        assert_eq!(content.data_sources[0].kind, "perfCounter");
+        assert_eq!(content.channels[0].protocol.as_deref(), Some("ods"));
+    }
+
+    /// Both endpoint templates are independently optional.
+    #[test]
+    fn endpoint_templates_are_optional() {
+        let json = r#"{
+            "configurations": [{
+                "configurationId": "dcr-1",
+                "content": { "channels": [{ "id": "gig-1", "protocol": "gig" }] }
+            }]
+        }"#;
+
+        let parsed = Configurations::from_json(json).expect("payload should parse");
+        let channel = &parsed.configurations[0]
+            .content
+            .as_ref()
+            .expect("content present")
+            .channels[0];
+        assert!(channel.otel_logs_endpoint_uri_template.is_none());
+        assert!(channel.otel_traces_endpoint_uri_template.is_none());
+    }
+
+    /// An entirely empty payload is valid and yields no configurations.
+    #[test]
+    fn empty_payload_parses() {
+        let parsed = Configurations::from_json("{}").expect("empty payload should parse");
+        assert!(parsed.configurations.is_empty());
+    }
+
+    /// Malformed JSON must surface as a deserialization error rather than a panic.
+    #[test]
+    fn malformed_json_is_an_error() {
+        let err = Configurations::from_json("{ not json").expect_err("should fail");
+        assert!(matches!(err, crate::Error::Deserialization { .. }));
+    }
+
+    /// The live agent settings shape: `content.kind` plus `content.settings`.
+    const AGENT_SETTINGS_PAYLOAD: &str = r#"{
+        "configurations": [{
+            "configurationId": "dcr-00000000000000000000000000000003",
+            "eTag": "dcr-00000000000000000000000000000003/%22e3e3e3e3%22",
+            "op": "added",
+            "content": {
+                "kind": "AgentSettings",
+                "settings": [
+                    { "name": "MaxDiskQuotaInMB", "value": "10240" },
+                    { "name": "OtlpGrpcLogsTracesPort", "value": "4319" },
+                    { "name": "OtlpHttpProtobufLogsTracesPort", "value": "4320" }
+                ]
+            }
+        }]
+    }"#;
+
+    #[test]
+    fn parses_an_agent_settings_rule() {
+        let parsed = Configurations::from_json(AGENT_SETTINGS_PAYLOAD).expect("should parse");
+        let content = parsed.configurations[0]
+            .content
+            .as_ref()
+            .expect("content present");
+
+        assert!(content.is_agent_settings());
+        assert_eq!(content.settings.len(), 3);
+        // An agent settings rule carries no data sources or channels.
+        assert!(content.data_sources.is_empty());
+        assert!(content.channels.is_empty());
+    }
+
+    #[test]
+    fn looks_up_agent_settings_by_name() {
+        let parsed = Configurations::from_json(AGENT_SETTINGS_PAYLOAD).expect("should parse");
+
+        assert_eq!(parsed.agent_setting("OtlpGrpcLogsTracesPort"), Some("4319"));
+        assert_eq!(
+            parsed.agent_setting("OtlpHttpProtobufLogsTracesPort"),
+            Some("4320")
+        );
+        assert_eq!(parsed.agent_setting("MaxDiskQuotaInMB"), Some("10240"));
+        assert_eq!(parsed.agent_setting("NoSuchSetting"), None);
+    }
+
+    /// Setting names are matched case-insensitively, as elsewhere in the payload.
+    #[test]
+    fn agent_setting_lookup_is_case_insensitive() {
+        let parsed = Configurations::from_json(AGENT_SETTINGS_PAYLOAD).expect("should parse");
+        assert_eq!(parsed.agent_setting("otlpgrpclogstracesport"), Some("4319"));
+    }
+
+    /// A data-source rule is not an agent settings rule, and exposes no settings.
+    #[test]
+    fn data_source_rule_is_not_agent_settings() {
+        let json = r#"{
+            "configurations": [{
+                "configurationId": "dcr-1",
+                "content": {
+                    "dataSources": [{ "id": "logs", "kind": "otelLogs" }],
+                    "channels": [{ "id": "gig-1", "protocol": "gig" }]
+                }
+            }]
+        }"#;
+
+        let parsed = Configurations::from_json(json).expect("should parse");
+        let content = parsed.configurations[0]
+            .content
+            .as_ref()
+            .expect("content present");
+
+        assert!(!content.is_agent_settings());
+        assert_eq!(parsed.agent_setting("OtlpGrpcLogsTracesPort"), None);
+    }
+
+    /// The specification writes the settings array as `agentSettings`; accept it as an alias.
+    #[test]
+    fn accepts_the_agent_settings_alias() {
+        let json = r#"{
+            "configurations": [{
+                "configurationId": "dcr-1",
+                "content": {
+                    "kind": "AgentSettings",
+                    "agentSettings": [
+                        { "name": "OtlpGrpcLogsTracesPort", "value": "4329" }
+                    ]
+                }
+            }]
+        }"#;
+
+        let parsed = Configurations::from_json(json).expect("should parse");
+        assert_eq!(parsed.agent_setting("OtlpGrpcLogsTracesPort"), Some("4329"));
+    }
+
+    /// An unrecognised rule kind must be skipped, not rejected, so a newer control plane can add
+    /// kinds without breaking existing agents.
+    #[test]
+    fn unknown_rule_kind_is_ignored() {
+        let json = r#"{
+            "configurations": [{
+                "configurationId": "dcr-1",
+                "content": { "kind": "SomeFutureKind", "settings": [{ "name": "X", "value": "1" }] }
+            }]
+        }"#;
+
+        let parsed = Configurations::from_json(json).expect("should parse");
+        let content = parsed.configurations[0]
+            .content
+            .as_ref()
+            .expect("content present");
+
+        assert!(!content.is_agent_settings());
+        assert_eq!(parsed.agent_setting("X"), None);
+    }
+
+    /// A mixed payload carries both an agent settings rule and data-source rules.
+    #[test]
+    fn mixed_payload_exposes_settings_and_data_sources() {
+        let json = r#"{
+            "configurations": [
+                {
+                    "configurationId": "dcr-settings",
+                    "content": {
+                        "kind": "AgentSettings",
+                        "settings": [{ "name": "OtlpGrpcLogsTracesPort", "value": "4329" }]
+                    }
+                },
+                {
+                    "configurationId": "dcr-data",
+                    "content": {
+                        "dataSources": [{ "id": "logs", "kind": "otelLogs" }],
+                        "channels": [{ "id": "gig-1", "protocol": "gig" }]
+                    }
+                }
+            ]
+        }"#;
+
+        let parsed = Configurations::from_json(json).expect("should parse");
+        assert_eq!(parsed.agent_setting("OtlpGrpcLogsTracesPort"), Some("4329"));
+
+        let data_rule = parsed.configurations[1]
+            .content
+            .as_ref()
+            .expect("content present");
+        assert!(!data_rule.is_agent_settings());
+        assert_eq!(data_rule.data_sources.len(), 1);
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-config-translators/src/cli.rs
+++ b/rust/otap-dataflow/crates/contrib-config-translators/src/cli.rs
@@ -1,0 +1,99 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Development CLI for the vendor configuration translators.
+//!
+//! Reads a vendor configuration document and writes the equivalent OTAP dataflow pipeline YAML.
+//! Intended for inspecting translator output against real payloads without going through the
+//! test harness.
+//!
+//! Note this lives at `src/cli.rs` rather than the conventional `src/bin/`, because the
+//! repository's top-level `.gitignore` matches `bin/` and would make the file invisible to git.
+//!
+//! ```text
+//! cargo run -p otel-arrow-dfe-contrib-config-translators --bin config-translator -- \
+//!   --input path/to/AMCSConfig.json
+//! ```
+//!
+//! The generated file can then be handed straight to the engine:
+//!
+//! ```text
+//! cargo run --bin df_engine -- --config generated.yaml --num-cores 1
+//! ```
+
+// This binary exists to write a configuration document to stdout and diagnostics to stderr, which
+// is the one place in the workspace where printing to the console is the intended behaviour
+// rather than stray debugging output.
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
+use clap::Parser;
+use otel_arrow_dfe_config::engine::OtelDataflowSpec;
+use otel_arrow_dfe_contrib_config_translators::ConfigTranslator;
+use otel_arrow_dfe_contrib_config_translators::amcs::{AMCS_DIALECT, AmcsTranslator};
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+/// Translate a vendor configuration document into an OTAP dataflow pipeline specification.
+#[derive(Parser, Debug)]
+#[command(name = "config-translator", about, long_about = None)]
+struct Args {
+    /// Path to the vendor configuration document to translate.
+    #[arg(short, long)]
+    input: PathBuf,
+
+    /// Where to write the generated YAML. Defaults to stdout.
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+
+    /// Configuration dialect to translate from.
+    #[arg(short, long, default_value = AMCS_DIALECT)]
+    dialect: String,
+
+    /// Verify that the generated YAML parses back through the engine configuration loader.
+    #[arg(long)]
+    validate: bool,
+}
+
+fn main() -> ExitCode {
+    let args = Args::parse();
+
+    match run(&args) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(message) => {
+            // Diagnostics belong on stderr so stdout stays a clean YAML document.
+            eprintln!("config-translator: {message}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Translate the input document and emit the result.
+fn run(args: &Args) -> Result<(), String> {
+    if args.dialect != AMCS_DIALECT {
+        return Err(format!(
+            "unsupported dialect `{}`; only `{AMCS_DIALECT}` is currently available",
+            args.dialect
+        ));
+    }
+
+    let raw = std::fs::read_to_string(&args.input)
+        .map_err(|e| format!("cannot read {}: {e}", args.input.display()))?;
+
+    let yaml = AmcsTranslator::new()
+        .translate_to_yaml(&raw)
+        .map_err(|e| format!("translation failed: {e}"))?;
+
+    if args.validate {
+        let _ = OtelDataflowSpec::from_yaml(&yaml)
+            .map_err(|e| format!("generated configuration was rejected by the engine: {e}"))?;
+        eprintln!("config-translator: generated configuration parsed and validated successfully");
+    }
+
+    match &args.output {
+        Some(path) => std::fs::write(path, &yaml)
+            .map_err(|e| format!("cannot write {}: {e}", path.display()))?,
+        None => println!("{yaml}"),
+    }
+
+    Ok(())
+}

--- a/rust/otap-dataflow/crates/contrib-config-translators/src/error.rs
+++ b/rust/otap-dataflow/crates/contrib-config-translators/src/error.rs
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Errors produced while translating a vendor configuration into an
+//! [`OtelDataflowSpec`](otel_arrow_dfe_config::engine::OtelDataflowSpec).
+
+/// Errors that can occur while translating a vendor configuration.
+#[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// The supplied configuration could not be deserialized.
+    #[error("failed to deserialize {format} configuration: {details}")]
+    Deserialization {
+        /// The serialization format that was attempted (for example `JSON`).
+        format: &'static str,
+        /// The underlying parser error.
+        details: String,
+    },
+
+    /// The translated pipeline specification could not be serialized to YAML.
+    #[error("failed to serialize the generated pipeline specification to YAML: {details}")]
+    Serialization {
+        /// The underlying serializer error.
+        details: String,
+    },
+
+    /// The translated configuration did not produce a usable pipeline.
+    #[error("the configuration did not yield any pipeline nodes: {details}")]
+    EmptyPipeline {
+        /// Why no nodes could be produced.
+        details: String,
+    },
+
+    /// The generated pipeline specification was rejected by the engine config model.
+    #[error("the generated pipeline specification is invalid: {0}")]
+    InvalidPipeline(#[from] Box<otel_arrow_dfe_config::error::Error>),
+
+    /// A listener address could not be resolved to a socket address.
+    #[error("cannot resolve listener address `{host}:{port}`: {details}")]
+    InvalidListenerAddress {
+        /// The configured host.
+        host: String,
+        /// The configured port.
+        port: u16,
+        /// Why resolution failed.
+        details: String,
+    },
+}
+
+impl From<otel_arrow_dfe_config::error::Error> for Error {
+    fn from(value: otel_arrow_dfe_config::error::Error) -> Self {
+        Self::InvalidPipeline(Box::new(value))
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-config-translators/src/lib.rs
+++ b/rust/otap-dataflow/crates/contrib-config-translators/src/lib.rs
@@ -1,0 +1,62 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Vendor-specific configuration translators.
+//!
+//! A *translator* turns a vendor's own configuration document into an
+//! [`OtelDataflowSpec`] that the OTAP dataflow engine can run. This mirrors the
+//! [`ConfigProvider`](otel_arrow_dfe_config::config_provider::ConfigProvider) abstraction one stage
+//! later in the chain: a provider resolves a URI to raw content, whereas a translator converts
+//! foreign content into the engine's own pipeline model.
+//!
+//! ```text
+//!   vendor config (JSON)  --ConfigTranslator-->  OtelDataflowSpec  --serialize-->  pipeline YAML
+//! ```
+//!
+//! # Available translators
+//!
+//! - [`amcs`] -- Azure Monitor Configuration Service (AMCS) third-party (3P) configuration,
+//!   as delivered to the Azure Monitor Agent for customer-authored Data Collection Rules.
+//!
+//! A first-party (1P) Geneva/GigLA translator can be added as a sibling module implementing the
+//! same [`ConfigTranslator`] trait.
+
+pub mod amcs;
+pub mod error;
+
+use otel_arrow_dfe_config::engine::OtelDataflowSpec;
+
+pub use error::Error;
+
+/// Converts a vendor-specific configuration document into an engine pipeline specification.
+///
+/// Implementations are expected to be pure: given the same input (and the same environment
+/// snapshot, where relevant) they must produce the same specification.
+pub trait ConfigTranslator {
+    /// A short, stable name identifying the configuration dialect this translator understands
+    /// (for example `amcs`). Used in diagnostics and for translator selection.
+    fn dialect(&self) -> &str;
+
+    /// Translate raw vendor configuration content into a pipeline specification.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error`] if the input cannot be parsed, or if the resulting specification
+    /// would be rejected by the engine configuration model.
+    fn translate(&self, raw: &str) -> Result<OtelDataflowSpec, Error>;
+
+    /// Translate raw vendor configuration content directly to a pipeline YAML document.
+    ///
+    /// The default implementation calls [`ConfigTranslator::translate`] and serializes the
+    /// result, which is what every current translator wants.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error`] if translation fails, or if the specification cannot be serialized.
+    fn translate_to_yaml(&self, raw: &str) -> Result<String, Error> {
+        let spec = self.translate(raw)?;
+        serde_yaml::to_string(&spec).map_err(|e| Error::Serialization {
+            details: e.to_string(),
+        })
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-config-translators/src/lib.rs
+++ b/rust/otap-dataflow/crates/contrib-config-translators/src/lib.rs
@@ -23,10 +23,46 @@
 
 pub mod amcs;
 pub mod error;
+mod yaml_style;
 
-use otel_arrow_dfe_config::engine::OtelDataflowSpec;
+use otel_arrow_dfe_config::engine::{EngineConfig, OtelDataflowSpec};
 
 pub use error::Error;
+
+/// Serializes a specification to YAML, omitting the `engine` block when it carries nothing but
+/// engine defaults.
+///
+/// `OtelDataflowSpec::engine` is `#[serde(default)]`, so an absent block deserializes back to
+/// `EngineConfig::default()` and the engine behaves identically. Writing the block out anyway
+/// would pin whatever the defaults happened to be at generation time -- currently around sixty
+/// lines of internal-observability pipeline that dwarf the pipeline we actually generate, and
+/// that would silently stop tracking the engine if those defaults ever change.
+///
+/// Any engine configuration we set deliberately differs from the default and is therefore kept.
+fn spec_to_yaml(spec: &OtelDataflowSpec) -> Result<String, Error> {
+    let mut value = serde_yaml::to_value(spec).map_err(|e| Error::Serialization {
+        details: e.to_string(),
+    })?;
+    let default_engine =
+        serde_yaml::to_value(EngineConfig::default()).map_err(|e| Error::Serialization {
+            details: e.to_string(),
+        })?;
+
+    if let serde_yaml::Value::Mapping(map) = &mut value {
+        let key = serde_yaml::Value::String("engine".to_owned());
+        if map.get(&key) == Some(&default_engine) {
+            let _ = map.remove(&key);
+        }
+    }
+
+    yaml_style::sort_nodes(&mut value);
+
+    serde_yaml::to_string(&value)
+        .map(|yaml| yaml_style::prettify(&yaml))
+        .map_err(|e| Error::Serialization {
+            details: e.to_string(),
+        })
+}
 
 /// Converts a vendor-specific configuration document into an engine pipeline specification.
 ///
@@ -55,8 +91,6 @@ pub trait ConfigTranslator {
     /// Returns an [`Error`] if translation fails, or if the specification cannot be serialized.
     fn translate_to_yaml(&self, raw: &str) -> Result<String, Error> {
         let spec = self.translate(raw)?;
-        serde_yaml::to_string(&spec).map_err(|e| Error::Serialization {
-            details: e.to_string(),
-        })
+        spec_to_yaml(&spec)
     }
 }

--- a/rust/otap-dataflow/crates/contrib-config-translators/src/yaml_style.rs
+++ b/rust/otap-dataflow/crates/contrib-config-translators/src/yaml_style.rs
@@ -1,0 +1,218 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cosmetic formatting for generated pipeline YAML.
+//!
+//! `serde_yaml` emits correct but dense YAML: block sequences sit at the same indentation as the
+//! key that owns them, and nothing separates one node from the next. Hand-written pipeline configs
+//! in this repository indent sequence items under their key and leave a blank line between nodes,
+//! which is what a reviewer diffing generated output against a hand-written sample expects to see.
+//!
+//! This module only ever adds leading spaces and blank lines. It never rewrites the content of a
+//! line, so quoting and escaping stay exactly as `serde_yaml` produced them. As a backstop,
+//! [`prettify`] re-parses its own output and returns the input unchanged if the round-trip is not
+//! value-identical, so a formatting bug can never alter the configuration the engine reads.
+
+/// Spaces added per enclosing block sequence.
+const SEQUENCE_INDENT: usize = 2;
+
+/// Orders node entries so a generated pipeline reads in data-flow order.
+///
+/// Nodes live in a `HashMap`, so `serde_yaml` emits them in an arbitrary order that varies between
+/// runs -- a batch node can precede the receiver that feeds it, and two runs of the same input
+/// produce different files. Sorting by role and then by name makes the output stable and readable.
+///
+/// YAML mappings are unordered, so this changes presentation only; the parsed value is unaffected.
+pub(crate) fn sort_nodes(value: &mut serde_yaml::Value) {
+    let Some(groups) = value.get_mut("groups").and_then(|g| g.as_mapping_mut()) else {
+        return;
+    };
+
+    for (_, group) in groups.iter_mut() {
+        let Some(pipelines) = group.get_mut("pipelines").and_then(|p| p.as_mapping_mut()) else {
+            continue;
+        };
+        for (_, pipeline) in pipelines.iter_mut() {
+            let Some(nodes) = pipeline.get_mut("nodes").and_then(|n| n.as_mapping_mut()) else {
+                continue;
+            };
+
+            let mut entries: Vec<_> = std::mem::take(nodes).into_iter().collect();
+            entries.sort_by_cached_key(|(name, node)| {
+                let urn = node
+                    .get("type")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or_default();
+                (role_rank(urn), name.as_str().unwrap_or_default().to_owned())
+            });
+            for (name, node) in entries {
+                let _ = nodes.insert(name, node);
+            }
+        }
+    }
+}
+
+/// Position of a node URN in data-flow order.
+fn role_rank(urn: &str) -> u8 {
+    match () {
+        () if urn.contains(":receiver:") => 0,
+        () if urn.contains(":processor:fanout") => 1,
+        () if urn.contains(":processor:filter") => 2,
+        () if urn.contains(":processor:batch") => 3,
+        () if urn.contains(":exporter:") => 5,
+        () => 4,
+    }
+}
+
+/// Re-indents block sequences and separates node entries with blank lines.
+///
+/// Returns `yaml` unchanged if the transformation would alter the parsed value, or if the document
+/// contains a block scalar, whose interior lines are content rather than structure.
+#[must_use]
+pub(crate) fn prettify(yaml: &str) -> String {
+    // A block scalar's body is data; shifting it would change the value.
+    if yaml.contains(": |") || yaml.contains(": >") {
+        return yaml.to_owned();
+    }
+
+    let styled = restyle(yaml);
+
+    match (
+        serde_yaml::from_str::<serde_yaml::Value>(yaml),
+        serde_yaml::from_str::<serde_yaml::Value>(&styled),
+    ) {
+        (Ok(before), Ok(after)) if before == after => styled,
+        _ => yaml.to_owned(),
+    }
+}
+
+/// Applies the indentation and blank-line rules.
+fn restyle(yaml: &str) -> String {
+    // Each entry is one enclosing block sequence: the indentation `serde_yaml` gave its items, and
+    // the total shift applied to lines inside it.
+    let mut sequences: Vec<(usize, usize)> = Vec::new();
+    let mut out = String::with_capacity(yaml.len() + yaml.len() / 8);
+
+    // Indentation of the `nodes:` key whose children get blank lines between them, and whether one
+    // child has already been seen.
+    let mut nodes_indent: Option<usize> = None;
+    let mut seen_first_node = false;
+
+    for line in yaml.lines() {
+        if line.trim().is_empty() {
+            out.push('\n');
+            continue;
+        }
+
+        let indent = line.len() - line.trim_start().len();
+        let body = &line[indent..];
+        let is_item = body.starts_with("- ") || body == "-";
+
+        // A line at or left of a sequence's own indentation ends it, unless it is another item of
+        // that same sequence. Continuation lines sit further right and keep it open.
+        while let Some(&(seq_indent, _)) = sequences.last() {
+            if seq_indent > indent || (seq_indent == indent && !is_item) {
+                let _ = sequences.pop();
+            } else {
+                break;
+            }
+        }
+
+        if is_item && sequences.last().map(|&(i, _)| i) != Some(indent) {
+            let parent_shift = sequences.last().map_or(0, |&(_, shift)| shift);
+            sequences.push((indent, parent_shift + SEQUENCE_INDENT));
+        }
+
+        let shift = sequences.last().map_or(0, |&(_, shift)| shift);
+
+        // Blank line between sibling node entries, matching hand-written configs.
+        if let Some(parent) = nodes_indent {
+            if indent <= parent {
+                // Left the `nodes:` block entirely.
+                nodes_indent = None;
+            } else if indent == parent + 2 && sequences.is_empty() {
+                if seen_first_node {
+                    out.push('\n');
+                }
+                seen_first_node = true;
+            }
+        }
+        if body == "nodes:" {
+            nodes_indent = Some(indent);
+            seen_first_node = false;
+        }
+
+        for _ in 0..shift {
+            out.push(' ');
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Scenario: a block sequence owned by a mapping key is formatted.
+    /// Guarantees: items are indented under their key rather than left at the key's own column,
+    /// which is how the hand-written sample configs in this repository are written.
+    #[test]
+    fn sequence_items_are_indented_under_their_key() {
+        let input = "outputs:\n- default\n";
+
+        let out = prettify(input);
+
+        assert_eq!(out, "outputs:\n  - default\n");
+    }
+
+    /// Scenario: a sequence of mappings, and a sequence nested inside one of those mappings.
+    /// Guarantees: every level is shifted by its own depth, so continuation lines stay aligned with
+    /// the item that owns them and the nested sequence indents again.
+    #[test]
+    fn nested_sequences_indent_once_per_level() {
+        let input = "connections:\n- from: a\n  to:\n  - b\n";
+
+        let out = prettify(input);
+
+        assert_eq!(out, "connections:\n  - from: a\n    to:\n      - b\n");
+    }
+
+    /// Scenario: several sibling entries under a `nodes:` mapping.
+    /// Guarantees: a blank line separates them, and none is added before the first, so the block
+    /// reads as discrete nodes rather than one wall of keys.
+    #[test]
+    fn node_entries_are_separated_by_blank_lines() {
+        let input = "nodes:\n  a:\n    type: x\n  b:\n    type: y\n";
+
+        let out = prettify(input);
+
+        assert_eq!(out, "nodes:\n  a:\n    type: x\n\n  b:\n    type: y\n");
+    }
+
+    /// Scenario: a document containing a block scalar, whose body lines are data.
+    /// Guarantees: it is returned untouched, because shifting those lines would change the string
+    /// they encode.
+    #[test]
+    fn block_scalars_are_left_alone() {
+        let input = "note: |\n  first\n  second\n";
+
+        assert_eq!(prettify(input), input);
+    }
+
+    /// Scenario: any document is formatted.
+    /// Guarantees: formatting is value-preserving. This is the property that lets the style pass
+    /// run on real output at all -- a cosmetic bug must never change what the engine reads.
+    #[test]
+    fn formatting_preserves_the_parsed_value() {
+        let input = "nodes:\n  a:\n    type: x\n    outputs:\n    - default\nconnections:\n- from: a\n  to:\n  - b\n";
+
+        let out = prettify(input);
+
+        let before: serde_yaml::Value = serde_yaml::from_str(input).expect("input parses");
+        let after: serde_yaml::Value = serde_yaml::from_str(&out).expect("output parses");
+        assert_eq!(before, after);
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-config-translators/tests/fixtures/AMCSConfig.json
+++ b/rust/otap-dataflow/crates/contrib-config-translators/tests/fixtures/AMCSConfig.json
@@ -1,0 +1,89 @@
+{
+    "configurations": [
+        {
+            "configurationId": "dcr-00000000000000000000000000000002",
+            "eTag": "dcr-00000000000000000000000000000002/%22e1e1e1e1-0000-0000-0000-0000000000e1%22",
+            "op": "added",
+            "content": {
+                "dataSources": [
+                    {
+                        "configuration": {
+                            "scheduledTransferPeriod": "PT1M",
+                            "counters": [
+                                {
+                                    "samplingFrequencyInSeconds": 30,
+                                    "counterSpecifiers": [
+                                        "\\Process(_Total)\\Thread Count"
+                                    ]
+                                }
+                            ]
+                        },
+                        "id": "myPerfCounterDataSource1",
+                        "kind": "perfCounter",
+                        "streams": [
+                            {
+                                "stream": "GENERIC_PERF_BLOB",
+                                "solution": "LogManagement"
+                            }
+                        ],
+                        "sendToChannels": [
+                            "ods-aaaaaaaa-0000-0000-0000-00000000000a"
+                        ]
+                    },
+                    {
+                        "configuration": {
+                            "resourceAttributeRouting": {
+                                "attributeName": "service.name",
+                                "attributeValue": "amcs"
+                            }
+                        },
+                        "id": "myOtelLogs1DataSource",
+                        "kind": "otelLogs",
+                        "streams": [
+                            {
+                                "stream": "OPENTELEMETRY_LOGS_AGENT"
+                            }
+                        ],
+                        "sendToChannels": [
+                            "gigl-dce-00000000000000000000000000000002"
+                        ]
+                    },
+                    {
+                        "configuration": {
+                            "resourceAttributeRouting": {
+                                "attributeName": "service.name",
+                                "attributeValue": "amcs"
+                            }
+                        },
+                        "id": "myOtelTraces1DataSource",
+                        "kind": "otelTraces",
+                        "streams": [
+                            {
+                                "stream": "OPENTELEMETRY_TRACES_AGENT"
+                            }
+                        ],
+                        "sendToChannels": [
+                            "gigl-dce-00000000000000000000000000000002"
+                        ]
+                    }
+                ],
+                "channels": [
+                    {
+                        "endpoint": "https://aaaaaaaa-0000-0000-0000-00000000000a.ods.opinsights.azure.com",
+                        "tokenEndpointUri": "https://handler.control.monitor.azure.com//subscriptions/00000000-0000-0000-0000-000000000002/resourceGroups/example-rg-2/providers/microsoft.operationalinsights/workspaces/example-workspace/agentConfigurations/dcr-00000000000000000000000000000002/channels/ods-aaaaaaaa-0000-0000-0000-00000000000a/issueIngestionToken?operatingLocation=eastus2euap&api-version=2022-06-02&platform=windows&includeMeConfig=true",
+                        "id": "ods-aaaaaaaa-0000-0000-0000-00000000000a",
+                        "protocol": "ods"
+                    },
+                    {
+                        "endpointUriTemplate": "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000002/streams/<STREAM>?api-version=2021-11-01-preview",
+                        "tokenEndpointUri": "https://handler.control.monitor.azure.com//subscriptions/00000000-0000-0000-0000-000000000002/resourceGroups/example-rg-2/providers/microsoft.operationalinsights/workspaces/example-workspace/agentConfigurations/dcr-00000000000000000000000000000002/channels/gigl-dce-00000000000000000000000000000002/issueIngestionToken?operatingLocation=eastus2euap&api-version=2022-06-02&platform=windows&includeMeConfig=true",
+                        "otelLogsEndpointUriTemplate": "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000002/streams/<STREAM>/otlp/v1/logs?api-version=2021-11-01-preview",
+                        "otelTracesEndpointUriTemplate": "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000002/streams/<STREAM>/otlp/v1/traces?api-version=2021-11-01-preview",
+                        "id": "gigl-dce-00000000000000000000000000000002",
+                        "protocol": "gig"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/rust/otap-dataflow/crates/contrib-config-translators/tests/fixtures/AMCSConfig2.json
+++ b/rust/otap-dataflow/crates/contrib-config-translators/tests/fixtures/AMCSConfig2.json
@@ -1,0 +1,83 @@
+{
+    "configurations": [
+        {
+            "configurationId": "dcr-00000000000000000000000000000002",
+            "eTag": "dcr-00000000000000000000000000000002/%22e1e1e1e1-0000-0000-0000-0000000000e1%22",
+            "op": "added",
+            "content": {
+                "dataSources": [
+                    {
+                        "configuration": {
+                            "scheduledTransferPeriod": "PT1M",
+                            "counters": [
+                                {
+                                    "samplingFrequencyInSeconds": 30,
+                                    "counterSpecifiers": [
+                                        "\\Process(_Total)\\Thread Count"
+                                    ]
+                                }
+                            ]
+                        },
+                        "id": "myPerfCounterDataSource1",
+                        "kind": "perfCounter",
+                        "streams": [
+                            {
+                                "stream": "GENERIC_PERF_BLOB",
+                                "solution": "LogManagement"
+                            }
+                        ],
+                        "sendToChannels": [
+                            "ods-aaaaaaaa-0000-0000-0000-00000000000a"
+                        ]
+                    },
+                    {
+                        "configuration": {
+                            "resourceAttributeRouting": {
+                                "attributeName": "service.name",
+                                "attributeValue": "amcs"
+                            }
+                        },
+                        "id": "myOtelLogs1DataSource",
+                        "kind": "otelLogs",
+                        "streams": [
+                            {
+                                "stream": "OPENTELEMETRY_LOGS_AGENT"
+                            }
+                        ],
+                        "sendToChannels": [
+                            "gigl-dce-00000000000000000000000000000002"
+                        ]
+                    },
+                    {
+                        "id": "myOtelTraces1DataSource",
+                        "kind": "otelTraces",
+                        "streams": [
+                            {
+                                "stream": "OPENTELEMETRY_TRACES_AGENT"
+                            }
+                        ],
+                        "sendToChannels": [
+                            "gigl-dce-00000000000000000000000000000002"
+                        ]
+                    }
+                ],
+                "channels": [
+                    {
+                        "endpoint": "https://aaaaaaaa-0000-0000-0000-00000000000a.ods.opinsights.azure.com",
+                        "tokenEndpointUri": "https://handler.control.monitor.azure.com//subscriptions/00000000-0000-0000-0000-000000000002/resourceGroups/example-rg-2/providers/microsoft.operationalinsights/workspaces/example-workspace/agentConfigurations/dcr-00000000000000000000000000000002/channels/ods-aaaaaaaa-0000-0000-0000-00000000000a/issueIngestionToken?operatingLocation=eastus2euap&api-version=2022-06-02&platform=windows&includeMeConfig=true",
+                        "id": "ods-aaaaaaaa-0000-0000-0000-00000000000a",
+                        "protocol": "ods"
+                    },
+                    {
+                        "endpointUriTemplate": "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000002/streams/<STREAM>?api-version=2021-11-01-preview",
+                        "tokenEndpointUri": "https://handler.control.monitor.azure.com//subscriptions/00000000-0000-0000-0000-000000000002/resourceGroups/example-rg-2/providers/microsoft.operationalinsights/workspaces/example-workspace/agentConfigurations/dcr-00000000000000000000000000000002/channels/gigl-dce-00000000000000000000000000000002/issueIngestionToken?operatingLocation=eastus2euap&api-version=2022-06-02&platform=windows&includeMeConfig=true",
+                        "otelLogsEndpointUriTemplate": "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000002/streams/<STREAM>/otlp/v1/logs?api-version=2021-11-01-preview",
+                        "otelTracesEndpointUriTemplate": "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000002/streams/<STREAM>/otlp/v1/traces?api-version=2021-11-01-preview",
+                        "id": "gigl-dce-00000000000000000000000000000002",
+                        "protocol": "gig"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/rust/otap-dataflow/crates/contrib-config-translators/tests/fixtures/AMCSConfig3.json
+++ b/rust/otap-dataflow/crates/contrib-config-translators/tests/fixtures/AMCSConfig3.json
@@ -1,0 +1,174 @@
+{
+    "configurations": [
+        {
+            "configurationId": "dcr-00000000000000000000000000000002",
+            "eTag": "dcr-00000000000000000000000000000002/%22e1e1e1e1-0000-0000-0000-0000000000e1%22",
+            "op": "added",
+            "content": {
+                "dataSources": [
+                    {
+                        "configuration": {
+                            "scheduledTransferPeriod": "PT1M",
+                            "counters": [
+                                {
+                                    "samplingFrequencyInSeconds": 30,
+                                    "counterSpecifiers": [
+                                        "\\Process(_Total)\\Thread Count"
+                                    ]
+                                }
+                            ]
+                        },
+                        "id": "myPerfCounterDataSource1",
+                        "kind": "perfCounter",
+                        "streams": [
+                            {
+                                "stream": "LINUX_PERF_BLOB",
+                                "solution": "LogManagement"
+                            }
+                        ],
+                        "sendToChannels": [
+                            "ods-aaaaaaaa-0000-0000-0000-00000000000a"
+                        ]
+                    },
+                    {
+                        "configuration": {
+                            "resourceAttributeRouting": {
+                                "attributeName": "service.name",
+                                "attributeValue": "amcs_1"
+                            }
+                        },
+                        "id": "myOtelLogs1DataSource",
+                        "kind": "otelLogs",
+                        "streams": [
+                            {
+                                "stream": "OPENTELEMETRY_LOGS_AGENT_1"
+                            }
+                        ],
+                        "sendToChannels": [
+                            "gigl-dce-00000000000000000000000000000002"
+                        ]
+                    },
+                    {
+                        "configuration": {
+                            "resourceAttributeRouting": {
+                                "attributeName": "service.name",
+                                "attributeValue": "amcs_1"
+                            }
+                        },
+                        "id": "myOtelTraces1DataSource",
+                        "kind": "otelTraces",
+                        "streams": [
+                            {
+                                "stream": "OPENTELEMETRY_TRACES_AGENT_1"
+                            }
+                        ],
+                        "sendToChannels": [
+                            "gigl-dce-00000000000000000000000000000002"
+                        ]
+                    }
+                ],
+                "channels": [
+                    {
+                        "endpoint": "https://aaaaaaaa-0000-0000-0000-00000000000a.ods.opinsights.azure.com",
+                        "tokenEndpointUri": "https://handler.control.monitor.azure.com//subscriptions/00000000-0000-0000-0000-000000000002/resourceGroups/example-rg-2/providers/microsoft.operationalinsights/workspaces/example-workspace/agentConfigurations/dcr-00000000000000000000000000000002/channels/ods-aaaaaaaa-0000-0000-0000-00000000000a/issueIngestionToken?operatingLocation=eastus2euap&api-version=2022-06-02&platform=linux&includeMeConfig=true",
+                        "id": "ods-aaaaaaaa-0000-0000-0000-00000000000a",
+                        "protocol": "ods"
+                    },
+                    {
+                        "endpointUriTemplate": "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000002/streams/<STREAM>?api-version=2021-11-01-preview",
+                        "tokenEndpointUri": "https://handler.control.monitor.azure.com//subscriptions/00000000-0000-0000-0000-000000000002/resourceGroups/example-rg-2/providers/microsoft.operationalinsights/workspaces/example-workspace/agentConfigurations/dcr-00000000000000000000000000000002/channels/gigl-dce-00000000000000000000000000000002/issueIngestionToken?operatingLocation=eastus2euap&api-version=2022-06-02&platform=linux&includeMeConfig=true",
+                        "otelLogsEndpointUriTemplate": "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000002/streams/<STREAM>/otlp/v1/logs?api-version=2021-11-01-preview",
+                        "otelTracesEndpointUriTemplate": "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000002/streams/<STREAM>/otlp/v1/traces?api-version=2021-11-01-preview",
+                        "id": "gigl-dce-00000000000000000000000000000002",
+                        "protocol": "gig"
+                    }
+                ]
+            }
+        },
+        {
+            "configurationId": "dcr-00000000000000000000000000000004",
+            "eTag": "dcr-00000000000000000000000000000004/%22e2e2e2e2-0000-0000-0000-0000000000e2%22",
+            "op": "added",
+            "content": {
+                "dataSources": [
+                    {
+                        "configuration": {
+                            "scheduledTransferPeriod": "PT1M",
+                            "counters": [
+                                {
+                                    "samplingFrequencyInSeconds": 30,
+                                    "counterSpecifiers": [
+                                        "\\Process(_Total)\\Thread Count"
+                                    ]
+                                }
+                            ]
+                        },
+                        "id": "myPerfCounterDataSource1",
+                        "kind": "perfCounter",
+                        "streams": [
+                            {
+                                "stream": "LINUX_PERF_BLOB",
+                                "solution": "LogManagement"
+                            }
+                        ],
+                        "sendToChannels": [
+                            "ods-aaaaaaaa-0000-0000-0000-00000000000a"
+                        ]
+                    },
+                    {
+                        "configuration": {
+                            "resourceAttributeRouting": {
+                                "attributeName": "service.name",
+                                "attributeValue": "amcs_2"
+                            }
+                        },
+                        "id": "myOtelLogs1DataSource",
+                        "kind": "otelLogs",
+                        "streams": [
+                            {
+                                "stream": "OPENTELEMETRY_LOGS_AGENT_2"
+                            }
+                        ],
+                        "sendToChannels": [
+                            "gigl-dce-00000000000000000000000000000002"
+                        ]
+                    },
+                    {
+                        "configuration": {
+                            "resourceAttributeRouting": {
+                                "attributeName": "service.name",
+                                "attributeValue": "amcs_2"
+                            }
+                        },
+                        "id": "myOtelTraces1DataSource",
+                        "kind": "otelTraces",
+                        "streams": [
+                            {
+                                "stream": "OPENTELEMETRY_TRACES_AGENT_2"
+                            }
+                        ],
+                        "sendToChannels": [
+                            "gigl-dce-00000000000000000000000000000002"
+                        ]
+                    }
+                ],
+                "channels": [
+                    {
+                        "endpoint": "https://aaaaaaaa-0000-0000-0000-00000000000a.ods.opinsights.azure.com",
+                        "tokenEndpointUri": "https://handler.control.monitor.azure.com//subscriptions/00000000-0000-0000-0000-000000000002/resourceGroups/example-rg-2/providers/microsoft.operationalinsights/workspaces/example-workspace/agentConfigurations/dcr-00000000000000000000000000000004/channels/ods-aaaaaaaa-0000-0000-0000-00000000000a/issueIngestionToken?operatingLocation=eastus2euap&api-version=2022-06-02&platform=linux&includeMeConfig=true",
+                        "id": "ods-aaaaaaaa-0000-0000-0000-00000000000a",
+                        "protocol": "ods"
+                    },
+                    {
+                        "endpointUriTemplate": "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000004/streams/<STREAM>?api-version=2021-11-01-preview",
+                        "tokenEndpointUri": "https://handler.control.monitor.azure.com//subscriptions/00000000-0000-0000-0000-000000000002/resourceGroups/example-rg-2/providers/microsoft.operationalinsights/workspaces/example-workspace/agentConfigurations/dcr-00000000000000000000000000000004/channels/gigl-dce-00000000000000000000000000000002/issueIngestionToken?operatingLocation=eastus2euap&api-version=2022-06-02&platform=linux&includeMeConfig=true",
+                        "otelLogsEndpointUriTemplate": "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000004/streams/<STREAM>/otlp/v1/logs?api-version=2021-11-01-preview",
+                        "otelTracesEndpointUriTemplate": "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000004/streams/<STREAM>/otlp/v1/traces?api-version=2021-11-01-preview",
+                        "id": "gigl-dce-00000000000000000000000000000002",
+                        "protocol": "gig"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/rust/otap-dataflow/crates/contrib-config-translators/tests/fixtures/AMCSConfig4.json
+++ b/rust/otap-dataflow/crates/contrib-config-translators/tests/fixtures/AMCSConfig4.json
@@ -1,0 +1,182 @@
+{
+    "dataSources": [
+        {
+            "configuration": {
+                "extensionName": "ContainerInsights"
+            },
+            "id": "ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b",
+            "kind": "extension",
+            "streams": [
+                {
+                    "stream": "CONTAINER_LOG_BLOB",
+                    "solution": "Containers",
+                    "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:CONTAINER_LOG_BLOB"
+                },
+                {
+                    "stream": "CONTAINERINSIGHTS_CONTAINERLOGV2",
+                    "solution": "ContainerInsights",
+                    "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:CONTAINERINSIGHTS_CONTAINERLOGV2"
+                },
+                {
+                    "stream": "KUBE_EVENTS_BLOB",
+                    "solution": "ContainerInsights",
+                    "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_EVENTS_BLOB"
+                },
+                {
+                    "stream": "KUBE_POD_INVENTORY_BLOB",
+                    "solution": "ContainerInsights",
+                    "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_POD_INVENTORY_BLOB"
+                },
+                {
+                    "stream": "KUBE_NODE_INVENTORY_BLOB",
+                    "solution": "ContainerInsights",
+                    "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_NODE_INVENTORY_BLOB"
+                },
+                {
+                    "stream": "KUBE_PV_INVENTORY_BLOB",
+                    "solution": "ContainerInsights",
+                    "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_PV_INVENTORY_BLOB"
+                },
+                {
+                    "stream": "KUBE_SERVICES_BLOB",
+                    "solution": "ContainerInsights",
+                    "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_SERVICES_BLOB"
+                },
+                {
+                    "stream": "KUBE_MON_AGENT_EVENTS_BLOB",
+                    "solution": "Containers",
+                    "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_MON_AGENT_EVENTS_BLOB"
+                },
+                {
+                    "stream": "INSIGHTS_METRICS_BLOB",
+                    "solution": "VMInsights",
+                    "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:INSIGHTS_METRICS_BLOB"
+                },
+                {
+                    "stream": "CONTAINER_INVENTORY_BLOB",
+                    "solution": "ContainerInsights",
+                    "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:CONTAINER_INVENTORY_BLOB"
+                },
+                {
+                    "stream": "CONTAINER_NODE_INVENTORY_BLOB",
+                    "solution": "ContainerInsights",
+                    "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:CONTAINER_NODE_INVENTORY_BLOB"
+                },
+                {
+                    "stream": "LINUX_PERF_BLOB",
+                    "solution": "LogManagement",
+                    "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:LINUX_PERF_BLOB"
+                }
+            ],
+            "sendToChannels": [
+                "ods-bbbbbbbb-0000-0000-0000-00000000000b"
+            ]
+        },
+        {
+            "configuration": {
+                "extensionName": "ContainerInsights"
+            },
+            "id": "ContainerInsightsExtension:gigl-dce-00000000000000000000000000000001",
+            "kind": "extension",
+            "streams": [
+                {
+                    "stream": "RETINA_NETWORK_FLOW_LOGS",
+                    "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:gigl-dce-00000000000000000000000000000001:RETINA_NETWORK_FLOW_LOGS"
+                }
+            ],
+            "sendToChannels": [
+                "gigl-dce-00000000000000000000000000000001"
+            ]
+        },
+        {
+            "configuration": {
+                "resourceAttributeRouting": {
+                    "attributeName": "service.name",
+                    "attributeValue": "amcs"
+                }
+            },
+            "id": "myOtelLogs1DataSource",
+            "kind": "otelLogs",
+            "streams": [
+                {
+                    "stream": "OPENTELEMETRY_LOGS_AGENT"
+                }
+            ],
+            "sendToChannels": [
+                "gigl-dce-00000000000000000000000000000001"
+            ]
+        }
+    ],
+    "channels": [
+        {
+            "endpoint": "https://bbbbbbbb-0000-0000-0000-00000000000b.ods.opinsights.azure.com",
+            "tokenEndpointUri": "https://global.handler.control.monitor.azure.com/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/example-rg/providers/Microsoft.ContainerService/managedClusters/example-cluster/agentConfigurations/dcr-00000000000000000000000000000001/channels/ods-bbbbbbbb-0000-0000-0000-00000000000b/issueIngestionToken?operatingLocation=eastus2euap&platform=linux&includeMeConfig=true&api-version=2022-06-02",
+            "id": "ods-bbbbbbbb-0000-0000-0000-00000000000b",
+            "protocol": "ods"
+        },
+        {
+            "endpointUriTemplate": "https://example-dce-1.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000001/streams/<STREAM>?api-version=2021-11-01-preview",
+            "tokenEndpointUri": "https://global.handler.control.monitor.azure.com/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/example-rg/providers/Microsoft.ContainerService/managedClusters/example-cluster/agentConfigurations/dcr-00000000000000000000000000000001/channels/gigl-dce-00000000000000000000000000000001/issueIngestionToken?operatingLocation=eastus2euap&platform=linux&includeMeConfig=true&api-version=2022-06-02",
+            "otelLogsEndpointUriTemplate": "https://example-dce-1.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000001/streams/<STREAM>/otlp/v1/logs?api-version=2021-11-01-preview",
+            "id": "gigl-dce-00000000000000000000000000000001",
+            "protocol": "gig"
+        }
+    ],
+    "extensionConfigurations": {
+        "ContainerInsights": [
+            {
+                "id": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b",
+                "originIds": [
+                    "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/example-rg/providers/Microsoft.Insights/dataCollectionRules/MSCI-eastus2euap-example-cluster"
+                ],
+                "extensionSettings": {
+                    "dataCollectionSettings": {
+                        "interval": "1m",
+                        "namespaceFilteringMode": "Off",
+                        "namespaces": [
+                            "kube-system",
+                            "gatekeeper-system",
+                            "azure-arc"
+                        ],
+                        "enableContainerLogV2": true
+                    }
+                },
+                "outputStreams": {
+                    "CONTAINER_LOG_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:CONTAINER_LOG_BLOB",
+                    "CONTAINERINSIGHTS_CONTAINERLOGV2": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:CONTAINERINSIGHTS_CONTAINERLOGV2",
+                    "KUBE_EVENTS_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_EVENTS_BLOB",
+                    "KUBE_POD_INVENTORY_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_POD_INVENTORY_BLOB",
+                    "KUBE_NODE_INVENTORY_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_NODE_INVENTORY_BLOB",
+                    "KUBE_PV_INVENTORY_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_PV_INVENTORY_BLOB",
+                    "KUBE_SERVICES_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_SERVICES_BLOB",
+                    "KUBE_MON_AGENT_EVENTS_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_MON_AGENT_EVENTS_BLOB",
+                    "INSIGHTS_METRICS_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:INSIGHTS_METRICS_BLOB",
+                    "CONTAINER_INVENTORY_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:CONTAINER_INVENTORY_BLOB",
+                    "CONTAINER_NODE_INVENTORY_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:CONTAINER_NODE_INVENTORY_BLOB",
+                    "LINUX_PERF_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:LINUX_PERF_BLOB"
+                }
+            },
+            {
+                "id": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:gigl-dce-00000000000000000000000000000001",
+                "originIds": [
+                    "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/example-rg/providers/Microsoft.Insights/dataCollectionRules/MSCI-eastus2euap-example-cluster"
+                ],
+                "extensionSettings": {
+                    "dataCollectionSettings": {
+                        "interval": "1m",
+                        "namespaceFilteringMode": "Off",
+                        "namespaces": [
+                            "kube-system",
+                            "gatekeeper-system",
+                            "azure-arc"
+                        ],
+                        "enableContainerLogV2": true
+                    }
+                },
+                "outputStreams": {
+                    "RETINA_NETWORK_FLOW_LOGS": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:gigl-dce-00000000000000000000000000000001:RETINA_NETWORK_FLOW_LOGS"
+                }
+            }
+        ]
+    }
+}

--- a/rust/otap-dataflow/crates/contrib-config-translators/tests/fixtures/AMCSConfig5.json
+++ b/rust/otap-dataflow/crates/contrib-config-translators/tests/fixtures/AMCSConfig5.json
@@ -1,0 +1,161 @@
+{
+    "configurations": [
+        {
+            "configurationId": "dcr-00000000000000000000000000000001",
+            "content": {
+                "dataSources": [
+                    {
+                        "configuration": { "extensionName": "ContainerInsights" },
+                        "id": "ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b",
+                        "kind": "extension",
+                        "streams": [
+                            {
+                                "stream": "CONTAINER_LOG_BLOB",
+                                "solution": "Containers",
+                                "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:CONTAINER_LOG_BLOB"
+                            },
+                            {
+                                "stream": "CONTAINERINSIGHTS_CONTAINERLOGV2",
+                                "solution": "ContainerInsights",
+                                "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:CONTAINERINSIGHTS_CONTAINERLOGV2"
+                            },
+                            {
+                                "stream": "KUBE_EVENTS_BLOB",
+                                "solution": "ContainerInsights",
+                                "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_EVENTS_BLOB"
+                            },
+                            {
+                                "stream": "KUBE_POD_INVENTORY_BLOB",
+                                "solution": "ContainerInsights",
+                                "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_POD_INVENTORY_BLOB"
+                            },
+                            {
+                                "stream": "KUBE_NODE_INVENTORY_BLOB",
+                                "solution": "ContainerInsights",
+                                "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_NODE_INVENTORY_BLOB"
+                            },
+                            {
+                                "stream": "KUBE_PV_INVENTORY_BLOB",
+                                "solution": "ContainerInsights",
+                                "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_PV_INVENTORY_BLOB"
+                            },
+                            {
+                                "stream": "KUBE_SERVICES_BLOB",
+                                "solution": "ContainerInsights",
+                                "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_SERVICES_BLOB"
+                            },
+                            {
+                                "stream": "KUBE_MON_AGENT_EVENTS_BLOB",
+                                "solution": "Containers",
+                                "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_MON_AGENT_EVENTS_BLOB"
+                            },
+                            {
+                                "stream": "INSIGHTS_METRICS_BLOB",
+                                "solution": "VMInsights",
+                                "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:INSIGHTS_METRICS_BLOB"
+                            },
+                            {
+                                "stream": "CONTAINER_INVENTORY_BLOB",
+                                "solution": "ContainerInsights",
+                                "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:CONTAINER_INVENTORY_BLOB"
+                            },
+                            {
+                                "stream": "CONTAINER_NODE_INVENTORY_BLOB",
+                                "solution": "ContainerInsights",
+                                "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:CONTAINER_NODE_INVENTORY_BLOB"
+                            },
+                            {
+                                "stream": "LINUX_PERF_BLOB",
+                                "solution": "LogManagement",
+                                "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:LINUX_PERF_BLOB"
+                            }
+                        ],
+                        "sendToChannels": [ "ods-bbbbbbbb-0000-0000-0000-00000000000b" ]
+                    },
+                    {
+                        "configuration": { "extensionName": "ContainerInsights" },
+                        "id": "ContainerInsightsExtension:gigl-dce-00000000000000000000000000000001",
+                        "kind": "extension",
+                        "streams": [
+                            {
+                                "stream": "RETINA_NETWORK_FLOW_LOGS",
+                                "extensionOutputStream": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:gigl-dce-00000000000000000000000000000001:RETINA_NETWORK_FLOW_LOGS"
+                            }
+                        ],
+                        "sendToChannels": [ "gigl-dce-00000000000000000000000000000001" ]
+                    },
+                    {
+                        "configuration": {
+                            "resourceAttributeRouting": {
+                                "attributeName": "service.name",
+                                "attributeValue": "amcs"
+                            }
+                        },
+                        "id": "myOtelLogs1DataSource",
+                        "kind": "otelLogs",
+                        "streams": [ { "stream": "OPENTELEMETRY_LOGS_AGENT" } ],
+                        "sendToChannels": [ "gigl-dce-00000000000000000000000000000001" ]
+                    }
+                ],
+                "channels": [
+                    {
+                        "endpoint": "https://bbbbbbbb-0000-0000-0000-00000000000b.ods.opinsights.azure.com",
+                        "tokenEndpointUri": "https://global.handler.control.monitor.azure.com/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/example-rg/providers/Microsoft.ContainerService/managedClusters/example-cluster/agentConfigurations/dcr-00000000000000000000000000000001/channels/ods-bbbbbbbb-0000-0000-0000-00000000000b/issueIngestionToken?operatingLocation=eastus2euap&platform=linux&includeMeConfig=true&api-version=2022-06-02",
+                        "id": "ods-bbbbbbbb-0000-0000-0000-00000000000b",
+                        "protocol": "ods"
+                    },
+                    {
+                        "endpointUriTemplate": "https://example-dce-1.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000001/streams/<STREAM>?api-version=2021-11-01-preview",
+                        "tokenEndpointUri": "https://global.handler.control.monitor.azure.com/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/example-rg/providers/Microsoft.ContainerService/managedClusters/example-cluster/agentConfigurations/dcr-00000000000000000000000000000001/channels/gigl-dce-00000000000000000000000000000001/issueIngestionToken?operatingLocation=eastus2euap&platform=linux&includeMeConfig=true&api-version=2022-06-02",
+                        "otelLogsEndpointUriTemplate": "https://example-dce-1.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000001/streams/<STREAM>/otlp/v1/logs?api-version=2021-11-01-preview",
+                        "id": "gigl-dce-00000000000000000000000000000001",
+                        "protocol": "gig"
+                    }
+                ],
+                "extensionConfigurations": {
+                    "ContainerInsights": [
+                        {
+                            "id": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b",
+                            "originIds": [ "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/example-rg/providers/Microsoft.Insights/dataCollectionRules/MSCI-eastus2euap-example-cluster" ],
+                            "extensionSettings": {
+                                "dataCollectionSettings": {
+                                    "interval": "1m",
+                                    "namespaceFilteringMode": "Off",
+                                    "namespaces": [ "kube-system", "gatekeeper-system", "azure-arc" ],
+                                    "enableContainerLogV2": true
+                                }
+                            },
+                            "outputStreams": {
+                                "CONTAINER_LOG_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:CONTAINER_LOG_BLOB",
+                                "CONTAINERINSIGHTS_CONTAINERLOGV2": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:CONTAINERINSIGHTS_CONTAINERLOGV2",
+                                "KUBE_EVENTS_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_EVENTS_BLOB",
+                                "KUBE_POD_INVENTORY_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_POD_INVENTORY_BLOB",
+                                "KUBE_NODE_INVENTORY_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_NODE_INVENTORY_BLOB",
+                                "KUBE_PV_INVENTORY_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_PV_INVENTORY_BLOB",
+                                "KUBE_SERVICES_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_SERVICES_BLOB",
+                                "KUBE_MON_AGENT_EVENTS_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:KUBE_MON_AGENT_EVENTS_BLOB",
+                                "INSIGHTS_METRICS_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:INSIGHTS_METRICS_BLOB",
+                                "CONTAINER_INVENTORY_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:CONTAINER_INVENTORY_BLOB",
+                                "CONTAINER_NODE_INVENTORY_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:CONTAINER_NODE_INVENTORY_BLOB",
+                                "LINUX_PERF_BLOB": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:ods-bbbbbbbb-0000-0000-0000-00000000000b:LINUX_PERF_BLOB"
+                            }
+                        },
+                        {
+                            "id": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:gigl-dce-00000000000000000000000000000001",
+                            "originIds": [ "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/example-rg/providers/Microsoft.Insights/dataCollectionRules/MSCI-eastus2euap-example-cluster" ],
+                            "extensionSettings": {
+                                "dataCollectionSettings": {
+                                    "interval": "1m",
+                                    "namespaceFilteringMode": "Off",
+                                    "namespaces": [ "kube-system", "gatekeeper-system", "azure-arc" ],
+                                    "enableContainerLogV2": true
+                                }
+                            },
+                            "outputStreams": { "RETINA_NETWORK_FLOW_LOGS": "dcr-00000000000000000000000000000001:ContainerInsightsExtension:gigl-dce-00000000000000000000000000000001:RETINA_NETWORK_FLOW_LOGS" }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/rust/otap-dataflow/crates/contrib-config-translators/tests/fixtures/AMCSConfigAgentSettings.json
+++ b/rust/otap-dataflow/crates/contrib-config-translators/tests/fixtures/AMCSConfigAgentSettings.json
@@ -1,0 +1,111 @@
+{
+    "configurations": [
+        {
+            "configurationId": "dcr-00000000000000000000000000000003",
+            "eTag": "dcr-00000000000000000000000000000003/%22e3e3e3e3-0000-0000-0000-0000000000e3%22",
+            "op": "added",
+            "content": {
+                "kind": "AgentSettings",
+                "settings": [
+                    {
+                        "name": "MaxDiskQuotaInMB",
+                        "value": "10240"
+                    },
+                    {
+                        "name": "OtlpGrpcLogsTracesPort",
+                        "value": "4329"
+                    },
+                    {
+                        "name": "OtlpHttpProtobufLogsTracesPort",
+                        "value": "4330"
+                    }
+                ]
+            }
+        },
+        {
+            "configurationId": "dcr-00000000000000000000000000000002",
+            "eTag": "dcr-00000000000000000000000000000002/%22e1e1e1e1-0000-0000-0000-0000000000e1%22",
+            "op": "added",
+            "content": {
+                "dataSources": [
+                    {
+                        "configuration": {
+                            "scheduledTransferPeriod": "PT1M",
+                            "counters": [
+                                {
+                                    "samplingFrequencyInSeconds": 30,
+                                    "counterSpecifiers": [
+                                        "\\Process(_Total)\\Thread Count"
+                                    ]
+                                }
+                            ]
+                        },
+                        "id": "myPerfCounterDataSource1",
+                        "kind": "perfCounter",
+                        "streams": [
+                            {
+                                "stream": "GENERIC_PERF_BLOB",
+                                "solution": "LogManagement"
+                            }
+                        ],
+                        "sendToChannels": [
+                            "ods-aaaaaaaa-0000-0000-0000-00000000000a"
+                        ]
+                    },
+                    {
+                        "configuration": {
+                            "resourceAttributeRouting": {
+                                "attributeName": "service.name",
+                                "attributeValue": "amcs"
+                            }
+                        },
+                        "id": "myOtelLogs1DataSource",
+                        "kind": "otelLogs",
+                        "streams": [
+                            {
+                                "stream": "OPENTELEMETRY_LOGS_AGENT"
+                            }
+                        ],
+                        "sendToChannels": [
+                            "gigl-dce-00000000000000000000000000000002"
+                        ]
+                    },
+                    {
+                        "configuration": {
+                            "resourceAttributeRouting": {
+                                "attributeName": "service.name",
+                                "attributeValue": "amcs"
+                            }
+                        },
+                        "id": "myOtelTraces1DataSource",
+                        "kind": "otelTraces",
+                        "streams": [
+                            {
+                                "stream": "OPENTELEMETRY_TRACES_AGENT"
+                            }
+                        ],
+                        "sendToChannels": [
+                            "gigl-dce-00000000000000000000000000000002"
+                        ]
+                    }
+                ],
+                "channels": [
+                    {
+                        "endpoint": "https://aaaaaaaa-0000-0000-0000-00000000000a.ods.opinsights.azure.com",
+                        "tokenEndpointUri": "https://handler.control.monitor.azure.com//issueIngestionToken?api-version=2022-06-02",
+                        "id": "ods-aaaaaaaa-0000-0000-0000-00000000000a",
+                        "protocol": "ods"
+                    },
+                    {
+                        "endpointUriTemplate": "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000002/streams/<STREAM>?api-version=2021-11-01-preview",
+                        "tokenEndpointUri": "https://handler.control.monitor.azure.com//issueIngestionToken?api-version=2022-06-02",
+                        "otelLogsEndpointUriTemplate": "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000002/streams/<STREAM>/otlp/v1/logs?api-version=2021-11-01-preview",
+                        "otelTracesEndpointUriTemplate": "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000002/streams/<STREAM>/otlp/v1/traces?api-version=2021-11-01-preview",
+                        "id": "gigl-dce-00000000000000000000000000000002",
+                        "protocol": "gig"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/rust/otap-dataflow/crates/contrib-config-translators/tests/fixtures/AMCSConfigAgentSettingsOnly.json
+++ b/rust/otap-dataflow/crates/contrib-config-translators/tests/fixtures/AMCSConfigAgentSettingsOnly.json
@@ -1,0 +1,26 @@
+{
+    "configurations": [
+        {
+            "configurationId": "dcr-00000000000000000000000000000003",
+            "eTag": "dcr-00000000000000000000000000000003/%22e3e3e3e3-0000-0000-0000-0000000000e3%22",
+            "op": "added",
+            "content": {
+                "kind": "AgentSettings",
+                "settings": [
+                    {
+                        "name": "MaxDiskQuotaInMB",
+                        "value": "10240"
+                    },
+                    {
+                        "name": "OtlpGrpcLogsTracesPort",
+                        "value": "4329"
+                    },
+                    {
+                        "name": "OtlpHttpProtobufLogsTracesPort",
+                        "value": "4330"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/rust/otap-dataflow/crates/contrib-config-translators/tests/parity.rs
+++ b/rust/otap-dataflow/crates/contrib-config-translators/tests/parity.rs
@@ -1,0 +1,229 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Parity tests against the .NET reference implementation.
+//!
+//! The expected values below are **not** hand-written. They were produced by invoking the real
+//! `AMCSParser.ExtractConfigurationByIdentifier` from the prebuilt `AMCSConfiguration.dll` in the
+//! `PipelineAgent` repository against these exact fixtures, with
+//! `OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT=-1` so each binding appears once.
+//!
+//! Every assertion here therefore encodes observed .NET behaviour, which is what makes this a
+//! port rather than a reimplementation.
+//!
+//! # Known intentional divergence
+//!
+//! `AMCSParser.cs:235-242` selects the endpoint template with:
+//!
+//! ```csharp
+//! if (eventName == Log && otelLogsEndpointUriTemplate != null) { ...logs... }
+//! else if (otelTracesEndpointUriTemplate != null)              { ...traces... }
+//! ```
+//!
+//! so a logs data source whose channel has no logs template falls through and is given a
+//! **traces** URL. None of the fixtures exercise that path, so it does not affect the values
+//! below, but this port deliberately does not reproduce it. See `endpoint_template` in
+//! `crate::amcs::extract`.
+
+use otel_arrow_dfe_contrib_config_translators::amcs::extract::{
+    OtlpEventName, extract_configuration,
+};
+use otel_arrow_dfe_contrib_config_translators::amcs::listener::{
+    DEFAULT_HOST, DEFAULT_OTLP_GRPC_LOGS_TRACES_PORT, ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT,
+    OtlpProtocol, StaticEnvironment,
+};
+use otel_arrow_dfe_contrib_config_translators::amcs::schema::Configurations;
+
+/// One expected endpoint binding, as reported by the .NET reference.
+struct Expected {
+    identifier: &'static str,
+    event_name: OtlpEventName,
+    endpoint_url: &'static str,
+    routing: Option<(&'static str, &'static str)>,
+}
+
+/// Load a fixture and extract bindings with only the gRPC listener enabled, matching the
+/// environment used to capture the reference values.
+fn extract(
+    name: &str,
+) -> Vec<otel_arrow_dfe_contrib_config_translators::amcs::extract::OtlpEventInfo> {
+    let path = format!("{}/tests/fixtures/{name}.json", env!("CARGO_MANIFEST_DIR"));
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read fixture {path}: {e}"));
+    let configs = Configurations::from_json(&raw)
+        .unwrap_or_else(|e| panic!("fixture {name} should parse: {e}"));
+
+    let env = StaticEnvironment::new().with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "-1");
+    extract_configuration(&env, &configs)
+}
+
+/// Assert that extraction of `name` matches the reference bindings exactly.
+fn assert_parity(name: &str, expected: &[Expected]) {
+    let actual = extract(name);
+
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{name}: expected {} bindings, got {}: {actual:#?}",
+        expected.len(),
+        actual.len()
+    );
+
+    for want in expected {
+        let found = actual
+            .iter()
+            .find(|a| a.identifier == want.identifier && a.event_name == want.event_name)
+            .unwrap_or_else(|| {
+                panic!(
+                    "{name}: no binding for {} / {:?} in {actual:#?}",
+                    want.identifier, want.event_name
+                )
+            });
+
+        assert_eq!(
+            found.endpoint_urls,
+            vec![want.endpoint_url.to_string()],
+            "{name}: endpoint URL mismatch for {} / {:?}",
+            want.identifier,
+            want.event_name
+        );
+
+        let actual_routing = found
+            .routing_info
+            .as_ref()
+            .map(|r| (r.name.as_str(), r.value.as_str()));
+        assert_eq!(
+            actual_routing, want.routing,
+            "{name}: routing mismatch for {} / {:?}",
+            want.identifier, want.event_name
+        );
+
+        // Listener details come from the environment and must match the reference too.
+        assert_eq!(found.listener.host, DEFAULT_HOST);
+        assert_eq!(found.listener.port, DEFAULT_OTLP_GRPC_LOGS_TRACES_PORT);
+        assert_eq!(found.listener.protocol, OtlpProtocol::Grpc);
+    }
+}
+
+const DCE: &str = "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com";
+
+/// `AMCSConfig`: one rule, logs and traces, both routed on `service.name = amcs`.
+#[test]
+fn parity_amcs_config() {
+    assert_parity(
+        "AMCSConfig",
+        &[
+            Expected {
+                identifier: "dcr-00000000000000000000000000000002.gigl-dce-00000000000000000000000000000002",
+                event_name: OtlpEventName::Log,
+                endpoint_url: const_format_logs(),
+                routing: Some(("service.name", "amcs")),
+            },
+            Expected {
+                identifier: "dcr-00000000000000000000000000000002.gigl-dce-00000000000000000000000000000002",
+                event_name: OtlpEventName::Span,
+                endpoint_url: const_format_traces(),
+                routing: Some(("service.name", "amcs")),
+            },
+        ],
+    );
+}
+
+/// `AMCSConfig2` is the same shape, except its **traces** data source declares no
+/// `resourceAttributeRouting`. The reference reports `RoutingInfo: null` for the span binding
+/// while the log binding keeps its filter, so routing must be tracked per signal.
+#[test]
+fn parity_amcs_config2_has_per_signal_routing() {
+    assert_parity(
+        "AMCSConfig2",
+        &[
+            Expected {
+                identifier: "dcr-00000000000000000000000000000002.gigl-dce-00000000000000000000000000000002",
+                event_name: OtlpEventName::Log,
+                endpoint_url: const_format_logs(),
+                routing: Some(("service.name", "amcs")),
+            },
+            Expected {
+                identifier: "dcr-00000000000000000000000000000002.gigl-dce-00000000000000000000000000000002",
+                event_name: OtlpEventName::Span,
+                endpoint_url: const_format_traces(),
+                // The reference reports no routing for this binding.
+                routing: None,
+            },
+        ],
+    );
+}
+
+/// `AMCSConfig3`: two rules in one payload, sending to the same channel id but with distinct
+/// routing values and distinct streams.
+#[test]
+fn parity_amcs_config3_multi_rule() {
+    assert_parity(
+        "AMCSConfig3",
+        &[
+            Expected {
+                identifier: "dcr-00000000000000000000000000000002.gigl-dce-00000000000000000000000000000002",
+                event_name: OtlpEventName::Log,
+                endpoint_url: "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000002/streams/OPENTELEMETRY_LOGS_AGENT_1/otlp/v1/logs?api-version=2021-11-01-preview",
+                routing: Some(("service.name", "amcs_1")),
+            },
+            Expected {
+                identifier: "dcr-00000000000000000000000000000002.gigl-dce-00000000000000000000000000000002",
+                event_name: OtlpEventName::Span,
+                endpoint_url: "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000002/streams/OPENTELEMETRY_TRACES_AGENT_1/otlp/v1/traces?api-version=2021-11-01-preview",
+                routing: Some(("service.name", "amcs_1")),
+            },
+            Expected {
+                identifier: "dcr-00000000000000000000000000000004.gigl-dce-00000000000000000000000000000002",
+                event_name: OtlpEventName::Log,
+                endpoint_url: "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000004/streams/OPENTELEMETRY_LOGS_AGENT_2/otlp/v1/logs?api-version=2021-11-01-preview",
+                routing: Some(("service.name", "amcs_2")),
+            },
+            Expected {
+                identifier: "dcr-00000000000000000000000000000004.gigl-dce-00000000000000000000000000000002",
+                event_name: OtlpEventName::Span,
+                endpoint_url: "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000004/streams/OPENTELEMETRY_TRACES_AGENT_2/otlp/v1/traces?api-version=2021-11-01-preview",
+                routing: Some(("service.name", "amcs_2")),
+            },
+        ],
+    );
+}
+
+/// `AMCSConfig4` declares no data sources; the reference returns an empty map.
+#[test]
+fn parity_amcs_config4_is_empty() {
+    assert_parity("AMCSConfig4", &[]);
+}
+
+/// `AMCSConfig5`: `extension` data sources are ignored, and the `gig` channel has a logs template
+/// but no traces template, so the reference reports a single logs binding.
+#[test]
+fn parity_amcs_config5_logs_only() {
+    assert_parity(
+        "AMCSConfig5",
+        &[Expected {
+            identifier: "dcr-00000000000000000000000000000001.gigl-dce-00000000000000000000000000000001",
+            event_name: OtlpEventName::Log,
+            endpoint_url: "https://example-dce-1.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000001/streams/OPENTELEMETRY_LOGS_AGENT/otlp/v1/logs?api-version=2021-11-01-preview",
+            routing: Some(("service.name", "amcs")),
+        }],
+    );
+}
+
+/// The logs endpoint shared by `AMCSConfig` and `AMCSConfig2`.
+const fn const_format_logs() -> &'static str {
+    "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000002/streams/OPENTELEMETRY_LOGS_AGENT/otlp/v1/logs?api-version=2021-11-01-preview"
+}
+
+/// The traces endpoint shared by `AMCSConfig` and `AMCSConfig2`.
+const fn const_format_traces() -> &'static str {
+    "https://example-dce-2.eastus2euap-1.ingest.monitor.azure.com/dataCollectionRules/dcr-00000000000000000000000000000002/streams/OPENTELEMETRY_TRACES_AGENT/otlp/v1/traces?api-version=2021-11-01-preview"
+}
+
+/// Sanity check that the endpoint constants really are rooted at the fixture's data collection
+/// endpoint, so a typo in the expectations above cannot silently pass.
+#[test]
+fn expected_endpoints_are_rooted_at_the_fixture_dce() {
+    assert!(const_format_logs().starts_with(DCE));
+    assert!(const_format_traces().starts_with(DCE));
+}

--- a/rust/otap-dataflow/crates/contrib-config-translators/tests/translate.rs
+++ b/rust/otap-dataflow/crates/contrib-config-translators/tests/translate.rs
@@ -1,0 +1,417 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end translation tests against the real AMCS payloads used by the .NET agent's own
+//! test suite.
+//!
+//! The fixtures in `tests/fixtures/` are verbatim copies of
+//! `PipelineAgentTests/TestData/ConfigPackage/AMCSConfig*` from the `PipelineAgent` repository,
+//! renamed with a `.json` extension. They are the same inputs `AmcsConfigProviderTests` exercises,
+//! so behaviour here can be compared directly against the .NET reference implementation.
+//!
+//! Fixture coverage:
+//!
+//! | Fixture | Shape |
+//! |---|---|
+//! | `AMCSConfig` | one rule; logs + traces + `perfCounter`; `gig` + `ods` channels |
+//! | `AMCSConfig2` | as above, different identifiers |
+//! | `AMCSConfig3` | **two rules** sharing one channel id, with different routing values |
+//! | `AMCSConfig4` | no data sources at all |
+//! | `AMCSConfig5` | **logs only** -- the `gig` channel has no traces template |
+
+use otel_arrow_dfe_config::engine::OtelDataflowSpec;
+use otel_arrow_dfe_contrib_config_translators::ConfigTranslator;
+use otel_arrow_dfe_contrib_config_translators::amcs::AmcsTranslator;
+use otel_arrow_dfe_contrib_config_translators::amcs::listener::{
+    ENV_OTLP_GRPC_LOGS_TRACES_PORT, ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, StaticEnvironment,
+};
+use otel_arrow_dfe_contrib_config_translators::error::Error;
+
+/// Load a fixture by name.
+fn fixture(name: &str) -> String {
+    let path = format!("{}/tests/fixtures/{name}.json", env!("CARGO_MANIFEST_DIR"));
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read fixture {path}: {e}"))
+}
+
+/// A translator with both listeners enabled on their default ports.
+fn default_translator() -> AmcsTranslator<StaticEnvironment> {
+    AmcsTranslator::with_environment(StaticEnvironment::new())
+}
+
+/// A translator with only the gRPC listener enabled, so each binding appears once.
+fn grpc_only_translator() -> AmcsTranslator<StaticEnvironment> {
+    AmcsTranslator::with_environment(
+        StaticEnvironment::new().with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "-1"),
+    )
+}
+
+/// Translate a fixture, asserting success.
+fn translate(translator: &AmcsTranslator<StaticEnvironment>, name: &str) -> String {
+    translator
+        .translate_to_yaml(&fixture(name))
+        .unwrap_or_else(|e| panic!("translation of {name} failed: {e}"))
+}
+
+/// Every fixture that yields a pipeline must produce YAML the engine's own loader accepts.
+/// This is the guard against emitting a specification the engine would refuse to start.
+#[test]
+fn all_usable_fixtures_round_trip_through_the_engine_loader() {
+    for name in ["AMCSConfig", "AMCSConfig2", "AMCSConfig3", "AMCSConfig5"] {
+        let yaml = translate(&default_translator(), name);
+        let spec = OtelDataflowSpec::from_yaml(&yaml);
+        assert!(
+            spec.is_ok(),
+            "engine rejected the configuration generated from {name}: {spec:?}\n{yaml}"
+        );
+    }
+}
+
+/// No `<STREAM>` placeholder may survive into a generated configuration.
+#[test]
+fn no_fixture_leaves_an_unsubstituted_stream_placeholder() {
+    for name in ["AMCSConfig", "AMCSConfig2", "AMCSConfig3", "AMCSConfig5"] {
+        let yaml = translate(&default_translator(), name);
+        assert!(
+            !yaml.contains("<STREAM>"),
+            "{name} produced an unsubstituted <STREAM> placeholder:\n{yaml}"
+        );
+    }
+}
+
+/// The canonical single-rule fixture produces one receiver and one exporter carrying both the
+/// logs and the traces endpoint.
+#[test]
+fn canonical_fixture_produces_one_receiver_and_one_exporter() {
+    let yaml = translate(&grpc_only_translator(), "AMCSConfig");
+
+    assert_eq!(
+        yaml.matches("urn:otel:receiver:otlp").count(),
+        1,
+        "expected exactly one receiver:\n{yaml}"
+    );
+    assert_eq!(
+        yaml.matches("urn:otel:exporter:otlp_http").count(),
+        1,
+        "logs and traces for one identifier share an exporter:\n{yaml}"
+    );
+
+    assert!(yaml.contains("OPENTELEMETRY_LOGS_AGENT"));
+    assert!(yaml.contains("OPENTELEMETRY_TRACES_AGENT"));
+    assert!(yaml.contains("otlp/v1/logs"));
+    assert!(yaml.contains("otlp/v1/traces"));
+    assert!(yaml.contains("service.name"));
+}
+
+/// `perfCounter` data sources and `ods` channels carry no OTLP endpoints and must not appear.
+#[test]
+fn non_otlp_data_sources_and_ods_channels_are_excluded() {
+    let yaml = translate(&default_translator(), "AMCSConfig");
+
+    assert!(
+        !yaml.contains("GENERIC_PERF_BLOB") && !yaml.contains("LINUX_PERF_BLOB"),
+        "a perfCounter stream leaked into the configuration:\n{yaml}"
+    );
+    assert!(
+        !yaml.contains("opinsights"),
+        "an ods channel endpoint leaked into the configuration:\n{yaml}"
+    );
+}
+
+/// Ragu's multi-DCR scenario: `AMCSConfig3` carries two rules in one payload. Both must appear,
+/// each with its own routing value, and they must not collide even though they send to the same
+/// channel id.
+#[test]
+fn multiple_rules_in_one_payload_produce_separate_branches() {
+    let yaml = translate(&grpc_only_translator(), "AMCSConfig3");
+
+    assert_eq!(
+        yaml.matches("urn:otel:exporter:otlp_http").count(),
+        2,
+        "expected one exporter per rule:\n{yaml}"
+    );
+    assert_eq!(yaml.matches("urn:otel:receiver:otlp").count(), 1);
+
+    // Distinct routing values prove the two rules stayed separate.
+    assert!(
+        yaml.contains("amcs_1"),
+        "missing routing for the first rule"
+    );
+    assert!(
+        yaml.contains("amcs_2"),
+        "missing routing for the second rule"
+    );
+
+    // Distinct streams prove each rule kept its own endpoints.
+    assert!(yaml.contains("OPENTELEMETRY_LOGS_AGENT_1"));
+    assert!(yaml.contains("OPENTELEMETRY_LOGS_AGENT_2"));
+    assert!(yaml.contains("OPENTELEMETRY_TRACES_AGENT_1"));
+    assert!(yaml.contains("OPENTELEMETRY_TRACES_AGENT_2"));
+}
+
+/// `AMCSConfig5` has a `gig` channel with a logs template but **no** traces template. The
+/// generated configuration must carry a logs endpoint, no traces endpoint, and must actively drop
+/// traces -- otherwise the exporter would fall back to `endpoint + "/v1/traces"` and misroute them.
+#[test]
+fn logs_only_fixture_emits_no_traces_endpoint_and_drops_traces() {
+    let yaml = translate(&grpc_only_translator(), "AMCSConfig5");
+
+    assert!(
+        yaml.contains("logs_endpoint"),
+        "expected a logs endpoint:\n{yaml}"
+    );
+    assert!(
+        !yaml.contains("traces_endpoint"),
+        "a traces endpoint was emitted for a channel that has no traces template:\n{yaml}"
+    );
+    assert!(
+        yaml.contains("urn:otel:processor:filter"),
+        "a logs-only branch needs a filter to drop traces:\n{yaml}"
+    );
+    assert!(
+        yaml.contains("span_names"),
+        "expected a span_names constraint that drops traces:\n{yaml}"
+    );
+
+    // The `extension` data sources in this fixture are not OTLP and must be ignored.
+    assert!(!yaml.contains("RETINA_NETWORK_FLOW_LOGS"));
+    assert!(!yaml.contains("CONTAINER_LOG_BLOB"));
+    assert!(yaml.contains("OPENTELEMETRY_LOGS_AGENT"));
+}
+
+/// A payload with no OTLP data sources cannot produce a pipeline, and must say so rather than
+/// emitting an empty or invalid configuration.
+#[test]
+fn fixture_without_otlp_data_sources_is_an_empty_pipeline_error() {
+    let err = default_translator()
+        .translate_to_yaml(&fixture("AMCSConfig4"))
+        .expect_err("AMCSConfig4 declares no OTLP data sources");
+
+    assert!(
+        matches!(err, Error::EmptyPipeline { .. }),
+        "expected EmptyPipeline, got {err:?}"
+    );
+}
+
+/// Both listeners enabled means both protocols appear on the single shared receiver, on their
+/// default ports, resolved to literal addresses.
+#[test]
+fn both_listeners_appear_on_the_shared_receiver() {
+    let yaml = translate(&default_translator(), "AMCSConfig");
+
+    assert!(
+        yaml.contains(":4319"),
+        "missing the default gRPC port:\n{yaml}"
+    );
+    assert!(
+        yaml.contains(":4320"),
+        "missing the default HTTP port:\n{yaml}"
+    );
+    assert!(
+        !yaml.contains("localhost:"),
+        "listening_addr must be a literal socket address, not a hostname:\n{yaml}"
+    );
+}
+
+/// Disabling both listeners leaves nothing to build.
+#[test]
+fn disabling_every_listener_yields_an_empty_pipeline_error() {
+    let translator = AmcsTranslator::with_environment(
+        StaticEnvironment::new()
+            .with(ENV_OTLP_GRPC_LOGS_TRACES_PORT, "-1")
+            .with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "-1"),
+    );
+
+    let err = translator
+        .translate_to_yaml(&fixture("AMCSConfig"))
+        .expect_err("no listeners means no pipeline");
+
+    assert!(matches!(err, Error::EmptyPipeline { .. }));
+}
+
+/// Adding the second listener must not duplicate exporters: listeners configure the receiver,
+/// identifiers configure the branches.
+#[test]
+fn listener_count_does_not_change_the_number_of_exporters() {
+    let one = translate(&grpc_only_translator(), "AMCSConfig");
+    let two = translate(&default_translator(), "AMCSConfig");
+
+    assert_eq!(
+        one.matches("urn:otel:exporter:otlp_http").count(),
+        two.matches("urn:otel:exporter:otlp_http").count(),
+        "the number of exporters must depend on identifiers, not listeners"
+    );
+}
+
+/// Translation must be stable across runs so generated configurations can be cached and compared.
+///
+/// The engine stores nodes in a `HashMap`, so the serialized YAML text is not byte-stable. The
+/// specification it represents must be.
+#[test]
+fn translation_is_stable_across_runs() {
+    for name in ["AMCSConfig", "AMCSConfig3", "AMCSConfig5"] {
+        let raw = fixture(name);
+        let first = default_translator()
+            .translate(&raw)
+            .unwrap_or_else(|e| panic!("first translation of {name} failed: {e}"));
+        let second = default_translator()
+            .translate(&raw)
+            .unwrap_or_else(|e| panic!("second translation of {name} failed: {e}"));
+        assert_eq!(first, second, "{name} translated differently across runs");
+    }
+}
+
+/// Scenario: a payload is translated through the library API without any file being written.
+/// Guarantees: the engine configuration is produced entirely in memory, so the embedding host can
+/// hand the specification straight to the engine and treat any YAML dump as a debug artifact
+/// rather than the interface. Removing the file write cannot change what the engine runs.
+#[test]
+fn translation_produces_a_spec_without_touching_the_filesystem() {
+    let raw = fixture("AMCSConfig");
+
+    // `translate` returns the specification itself; no path, handle or temporary file is involved.
+    let spec = default_translator()
+        .translate(&raw)
+        .expect("translation should succeed");
+
+    // The same specification is what a YAML dump would serialize, so the dump carries no
+    // information the in-memory value lacks.
+    let yaml = serde_yaml::to_string(&spec).expect("spec should serialize");
+    let reparsed = OtelDataflowSpec::from_yaml(&yaml).expect("dump should parse back");
+    assert_eq!(
+        spec, reparsed,
+        "a YAML round-trip must not alter the specification"
+    );
+}
+
+/// Custom listener host and port settings must reach the generated receiver.
+#[test]
+fn custom_listener_settings_reach_the_receiver() {
+    let translator = AmcsTranslator::with_environment(
+        StaticEnvironment::new()
+            .with(ENV_OTLP_GRPC_LOGS_TRACES_PORT, "15317")
+            .with(
+                otel_arrow_dfe_contrib_config_translators::amcs::listener::ENV_OTLP_GRPC_LOGS_TRACES_HOST,
+                "0.0.0.0",
+            )
+            .with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "-1"),
+    );
+
+    let yaml = translator
+        .translate_to_yaml(&fixture("AMCSConfig"))
+        .expect("translation should succeed");
+
+    assert!(
+        yaml.contains("0.0.0.0:15317"),
+        "custom listener settings did not reach the receiver:\n{yaml}"
+    );
+    assert!(!yaml.contains(":4320"), "the HTTP listener was disabled");
+}
+
+// -------------------------------------------------------------------------------------------
+// Agent Settings DCR, per Telemetry-Collection-Spec/AMACoreAgent/otel-port-configuration.md.
+// -------------------------------------------------------------------------------------------
+
+/// Scenario 8: no environment variables, an agent settings rule supplying both ports, and OTel
+/// data sources present -- the listeners use the agent settings values.
+#[test]
+fn agent_settings_ports_reach_the_receiver() {
+    let yaml = translate(&default_translator(), "AMCSConfigAgentSettings");
+
+    assert!(
+        yaml.contains("127.0.0.1:4329"),
+        "gRPC listener should use the agent settings port 4329:\n{yaml}"
+    );
+    assert!(
+        yaml.contains("127.0.0.1:4330"),
+        "HTTP listener should use the agent settings port 4330:\n{yaml}"
+    );
+    assert!(
+        !yaml.contains(":4319") && !yaml.contains(":4320"),
+        "default ports must not appear when agent settings supply values:\n{yaml}"
+    );
+}
+
+/// Scenario 4: environment variables always win over the agent settings rule.
+#[test]
+fn environment_overrides_agent_settings_end_to_end() {
+    let translator = AmcsTranslator::with_environment(
+        StaticEnvironment::new()
+            .with(ENV_OTLP_GRPC_LOGS_TRACES_PORT, "4319")
+            .with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "4320"),
+    );
+
+    let yaml = translator
+        .translate_to_yaml(&fixture("AMCSConfigAgentSettings"))
+        .expect("translation should succeed");
+
+    assert!(yaml.contains("127.0.0.1:4319"));
+    assert!(yaml.contains("127.0.0.1:4320"));
+    assert!(
+        !yaml.contains(":4329") && !yaml.contains(":4330"),
+        "agent settings must be ignored when the environment supplies ports:\n{yaml}"
+    );
+}
+
+/// Scenarios 2, 6 and 10: an agent settings rule on its own is **not** sufficient to open a port.
+/// Without an OTel data-source rule there is nothing to build.
+#[test]
+fn agent_settings_alone_opens_no_ports() {
+    let err = default_translator()
+        .translate_to_yaml(&fixture("AMCSConfigAgentSettingsOnly"))
+        .expect_err("an agent settings rule alone must not produce a pipeline");
+
+    assert!(
+        matches!(err, Error::EmptyPipeline { .. }),
+        "expected EmptyPipeline, got {err:?}"
+    );
+}
+
+/// Scenario 14: `-1` in the environment disables the listeners even when agent settings supply
+/// ports and OTel data sources are present.
+#[test]
+fn environment_disable_beats_agent_settings_end_to_end() {
+    let translator = AmcsTranslator::with_environment(
+        StaticEnvironment::new()
+            .with(ENV_OTLP_GRPC_LOGS_TRACES_PORT, "-1")
+            .with(ENV_OTLP_HTTP_PROTOBUF_LOGS_TRACES_PORT, "-1"),
+    );
+
+    let err = translator
+        .translate_to_yaml(&fixture("AMCSConfigAgentSettings"))
+        .expect_err("both listeners disabled means no pipeline");
+
+    assert!(matches!(err, Error::EmptyPipeline { .. }));
+}
+
+/// The agent settings rule must never become a pipeline branch of its own: the payload has one
+/// data-source rule, so exactly one exporter is expected.
+#[test]
+fn agent_settings_rule_is_not_treated_as_a_branch() {
+    let yaml = translate(&grpc_only_translator(), "AMCSConfigAgentSettings");
+
+    assert_eq!(
+        yaml.matches("urn:otel:exporter:otlp_http").count(),
+        1,
+        "the agent settings rule must not produce a branch:\n{yaml}"
+    );
+    assert!(
+        !yaml.contains("MaxDiskQuotaInMB") && !yaml.contains("d7e9af8dbad14f40900dbf304e999ae2"),
+        "agent settings content leaked into the pipeline:\n{yaml}"
+    );
+
+    // The single branch still comes from the data-source rule.
+    assert!(yaml.contains("OPENTELEMETRY_LOGS_AGENT"));
+    assert!(yaml.contains("OPENTELEMETRY_TRACES_AGENT"));
+}
+
+/// A payload carrying an agent settings rule must still produce a configuration the engine
+/// accepts.
+#[test]
+fn agent_settings_payload_round_trips_through_the_engine_loader() {
+    let yaml = translate(&default_translator(), "AMCSConfigAgentSettings");
+    let spec = OtelDataflowSpec::from_yaml(&yaml);
+    assert!(
+        spec.is_ok(),
+        "engine rejected the configuration: {spec:?}\n{yaml}"
+    );
+}

--- a/rust/otap-dataflow/crates/contrib-config-translators/tests/translate.rs
+++ b/rust/otap-dataflow/crates/contrib-config-translators/tests/translate.rs
@@ -415,3 +415,36 @@ fn agent_settings_payload_round_trips_through_the_engine_loader() {
         "engine rejected the configuration: {spec:?}\n{yaml}"
     );
 }
+
+/// Scenario: a generated YAML document is inspected for the engine-wide `engine:` block.
+/// Guarantees: the block is omitted while it holds nothing but engine defaults. It is
+/// `#[serde(default)]`, so an absent block parses back to exactly `EngineConfig::default()` and
+/// the engine behaves identically -- but emitting it would freeze roughly sixty lines of internal
+/// observability pipeline into every generated config, dwarfing the pipeline we actually generate
+/// and silently pinning defaults that would otherwise track the engine. Deliberate engine
+/// settings differ from the default and so are still written out.
+#[test]
+fn default_engine_configuration_is_not_pinned_into_the_output() {
+    let yaml = default_translator()
+        .translate_to_yaml(&fixture("AMCSConfig"))
+        .expect("translation should succeed");
+
+    assert!(
+        !yaml.contains("\nengine:"),
+        "a defaults-only engine block must not be written out:\n{yaml}"
+    );
+    // The observability pipeline is the bulky part of those defaults; make its absence explicit
+    // so this test fails loudly if the block ever creeps back in.
+    assert!(
+        !yaml.contains("internal_telemetry"),
+        "default observability pipeline leaked into the output:\n{yaml}"
+    );
+
+    // Omitting the block must not change what the engine actually runs.
+    let spec = OtelDataflowSpec::from_yaml(&yaml).expect("output should parse back");
+    assert_eq!(
+        spec.engine,
+        otel_arrow_dfe_config::engine::EngineConfig::default(),
+        "an absent engine block must deserialize to the engine defaults"
+    );
+}


### PR DESCRIPTION
## What

Adds `otel-arrow-dfe-contrib-config-translators`, a crate that turns the AMCS
(Azure Monitor Configuration Service) configuration payload an Azure Monitor
agent already receives into an engine pipeline specification. A host can then
run OTLP collection driven by a customer-authored Data Collection Rule without
hand-writing a pipeline.

`ConfigTranslator` is the trait a future first-party (Geneva/GigLA) translator
implements. It sits one stage earlier than `ConfigProvider`: a provider
resolves a URI to raw content, a translator converts foreign content into the
engine's own model.

```text
vendor config (JSON) --ConfigTranslator--> OtelDataflowSpec --> pipeline YAML
```

## Why

The agent already receives this document and already parses it, in .NET, to
decide where telemetry goes. Until now nothing turned it into a pipeline the
engine can run, so wiring the two together meant writing YAML by hand per
rule, which does not survive a rule change.

## Design notes for reviewers

- **Port, not reimplementation.** The extraction stage is a port of the
  shipping .NET `AMCSParser.ExtractConfiguration`. It reads the same payload
  and reproduces the same endpoint set, then continues past where the .NET
  agent stops in order to build pipeline nodes.
- **Fan-out for multiple rules.** A node's output port cannot address more
  than one target (`UnsupportedConnectionDispatchPolicy`), so several Data
  Collection Rules on one host are served by one receiver feeding
  `urn:otel:processor:fanout`, which clones pdata to named ports.
- **One batch per export path.** No batch instance spans two rules, so no
  rule's data can be merged into another's batch.
- **No filter node when a rule routes on nothing and exports both signals.**
  A filter matching everything would only cost a copy per message.
- **Dropping a signal needs a non-empty match list.** The filter processor
  treats an empty list as "match everything", so a path with no endpoint for a
  signal uses a sentinel that cannot occur in real telemetry.
- **Listener ports** come from the environment, else the AgentSettings rule,
  else the default, resolved per protocol. `-1` disables a listener; an
  otherwise invalid value falls through.
- **Failing loudly.** A payload that yields no nodes is an error rather than
  an empty pipeline, so a misconfiguration cannot present as an agent that
  listens nowhere and exports nothing.

## Testing

- 106 tests: 79 unit, 6 parity, 20 integration, 1 doc.
- **Parity is asserted against the real .NET parser**, not against
  expectations. Ground truth was captured by loading the shipped
  `AMCSConfiguration.dll` and invoking
  `AMCSParser.ExtractConfigurationByIdentifier` over every fixture. This
  caught a bug reasoning alone did not: routing is per-signal, not per-rule.
- Every fixture that should translate passes `df_engine --validate-and-exit`,
  which checks component URNs and per-component config rather than only YAML
  shape.
- Generated configs were run under a real `df_engine`, confirming the
  multi-rule fan-out starts, and that an AgentSettings payload binds the ports
  the rule names while leaving the defaults unbound.
- Generated YAML is byte-stable across runs and ordered by data flow, so
  regenerating it produces a reviewable diff.

## Intentional divergence from the .NET reference

`AMCSParser.cs` selects the endpoint template with an
`if (logs) ... else if (traces)` chain, so a logs data source whose channel has
no logs template falls through and is emitted with a **traces** URL. A fixture
in this PR has that shape. The Rust port does not reproduce it; the signal is
dropped instead. Called out because a diff of Rust against .NET output for such
a rule will differ, and that difference is deliberate.

## Notes

- The library performs no filesystem I/O. `translate` returns the
  specification directly, so an embedding host can hand it to the engine. The
  YAML dump is a debug artifact, and the only file access lives in the debug
  CLI.
- Metrics are not dropped. AMCS describes only `otelLogs` and `otelTraces`,
  and neither the filter nor the exporter discards a signal by default, so
  OTLP metrics sent to the agent would be posted to a synthesised endpoint.
  Out of scope for the functionality being shipped; documented on
  `needs_filter`.
- Credential binding is not emitted. It needs an `extensions` entry the host
  owns, and the exporter accepts `agent_fed_credential_provider` or
  `bearer_token_provider` but not both. `credential_capability_name()` names
  the one to bind.
- The branch was rebased onto current `main` after being ~660 commits behind,
  picking up the crate rename, the ASCII-only source rule, mandatory test
  documentation, and `.chloggen` entries.

---

## Why this is one PR

This is a single new crate implementing one concern -- translating an AMCS
configuration into a pipeline -- and its stages are only meaningful together:
extraction has no consumer without emission, and emission has no input without
extraction. It is split into five commits so it can be reviewed a stage at a
time.

Suggested reading order: `lib.rs` (the trait), `amcs/schema.rs` (the input
model), `amcs/listener.rs` (ports), `amcs/extract.rs` (the port of the .NET
parser), `amcs/emit.rs` (pipeline construction), then `tests/parity.rs` for the
evidence it matches the shipping parser.

Commit 3 is a useful checkpoint: the parity tests pass there, so the port can be
judged faithful before any pipeline construction is read.
