### PR TITLE
chore(repo): Adjust root codeowners of otap-dataflow/crates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,7 +15,7 @@
 * @open-telemetry/arrow-approvers
 
 # OTAP Dataflow runtime architecture
-/rust/otap-dataflow/crates/ @lquerel @jmacd @lalitb @utpilla
+/rust/otap-dataflow/crates/ @albertlockett @drewrelmas @JakeDern @jmacd @lalitb @lquerel @utpilla
 /rust/otap-dataflow/crates/telemetry*/ @lquerel @jmacd @drewrelmas @cijothomas
 /rust/otap-dataflow/crates/pdata*/ @lquerel @jmacd @albertlockett @JakeDern
 /rust/otap-dataflow/crates/query-engine*/ @lquerel @jmacd @albertlockett

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,7 +15,7 @@
 * @open-telemetry/arrow-approvers
 
 # OTAP Dataflow runtime architecture
-/rust/otap-dataflow/crates/ @albertlockett @drewrelmas @JakeDern @jmacd @lalitb @lquerel @utpilla
+/rust/otap-dataflow/crates/ @open-telemetry/arrow-maintainers
 /rust/otap-dataflow/crates/telemetry*/ @lquerel @jmacd @drewrelmas @cijothomas
 /rust/otap-dataflow/crates/pdata*/ @lquerel @jmacd @albertlockett @JakeDern
 /rust/otap-dataflow/crates/query-engine*/ @lquerel @jmacd @albertlockett


### PR DESCRIPTION
# Chore Summary

Add all maintainers as CODEOWNER on `otap-dataflow/crates` paths

## Related issue

Blocking #3910