### PR TITLE
Display errors when Azure Monitor returns unexpected status codes

### DIFF
--- a/rust/otap-dataflow/.chloggen/azure-monitor-unexpected-error.yaml
+++ b/rust/otap-dataflow/.chloggen/azure-monitor-unexpected-error.yaml
@@ -11,7 +11,7 @@ component: pipeline
 note: Display errors when Azure Monitor returns unexpected status codes
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [3921]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/rust/otap-dataflow/.chloggen/azure-monitor-unexpected-error.yaml
+++ b/rust/otap-dataflow/.chloggen/azure-monitor-unexpected-error.yaml
@@ -1,0 +1,21 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pipeline
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Display errors when Azure Monitor returns unexpected status codes
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries. Breaking entries must include a `Migration:`
+# section with the specific action consumers must take. Keep notes to 200
+# characters and subtext to 300 characters.
+subtext:

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/error.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/error.rs
@@ -81,7 +81,7 @@ pub enum Error {
     },
 
     /// Unexpected HTTP status.
-    #[error("Unexpected status ({status})")]
+    #[error("Unexpected status ({status}): {body}")]
     UnexpectedStatus {
         /// The HTTP status code.
         status: StatusCode,
@@ -361,10 +361,10 @@ mod tests {
     fn test_unexpected_status_message() {
         let error = Error::UnexpectedStatus {
             status: StatusCode::IM_A_TEAPOT,
-            body: "I'm a teapot".to_string(),
+            body: "hello from the teapot".to_string(),
         };
         // Note: http crate canonical_reason() returns "I'm a teapot" (lowercase)
-        assert_eq!(error.to_string(), "Unexpected status (418 I'm a teapot)");
+        assert_eq!(error.to_string(), "Unexpected status (418 I'm a teapot): hello from the teapot");
     }
 
     // ==================== Export Error Tests ====================

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/error.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/error.rs
@@ -364,7 +364,10 @@ mod tests {
             body: "hello from the teapot".to_string(),
         };
         // Note: http crate canonical_reason() returns "I'm a teapot" (lowercase)
-        assert_eq!(error.to_string(), "Unexpected status (418 I'm a teapot): hello from the teapot");
+        assert_eq!(
+            error.to_string(),
+            "Unexpected status (418 I'm a teapot): hello from the teapot"
+        );
     }
 
     // ==================== Export Error Tests ====================


### PR DESCRIPTION
# Change summary

When Azure Monitor returns an unexpected status (eg., 400 bad request), the body of the response it not shown in the error message, making it hard to debug the issue. This change makes sure the body is shown.

## Validation

Unit tests

## User-facing changes

See above