### PR TITLE
feat: ApiKeyProvider capability definition

### DIFF
--- a/rust/otap-dataflow/.chloggen/api-key-provider-capability.yaml
+++ b/rust/otap-dataflow/.chloggen/api-key-provider-capability.yaml
@@ -20,4 +20,4 @@ issues: [3901]
 subtext: |
   A capability for feeding API Keys into components (typically used for
   authorization) retrieved via extensions. API Key values are treated as secrets
-  and may be accompanied by optional attributes and\or expiration.
+  and may be accompanied by optional attributes and/or expiration.

--- a/rust/otap-dataflow/.chloggen/api-key-provider-capability.yaml
+++ b/rust/otap-dataflow/.chloggen/api-key-provider-capability.yaml
@@ -1,0 +1,23 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: new_component
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: engine
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: |
+  Add the `ApiKeyProvider` capability.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3901]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  A capability for feeding API Keys into components (typically used for
+  authorization) retrieved via extensions. API Key values are treated as secrets
+  and may be accompanied by optional attributes and\or expiration.

--- a/rust/otap-dataflow/crates/engine/src/capability/auth/api_key_provider.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/auth/api_key_provider.rs
@@ -18,14 +18,12 @@
 //! - `local_entry::<E>` / `shared_entry::<E>` factory bridges
 //! - A `KNOWN_CAPABILITIES` distributed-slice entry
 
+use crate::capability::auth::ApiKey;
 use crate::capability::error::CapabilityError;
 use futures::Stream;
 use otel_arrow_dfe_engine_macros::capability;
-use secrecy::{ExposeSecret, SecretString};
-use serde_json::{Map, Value};
 use std::pin::Pin;
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 /// How close to [`ApiKey::expires_on`] an API Key stops being usable.
 ///
@@ -47,74 +45,6 @@ use std::time::{Duration, Instant};
 /// request's own duration plus that clock skew; 30s matches the default API Key
 /// endpoint timeout.
 pub const API_KEY_USABLE_MARGIN: Duration = Duration::from_secs(30);
-
-/// An API Key.
-///
-/// The value is wrapped in [`SecretString`], which zeroizes on drop and masks
-/// itself in [`Debug`] output, so it cannot leak into logs or telemetry. The
-/// `SecretString` sits behind an [`Arc`] so cloning an API Key (handing it to
-/// multiple subscribers, or returning it from `get_api_key` on the hot path) is
-/// a cheap refcount bump that shares one plaintext allocation rather than
-/// copying the secret bytes.
-///
-/// `expires_on` is a monotonic [`Instant`] -- an absolute wall-clock expiry is
-/// converted to an `Instant` once, so the value is immune to wall-clock jumps
-/// thereafter. `None` means no known expiry. The API Key value is opaque to
-/// this type: an expiry is only ever what a caller supplies from the issuer's
-/// response metadata, never parsed out of the API Key itself.
-#[derive(Clone, Debug)]
-pub struct ApiKey {
-    value: Arc<SecretString>,
-    attributes: Option<Arc<Map<String, Value>>>,
-    expires_on: Option<Instant>,
-}
-
-impl ApiKey {
-    /// Creates an API Key from its value.
-    #[must_use]
-    pub fn new(value: impl Into<SecretString>) -> Self {
-        Self {
-            value: Arc::new(value.into()),
-            attributes: None,
-            expires_on: None,
-        }
-    }
-
-    /// Adds attributes to an API Key.
-    #[must_use]
-    pub fn with_attributes(mut self, attributes: Map<String, Value>) -> Self {
-        self.attributes = Some(Arc::new(attributes));
-        self
-    }
-
-    /// Adds expiry to an API Key.
-    #[must_use]
-    pub fn with_expiry(mut self, expires_on: Instant) -> Self {
-        self.expires_on = Some(expires_on);
-        self
-    }
-
-    /// Exposes the API Key value secret.
-    ///
-    /// Named `expose_value` (rather than a plain getter) so every plaintext
-    /// access is explicit and greppable.
-    #[must_use]
-    pub fn expose_value(&self) -> &str {
-        self.value.expose_secret()
-    }
-
-    /// Gets API Key attributes.
-    #[must_use]
-    pub fn get_attributes(&self) -> Option<&Map<String, Value>> {
-        self.attributes.as_deref()
-    }
-
-    /// Gets the API Key expiry.
-    #[must_use]
-    pub fn get_expires_on(&self) -> Option<Instant> {
-        self.expires_on
-    }
-}
 
 /// A per-consumer subscription to API Key refreshes.
 ///

