### PR TITLE
chore(repo): Swap otap-dataflow dependencies to contrib-data-engine crates

### DIFF
--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -7179,6 +7179,8 @@ dependencies = [
 [[package]]
 name = "otel-arrow-contrib-data-engine-expressions"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b58a41bd9f7c43e4b337993a68e02b660d0323d6974f6cd8c9b8ed22642fc5b"
 dependencies = [
  "caseless",
  "chrono",
@@ -7190,6 +7192,8 @@ dependencies = [
 [[package]]
 name = "otel-arrow-contrib-data-engine-kql-parser"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "014d8adc2d00f77e23dd7bed55dfabf58ca7b53aad68f7c861b5939fbc3a0b59"
 dependencies = [
  "chrono",
  "otel-arrow-contrib-data-engine-expressions",
@@ -7202,6 +7206,8 @@ dependencies = [
 [[package]]
 name = "otel-arrow-contrib-data-engine-parser-abstractions"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e0038dec22377f113084e9d13aa16a268235ca1c9d4aca3e1a94e0c42356ee"
 dependencies = [
  "chrono",
  "otel-arrow-contrib-data-engine-expressions",
@@ -7213,6 +7219,8 @@ dependencies = [
 [[package]]
 name = "otel-arrow-contrib-data-engine-recordset"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63af15bf7b4983c4af6ddaef792064d75cbb7bce6346e8aae635c0b2d5647bbb"
 dependencies = [
  "chrono",
  "hex",

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -75,9 +75,10 @@ otel-arrow-dfe-pdata = { path = "crates/pdata" }
 otel-arrow-dfe-pdata-views = { path = "crates/pdata-views" }
 otel-arrow-dfe-telemetry = { path = "crates/telemetry" }
 otel-arrow-dfe-quiver = { path = "crates/quiver" }
-otel-arrow-contrib-data-engine-expressions = { path = "../experimental/data_engine/expressions", version = "=0.1.0" }
-otel-arrow-contrib-data-engine-kql-parser = { path = "../experimental/data_engine/kql-parser", version = "=0.1.0" }
-otel-arrow-contrib-data-engine-parser-abstractions = { path = "../experimental/data_engine/parser-abstractions", version = "=0.1.0" }
+otel-arrow-contrib-data-engine-expressions = "0.1.0"
+otel-arrow-contrib-data-engine-kql-parser = "0.1.0"
+otel-arrow-contrib-data-engine-parser-abstractions = "0.1.0"
+otel-arrow-contrib-data-engine-recordset = "0.1.0"
 
 aws-config = "1.0"
 aws-msk-iam-sasl-signer = "1.0.1"
@@ -270,7 +271,6 @@ time = ">=0.3.47, <0.3.56"
 wiremock = "0.6.5"
 anyhow = "1.0.98"
 crossterm = "0.29"
-otel-arrow-contrib-data-engine-recordset = { path = "../experimental/data_engine/engine-recordset", version = "=0.1.0" }
 eventheader_dynamic = "0.5.0"
 include_dir = "0.7.4"
 mime_guess = "2.0.5"


### PR DESCRIPTION
# Chore Summary

Swap the `data-engine` dependencies to crate references instead of git paths. Crates have been published:
- https://crates.io/crates/otel-arrow-contrib-data-engine-kql-parser
- https://crates.io/crates/otel-arrow-contrib-data-engine-expressions
- https://crates.io/crates/otel-arrow-contrib-data-engine-parser-abstractions
- https://crates.io/crates/otel-arrow-contrib-data-engine-recordset

## Related issue

Follows #3916
