### PR TITLE
fix(transform_processor): Nack permanent flag and payload handling

### DIFF
--- a/rust/otap-dataflow/.chloggen/transform-processor-nack-corrections.yaml
+++ b/rust/otap-dataflow/.chloggen/transform-processor-nack-corrections.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: pipeline
+note: Corrects population of Nack permanent flag and payload in transform processor
+issues: [3904]

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/partition_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/partition_processor/mod.rs
@@ -162,9 +162,8 @@ impl PartitionProcessor {
         if let Some(inbound) = self.contexts.clear_outbound(outbound_key) {
             // if we're in this location, we've cleared the final outbound context for some inbound
             // batch, which means we can now Ack or Nack the inbound context
-            let (context, error_reason) = inbound;
-            let pdata = OtapPdata::new(context, OtapPayload::empty(signal_type));
-            if let Some(error) = error_reason {
+            let pdata = OtapPdata::new(inbound.context, OtapPayload::empty(signal_type));
+            if let Some(error) = inbound.error_reason {
                 effect_handler.notify_nack(NackMsg::new(error, pdata)).await
             } else {
                 effect_handler.notify_ack(AckMsg::new(pdata)).await
@@ -302,7 +301,7 @@ impl Processor<OtapPdata> for PartitionProcessor {
                         // create context key for inbound batch
                         let inbound_ctx_key = self
                             .contexts
-                            .insert_inbound(inbound_context.clone(), None)
+                            .insert_inbound(inbound_context.clone(), None, None)
                             .ok_or_else(|| otel_arrow_dfe_engine::error::Error::ProcessorError {
                                 processor: effect_handler.processor_id(),
                                 kind: ProcessorErrorKind::Other,

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/partition_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/partition_processor/mod.rs
@@ -19,7 +19,7 @@ use otel_arrow_dfe_config::SignalType;
 use otel_arrow_dfe_config::node::NodeUserConfig;
 use otel_arrow_dfe_engine::config::ProcessorConfig;
 use otel_arrow_dfe_engine::context::PipelineContext;
-use otel_arrow_dfe_engine::control::{AckMsg, NackMsg, NodeControlMsg};
+use otel_arrow_dfe_engine::control::{AckMsg, NackCause, NackMsg, NodeControlMsg};
 use otel_arrow_dfe_engine::error::ProcessorErrorKind;
 use otel_arrow_dfe_engine::local::processor::{EffectHandler, Processor};
 use otel_arrow_dfe_engine::message::Message;
@@ -31,7 +31,7 @@ use otel_arrow_dfe_engine::{
     MessageSourceLocalEffectHandlerExtension, ProcessorFactory, ProducerEffectHandlerExtension,
 };
 use otel_arrow_dfe_otap::OTAP_PROCESSOR_FACTORIES;
-use otel_arrow_dfe_otap::accessory::context::split_contexts::Contexts;
+use otel_arrow_dfe_otap::accessory::context::split_contexts::{Contexts, OutboundError};
 use otel_arrow_dfe_otap::accessory::slots::Key;
 use otel_arrow_dfe_otap::pdata::OtapPdata;
 use otel_arrow_dfe_otap::transport_headers::{TransportHeader, ValueKind};
@@ -163,8 +163,10 @@ impl PartitionProcessor {
             // if we're in this location, we've cleared the final outbound context for some inbound
             // batch, which means we can now Ack or Nack the inbound context
             let pdata = OtapPdata::new(inbound.context, OtapPayload::empty(signal_type));
-            if let Some(error) = inbound.error_reason {
-                effect_handler.notify_nack(NackMsg::new(error, pdata)).await
+            if let Some(error) = inbound.error {
+                effect_handler
+                    .notify_nack(NackMsg::new_with_cause(error.reason, pdata, error.cause))
+                    .await
             } else {
                 effect_handler.notify_ack(AckMsg::new(pdata)).await
             }
@@ -204,8 +206,13 @@ impl Processor<OtapPdata> for PartitionProcessor {
 
                 NodeControlMsg::Nack(nack_msg) => {
                     let outbound_key: Key = nack_msg.unwind.route.calldata.try_into()?;
-                    self.contexts
-                        .set_failed_outbound(outbound_key, nack_msg.reason);
+                    self.contexts.set_failed_outbound(
+                        outbound_key,
+                        OutboundError {
+                            reason: nack_msg.reason,
+                            cause: nack_msg.cause,
+                        },
+                    );
                     self.handle_ack_nack(
                         outbound_key,
                         nack_msg.refused.signal_type(),
@@ -329,7 +336,11 @@ impl Processor<OtapPdata> for PartitionProcessor {
                                     // indicating that some partition was not emitted.
                                     self.contexts.set_failed_inbound(
                                         inbound_ctx_key,
-                                        "insufficient outbound slots for partitions".into(),
+                                        OutboundError {
+                                            reason: "insufficient outbound slots for partitions"
+                                                .into(),
+                                            cause: NackCause::RouteFull,
+                                        },
                                     );
                                 }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/partition_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/partition_processor/mod.rs
@@ -599,9 +599,10 @@ mod test {
         reason: &str,
         cause: NackCause,
     ) -> Result<(), otel_arrow_dfe_engine::error::Error> {
-        let nack = next_nack(NackMsg::new(
+        let nack = next_nack(NackMsg::new_permanent_with_cause(
             reason,
             OtapPdata::new(context, OtapPayload::empty(signal_type)),
+            cause,
         ));
         let (_, nack) = nack.unwrap();
         ctx.process(Message::Control(NodeControlMsg::Nack(nack)))

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/partition_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/partition_processor/mod.rs
@@ -597,6 +597,7 @@ mod test {
         context: Context,
         signal_type: SignalType,
         reason: &str,
+        cause: NackCause,
     ) -> Result<(), otel_arrow_dfe_engine::error::Error> {
         let nack = next_nack(NackMsg::new(
             reason,
@@ -1183,6 +1184,7 @@ mod test {
                     outbound_contexts.pop().unwrap(),
                     SignalType::Logs,
                     "error happened",
+                    NackCause::Refused,
                 )
                 .await
                 .unwrap();
@@ -1193,7 +1195,8 @@ mod test {
                     PipelineCompletionMsg::DeliverNack { nack } => {
                         let (node_id, nack) = next_nack(nack).expect("expected ack subscriber");
                         assert_eq!(node_id, upstream_node_id);
-                        assert_eq!(nack.reason, "error happened")
+                        assert_eq!(nack.reason, "error happened");
+                        assert_eq!(nack.cause, NackCause::Refused);
                     }
                     other => {
                         panic!("got unexpected pipeline ctrl message {other:?}")

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -11,6 +11,29 @@
 //! still being developed.
 //!
 //! ToDo: Detect unsupported pipelines at config time instead of run time.
+//!
+//! # Ack/Nack behaviour
+//!
+//! Some transformations may split the into multiple outbound batches (notably when the `route_to`
+//! operator is used the query). When this happens, a new context will be created for the outbound
+//! batches, and this component will subscribe to Acks/Nacks on these outbound contexts. Once all
+//! outbound contexts have been Ack'd or Nack'd this component will then produce an Ack or Nack for
+//! the inbound context.
+//!
+//! The rules by which it creates this Ack/Nack for the inbound context are as follows:
+//!
+//! If all outbound contexts were Ack'd, this component will produce an Ack.
+//!
+//! Otherwise, (when at least one outbound context was NAck'd). The Nack reason will be the first
+//! error received from the Nack of any Nack'd outbound batch.
+//!
+//! This Nack will be non-permanent ONLY if all the outbound contexts were Nack'd with
+//! `permanent=false` (e.g. if all the downstream errors were transient). It has this behaviour to
+//! avoid a) having the data retried in the case of a permanent downstream error and b) replaying
+//! data that has already been Ack'd. This means *a transient downstream error will not necessarily
+//! cause the batch to be retried*, and it may be considered good practice to put any retry
+//! processors downstream of this component.
+//!
 
 otel_arrow_dfe_telemetry::otel_component_scope!(
     urn = TRANSFORM_PROCESSOR_URN,

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -14,11 +14,11 @@
 //!
 //! # Ack/Nack behaviour
 //!
-//! Some transformations may split the into multiple outbound batches (notably when the `route_to`
-//! operator is used the query). When this happens, a new context will be created for the outbound
-//! batches, and this component will subscribe to Acks/Nacks on these outbound contexts. Once all
-//! outbound contexts have been Ack'd or Nack'd this component will then produce an Ack or Nack for
-//! the inbound context.
+//! Some transformations may split the batch into multiple outbound batches (notably when the
+//! `route_to` operator is used in the query). When this happens, a new context will be created for
+//! the outbound batches, and this component will subscribe to Acks/Nacks on these outbound
+//! contexts. Once all outbound contexts have been Ack'd or Nack'd, this component will then
+//! produce an Ack or Nack for the inbound context.
 //!
 //! The rules by which it creates this Ack/Nack for the inbound context are as follows:
 //!

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -253,6 +253,7 @@ impl TransformProcessor {
     /// while managing subscriptions and context
     async fn handle_exec_result(
         &mut self,
+        inbound_payload: Option<OtapPayload>,
         inbound_context: Context,
         signal: SignalType,
         pipeline_result: Result<OtapArrowRecords, TransformOperationError>,
@@ -364,7 +365,7 @@ impl TransformProcessor {
         // all routed outbound batches have been Ack/Nack'd
         let inbound_ctx_key = self
             .contexts
-            .insert_inbound(inbound_context, None)
+            .insert_inbound(inbound_context, inbound_payload, None)
             .ok_or_else(|| {
                 TransformOperationError::new(
                     TransformErrorType::InboundCapacity,
@@ -487,10 +488,16 @@ impl TransformProcessor {
         if let Some(inbound) = self.contexts.clear_outbound(outbound_key) {
             // if here, we have cleared the final outbound context for some inbound batch,
             // which means we can now Ack or Nack the inbound context
-            let (context, error_reason) = inbound;
-            let pdata = OtapPdata::new(context, OtapPayload::empty(signal_type));
-            if let Some(error) = error_reason {
-                effect_handler.notify_nack(NackMsg::new(error, pdata)).await
+            let payload = inbound.payload.unwrap_or(OtapPayload::empty(signal_type));
+            let pdata = OtapPdata::new(inbound.context, payload);
+            if let Some(error) = inbound.error_reason {
+                let nack_msg = if inbound.outbound_all_transient_errors {
+                    // this constructor creates a non-permanent Nack
+                    NackMsg::new(error, pdata)
+                } else {
+                    NackMsg::new_permanent(error, pdata)
+                };
+                effect_handler.notify_nack(nack_msg).await
             } else {
                 effect_handler.notify_ack(AckMsg::new(pdata)).await
             }
@@ -554,8 +561,11 @@ impl Processor<OtapPdata> for TransformProcessor {
                     }
                 }
                 NodeControlMsg::Ack(ack_message) => {
+                    let outbound_key: Key = ack_message.unwind.route.calldata.try_into()?;
+                    self.contexts
+                        .set_outbound_all_transient_errors(outbound_key, false);
                     self.handle_ack_nack_inbound(
-                        ack_message.unwind.route.calldata.try_into()?,
+                        outbound_key,
                         ack_message.accepted.signal_type(),
                         effect_handler,
                     )
@@ -565,6 +575,10 @@ impl Processor<OtapPdata> for TransformProcessor {
                     let outbound_key: Key = nack_message.unwind.route.calldata.try_into()?;
                     self.contexts
                         .set_failed_outbound(outbound_key, nack_message.reason);
+                    if nack_message.permanent {
+                        self.contexts
+                            .set_outbound_all_transient_errors(outbound_key, false);
+                    }
                     self.handle_ack_nack_inbound(
                         outbound_key,
                         nack_message.refused.signal_type(),
@@ -578,6 +592,7 @@ impl Processor<OtapPdata> for TransformProcessor {
             },
             Message::PData(pdata) => {
                 let (context, payload) = pdata.into_parts();
+                let inbound_payload = context.may_return_payload().then_some(payload.clone());
                 let pdata_signal_type = payload.signal_type();
                 let mut payload = Some(payload);
                 let mut transformed = false;
@@ -691,6 +706,7 @@ impl Processor<OtapPdata> for TransformProcessor {
                     let counters = self.execution_state.counters();
                     match self
                         .handle_exec_result(
+                            inbound_payload,
                             context,
                             pdata_signal_type,
                             result,

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -899,7 +899,6 @@ mod test {
     }
 
     /// Helper to send a permanent Nack for a given context
-    #[allow(dead_code)]
     async fn send_permanent_nack(
         ctx: &mut TestContext<OtapPdata>,
         context: Context,
@@ -3516,6 +3515,503 @@ mod test {
                     }
                     other => {
                         panic!("expected DeliverNack, got {other:?}")
+                    }
+                };
+            })
+            .validate(|_ctx| async move {});
+    }
+
+    /// Scenario: A routed transform splits into a default output and a routed output. The
+    /// default output is ACK'd (success) and the routed output is NACK'd with a transient error.
+    /// Guarantees: The upstream nack is permanent because at least one downstream consumer
+    /// successfully consumed the data (ACK), making the batch non-retryable as a whole.
+    #[test]
+    fn test_nack_permanence_mixed_ack_and_transient_nack() {
+        let runtime = TestRuntime::<OtapPdata>::new();
+        let query = r#"logs
+            | if (severity_text == "ERROR") {
+                route_to "error_port"
+            }
+            "#;
+        let mut processor = try_create_with_opl_query(query, &runtime).expect("created processor");
+        let error_port_rx = set_pdata_sender("error_port", &mut processor);
+
+        runtime
+            .set_processor(processor)
+            .run_test(|mut ctx| async move {
+                let (runtime_ctrl_tx, _runtime_ctrl_rx) = runtime_ctrl_msg_channel(10);
+                let (completion_tx, mut completion_rx) = pipeline_completion_msg_channel(10);
+                ctx.set_runtime_ctrl_sender(runtime_ctrl_tx);
+                ctx.set_pipeline_completion_sender(completion_tx);
+
+                let log_records = create_log_records(&["ERROR", "INFO"]);
+                let input = to_otap_logs(log_records);
+
+                let upstream_node_id = 999;
+                let pdata = create_pdata_with_subscriber(
+                    input,
+                    Interests::ACKS | Interests::NACKS,
+                    1,
+                    upstream_node_id,
+                );
+
+                ctx.process(Message::PData(pdata))
+                    .await
+                    .expect("no process error");
+
+                let (outbound_ctx_default, _) = ctx.drain_pdata().await.pop().unwrap().into_parts();
+                let (outbound_ctx_routed, _) = error_port_rx.recv().await.unwrap().into_parts();
+
+                // default output is ACK'd (downstream consumed the data)
+                send_ack(&mut ctx, outbound_ctx_default, SignalType::Logs)
+                    .await
+                    .unwrap();
+                assert!(completion_rx.is_empty());
+
+                // routed output is NACK'd with a transient error
+                send_nack(
+                    &mut ctx,
+                    outbound_ctx_routed,
+                    SignalType::Logs,
+                    "transient error on routed",
+                )
+                .await
+                .unwrap();
+
+                let completion = completion_rx.recv().await.unwrap();
+                match completion {
+                    PipelineCompletionMsg::DeliverNack { nack } => {
+                        let (node_id, nack) =
+                            next_nack(nack).expect("expected upstream nack subscriber");
+                        assert_eq!(node_id, upstream_node_id);
+                        assert!(
+                            nack.permanent,
+                            "nack should be permanent when any downstream ACK'd (data was consumed)"
+                        );
+                        assert_eq!(nack.reason, "transient error on routed");
+                    }
+                    other => {
+                        panic!("expected DeliverNack, got {other:?}")
+                    }
+                };
+            })
+            .validate(|_ctx| async move {});
+    }
+
+    /// Scenario: A routed transform splits into a default output and a routed output. The
+    /// default output responds with a transient nack and the routed output responds with a
+    /// permanent nack.
+    /// Guarantees: The upstream nack is permanent because at least one downstream failure
+    /// was permanent (non-retryable).
+    #[test]
+    fn test_nack_permanence_one_permanent_nack() {
+        let runtime = TestRuntime::<OtapPdata>::new();
+        let query = r#"logs
+            | if (severity_text == "ERROR") {
+                route_to "error_port"
+            }
+            "#;
+        let mut processor = try_create_with_opl_query(query, &runtime).expect("created processor");
+        let error_port_rx = set_pdata_sender("error_port", &mut processor);
+
+        runtime
+            .set_processor(processor)
+            .run_test(|mut ctx| async move {
+                let (runtime_ctrl_tx, _runtime_ctrl_rx) = runtime_ctrl_msg_channel(10);
+                let (completion_tx, mut completion_rx) = pipeline_completion_msg_channel(10);
+                ctx.set_runtime_ctrl_sender(runtime_ctrl_tx);
+                ctx.set_pipeline_completion_sender(completion_tx);
+
+                let log_records = create_log_records(&["ERROR", "INFO"]);
+                let input = to_otap_logs(log_records);
+
+                let upstream_node_id = 999;
+                let pdata = create_pdata_with_subscriber(
+                    input,
+                    Interests::ACKS | Interests::NACKS,
+                    1,
+                    upstream_node_id,
+                );
+
+                ctx.process(Message::PData(pdata))
+                    .await
+                    .expect("no process error");
+
+                let (outbound_ctx_default, _) = ctx.drain_pdata().await.pop().unwrap().into_parts();
+                let (outbound_ctx_routed, _) = error_port_rx.recv().await.unwrap().into_parts();
+
+                // default output responds with a transient nack
+                send_nack(
+                    &mut ctx,
+                    outbound_ctx_default,
+                    SignalType::Logs,
+                    "transient error on default",
+                )
+                .await
+                .unwrap();
+                assert!(completion_rx.is_empty());
+
+                // routed output responds with a permanent nack
+                send_permanent_nack(
+                    &mut ctx,
+                    outbound_ctx_routed,
+                    SignalType::Logs,
+                    "permanent error on routed",
+                )
+                .await
+                .unwrap();
+
+                let completion = completion_rx.recv().await.unwrap();
+                match completion {
+                    PipelineCompletionMsg::DeliverNack { nack } => {
+                        let (node_id, nack) =
+                            next_nack(nack).expect("expected upstream nack subscriber");
+                        assert_eq!(node_id, upstream_node_id);
+                        assert!(
+                            nack.permanent,
+                            "nack should be permanent when any downstream nack was permanent"
+                        );
+                        // first error wins
+                        assert_eq!(nack.reason, "transient error on default");
+                    }
+                    other => {
+                        panic!("expected DeliverNack, got {other:?}")
+                    }
+                };
+            })
+            .validate(|_ctx| async move {});
+    }
+
+    /// Scenario: A transform with a single output (no routing) receives a transient nack
+    /// from downstream.
+    /// Guarantees: The upstream nack is non-permanent since the only downstream failure
+    /// was transient.
+    #[test]
+    fn test_nack_permanence_single_transient_nack() {
+        let runtime = TestRuntime::<OtapPdata>::new();
+        let mut processor = try_create_with_opl_query("logs | route_to \"test_port\"", &runtime)
+            .expect("created processor");
+        let test_port_rx = set_pdata_sender("test_port", &mut processor);
+
+        runtime
+            .set_processor(processor)
+            .run_test(|mut ctx| async move {
+                let (runtime_ctrl_tx, _runtime_ctrl_rx) = runtime_ctrl_msg_channel(10);
+                let (completion_tx, mut completion_rx) = pipeline_completion_msg_channel(10);
+                ctx.set_runtime_ctrl_sender(runtime_ctrl_tx);
+                ctx.set_pipeline_completion_sender(completion_tx);
+
+                let input = to_otap_logs(vec![LogRecord::build().severity_text("ERROR").finish()]);
+                let upstream_node_id = 999;
+                let pdata = create_pdata_with_subscriber(
+                    input,
+                    Interests::ACKS | Interests::NACKS,
+                    1,
+                    upstream_node_id,
+                );
+
+                ctx.process(Message::PData(pdata))
+                    .await
+                    .expect("no process error");
+                assert!(ctx.drain_pdata().await.is_empty());
+
+                let (routed_context, _) = test_port_rx
+                    .recv()
+                    .await
+                    .expect("routed output")
+                    .into_parts();
+
+                send_nack(
+                    &mut ctx,
+                    routed_context,
+                    SignalType::Logs,
+                    "transient downstream error",
+                )
+                .await
+                .unwrap();
+
+                let completion = completion_rx.recv().await.unwrap();
+                match completion {
+                    PipelineCompletionMsg::DeliverNack { nack } => {
+                        let (node_id, nack) =
+                            next_nack(nack).expect("expected upstream nack subscriber");
+                        assert_eq!(node_id, upstream_node_id);
+                        assert!(
+                            !nack.permanent,
+                            "nack should be non-permanent for a single transient downstream error"
+                        );
+                        assert_eq!(nack.reason, "transient downstream error");
+                    }
+                    other => {
+                        panic!("expected DeliverNack, got {other:?}")
+                    }
+                };
+            })
+            .validate(|_ctx| async move {});
+    }
+
+    /// Scenario: A transform with a single output (no routing) receives a permanent nack
+    /// from downstream.
+    /// Guarantees: The upstream nack is permanent since the downstream failure was permanent.
+    #[test]
+    fn test_nack_permanence_single_permanent_nack() {
+        let runtime = TestRuntime::<OtapPdata>::new();
+        let mut processor = try_create_with_opl_query("logs | route_to \"test_port\"", &runtime)
+            .expect("created processor");
+        let test_port_rx = set_pdata_sender("test_port", &mut processor);
+
+        runtime
+            .set_processor(processor)
+            .run_test(|mut ctx| async move {
+                let (runtime_ctrl_tx, _runtime_ctrl_rx) = runtime_ctrl_msg_channel(10);
+                let (completion_tx, mut completion_rx) = pipeline_completion_msg_channel(10);
+                ctx.set_runtime_ctrl_sender(runtime_ctrl_tx);
+                ctx.set_pipeline_completion_sender(completion_tx);
+
+                let input = to_otap_logs(vec![LogRecord::build().severity_text("ERROR").finish()]);
+                let upstream_node_id = 999;
+                let pdata = create_pdata_with_subscriber(
+                    input,
+                    Interests::ACKS | Interests::NACKS,
+                    1,
+                    upstream_node_id,
+                );
+
+                ctx.process(Message::PData(pdata))
+                    .await
+                    .expect("no process error");
+                assert!(ctx.drain_pdata().await.is_empty());
+
+                let (routed_context, _) = test_port_rx
+                    .recv()
+                    .await
+                    .expect("routed output")
+                    .into_parts();
+
+                send_permanent_nack(
+                    &mut ctx,
+                    routed_context,
+                    SignalType::Logs,
+                    "permanent downstream error",
+                )
+                .await
+                .unwrap();
+
+                let completion = completion_rx.recv().await.unwrap();
+                match completion {
+                    PipelineCompletionMsg::DeliverNack { nack } => {
+                        let (node_id, nack) =
+                            next_nack(nack).expect("expected upstream nack subscriber");
+                        assert_eq!(node_id, upstream_node_id);
+                        assert!(
+                            nack.permanent,
+                            "nack should be permanent for a single permanent downstream error"
+                        );
+                        assert_eq!(nack.reason, "permanent downstream error");
+                    }
+                    other => {
+                        panic!("expected DeliverNack, got {other:?}")
+                    }
+                };
+            })
+            .validate(|_ctx| async move {});
+    }
+
+    /// Scenario: An inbound batch subscribes with RETURN_DATA interest and is NACK'd downstream.
+    /// Guarantees: The upstream nack includes the original inbound payload, allowing upstream
+    /// components (e.g. retry processors) to re-process the data.
+    #[test]
+    fn test_nack_includes_payload_when_return_data_requested() {
+        let runtime = TestRuntime::<OtapPdata>::new();
+        let mut processor = try_create_with_opl_query("logs | route_to \"test_port\"", &runtime)
+            .expect("created processor");
+        let test_port_rx = set_pdata_sender("test_port", &mut processor);
+
+        runtime
+            .set_processor(processor)
+            .run_test(|mut ctx| async move {
+                let (runtime_ctrl_tx, _runtime_ctrl_rx) = runtime_ctrl_msg_channel(10);
+                let (completion_tx, mut completion_rx) = pipeline_completion_msg_channel(10);
+                ctx.set_runtime_ctrl_sender(runtime_ctrl_tx);
+                ctx.set_pipeline_completion_sender(completion_tx);
+
+                let input = to_otap_logs(vec![LogRecord::build().severity_text("ERROR").finish()]);
+                let expected_num_items = OtapPayload::from(input.clone()).num_items();
+
+                let upstream_node_id = 999;
+                // subscribe with RETURN_DATA so payload is preserved during unwind
+                let pdata = create_pdata_with_subscriber(
+                    input,
+                    Interests::NACKS | Interests::RETURN_DATA,
+                    1,
+                    upstream_node_id,
+                );
+
+                ctx.process(Message::PData(pdata))
+                    .await
+                    .expect("no process error");
+                assert!(ctx.drain_pdata().await.is_empty());
+
+                let (routed_context, _) = test_port_rx
+                    .recv()
+                    .await
+                    .expect("routed output")
+                    .into_parts();
+
+                send_nack(
+                    &mut ctx,
+                    routed_context,
+                    SignalType::Logs,
+                    "downstream error",
+                )
+                .await
+                .unwrap();
+
+                let completion = completion_rx.recv().await.unwrap();
+                match completion {
+                    PipelineCompletionMsg::DeliverNack { nack } => {
+                        let (node_id, mut nack) =
+                            next_nack(nack).expect("expected upstream nack subscriber");
+                        assert_eq!(node_id, upstream_node_id);
+                        assert_eq!(
+                            nack.refused.num_items(),
+                            expected_num_items,
+                            "nack should include the original payload when RETURN_DATA is set"
+                        );
+                    }
+                    other => {
+                        panic!("expected DeliverNack, got {other:?}")
+                    }
+                };
+            })
+            .validate(|_ctx| async move {});
+    }
+
+    /// Scenario: An inbound batch subscribes with NACKS interest but without RETURN_DATA, and
+    /// is NACK'd downstream.
+    /// Guarantees: The upstream nack has an empty payload since the subscriber did not request
+    /// data return.
+    #[test]
+    fn test_nack_excludes_payload_when_return_data_not_requested() {
+        let runtime = TestRuntime::<OtapPdata>::new();
+        let mut processor = try_create_with_opl_query("logs | route_to \"test_port\"", &runtime)
+            .expect("created processor");
+        let test_port_rx = set_pdata_sender("test_port", &mut processor);
+
+        runtime
+            .set_processor(processor)
+            .run_test(|mut ctx| async move {
+                let (runtime_ctrl_tx, _runtime_ctrl_rx) = runtime_ctrl_msg_channel(10);
+                let (completion_tx, mut completion_rx) = pipeline_completion_msg_channel(10);
+                ctx.set_runtime_ctrl_sender(runtime_ctrl_tx);
+                ctx.set_pipeline_completion_sender(completion_tx);
+
+                let input = to_otap_logs(vec![LogRecord::build().severity_text("ERROR").finish()]);
+
+                let upstream_node_id = 999;
+                // subscribe with NACKS only -- no RETURN_DATA
+                let pdata =
+                    create_pdata_with_subscriber(input, Interests::NACKS, 1, upstream_node_id);
+
+                ctx.process(Message::PData(pdata))
+                    .await
+                    .expect("no process error");
+                assert!(ctx.drain_pdata().await.is_empty());
+
+                let (routed_context, _) = test_port_rx
+                    .recv()
+                    .await
+                    .expect("routed output")
+                    .into_parts();
+
+                send_nack(
+                    &mut ctx,
+                    routed_context,
+                    SignalType::Logs,
+                    "downstream error",
+                )
+                .await
+                .unwrap();
+
+                let completion = completion_rx.recv().await.unwrap();
+                match completion {
+                    PipelineCompletionMsg::DeliverNack { nack } => {
+                        let (node_id, mut nack) =
+                            next_nack(nack).expect("expected upstream nack subscriber");
+                        assert_eq!(node_id, upstream_node_id);
+                        assert_eq!(
+                            nack.refused.num_items(),
+                            0,
+                            "nack should have empty payload when RETURN_DATA is not set"
+                        );
+                    }
+                    other => {
+                        panic!("expected DeliverNack, got {other:?}")
+                    }
+                };
+            })
+            .validate(|_ctx| async move {});
+    }
+
+    /// Scenario: An inbound batch subscribes with RETURN_DATA interest and all downstream
+    /// outputs are ACK'd.
+    /// Guarantees: The upstream ack includes the original inbound payload.
+    #[test]
+    fn test_ack_includes_payload_when_return_data_requested() {
+        let runtime = TestRuntime::<OtapPdata>::new();
+        let mut processor = try_create_with_opl_query("logs | route_to \"test_port\"", &runtime)
+            .expect("created processor");
+        let test_port_rx = set_pdata_sender("test_port", &mut processor);
+
+        runtime
+            .set_processor(processor)
+            .run_test(|mut ctx| async move {
+                let (runtime_ctrl_tx, _runtime_ctrl_rx) = runtime_ctrl_msg_channel(10);
+                let (completion_tx, mut completion_rx) = pipeline_completion_msg_channel(10);
+                ctx.set_runtime_ctrl_sender(runtime_ctrl_tx);
+                ctx.set_pipeline_completion_sender(completion_tx);
+
+                let input = to_otap_logs(vec![LogRecord::build().severity_text("ERROR").finish()]);
+                let expected_num_items = OtapPayload::from(input.clone()).num_items();
+
+                let upstream_node_id = 999;
+                // subscribe with RETURN_DATA so payload is preserved during unwind
+                let pdata = create_pdata_with_subscriber(
+                    input,
+                    Interests::ACKS | Interests::RETURN_DATA,
+                    1,
+                    upstream_node_id,
+                );
+
+                ctx.process(Message::PData(pdata))
+                    .await
+                    .expect("no process error");
+                assert!(ctx.drain_pdata().await.is_empty());
+
+                let (routed_context, _) = test_port_rx
+                    .recv()
+                    .await
+                    .expect("routed output")
+                    .into_parts();
+
+                send_ack(&mut ctx, routed_context, SignalType::Logs)
+                    .await
+                    .unwrap();
+
+                let completion = completion_rx.recv().await.unwrap();
+                match completion {
+                    PipelineCompletionMsg::DeliverAck { ack } => {
+                        let (node_id, mut ack) =
+                            next_ack(ack).expect("expected upstream ack subscriber");
+                        assert_eq!(node_id, upstream_node_id);
+                        assert_eq!(
+                            ack.accepted.num_items(),
+                            expected_num_items,
+                            "ack should include the original payload when RETURN_DATA is set"
+                        );
+                    }
+                    other => {
+                        panic!("expected DeliverAck, got {other:?}")
                     }
                 };
             })

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -52,7 +52,7 @@ use otel_arrow_dfe_engine::{
     ProcessorFactory, ProducerEffectHandlerExtension,
     config::ProcessorConfig,
     context::PipelineContext,
-    control::{AckMsg, NackMsg, NodeControlMsg},
+    control::{AckMsg, NackCause, NackMsg, NodeControlMsg},
     error::{Error as EngineError, ProcessorErrorKind},
     local::processor::{EffectHandler, Processor},
     message::Message,
@@ -61,7 +61,10 @@ use otel_arrow_dfe_engine::{
 };
 use otel_arrow_dfe_otap::{
     OTAP_PROCESSOR_FACTORIES,
-    accessory::{context::split_contexts::Contexts, slots::Key},
+    accessory::{
+        context::split_contexts::{Contexts, OutboundError},
+        slots::Key,
+    },
     pdata::{Context, OtapPdata},
 };
 use otel_arrow_dfe_pdata::TryIntoWithOptions;
@@ -461,7 +464,10 @@ impl TransformProcessor {
                         // record the partial-send failure so that closure sends a NACK.
                         self.contexts.set_failed_inbound(
                             inbound_ctx_key,
-                            "outbound slots were not available".into(),
+                            OutboundError {
+                                reason: "outbound slots were not available".into(),
+                                cause: NackCause::RouteFull,
+                            },
                         );
                     } else {
                         // No default or named output was registered, so nothing can
@@ -513,12 +519,12 @@ impl TransformProcessor {
             // which means we can now Ack or Nack the inbound context
             let payload = inbound.payload.unwrap_or(OtapPayload::empty(signal_type));
             let pdata = OtapPdata::new(inbound.context, payload);
-            if let Some(error) = inbound.error_reason {
+            if let Some(error) = inbound.error {
                 let nack_msg = if inbound.outbound_all_transient_errors {
                     // this constructor creates a non-permanent Nack
-                    NackMsg::new(error, pdata)
+                    NackMsg::new_with_cause(error.reason, pdata, error.cause)
                 } else {
-                    NackMsg::new_permanent(error, pdata)
+                    NackMsg::new_permanent_with_cause(error.reason, pdata, error.cause)
                 };
                 effect_handler.notify_nack(nack_msg).await
             } else {
@@ -596,8 +602,13 @@ impl Processor<OtapPdata> for TransformProcessor {
                 }
                 NodeControlMsg::Nack(nack_message) => {
                     let outbound_key: Key = nack_message.unwind.route.calldata.try_into()?;
-                    self.contexts
-                        .set_failed_outbound(outbound_key, nack_message.reason);
+                    self.contexts.set_failed_outbound(
+                        outbound_key,
+                        OutboundError {
+                            reason: nack_message.reason,
+                            cause: nack_message.cause,
+                        },
+                    );
                     if nack_message.permanent {
                         self.contexts
                             .set_outbound_all_transient_errors(outbound_key, false);
@@ -911,10 +922,12 @@ mod test {
         context: Context,
         signal_type: SignalType,
         reason: &str,
+        cause: NackCause,
     ) -> Result<(), EngineError> {
-        let nack = next_nack(NackMsg::new(
+        let nack = next_nack(NackMsg::new_with_cause(
             reason,
             OtapPdata::new(context, OtapPayload::empty(signal_type)),
+            cause,
         ));
         let (_, nack) = nack.unwrap();
         ctx.process(Message::Control(NodeControlMsg::Nack(nack)))
@@ -927,10 +940,12 @@ mod test {
         context: Context,
         signal_type: SignalType,
         reason: &str,
+        cause: NackCause,
     ) -> Result<(), EngineError> {
-        let nack = next_nack(NackMsg::new_permanent(
+        let nack = next_nack(NackMsg::new_permanent_with_cause(
             reason,
             OtapPdata::new(context, OtapPayload::empty(signal_type)),
+            cause,
         ));
         let (_, nack) = nack.unwrap();
         ctx.process(Message::Control(NodeControlMsg::Nack(nack)))
@@ -1854,6 +1869,7 @@ mod test {
                     routed_context,
                     SignalType::Logs,
                     "downstream routed error",
+                    NackCause::NodeShutdown,
                 )
                 .await
                 .expect("nack routed output");
@@ -1864,6 +1880,7 @@ mod test {
                             next_nack(nack).expect("expected upstream subscriber");
                         assert_eq!(node_id, 999);
                         assert_eq!(nack.reason, "downstream routed error");
+                        assert_eq!(nack.cause, NackCause::NodeShutdown)
                     }
                     other => panic!("expected DeliverNack, got {other:?}"),
                 }
@@ -2754,6 +2771,7 @@ mod test {
                     outbound_ctx_routed,
                     SignalType::Logs,
                     "downstream routed error",
+                    NackCause::Refused,
                 )
                 .await
                 .unwrap();
@@ -2766,6 +2784,7 @@ mod test {
                         let (node_id, nack) = next_nack(nack).expect("expected nack subscriber");
                         assert_eq!(node_id, upstream_node_id);
                         assert_eq!(nack.reason, "downstream routed error");
+                        assert_eq!(nack.cause, NackCause::Refused)
                     }
                     other => {
                         panic!("got unexpected pipeline ctrl message {other:?}")
@@ -2835,6 +2854,7 @@ mod test {
                     outbound_ctx_default,
                     SignalType::Logs,
                     "downstream default error",
+                    NackCause::RouteFull,
                 )
                 .await
                 .unwrap();
@@ -2854,6 +2874,7 @@ mod test {
                         let (node_id, nack) = next_nack(nack).expect("expected nack subscriber");
                         assert_eq!(node_id, upstream_node_id);
                         assert_eq!(nack.reason, "downstream default error");
+                        assert_eq!(nack.cause, NackCause::RouteFull)
                     }
                     other => {
                         panic!("got unexpected pipeline ctrl message {other:?}")
@@ -2944,6 +2965,7 @@ mod test {
                         let (node_id, nack) = next_nack(nack).expect("expected nack subscriber");
                         assert_eq!(node_id, upstream_node_id);
                         assert_eq!(nack.reason, "outbound slots were not available");
+                        assert_eq!(nack.cause, NackCause::RouteFull);
                     }
                     other => {
                         panic!("got unexpected pipeline ctrl message {other:?}")
@@ -3060,6 +3082,7 @@ mod test {
                             next_nack(nack).expect("expected upstream subscriber");
                         assert_eq!(node_id, 999);
                         assert_eq!(nack.reason, "outbound slots were not available");
+                        assert_eq!(nack.cause, NackCause::RouteFull);
                     }
                     other => panic!("expected DeliverNack, got {other:?}"),
                 }
@@ -3505,6 +3528,7 @@ mod test {
                     outbound_ctx_default,
                     SignalType::Logs,
                     "transient error on default",
+                    NackCause::Refused,
                 )
                 .await
                 .unwrap();
@@ -3518,6 +3542,7 @@ mod test {
                     outbound_ctx_routed,
                     SignalType::Logs,
                     "transient error on routed",
+                    NackCause::NodeShutdown,
                 )
                 .await
                 .unwrap();
@@ -3535,6 +3560,7 @@ mod test {
                         );
                         // first error wins
                         assert_eq!(nack.reason, "transient error on default");
+                        assert_eq!(nack.cause, NackCause::Refused);
                     }
                     other => {
                         panic!("expected DeliverNack, got {other:?}")
@@ -3597,6 +3623,7 @@ mod test {
                     outbound_ctx_routed,
                     SignalType::Logs,
                     "transient error on routed",
+                    NackCause::Refused,
                 )
                 .await
                 .unwrap();
@@ -3612,6 +3639,7 @@ mod test {
                             "nack should be permanent when any downstream ACK'd (data was consumed)"
                         );
                         assert_eq!(nack.reason, "transient error on routed");
+                        assert_eq!(nack.cause, NackCause::Refused);
                     }
                     other => {
                         panic!("expected DeliverNack, got {other:?}")
@@ -3669,6 +3697,7 @@ mod test {
                     outbound_ctx_default,
                     SignalType::Logs,
                     "transient error on default",
+                    NackCause::RouteClosed,
                 )
                 .await
                 .unwrap();
@@ -3680,6 +3709,7 @@ mod test {
                     outbound_ctx_routed,
                     SignalType::Logs,
                     "permanent error on routed",
+                    NackCause::NodeShutdown,
                 )
                 .await
                 .unwrap();
@@ -3696,6 +3726,7 @@ mod test {
                         );
                         // first error wins
                         assert_eq!(nack.reason, "transient error on default");
+                        assert_eq!(nack.cause, NackCause::RouteClosed);
                     }
                     other => {
                         panic!("expected DeliverNack, got {other:?}")
@@ -3749,6 +3780,7 @@ mod test {
                     routed_context,
                     SignalType::Logs,
                     "transient downstream error",
+                    NackCause::Refused,
                 )
                 .await
                 .unwrap();
@@ -3764,6 +3796,7 @@ mod test {
                             "nack should be non-permanent for a single transient downstream error"
                         );
                         assert_eq!(nack.reason, "transient downstream error");
+                        assert_eq!(nack.cause, NackCause::Refused);
                     }
                     other => {
                         panic!("expected DeliverNack, got {other:?}")
@@ -3816,6 +3849,7 @@ mod test {
                     routed_context,
                     SignalType::Logs,
                     "permanent downstream error",
+                    NackCause::Refused,
                 )
                 .await
                 .unwrap();
@@ -3831,6 +3865,7 @@ mod test {
                             "nack should be permanent for a single permanent downstream error"
                         );
                         assert_eq!(nack.reason, "permanent downstream error");
+                        assert_eq!(nack.cause, NackCause::Refused);
                     }
                     other => {
                         panic!("expected DeliverNack, got {other:?}")
@@ -3886,6 +3921,7 @@ mod test {
                     routed_context,
                     SignalType::Logs,
                     "downstream error",
+                    NackCause::Refused,
                 )
                 .await
                 .unwrap();
@@ -3901,6 +3937,7 @@ mod test {
                             expected_num_items,
                             "nack should include the original payload when RETURN_DATA is set"
                         );
+                        assert_eq!(nack.cause, NackCause::Refused);
                     }
                     other => {
                         panic!("expected DeliverNack, got {other:?}")
@@ -3952,6 +3989,7 @@ mod test {
                     routed_context,
                     SignalType::Logs,
                     "downstream error",
+                    NackCause::RouteClosed,
                 )
                 .await
                 .unwrap();
@@ -3967,6 +4005,7 @@ mod test {
                             0,
                             "nack should have empty payload when RETURN_DATA is not set"
                         );
+                        assert_eq!(nack.cause, NackCause::RouteClosed);
                     }
                     other => {
                         panic!("expected DeliverNack, got {other:?}")

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -882,7 +882,7 @@ mod test {
             .await
     }
 
-    /// Helper to send a Nack for a given context
+    /// Helper to send a non-permanent Nack for a given context
     async fn send_nack(
         ctx: &mut TestContext<OtapPdata>,
         context: Context,
@@ -890,6 +890,23 @@ mod test {
         reason: &str,
     ) -> Result<(), EngineError> {
         let nack = next_nack(NackMsg::new(
+            reason,
+            OtapPdata::new(context, OtapPayload::empty(signal_type)),
+        ));
+        let (_, nack) = nack.unwrap();
+        ctx.process(Message::Control(NodeControlMsg::Nack(nack)))
+            .await
+    }
+
+    /// Helper to send a permanent Nack for a given context
+    #[allow(dead_code)]
+    async fn send_permanent_nack(
+        ctx: &mut TestContext<OtapPdata>,
+        context: Context,
+        signal_type: SignalType,
+        reason: &str,
+    ) -> Result<(), EngineError> {
+        let nack = next_nack(NackMsg::new_permanent(
             reason,
             OtapPdata::new(context, OtapPayload::empty(signal_type)),
         ));
@@ -3416,5 +3433,92 @@ mod test {
                 );
             })
             .validate(|_ctx| async move {})
+    }
+
+    /// Scenario: A routed transform splits into a default output and a routed output, and both
+    /// downstream consumers respond with non-permanent (transient) nacks.
+    /// Guarantees: The upstream inbound batch receives a non-permanent nack, indicating the
+    /// failure is retryable since all downstream failures were transient.
+    #[test]
+    fn test_nack_permanence_all_transient_nacks() {
+        let runtime = TestRuntime::<OtapPdata>::new();
+        let query = r#"logs
+            | if (severity_text == "ERROR") {
+                route_to "error_port"
+            }
+            "#;
+        let mut processor = try_create_with_opl_query(query, &runtime).expect("created processor");
+        let error_port_rx = set_pdata_sender("error_port", &mut processor);
+
+        runtime
+            .set_processor(processor)
+            .run_test(|mut ctx| async move {
+                let (runtime_ctrl_tx, _runtime_ctrl_rx) = runtime_ctrl_msg_channel(10);
+                let (completion_tx, mut completion_rx) = pipeline_completion_msg_channel(10);
+                ctx.set_runtime_ctrl_sender(runtime_ctrl_tx);
+                ctx.set_pipeline_completion_sender(completion_tx);
+
+                let log_records = create_log_records(&["ERROR", "INFO"]);
+                let input = to_otap_logs(log_records);
+
+                let upstream_node_id = 999;
+                let pdata = create_pdata_with_subscriber(
+                    input,
+                    Interests::ACKS | Interests::NACKS,
+                    1,
+                    upstream_node_id,
+                );
+
+                ctx.process(Message::PData(pdata))
+                    .await
+                    .expect("no process error");
+
+                // collect outbound contexts from both outputs
+                let (outbound_ctx_default, _) = ctx.drain_pdata().await.pop().unwrap().into_parts();
+                let (outbound_ctx_routed, _) = error_port_rx.recv().await.unwrap().into_parts();
+
+                // both downstream consumers respond with transient (non-permanent) nacks
+                send_nack(
+                    &mut ctx,
+                    outbound_ctx_default,
+                    SignalType::Logs,
+                    "transient error on default",
+                )
+                .await
+                .unwrap();
+                assert!(
+                    completion_rx.is_empty(),
+                    "upstream must not complete until all outbound batches are resolved"
+                );
+
+                send_nack(
+                    &mut ctx,
+                    outbound_ctx_routed,
+                    SignalType::Logs,
+                    "transient error on routed",
+                )
+                .await
+                .unwrap();
+
+                // the upstream inbound batch should now receive a non-permanent nack
+                let completion = completion_rx.recv().await.unwrap();
+                match completion {
+                    PipelineCompletionMsg::DeliverNack { nack } => {
+                        let (node_id, nack) =
+                            next_nack(nack).expect("expected upstream nack subscriber");
+                        assert_eq!(node_id, upstream_node_id);
+                        assert!(
+                            !nack.permanent,
+                            "nack should be non-permanent when all downstream errors are transient"
+                        );
+                        // first error wins
+                        assert_eq!(nack.reason, "transient error on default");
+                    }
+                    other => {
+                        panic!("expected DeliverNack, got {other:?}")
+                    }
+                };
+            })
+            .validate(|_ctx| async move {});
     }
 }

--- a/rust/otap-dataflow/crates/otap/src/accessory/context/split_contexts.rs
+++ b/rust/otap-dataflow/crates/otap/src/accessory/context/split_contexts.rs
@@ -71,6 +71,7 @@ impl Contexts {
     /// # Parameters
     ///
     /// - `context`: The context of the inbound batch.
+    /// - `payload`: The payload of the inbound batch.
     /// - `error_reason`: The error may have occurred processing the inbound batch.
     pub fn insert_inbound(
         &mut self,

--- a/rust/otap-dataflow/crates/otap/src/accessory/context/split_contexts.rs
+++ b/rust/otap-dataflow/crates/otap/src/accessory/context/split_contexts.rs
@@ -509,4 +509,105 @@ mod test {
             "Should complete after clearing the second (and last) outbound"
         );
     }
+
+    /// Scenario: An outbound key's transient-errors flag is explicitly set to false.
+    /// Guarantees: The inbound returned from clear_outbound reflects the updated flag value.
+    #[test]
+    fn test_set_outbound_all_transient_errors_to_false() {
+        let mut contexts = new_contexts();
+        let context = create_context_with_subscribers();
+        let inbound_key = contexts.insert_inbound(context, None, None).unwrap();
+        let outbound_key = contexts.insert_outbound(inbound_key).unwrap();
+
+        // set the flag to false (simulating an ACK or permanent NACK downstream)
+        contexts.set_outbound_all_transient_errors(outbound_key, false);
+
+        let inbound = contexts.clear_outbound(outbound_key).unwrap();
+        assert!(
+            !inbound.outbound_all_transient_errors,
+            "flag should be false after being explicitly set to false"
+        );
+    }
+
+    /// Scenario: set_outbound_all_transient_errors is called with a key from a different
+    /// Contexts instance.
+    /// Guarantees: The call does not panic when the outbound key is not found.
+    #[test]
+    fn test_set_outbound_all_transient_errors_with_invalid_key() {
+        let mut contexts = new_contexts();
+
+        let invalid_key = {
+            let mut temp_contexts = new_contexts();
+            let ctx = create_context_with_subscribers();
+            let inbound_key = temp_contexts.insert_inbound(ctx, None, None).unwrap();
+            temp_contexts.insert_outbound(inbound_key).unwrap()
+        };
+
+        // should not panic
+        contexts.set_outbound_all_transient_errors(invalid_key, false);
+    }
+
+    /// Scenario: An inbound batch is inserted with an associated payload.
+    /// Guarantees: The payload is preserved and returned when the inbound is completed
+    /// via clear_outbound.
+    #[test]
+    fn test_insert_inbound_with_payload() {
+        let mut contexts = new_contexts();
+        let pdata = create_test_pdata();
+        let (context, payload) = pdata.into_parts();
+
+        // subscribe so context needs completion tracking
+        let pdata = crate::pdata::OtapPdata::new(context, payload).test_subscribe_to(
+            otel_arrow_dfe_engine::Interests::ACKS,
+            smallvec::smallvec![otel_arrow_dfe_engine::control::Context8u8::from(1u64)],
+            1,
+        );
+        let (context, payload) = pdata.into_parts();
+
+        let inbound_key = contexts
+            .insert_inbound(context, Some(payload.clone()), None)
+            .unwrap();
+        assert!(!inbound_key.is_null());
+
+        let outbound_key = contexts.insert_outbound(inbound_key).unwrap();
+        let inbound = contexts.clear_outbound(outbound_key).unwrap();
+
+        assert!(
+            inbound.payload.is_some(),
+            "payload should be preserved in inbound"
+        );
+        assert_eq!(
+            inbound.payload.unwrap().signal_type(),
+            payload.signal_type(),
+            "returned payload should match the original"
+        );
+    }
+
+    /// Scenario: Multiple outbounds share one inbound, and set_outbound_all_transient_errors
+    /// is called with false on only one of them.
+    /// Guarantees: The inbound's flag is false after all outbounds are cleared, because
+    /// the flag can only transition from true to false (never back).
+    #[test]
+    fn test_multiple_outbounds_transient_errors_flag_set_false_on_one() {
+        let mut contexts = new_contexts();
+        let context = create_context_with_subscribers();
+        let inbound_key = contexts.insert_inbound(context, None, None).unwrap();
+
+        let outbound_key1 = contexts.insert_outbound(inbound_key).unwrap();
+        let outbound_key2 = contexts.insert_outbound(inbound_key).unwrap();
+        let outbound_key3 = contexts.insert_outbound(inbound_key).unwrap();
+
+        // only set false on one outbound (e.g. it was ACK'd)
+        contexts.set_outbound_all_transient_errors(outbound_key2, false);
+
+        // clear all outbounds
+        assert!(contexts.clear_outbound(outbound_key1).is_none());
+        assert!(contexts.clear_outbound(outbound_key2).is_none());
+
+        let inbound = contexts.clear_outbound(outbound_key3).unwrap();
+        assert!(
+            !inbound.outbound_all_transient_errors,
+            "flag should be false because at least one outbound set it to false"
+        );
+    }
 }

--- a/rust/otap-dataflow/crates/otap/src/accessory/context/split_contexts.rs
+++ b/rust/otap-dataflow/crates/otap/src/accessory/context/split_contexts.rs
@@ -5,6 +5,7 @@
 //! produced by processors that may split the incoming batch into
 //! multiple outbound batches
 
+use otel_arrow_dfe_pdata::OtapPayload;
 use slotmap::Key as _;
 use std::num::NonZeroUsize;
 
@@ -13,10 +14,24 @@ use crate::{
     pdata::Context,
 };
 
-struct Inbound {
-    context: Context,
-    error_reason: Option<String>,
+/// Context for inbound batch
+pub struct Inbound {
+    /// the pdata context for the inbound batch
+    pub context: Context,
+    
+    /// the payload for the inbound batch
+    pub payload: Option<OtapPayload>,
+    
+    /// error that may have been produced via processing for some outbound batch
+    pub error_reason: Option<String>,
+
     num_outbound: usize,
+    
+    /// Whether all the downstream batches resulted in errors which were transient.
+    /// If so, we could emit a Nack for the inbound batch that is transient, otherwise
+    /// if there are any errors we must emit a permanent Nack.
+    pub outbound_all_transient_errors: bool,
+
 }
 
 struct Outbound {
@@ -61,6 +76,7 @@ impl Contexts {
     pub fn insert_inbound(
         &mut self,
         context: Context,
+        payload: Option<OtapPayload>,
         error_reason: Option<String>,
     ) -> Option<Key> {
         if !context.needs_completion_tracking() {
@@ -71,7 +87,12 @@ impl Contexts {
         let inbound = Inbound {
             context,
             num_outbound: 0,
+            payload,
             error_reason,
+            
+            // initialize to true, can be set to false if/when there are any outbound batch results
+            // that are not a non-permanent Nack
+            outbound_all_transient_errors: true,
         };
 
         self.inbound.allocate(|| (inbound, ())).map(|(key, _)| key)
@@ -132,7 +153,7 @@ impl Contexts {
     /// Returns `Some((context, error_reason))` if the inbound slot is now empty. This would mean that
     /// all outbound batches for this inbound slot have been processed and the
     /// inbound batch can be completed.
-    pub fn clear_outbound(&mut self, outbound_key: Key) -> Option<(Context, Option<String>)> {
+    pub fn clear_outbound(&mut self, outbound_key: Key) -> Option<Inbound> {
         let inbound_key = {
             let outbound = self.outbound.take(outbound_key)?;
             outbound.inbound_key
@@ -146,11 +167,22 @@ impl Contexts {
 
         if num_outbound == 0 {
             let inbound = self.inbound.take(inbound_key)?;
-            Some((inbound.context, inbound.error_reason))
+            Some(inbound)
         } else {
             None
         }
     }
+
+    /// Set the value of `outbound_all_transient_errors` on the inbound context associated with
+    /// this outbound key. This should be set to `false` when any outbound succeeds (is ACk'd) or
+    /// is Nack'd with a permanent error.
+    pub fn set_outbound_all_transient_errors(&mut self, outbound_key: Key, value: bool) {
+        if let Some(inbound_key) = self.outbound.get(outbound_key).map(|o| o.inbound_key) {
+            if let Some(inbound) = self.inbound.get_mut(inbound_key) {
+                inbound.outbound_all_transient_errors = value
+            }
+        }
+    }    
 }
 
 #[cfg(test)]
@@ -187,7 +219,7 @@ mod test {
         let mut contexts = new_contexts();
         let original_context = create_context_with_subscribers();
         let inbound_key = contexts
-            .insert_inbound(original_context.clone(), None)
+            .insert_inbound(original_context.clone(), None, None)
             .unwrap();
         assert!(
             !inbound_key.is_null(),
@@ -210,7 +242,7 @@ mod test {
         let mut contexts = new_contexts();
         let original_context = create_context_without_subscribers();
         let key = contexts
-            .insert_inbound(original_context.clone(), None)
+            .insert_inbound(original_context.clone(), None, None)
             .unwrap();
         assert!(
             key.is_null(),
@@ -232,7 +264,7 @@ mod test {
         // Insert an inbound
         let original_context = create_context_with_subscribers();
         let inbound_key = contexts
-            .insert_inbound(original_context.clone(), None)
+            .insert_inbound(original_context.clone(), None, None)
             .unwrap();
 
         // Insert multiple outbounds
@@ -261,7 +293,7 @@ mod test {
         let invalid_key = {
             let mut temp_contexts = new_contexts();
             let ctx = create_context_with_subscribers();
-            let inbound_key = temp_contexts.insert_inbound(ctx, None).unwrap();
+            let inbound_key = temp_contexts.insert_inbound(ctx, None, None).unwrap();
             temp_contexts.insert_outbound(inbound_key).unwrap()
         };
 
@@ -277,7 +309,7 @@ mod test {
         let context = create_context_with_subscribers();
         let error_msg = "pipeline processing failed".to_string();
         let inbound_key = contexts
-            .insert_inbound(context, Some(error_msg.clone()))
+            .insert_inbound(context, None, Some(error_msg.clone()))
             .unwrap();
         let outbound_key = contexts.insert_outbound(inbound_key).unwrap();
 
@@ -293,7 +325,7 @@ mod test {
     fn test_double_clear_same_outbound() {
         let mut contexts = new_contexts();
         let context = create_context_with_subscribers();
-        let inbound_key = contexts.insert_inbound(context, None).unwrap();
+        let inbound_key = contexts.insert_inbound(context, None, None).unwrap();
         let outbound_key = contexts.insert_outbound(inbound_key).unwrap();
 
         // First clear should succeed
@@ -309,7 +341,7 @@ mod test {
     fn test_set_failed_single_outbound() {
         let mut contexts = new_contexts();
         let context = create_context_with_subscribers();
-        let inbound_key = contexts.insert_inbound(context, None).unwrap();
+        let inbound_key = contexts.insert_inbound(context, None, None).unwrap();
         let outbound_key = contexts.insert_outbound(inbound_key).unwrap();
 
         // Set the outbound as failed
@@ -328,7 +360,7 @@ mod test {
     fn test_set_failed_multiple_outbounds_first_error_wins() {
         let mut contexts = new_contexts();
         let context = create_context_with_subscribers();
-        let inbound_key = contexts.insert_inbound(context, None).unwrap();
+        let inbound_key = contexts.insert_inbound(context, None, None).unwrap();
 
         let outbound_key1 = contexts.insert_outbound(inbound_key).unwrap();
         let outbound_key2 = contexts.insert_outbound(inbound_key).unwrap();
@@ -371,7 +403,7 @@ mod test {
         let (original_context, _) = pdata.into_parts();
 
         let inbound_key = contexts
-            .insert_inbound(original_context.clone(), None)
+            .insert_inbound(original_context.clone(), None, None)
             .unwrap();
         assert!(!inbound_key.is_null());
 
@@ -389,7 +421,7 @@ mod test {
         let invalid_key = {
             let mut temp_contexts = new_contexts();
             let ctx = create_context_with_subscribers();
-            let inbound_key = temp_contexts.insert_inbound(ctx, None).unwrap();
+            let inbound_key = temp_contexts.insert_inbound(ctx, None, None).unwrap();
             temp_contexts.insert_outbound(inbound_key).unwrap()
         };
 
@@ -403,7 +435,7 @@ mod test {
 
         // Create a context without subscribers (results in null key)
         let context = create_context_without_subscribers();
-        let inbound_key = contexts.insert_inbound(context, None).unwrap();
+        let inbound_key = contexts.insert_inbound(context, None, None).unwrap();
         let outbound_key = contexts.insert_outbound(inbound_key).unwrap();
 
         assert!(outbound_key.is_null());
@@ -420,7 +452,7 @@ mod test {
         // Insert inbound with an initial error
         let inbound_error = "initial inbound error".to_string();
         let inbound_key = contexts
-            .insert_inbound(context, Some(inbound_error.clone()))
+            .insert_inbound(context, None, Some(inbound_error.clone()))
             .unwrap();
         let outbound_key = contexts.insert_outbound(inbound_key).unwrap();
 
@@ -444,7 +476,7 @@ mod test {
     fn test_clear_outbound_removes_outbound_from_slotmap() {
         let mut contexts = new_contexts();
         let context = create_context_with_subscribers();
-        let inbound_key = contexts.insert_inbound(context, None).unwrap();
+        let inbound_key = contexts.insert_inbound(context, None, None).unwrap();
 
         // Create two outbounds
         let outbound_key1 = contexts.insert_outbound(inbound_key).unwrap();

--- a/rust/otap-dataflow/crates/otap/src/accessory/context/split_contexts.rs
+++ b/rust/otap-dataflow/crates/otap/src/accessory/context/split_contexts.rs
@@ -5,6 +5,7 @@
 //! produced by processors that may split the incoming batch into
 //! multiple outbound batches
 
+use otel_arrow_dfe_engine::control::NackCause;
 use otel_arrow_dfe_pdata::OtapPayload;
 use slotmap::Key as _;
 use std::num::NonZeroUsize;
@@ -23,7 +24,7 @@ pub struct Inbound {
     pub payload: Option<OtapPayload>,
 
     /// error that may have been produced via processing for some outbound batch
-    pub error_reason: Option<String>,
+    pub error: Option<OutboundError>,
 
     num_outbound: usize,
 
@@ -31,6 +32,15 @@ pub struct Inbound {
     /// If so, we could emit a Nack for the inbound batch that is transient, otherwise
     /// if there are any errors we must emit a permanent Nack.
     pub outbound_all_transient_errors: bool,
+}
+
+/// represents error that may have been produced via processing for some outbound batch
+pub struct OutboundError {
+    /// reason for the error
+    pub reason: String,
+
+    /// identifier of cause of the error
+    pub cause: NackCause,
 }
 
 struct Outbound {
@@ -77,7 +87,7 @@ impl Contexts {
         &mut self,
         context: Context,
         payload: Option<OtapPayload>,
-        error_reason: Option<String>,
+        error: Option<OutboundError>,
     ) -> Option<Key> {
         if !context.needs_completion_tracking() {
             // No completion routing or metrics unwinding depends on this context.
@@ -88,7 +98,7 @@ impl Contexts {
             context,
             num_outbound: 0,
             payload,
-            error_reason,
+            error,
 
             // initialize to true, can be set to false if/when there are any outbound batch results
             // that are not a non-permanent Nack
@@ -124,19 +134,19 @@ impl Contexts {
 
     /// Set an error message on the inbound context associated with this outbound key explaining
     /// why the batch processing failed. Note - this method does not clear the outbound
-    pub fn set_failed_outbound(&mut self, outbound_key: Key, error_reason: String) {
+    pub fn set_failed_outbound(&mut self, outbound_key: Key, error: OutboundError) {
         if let Some(inbound_key) = self.outbound.get(outbound_key).map(|o| o.inbound_key) {
-            self.set_failed_inbound(inbound_key, error_reason);
+            self.set_failed_inbound(inbound_key, error);
         }
     }
 
     /// Set an error message on the inbound context associated with this key explaining why the
     /// batch processing failed.
-    pub fn set_failed_inbound(&mut self, inbound_key: Key, error_reason: String) {
+    pub fn set_failed_inbound(&mut self, inbound_key: Key, error: OutboundError) {
         if let Some(inbound) = self.inbound.get_mut(inbound_key) {
             // keep the original error if it exists
-            if inbound.error_reason.is_none() {
-                inbound.error_reason = Some(error_reason)
+            if inbound.error.is_none() {
+                inbound.error = Some(error)
             }
         }
     }
@@ -234,7 +244,7 @@ mod test {
 
         let inbound = contexts.clear_outbound(outbound_key).unwrap();
         assert_eq!(inbound.context, original_context);
-        assert_eq!(inbound.error_reason, None);
+        assert!(inbound.error.is_none());
         assert!(inbound.outbound_all_transient_errors);
         assert!(inbound.payload.is_none());
     }
@@ -284,7 +294,7 @@ mod test {
 
         let inbound = contexts.clear_outbound(outbound_key3).unwrap();
         assert_eq!(inbound.context, original_context);
-        assert_eq!(inbound.error_reason, None);
+        assert!(inbound.error.is_none());
         assert!(inbound.outbound_all_transient_errors);
         assert!(inbound.payload.is_none());
     }
@@ -313,7 +323,14 @@ mod test {
         let context = create_context_with_subscribers();
         let error_msg = "pipeline processing failed".to_string();
         let inbound_key = contexts
-            .insert_inbound(context, None, Some(error_msg.clone()))
+            .insert_inbound(
+                context,
+                None,
+                Some(OutboundError {
+                    reason: error_msg.clone(),
+                    cause: NackCause::Refused,
+                }),
+            )
             .unwrap();
         let outbound_key = contexts.insert_outbound(inbound_key).unwrap();
 
@@ -321,8 +338,10 @@ mod test {
         let result = contexts.clear_outbound(outbound_key);
         assert!(result.is_some());
         let inbound = result.unwrap();
-        assert!(inbound.error_reason.is_some());
-        assert_eq!(inbound.error_reason.unwrap(), error_msg);
+        assert!(inbound.error.is_some());
+        let inbound_err = inbound.error.unwrap();
+        assert_eq!(inbound_err.reason, error_msg);
+        assert_eq!(inbound_err.cause, NackCause::Refused);
     }
 
     #[test]
@@ -350,14 +369,21 @@ mod test {
 
         // Set the outbound as failed
         let error_msg = "export failed".to_string();
-        contexts.set_failed_outbound(outbound_key, error_msg.clone());
+        contexts.set_failed_outbound(
+            outbound_key,
+            OutboundError {
+                reason: error_msg.clone(),
+                cause: NackCause::RouteFull,
+            },
+        );
 
         // Clear the outbound and verify error is returned
         let result = contexts.clear_outbound(outbound_key);
         assert!(result.is_some());
         let inbound = result.unwrap();
-        assert!(inbound.error_reason.is_some());
-        assert_eq!(inbound.error_reason.unwrap(), error_msg);
+        let error = inbound.error.unwrap();
+        assert_eq!(error.reason, error_msg);
+        assert_eq!(error.cause, NackCause::RouteFull)
     }
 
     #[test]
@@ -372,11 +398,23 @@ mod test {
 
         // Set first outbound as failed
         let error_msg1 = "first error".to_string();
-        contexts.set_failed_outbound(outbound_key1, error_msg1.clone());
+        contexts.set_failed_outbound(
+            outbound_key1,
+            OutboundError {
+                reason: error_msg1.clone(),
+                cause: NackCause::NodeShutdown,
+            },
+        );
 
         // Set second outbound as failed (should be ignored since error_reason is already set)
         let error_msg2 = "second error".to_string();
-        contexts.set_failed_outbound(outbound_key2, error_msg2.clone());
+        contexts.set_failed_outbound(
+            outbound_key2,
+            OutboundError {
+                reason: error_msg2.clone(),
+                cause: NackCause::Unspecified,
+            },
+        );
 
         // Clear all outbounds
         assert!(contexts.clear_outbound(outbound_key1).is_none());
@@ -386,12 +424,9 @@ mod test {
         let result = contexts.clear_outbound(outbound_key3);
         assert!(result.is_some());
         let inbound = result.unwrap();
-        assert!(inbound.error_reason.is_some());
-        assert_eq!(
-            inbound.error_reason.unwrap(),
-            error_msg1,
-            "First error should be preserved"
-        );
+        let error = inbound.error.unwrap();
+        assert_eq!(error.reason, error_msg1, "First error should be preserved");
+        assert_eq!(error.cause, NackCause::NodeShutdown)
     }
 
     /// Scenario: A split input has pipeline metric interests but no Ack/Nack subscriber.
@@ -414,7 +449,7 @@ mod test {
         let outbound_key = contexts.insert_outbound(inbound_key).unwrap();
         let inbound = contexts.clear_outbound(outbound_key).unwrap();
         assert_eq!(inbound.context, original_context);
-        assert!(inbound.error_reason.is_none());
+        assert!(inbound.error.is_none());
     }
 
     #[test]
@@ -430,7 +465,13 @@ mod test {
         };
 
         // Setting failed with invalid key should not panic
-        contexts.set_failed_outbound(invalid_key, "error".to_string());
+        contexts.set_failed_outbound(
+            invalid_key,
+            OutboundError {
+                reason: "error".to_string(),
+                cause: NackCause::Refused,
+            },
+        );
     }
 
     #[test]
@@ -445,7 +486,13 @@ mod test {
         assert!(outbound_key.is_null());
 
         // Setting failed with null key should not panic
-        contexts.set_failed_outbound(outbound_key, "error".to_string());
+        contexts.set_failed_outbound(
+            outbound_key,
+            OutboundError {
+                reason: "error".to_string(),
+                cause: NackCause::Refused,
+            },
+        );
     }
 
     #[test]
@@ -456,24 +503,42 @@ mod test {
         // Insert inbound with an initial error
         let inbound_error = "initial inbound error".to_string();
         let inbound_key = contexts
-            .insert_inbound(context, None, Some(inbound_error.clone()))
+            .insert_inbound(
+                context,
+                None,
+                Some(OutboundError {
+                    reason: inbound_error.clone(),
+                    cause: NackCause::RouteClosed,
+                }),
+            )
             .unwrap();
         let outbound_key = contexts.insert_outbound(inbound_key).unwrap();
 
         // Try to set a different error via set_failed
         let outbound_error = "outbound error".to_string();
-        contexts.set_failed_outbound(outbound_key, outbound_error);
+        contexts.set_failed_outbound(
+            outbound_key,
+            OutboundError {
+                reason: outbound_error,
+                cause: NackCause::Refused,
+            },
+        );
 
         // Clear outbound and verify the original inbound error is preserved
         let result = contexts.clear_outbound(outbound_key);
         assert!(result.is_some());
         let inbound = result.unwrap();
-        assert!(inbound.error_reason.is_some());
+        let error = inbound.error.unwrap();
+
         assert_eq!(
-            inbound.error_reason.unwrap(),
-            inbound_error,
+            error.reason, inbound_error,
             "Original inbound error should be preserved"
         );
+        assert_eq!(
+            error.cause,
+            NackCause::RouteClosed,
+            "Original inbound error should be preserved"
+        )
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/otap/src/accessory/context/split_contexts.rs
+++ b/rust/otap-dataflow/crates/otap/src/accessory/context/split_contexts.rs
@@ -18,20 +18,19 @@ use crate::{
 pub struct Inbound {
     /// the pdata context for the inbound batch
     pub context: Context,
-    
+
     /// the payload for the inbound batch
     pub payload: Option<OtapPayload>,
-    
+
     /// error that may have been produced via processing for some outbound batch
     pub error_reason: Option<String>,
 
     num_outbound: usize,
-    
+
     /// Whether all the downstream batches resulted in errors which were transient.
     /// If so, we could emit a Nack for the inbound batch that is transient, otherwise
     /// if there are any errors we must emit a permanent Nack.
     pub outbound_all_transient_errors: bool,
-
 }
 
 struct Outbound {
@@ -89,7 +88,7 @@ impl Contexts {
             num_outbound: 0,
             payload,
             error_reason,
-            
+
             // initialize to true, can be set to false if/when there are any outbound batch results
             // that are not a non-permanent Nack
             outbound_all_transient_errors: true,
@@ -182,7 +181,7 @@ impl Contexts {
                 inbound.outbound_all_transient_errors = value
             }
         }
-    }    
+    }
 }
 
 #[cfg(test)]
@@ -232,9 +231,11 @@ mod test {
             "outbound key should not be null when there are subscribers"
         );
 
-        let (inbound_ctx, error_reason) = contexts.clear_outbound(outbound_key).unwrap();
-        assert_eq!(original_context, inbound_ctx);
-        assert_eq!(error_reason, None);
+        let inbound = contexts.clear_outbound(outbound_key).unwrap();
+        assert_eq!(inbound.context, original_context);
+        assert_eq!(inbound.error_reason, None);
+        assert!(inbound.outbound_all_transient_errors);
+        assert!(inbound.payload.is_none());
     }
 
     #[test]
@@ -280,9 +281,11 @@ mod test {
         assert!(contexts.clear_outbound(outbound_key2).is_none());
         assert!(contexts.clear_outbound(outbound_key1).is_none());
 
-        let (inbound_ctx, error_reason) = contexts.clear_outbound(outbound_key3).unwrap();
-        assert_eq!(original_context, inbound_ctx);
-        assert_eq!(error_reason, None);
+        let inbound = contexts.clear_outbound(outbound_key3).unwrap();
+        assert_eq!(inbound.context, original_context);
+        assert_eq!(inbound.error_reason, None);
+        assert!(inbound.outbound_all_transient_errors);
+        assert!(inbound.payload.is_none());
     }
 
     #[test]
@@ -316,9 +319,9 @@ mod test {
         // Clear outbound and check error is returned
         let result = contexts.clear_outbound(outbound_key);
         assert!(result.is_some());
-        let (_, error_reason) = result.unwrap();
-        assert!(error_reason.is_some());
-        assert_eq!(error_reason.unwrap(), error_msg);
+        let inbound = result.unwrap();
+        assert!(inbound.error_reason.is_some());
+        assert_eq!(inbound.error_reason.unwrap(), error_msg);
     }
 
     #[test]
@@ -351,9 +354,9 @@ mod test {
         // Clear the outbound and verify error is returned
         let result = contexts.clear_outbound(outbound_key);
         assert!(result.is_some());
-        let (_, error_reason) = result.unwrap();
-        assert!(error_reason.is_some());
-        assert_eq!(error_reason.unwrap(), error_msg);
+        let inbound = result.unwrap();
+        assert!(inbound.error_reason.is_some());
+        assert_eq!(inbound.error_reason.unwrap(), error_msg);
     }
 
     #[test]
@@ -381,10 +384,10 @@ mod test {
         // When clearing the last outbound, the first error should be returned
         let result = contexts.clear_outbound(outbound_key3);
         assert!(result.is_some());
-        let (_, error_reason) = result.unwrap();
-        assert!(error_reason.is_some());
+        let inbound = result.unwrap();
+        assert!(inbound.error_reason.is_some());
         assert_eq!(
-            error_reason.unwrap(),
+            inbound.error_reason.unwrap(),
             error_msg1,
             "First error should be preserved"
         );
@@ -408,9 +411,9 @@ mod test {
         assert!(!inbound_key.is_null());
 
         let outbound_key = contexts.insert_outbound(inbound_key).unwrap();
-        let (completed_context, error) = contexts.clear_outbound(outbound_key).unwrap();
-        assert_eq!(completed_context, original_context);
-        assert!(error.is_none());
+        let inbound = contexts.clear_outbound(outbound_key).unwrap();
+        assert_eq!(inbound.context, original_context);
+        assert!(inbound.error_reason.is_none());
     }
 
     #[test]
@@ -463,10 +466,10 @@ mod test {
         // Clear outbound and verify the original inbound error is preserved
         let result = contexts.clear_outbound(outbound_key);
         assert!(result.is_some());
-        let (_, error_reason) = result.unwrap();
-        assert!(error_reason.is_some());
+        let inbound = result.unwrap();
+        assert!(inbound.error_reason.is_some());
         assert_eq!(
-            error_reason.unwrap(),
+            inbound.error_reason.unwrap(),
             inbound_error,
             "Original inbound error should be preserved"
         );


### PR DESCRIPTION
# Change summary

<!--Replace with a brief summary of the change in this PR-->

When transform processor handles a transformation that does routing, because the batch may be split, it creates new outbound contexts and handles `Ack`/`Nack`ing the inbound context depending on what happened to the outbound batches.

Before this change, `transform_processor`, when `Nack`ing an inbound batch, would always produce a `NackMsg` with `permanent=false` and the payload absent. This wasn't by design (it was basically just an oversight).

This corrects the behaviour such that:
a) the payload is either populated, or not, according to the wishes of the inbound context (by checking `context.may_return_payload()`)
b) The `Nack` will be non-permanent ONLY if all outbound batches were Nack'd with `permanent=false`. Stated differently, if ANY outbound batch either succeeded (was `Ack`d) or was `Nack`d with `permanent=true`, we will `Nack` the inbound batch with `permanent=true`. This is done to a) avoid retrying permanent failures and b) avoid replaying Ack'd data. 

## Related issue

<!--We highly recommend correlation of every PR to an issue-->

* Closes #3904

## Validation

<!--How did you confirm your change has the intended effect?-->

Unit tests

I also validated the behaviour using the configuration in the linked issue (which has the transform processor after the retry and does routing, followed by transient Nack exporter) and confirmed that we no longer see a metric like:

```
terminated_total{ ... reason="payload_missing", ...} 1 ...
```

and instead we now see (as expected)
```
retries_scheduled_total{...} 2
terminated_total{ ... reason="deadline", ...} 1 ...
```

## User-facing changes

<!--
Describe the impact, or write `None`.
User-facing changes require a `.chloggen/*.yaml` entry. If no entry is needed,
include `chore` in the PR title. Documentation-only changes are exempt.
-->

None

---

partition processor actually has the same issue, and I can fix this in a follow up