--- a/rust/otap-dataflow/crates/engine/src/capability/auth/api_key_provider.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/auth/api_key_provider.rs
@@ -173,5 +173,5 @@ pub trait ApiKeyProvider {
     /// `tokio::sync::watch`-backed implementation satisfies this naturally,
     /// since a fresh receiver observes the channel's current value on its first
     /// poll.
-    fn get_api_key_stream(&self) -> ApiKeyStream;
+    fn api_key_stream(&self) -> ApiKeyStream;
 }

--- a/rust/otap-dataflow/crates/engine/src/capability/auth/api_key_provider.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/auth/api_key_provider.rs
@@ -1,0 +1,177 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! The `ApiKeyProvider` capability.
+//!
+//! A small, purpose-built capability that hands out API Keys to data-path
+//! nodes. It is intentionally provider- and execution-model agnostic: the same
+//! trait serves active and passive providers across both the shared and local
+//! execution models. Consumers depend only on the two methods below, never on
+//! how an API Key is produced or refreshed.
+//!
+//! The `#[capability]` proc macro expands the trait into:
+//!
+//! - A `pub(crate) mod local` containing the `!Send` `ApiKeyProvider` trait variant
+//! - A `pub(crate) mod shared` containing the `Send + Sync` `ApiKeyProvider` trait variant
+//! - A `SharedAsLocalApiKeyProvider` adapter
+//! - A zero-sized `pub struct ApiKeyProvider` registration handle
+//! - `local_entry::<E>` / `shared_entry::<E>` factory bridges
+//! - A `KNOWN_CAPABILITIES` distributed-slice entry
+
+use crate::capability::error::CapabilityError;
+use futures::Stream;
+use otel_arrow_dfe_engine_macros::capability;
+use secrecy::{ExposeSecret, SecretString};
+use serde_json::{Map, Value};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// How close to [`ApiKey::expires_on`] an API Key stops being usable.
+///
+/// Part of the capability contract rather than either side's private tuning,
+/// because both sides have to agree on it:
+///
+/// - A **provider** must not serve an API Key inside this window, and must
+///   schedule its refresh far enough ahead of expiry to publish a replacement
+///   before the current one enters it. A provider whose refresh lead time is
+///   smaller than this margin strands its consumers: the API Key it is still
+///   serving has already stopped being usable.
+/// - A **consumer** must stop sending requests once its cached API Key is
+///   inside this window, so a request cannot outlive the credential it carries
+///   while in flight, in the presence of clock skew between the consumer, the
+///   API Key issuer and the service.
+///
+/// Fixed rather than configurable so a provider can validate its own refresh
+/// settings against the same value every consumer enforces. It has to cover a
+/// request's own duration plus that clock skew; 30s matches the default API Key
+/// endpoint timeout.
+pub const API_KEY_USABLE_MARGIN: Duration = Duration::from_secs(30);
+
+/// An API Key.
+///
+/// The value is wrapped in [`SecretString`], which zeroizes on drop and masks
+/// itself in [`Debug`] output, so it cannot leak into logs or telemetry. The
+/// `SecretString` sits behind an [`Arc`] so cloning an API Key (handing it to
+/// multiple subscribers, or returning it from `get_api_key` on the hot path) is
+/// a cheap refcount bump that shares one plaintext allocation rather than
+/// copying the secret bytes.
+///
+/// `expires_on` is a monotonic [`Instant`] -- an absolute wall-clock expiry is
+/// converted to an `Instant` once, so the value is immune to wall-clock jumps
+/// thereafter. `None` means no known expiry. The API Key value is opaque to
+/// this type: an expiry is only ever what a caller supplies from the issuer's
+/// response metadata, never parsed out of the API Key itself.
+#[derive(Clone, Debug)]
+pub struct ApiKey {
+    value: Arc<SecretString>,
+    attributes: Option<Arc<Map<String, Value>>>,
+    expires_on: Option<Instant>,
+}
+
+impl ApiKey {
+    /// Creates an API Key from its value.
+    #[must_use]
+    pub fn new(value: impl Into<SecretString>) -> Self {
+        Self {
+            value: Arc::new(value.into()),
+            attributes: None,
+            expires_on: None,
+        }
+    }
+
+    /// Adds attributes to an API Key.
+    #[must_use]
+    pub fn with_attributes(mut self, attributes: Map<String, Value>) -> Self {
+        self.attributes = Some(Arc::new(attributes));
+        self
+    }
+
+    /// Adds expiry to an API Key.
+    #[must_use]
+    pub fn with_expiry(mut self, expires_on: Instant) -> Self {
+        self.expires_on = Some(expires_on);
+        self
+    }
+
+    /// Exposes the API Key value secret.
+    ///
+    /// Named `expose_value` (rather than a plain getter) so every plaintext
+    /// access is explicit and greppable.
+    #[must_use]
+    pub fn expose_value(&self) -> &str {
+        self.value.expose_secret()
+    }
+
+    /// Gets API Key attributes.
+    #[must_use]
+    pub fn get_attributes(&self) -> Option<&Map<String, Value>> {
+        self.attributes.as_deref()
+    }
+
+    /// Gets the API Key expiry.
+    #[must_use]
+    pub fn get_expires_on(&self) -> Option<Instant> {
+        self.expires_on
+    }
+}
+
+/// A per-consumer subscription to API Key refreshes.
+///
+/// The item is a plain [`ApiKey`], not a `Result`: a refresh failure does not
+/// terminate the subscription. The stream simply does not emit until the next
+/// successful refresh, and failures surface via [`ApiKeyProvider::get_api_key`]
+/// and telemetry instead. Because the item is [`Clone`], a provider can fan one
+/// refreshed API Key out to all subscribers via a `watch`/`broadcast` channel.
+///
+/// Boxed to hide the concrete stream type so providers can back it differently
+/// (e.g. a `watch` channel or an `unfold`) without changing the signature. The
+/// `Send` bound is intentionally omitted: the subscription is always consumed
+/// on the core that created it (thread-per-core), so it need not be `Send`. The
+/// `#[capability]` macro emits this signature into both the `local` (`?Send`)
+/// and `shared` (`Send + Sync`) trait variants unchanged.
+pub type ApiKeyStream = Pin<Box<dyn Stream<Item = ApiKey> + 'static>>;
+
+/// Hands out API Keys to data-path nodes.
+#[capability(
+    name = "api_key_provider",
+    description = "Provides API Keys, refreshed in the background"
+)]
+pub trait ApiKeyProvider {
+    /// Returns the current valid API Key for the provider's configured
+    /// scope(s).
+    ///
+    /// The fast path reads a cached API Key; on a cache miss the provider
+    /// performs a lookup operation. A provider that shares its cache and
+    /// refresh state across cloned instances can coalesce concurrent misses
+    /// into a single call -- but that is a provider implementation detail, not
+    /// a guarantee of this trait. Returns a [`CapabilityError`] if no valid API
+    /// Key can be produced.
+    ///
+    /// The API Key is scoped to the resource(s) the provider was configured
+    /// for. There is no wiring-time check that a consumer's target resource
+    /// matches the provider's scope, so a mismatch surfaces at the service as
+    /// an auth failure (e.g. HTTP 401) rather than at startup. Consumers must
+    /// bind to a provider configured for their resource.
+    async fn get_api_key(&self) -> Result<ApiKey, CapabilityError>;
+
+    /// Subscribes to the stream of API Key refreshes.
+    ///
+    /// Yields each newly published API Key for the lifetime of the extension;
+    /// each call returns an independent subscription. The stream does not carry
+    /// errors: a failed refresh does not end the subscription, and the next
+    /// successful refresh still yields an API Key (see [`ApiKeyStream`]).
+    ///
+    /// # Contract
+    ///
+    /// A subscription created *after* an API Key has already been published
+    /// MUST immediately yield the current API Key rather than block until the
+    /// next refresh. This lets a consumer subscribe at any point (for example
+    /// after the provider's readiness gate has fired) and obtain a usable API
+    /// Key without a separate [`get_api_key`](Self::get_api_key) call, avoiding
+    /// a race between reading the current token and subscribing to updates. A
+    /// `tokio::sync::watch`-backed implementation satisfies this naturally,
+    /// since a fresh receiver observes the channel's current value on its first
+    /// poll.
+    fn get_api_key_stream(&self) -> ApiKeyStream;
+}

--- a/rust/otap-dataflow/crates/engine/src/capability/auth/mod.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/auth/mod.rs
@@ -19,4 +19,4 @@ pub mod api_key_provider;
 pub mod bearer_token_authorizer;
 pub mod bearer_token_provider;
 
-pub use models::{AuthorizedIdentity, AuthzDecision, BearerToken, ClaimValue, DenyReason};
+pub use models::{ApiKey, AuthorizedIdentity, AuthzDecision, BearerToken, ClaimValue, DenyReason};

--- a/rust/otap-dataflow/crates/engine/src/capability/auth/mod.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/auth/mod.rs
@@ -15,6 +15,7 @@
 mod models;
 
 pub mod agent_fed_credential_provider;
+pub mod api_key_provider;
 pub mod bearer_token_authorizer;
 pub mod bearer_token_provider;
 

--- a/rust/otap-dataflow/crates/engine/src/capability/auth/models/api_key.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/auth/models/api_key.rs
@@ -1,0 +1,142 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! The shared [`ApiKey`] credential.
+
+use secrecy::{ExposeSecret, SecretString};
+use serde_json::{Map, Value};
+use std::sync::Arc;
+use std::time::Instant;
+
+static HTTP_HEADER_NAME_ATTRIBUTE: &str = "http.header_name";
+static HTTP_SCHEME_ATTRIBUTE: &str = "http.scheme";
+
+/// An API Key.
+///
+/// The value is wrapped in [`SecretString`], which zeroizes on drop and masks
+/// itself in [`Debug`] output, so it cannot leak into logs or telemetry. The
+/// `SecretString` sits behind an [`Arc`] so cloning an API Key (handing it to
+/// multiple subscribers, or returning it from `get_api_key` on the hot path) is
+/// a cheap refcount bump that shares one plaintext allocation rather than
+/// copying the secret bytes.
+///
+/// `expires_on` is a monotonic [`Instant`] -- an absolute wall-clock expiry is
+/// converted to an `Instant` once, so the value is immune to wall-clock jumps
+/// thereafter. `None` means no known expiry. The API Key value is opaque to
+/// this type: an expiry is only ever what a caller supplies from the issuer's
+/// response metadata, never parsed out of the API Key itself.
+///
+/// `attributes` is a map for attaching metadata to the value consumers may use
+/// when handling the API Key. [`Debug`] output renders `attributes` verbatim so
+/// hosts must keep secrets out of the attribute map.
+#[derive(Clone, Debug)]
+pub struct ApiKey {
+    value: Arc<SecretString>,
+    attributes: Option<Arc<Map<String, Value>>>,
+    expires_on: Option<Instant>,
+}
+
+impl ApiKey {
+    /// Creates an API Key from its value.
+    #[must_use]
+    pub fn new(value: impl Into<SecretString>) -> Self {
+        Self {
+            value: Arc::new(value.into()),
+            attributes: None,
+            expires_on: None,
+        }
+    }
+
+    /// Adds attributes to an API Key.
+    #[must_use]
+    pub fn with_attributes(mut self, attributes: Map<String, Value>) -> Self {
+        self.attributes = Some(Arc::new(attributes));
+        self
+    }
+
+    /// Adds expiry to an API Key.
+    #[must_use]
+    pub fn with_expiry(mut self, expires_on: Instant) -> Self {
+        self.expires_on = Some(expires_on);
+        self
+    }
+
+    /// Adds `http.header_name` attribute to an API Key.
+    #[must_use]
+    pub fn with_http_header_name_attribute(mut self, header_name: &str) -> Self {
+        let header_name = header_name.trim();
+        assert!(!header_name.is_empty());
+        let mut attributes = self
+            .attributes
+            .map(Arc::unwrap_or_clone)
+            .unwrap_or_default();
+        attributes[HTTP_HEADER_NAME_ATTRIBUTE] = Value::String(header_name.into());
+        self.attributes = Some(Arc::new(attributes));
+        self
+    }
+
+    /// Adds `http.scheme` attribute to an API Key.
+    #[must_use]
+    pub fn with_http_scheme_attribute(mut self, scheme: &str) -> Self {
+        let scheme = scheme.trim();
+        assert!(!scheme.is_empty());
+        let mut attributes = self
+            .attributes
+            .map(Arc::unwrap_or_clone)
+            .unwrap_or_default();
+        attributes[HTTP_SCHEME_ATTRIBUTE] = Value::String(scheme.into());
+        self.attributes = Some(Arc::new(attributes));
+        self
+    }
+
+    /// Exposes the API Key value secret.
+    ///
+    /// Named `expose_value` (rather than a plain getter) so every plaintext
+    /// access is explicit and greppable.
+    #[must_use]
+    pub fn expose_value(&self) -> &str {
+        self.value.expose_secret()
+    }
+
+    /// Gets API Key attributes.
+    #[must_use]
+    pub fn get_attributes(&self) -> Option<&Map<String, Value>> {
+        self.attributes.as_deref()
+    }
+
+    /// Gets the API Key expiry.
+    #[must_use]
+    pub fn get_expires_on(&self) -> Option<Instant> {
+        self.expires_on
+    }
+
+    /// Gets the API Key `http.header_name` attribute.
+    #[must_use]
+    pub fn get_http_header_name_attribute(&self) -> Option<&str> {
+        if let Some(header_value) = self
+            .attributes
+            .as_ref()
+            .and_then(|v| v.get(HTTP_HEADER_NAME_ATTRIBUTE))
+            && let Value::String(header_value) = header_value
+        {
+            return Some(header_value.as_str());
+        }
+
+        None
+    }
+
+    /// Gets the API Key `http.scheme` attribute.
+    #[must_use]
+    pub fn get_http_scheme_attribute(&self) -> Option<&str> {
+        if let Some(scheme_value) = self
+            .attributes
+            .as_ref()
+            .and_then(|v| v.get(HTTP_SCHEME_ATTRIBUTE))
+            && let Value::String(scheme_value) = scheme_value
+        {
+            return Some(scheme_value.as_str());
+        }
+
+        None
+    }
+}

--- a/rust/otap-dataflow/crates/engine/src/capability/auth/models/api_key.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/auth/models/api_key.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 static HTTP_HEADER_NAME_ATTRIBUTE: &str = "http.header_name";
-static HTTP_SCHEME_ATTRIBUTE: &str = "http.scheme";
+static HTTP_HEADER_SCHEME_ATTRIBUTE: &str = "http.header_scheme";
 
 /// An API Key.
 ///
@@ -56,7 +56,7 @@ impl ApiKey {
 
     /// Adds expiry to an API Key.
     #[must_use]
-    pub fn with_expiry(mut self, expires_on: Instant) -> Self {
+    pub const fn with_expiry(mut self, expires_on: Instant) -> Self {
         self.expires_on = Some(expires_on);
         self
     }
@@ -64,8 +64,6 @@ impl ApiKey {
     /// Adds `http.header_name` attribute to an API Key.
     #[must_use]
     pub fn with_http_header_name_attribute(mut self, header_name: &str) -> Self {
-        let header_name = header_name.trim();
-        assert!(!header_name.is_empty());
         let mut attributes = self
             .attributes
             .map(Arc::unwrap_or_clone)
@@ -75,16 +73,14 @@ impl ApiKey {
         self
     }
 
-    /// Adds `http.scheme` attribute to an API Key.
+    /// Adds `http.header_scheme` attribute to an API Key.
     #[must_use]
-    pub fn with_http_scheme_attribute(mut self, scheme: &str) -> Self {
-        let scheme = scheme.trim();
-        assert!(!scheme.is_empty());
+    pub fn with_http_header_scheme_attribute(mut self, header_scheme: &str) -> Self {
         let mut attributes = self
             .attributes
             .map(Arc::unwrap_or_clone)
             .unwrap_or_default();
-        attributes[HTTP_SCHEME_ATTRIBUTE] = Value::String(scheme.into());
+        attributes[HTTP_HEADER_SCHEME_ATTRIBUTE] = Value::String(header_scheme.into());
         self.attributes = Some(Arc::new(attributes));
         self
     }
@@ -106,7 +102,7 @@ impl ApiKey {
 
     /// Gets the API Key expiry.
     #[must_use]
-    pub fn get_expires_on(&self) -> Option<Instant> {
+    pub const fn get_expires_on(&self) -> Option<Instant> {
         self.expires_on
     }
 
@@ -125,13 +121,13 @@ impl ApiKey {
         None
     }
 
-    /// Gets the API Key `http.scheme` attribute.
+    /// Gets the API Key `http.header_scheme` attribute.
     #[must_use]
-    pub fn get_http_scheme_attribute(&self) -> Option<&str> {
+    pub fn get_http_header_scheme_attribute(&self) -> Option<&str> {
         if let Some(scheme_value) = self
             .attributes
             .as_ref()
-            .and_then(|v| v.get(HTTP_SCHEME_ATTRIBUTE))
+            .and_then(|v| v.get(HTTP_HEADER_SCHEME_ATTRIBUTE))
             && let Value::String(scheme_value) = scheme_value
         {
             return Some(scheme_value.as_str());

--- a/rust/otap-dataflow/crates/engine/src/capability/auth/models/mod.rs
+++ b/rust/otap-dataflow/crates/engine/src/capability/auth/models/mod.rs
@@ -9,11 +9,13 @@
 //! submodules are private; each type is re-exported here and again from
 //! [`super`], so consumers reach them at `capability::auth::<Type>`.
 
+mod api_key;
 mod authorized_identity;
 mod authz_decision;
 mod bearer_token;
 mod deny_reason;
 
+pub use api_key::ApiKey;
 pub use authorized_identity::{AuthorizedIdentity, ClaimValue};
 pub use authz_decision::AuthzDecision;
 pub use bearer_token::BearerToken;

--- a/rust/otap-dataflow/crates/engine/src/local/capability.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/capability.rs
@@ -18,6 +18,10 @@ pub mod auth {
     pub mod agent_fed_credential_provider {
         pub use crate::capability::auth::agent_fed_credential_provider::local::AgentFedCredentialProvider;
     }
+    /// Local (!Send) trait variant of the api-key-provider capability.
+    pub mod api_key_provider {
+        pub use crate::capability::auth::api_key_provider::local::ApiKeyProvider;
+    }
     /// Local (!Send) trait variant of the bearer-token-authorizer capability.
     pub mod bearer_token_authorizer {
         pub use crate::capability::auth::bearer_token_authorizer::local::BearerTokenAuthorizer;

--- a/rust/otap-dataflow/crates/engine/src/shared/capability.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/capability.rs
@@ -18,6 +18,10 @@ pub mod auth {
     pub mod agent_fed_credential_provider {
         pub use crate::capability::auth::agent_fed_credential_provider::shared::AgentFedCredentialProvider;
     }
+    /// Shared (Send + Sync) trait variant of the api-key-provider capability.
+    pub mod api_key_provider {
+        pub use crate::capability::auth::api_key_provider::shared::ApiKeyProvider;
+    }
     /// Shared (Send + Sync) trait variant of the bearer-token-authorizer capability.
     pub mod bearer_token_authorizer {
         pub use crate::capability::auth::bearer_token_authorizer::shared::BearerTokenAuthorizer;


### PR DESCRIPTION
# Change summary

Adds a new capability for feeding API Keys into components.

## Related issue

Relates to #3901

## Validation

No implementation yet just the trait definition. Implementations will come as follow-ups.

## User-facing changes

New capability.
