### PR TITLE
Pdata codec series 02 runtime integration

### DIFF
--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -7797,6 +7797,7 @@ dependencies = [
  "datafusion",
  "hex",
  "itertools 0.15.0",
+ "linkme",
  "nix 0.31.3",
  "num_enum",
  "otel-arrow-dfe-config",

--- a/rust/otap-dataflow/benchmarks/benches/payload_measurements/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/payload_measurements/main.rs
@@ -8,15 +8,19 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 
+use otel_arrow_dfe_config::SignalType;
+use otel_arrow_dfe_otap::compression::CompressionMethod;
 use otel_arrow_dfe_otap::pdata::{Context, OtapPdata};
-use otel_arrow_dfe_pdata::OtapPayload;
 use otel_arrow_dfe_pdata::otap::OtapArrowRecords;
+use otel_arrow_dfe_pdata::otap::batching::make_item_batches;
 use otel_arrow_dfe_pdata::otlp::OtlpProtoBytes;
+use otel_arrow_dfe_pdata::otlp::batching::make_bytes_batches_owned;
 use otel_arrow_dfe_pdata::proto::OtlpProtoMessage;
 use otel_arrow_dfe_pdata::proto::opentelemetry::common::v1::*;
 use otel_arrow_dfe_pdata::proto::opentelemetry::logs::v1::*;
 use otel_arrow_dfe_pdata::proto::opentelemetry::resource::v1::*;
 use otel_arrow_dfe_pdata::testing::round_trip::{otlp_message_to_bytes, otlp_to_otap};
+use otel_arrow_dfe_pdata::{OtapPayload, TryIntoWithOptions};
 
 #[cfg(not(windows))]
 use tikv_jemallocator::Jemalloc;
@@ -179,10 +183,112 @@ fn measure_payload_size(c: &mut Criterion) {
     group.finish();
 }
 
+fn legacy_representation_paths(c: &mut Criterion) {
+    let mut group = c.benchmark_group("PData legacy representation paths");
+
+    for record_count in [10, 100, 1_000] {
+        let message = OtlpProtoMessage::Logs(create_logs_data(record_count));
+        let otlp_bytes: OtlpProtoBytes = otlp_message_to_bytes(&message);
+        let otap_records: OtapArrowRecords = otlp_to_otap(&message);
+
+        _ = group.bench_function(BenchmarkId::new("OTLP/forward", record_count), |b| {
+            b.iter_batched(
+                || OtapPayload::from(otlp_bytes.clone()),
+                |payload| {
+                    let forwarded: OtlpProtoBytes = payload
+                        .try_into_with_default()
+                        .expect("matching OTLP forwarding");
+                    black_box(forwarded)
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        _ = group.bench_function(BenchmarkId::new("OTLP/decode", record_count), |b| {
+            b.iter_batched(
+                || OtapPayload::from(otlp_bytes.clone()),
+                |payload| {
+                    let records: OtapArrowRecords =
+                        payload.try_into_with_default().expect("OTLP decode");
+                    black_box(records)
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        _ = group.bench_function(BenchmarkId::new("OTAP/encode_otlp", record_count), |b| {
+            b.iter_batched(
+                || otap_records.clone(),
+                |records| {
+                    let encoded: OtlpProtoBytes =
+                        records.try_into_with_default().expect("OTLP encode");
+                    black_box(encoded)
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        _ = group.bench_function(BenchmarkId::new("OTAP/native_move", record_count), |b| {
+            b.iter_batched(
+                || OtapPayload::from(otap_records.clone()),
+                |payload| {
+                    let records: OtapArrowRecords = payload
+                        .try_into_with_default()
+                        .expect("native payload move");
+                    black_box(records)
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        _ = group.bench_function(BenchmarkId::new("OTLP/batch", record_count), |b| {
+            b.iter_batched(
+                || vec![otlp_bytes.clone(), otlp_bytes.clone()],
+                |inputs| {
+                    black_box(
+                        make_bytes_batches_owned(SignalType::Logs, None, None, None, None, inputs)
+                            .expect("OTLP byte batching"),
+                    )
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        _ = group.bench_function(BenchmarkId::new("OTAP/batch", record_count), |b| {
+            b.iter_batched(
+                || vec![otap_records.clone(), otap_records.clone()],
+                |inputs| {
+                    black_box(
+                        make_item_batches(SignalType::Logs, None, inputs)
+                            .expect("OTAP item batching"),
+                    )
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        _ = group.bench_function(BenchmarkId::new("OTLP/zstd", record_count), |b| {
+            b.iter_batched_ref(
+                Vec::new,
+                |scratch| {
+                    CompressionMethod::Zstd
+                        .encode(black_box(otlp_bytes.as_bytes()), scratch)
+                        .expect("OTLP HTTP compression");
+                    _ = black_box(scratch.len());
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     payload_measurements,
     count_logs,
     count_payload_items,
-    measure_payload_size
+    measure_payload_size,
+    legacy_representation_paths
 );
 criterion_main!(payload_measurements);

--- a/rust/otap-dataflow/benchmarks/benches/payload_measurements/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/payload_measurements/main.rs
@@ -20,7 +20,9 @@ use otel_arrow_dfe_pdata::proto::opentelemetry::common::v1::*;
 use otel_arrow_dfe_pdata::proto::opentelemetry::logs::v1::*;
 use otel_arrow_dfe_pdata::proto::opentelemetry::resource::v1::*;
 use otel_arrow_dfe_pdata::testing::round_trip::{otlp_message_to_bytes, otlp_to_otap};
-use otel_arrow_dfe_pdata::{OtapPayload, TryIntoWithOptions};
+use otel_arrow_dfe_pdata::{
+    CodecState, EncodingPlan, OtapPayload, ResolvedCodec, TryIntoWithOptions,
+};
 
 #[cfg(not(windows))]
 use tikv_jemallocator::Jemalloc;
@@ -284,11 +286,84 @@ fn legacy_representation_paths(c: &mut Criterion) {
     group.finish();
 }
 
+fn direct_codec_paths(c: &mut Criterion) {
+    let mut group = c.benchmark_group("PData direct codec paths");
+
+    for record_count in [10, 100, 1_000] {
+        let message = OtlpProtoMessage::Logs(create_logs_data(record_count));
+        let otlp_bytes: OtlpProtoBytes = otlp_message_to_bytes(&message);
+        let encoded = otlp_bytes.clone_bytes();
+        let otap_records: OtapArrowRecords = otlp_to_otap(&message);
+
+        _ = group.bench_function(BenchmarkId::new("OTLP/count", record_count), |b| {
+            b.iter(|| black_box(ResolvedCodec::OTLP.count_items(SignalType::Logs, &encoded)))
+        });
+
+        _ = group.bench_function(BenchmarkId::new("OTLP/view", record_count), |b| {
+            let mut state = CodecState::default();
+            b.iter(|| {
+                black_box(
+                    state
+                        .view(ResolvedCodec::OTLP, SignalType::Logs, &encoded)
+                        .expect("OTLP codec view"),
+                )
+            })
+        });
+
+        _ = group.bench_function(BenchmarkId::new("OTLP/decode", record_count), |b| {
+            let mut state = CodecState::default();
+            b.iter(|| {
+                black_box(
+                    state
+                        .decode(ResolvedCodec::OTLP, SignalType::Logs, &encoded)
+                        .expect("OTLP codec decode"),
+                )
+            })
+        });
+
+        _ = group.bench_function(
+            BenchmarkId::new("OTAP/encode_prepared", record_count),
+            |b| {
+                let mut state = CodecState::default();
+                b.iter_batched(
+                    || otap_records.clone(),
+                    |mut records| {
+                        let output = state
+                            .prepare_encode(&mut records, &EncodingPlan::OTLP)
+                            .expect("OTLP prepared output");
+                        black_box(output.as_ref().len())
+                    },
+                    BatchSize::SmallInput,
+                )
+            },
+        );
+
+        _ = group.bench_function(BenchmarkId::new("OTAP/encode_owned", record_count), |b| {
+            let mut state = CodecState::default();
+            b.iter_batched(
+                || otap_records.clone(),
+                |mut records| {
+                    black_box(
+                        state
+                            .prepare_encode(&mut records, &EncodingPlan::OTLP)
+                            .expect("OTLP owned output")
+                            .into_bytes(),
+                    )
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     payload_measurements,
     count_logs,
     count_payload_items,
     measure_payload_size,
-    legacy_representation_paths
+    legacy_representation_paths,
+    direct_codec_paths
 );
 criterion_main!(payload_measurements);

--- a/rust/otap-dataflow/crates/config/src/conversion.rs
+++ b/rust/otap-dataflow/crates/config/src/conversion.rs
@@ -1,16 +1,22 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Options for protocol conversion.
+//! Options for encoded output.
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::num::NonZeroUsize;
 
-/// Options for protocol conversion.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+/// Output-specific options applied while encoding telemetry.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
 #[serde(deny_unknown_fields)]
-pub struct ConversionOptions {
-    /// default applies.
+pub struct EncodeOptions {
+    /// Maximum size of an encoded OTLP protobuf message.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub otlp_size_limit: Option<NonZeroUsize>,
 }
+
+/// Transitional alias for code that still passes the former conversion options.
+///
+/// Decoding has no configurable policy. New code should use [`EncodeOptions`]
+/// only at an output boundary.
+pub type ConversionOptions = EncodeOptions;

--- a/rust/otap-dataflow/crates/config/src/lib.rs
+++ b/rust/otap-dataflow/crates/config/src/lib.rs
@@ -73,6 +73,8 @@ pub enum SignalFormat {
     OtapRecords,
     /// OTLP protobuf bytes
     OtlpBytes,
+    /// Independently encoded bytes identified by a registered pdata codec.
+    Encoded,
     // TODO: maybe add types not included in OtapPdata including
     // OtlpProtoMessage, OtapArrowBytes, and possible opaque.
 }

--- a/rust/otap-dataflow/crates/config/src/lib.rs
+++ b/rust/otap-dataflow/crates/config/src/lib.rs
@@ -53,7 +53,7 @@ pub use topic::{
 /// Validation helpers for node configuration.
 pub mod validation;
 
-pub use conversion::ConversionOptions;
+pub use conversion::{ConversionOptions, EncodeOptions};
 
 /// Signal types
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/mod.rs
@@ -317,6 +317,9 @@ impl ConsoleExporter {
                     Err(ConsoleExportErrorType::OtapViewCreation)
                 }
             },
+            PayloadData::Encoded(_) => {
+                unreachable!("encoded payloads are not admitted during the storage transition")
+            }
         }
     }
 
@@ -346,6 +349,9 @@ impl ConsoleExporter {
                     Err(ConsoleExportErrorType::OtapViewCreation)
                 }
             },
+            PayloadData::Encoded(_) => {
+                unreachable!("encoded payloads are not admitted during the storage transition")
+            }
         }
     }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/file_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/file_exporter/mod.rs
@@ -403,6 +403,9 @@ fn encode_payload(
                 encode_traces(&view, frame, max_frame_bytes)?;
             }
         },
+        PayloadData::Encoded(_) => {
+            unreachable!("encoded payloads are not admitted during the storage transition")
+        }
     }
     Ok(())
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
@@ -631,6 +631,11 @@ impl Exporter<OtapPdata> for OTLPExporter {
                             let future = make_export_future(prepared, client);
                             inflight_exports.push(future);
                         }
+                        (_, PayloadData::Encoded(_)) => {
+                            unreachable!(
+                                "encoded payloads are not admitted during the storage transition"
+                            )
+                        }
                     }
                 }
                 _ => {

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
@@ -549,6 +549,11 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
 
                             (Uncompressed::InProtoBuffer, otap_batch.into())
                         }
+                        PayloadData::Encoded(_) => {
+                            unreachable!(
+                                "encoded payloads are not admitted during the storage transition"
+                            )
+                        }
                     };
 
                     let body = match compression {

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -94,6 +94,7 @@ const fn wakeup_slot(format: SignalFormat, signal: SignalType) -> WakeupSlot {
     let format_base = match format {
         SignalFormat::OtapRecords => 0,
         SignalFormat::OtlpBytes => 3,
+        SignalFormat::Encoded => 6,
     };
     let signal_offset = match signal {
         SignalType::Logs => 0,
@@ -449,6 +450,10 @@ impl FormatConfig {
         let (expect_sizer, with_msg) = match format {
             SignalFormat::OtapRecords => (Sizer::Items, "OTAP batch sizer: must be items"),
             SignalFormat::OtlpBytes => (Sizer::Bytes, "OTLP batch sizer: must be bytes"),
+            SignalFormat::Encoded => (
+                Sizer::Bytes,
+                "encoded batches require conversion before legacy batching",
+            ),
         };
         if self.sizer != expect_sizer {
             return Err(ConfigError::InvalidUserConfig {
@@ -834,6 +839,9 @@ impl BatchProcessor {
                 } else {
                     return Err(Self::no_active_format_error());
                 }
+            }
+            PayloadData::Encoded(_) => {
+                unreachable!("encoded payloads are not admitted during the storage transition")
             }
         };
         Ok(())
@@ -1389,6 +1397,11 @@ impl local::Processor<OtapPdata> for BatchProcessor {
                                     .flush_signal_impl(effect, when, FlushReason::Timer)
                                     .await?;
                             }
+                        }
+                        SignalFormat::Encoded => {
+                            unreachable!(
+                                "encoded payloads are not admitted during the storage transition"
+                            )
                         }
                     };
 
@@ -3388,6 +3401,7 @@ mod tests {
                     match output.signal_format() {
                         SignalFormat::OtapRecords => has_otap = true,
                         SignalFormat::OtlpBytes => has_otlp = true,
+                        SignalFormat::Encoded => panic!("unexpected encoded output"),
                     }
                 }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/content_router/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/content_router/mod.rs
@@ -604,6 +604,9 @@ impl ContentRouter {
                     },
                 }
             }
+            PayloadData::Encoded(_) => {
+                unreachable!("encoded payloads are not admitted during the storage transition")
+            }
         }
     }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -1079,6 +1079,9 @@ impl DurableBuffer {
                 };
                 (result, num_items)
             }
+            PayloadData::Encoded(_) => {
+                unreachable!("encoded payloads are not admitted during the storage transition")
+            }
         };
 
         // Handle ingest result

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/mod.rs
@@ -34,8 +34,10 @@ use otel_arrow_dfe_engine::processor::{
 use otel_arrow_dfe_engine::{
     ConsumerEffectHandlerExtension, MessageSourceLocalEffectHandlerExtension,
 };
-use otel_arrow_dfe_otap::{OTAP_PROCESSOR_FACTORIES, pdata::OtapPdata};
-use otel_arrow_dfe_pdata::TryIntoWithOptions;
+use otel_arrow_dfe_otap::{
+    OTAP_PROCESSOR_FACTORIES,
+    pdata::{NativePdataProcessor, NativeProcessorAdapter, OtapArrowPdata, OtapPdata},
+};
 use otel_arrow_dfe_pdata::otap::OtapArrowRecords;
 use otel_arrow_dfe_pdata::otap::filter::IdBitmapPool;
 use otel_arrow_dfe_telemetry::common_attributes::SignalAttributes;
@@ -131,9 +133,7 @@ impl FilterProcessor {
 #[async_trait(?Send)]
 impl local::Processor<OtapPdata> for FilterProcessor {
     fn runtime_requirements(&self) -> ProcessorRuntimeRequirements {
-        // The filter processor drops signal items, so it records
-        // `dropped.items` when it lies within a flow that enables it.
-        ProcessorRuntimeRequirements::none().with_drop_decisions()
+        NativePdataProcessor::runtime_requirements(self)
     }
 
     async fn process(
@@ -141,100 +141,116 @@ impl local::Processor<OtapPdata> for FilterProcessor {
         msg: Message<OtapPdata>,
         effect_handler: &mut local::EffectHandler<OtapPdata>,
     ) -> Result<(), Error> {
-        match msg {
-            Message::Control(control) => {
-                if let NodeControlMsg::CollectTelemetry {
-                    mut metrics_reporter,
-                } = control
-                {
-                    _ = metrics_reporter.report_measurement(&mut self.metrics);
-                    self.compute_duration.report(&mut metrics_reporter);
-                }
-                Ok(())
-            }
-            Message::PData(pdata) => {
-                let signal = pdata.signal_type();
-                // convert to arrow records
-                let (context, payload) = pdata.into_parts();
+        NativeProcessorAdapter::process(self, msg, effect_handler).await
+    }
+}
 
-                let mut arrow_records: OtapArrowRecords = payload.try_into_with_default()?;
-                arrow_records.decode_transport_optimized_ids()?;
+#[async_trait(?Send)]
+impl NativePdataProcessor for FilterProcessor {
+    fn runtime_requirements(&self) -> ProcessorRuntimeRequirements {
+        // The filter processor drops signal items, so it records
+        // `dropped.items` when it lies within a flow that enables it.
+        ProcessorRuntimeRequirements::none().with_drop_decisions()
+    }
 
-                let (filtered_arrow_records, _signals_consumed, dropped_items): (
-                    OtapArrowRecords,
-                    u64,
-                    u64,
-                ) =
-                    effect_handler.timed(&self.compute_duration, || -> Result<_, Error> {
-                        match signal {
-                            SignalType::Metrics => {
-                                let (filtered, consumed, filtered_count) = self
-                                    .config
-                                    .metric_filters()
-                                    .filter(arrow_records, &mut self.metric_id_pool)
-                                    .map_err(|e| {
-                                        let source_detail = format_error_sources(&e);
-                                        Error::ProcessorError {
-                                            processor: effect_handler.processor_id(),
-                                            kind: ProcessorErrorKind::Other,
-                                            error: format!("Filter error: {e}"),
-                                            source_detail,
-                                        }
-                                    })?;
-                                Ok((filtered, consumed, filtered_count))
-                            }
-                            SignalType::Logs => {
-                                let (filtered, consumed, filtered_count) =
-                                    self.config.log_filters().filter(arrow_records).map_err(
-                                        |e| {
-                                            let source_detail = format_error_sources(&e);
-                                            Error::ProcessorError {
-                                                processor: effect_handler.processor_id(),
-                                                kind: ProcessorErrorKind::Other,
-                                                error: format!("Filter error: {e}"),
-                                                source_detail,
-                                            }
-                                        },
-                                    )?;
-                                Ok((filtered, consumed, filtered_count))
-                            }
-                            SignalType::Traces => {
-                                let (filtered, consumed, filtered_count) =
-                                    self.config.trace_filters().filter(arrow_records).map_err(
-                                        |e| {
-                                            let source_detail = format_error_sources(&e);
-                                            Error::ProcessorError {
-                                                processor: effect_handler.processor_id(),
-                                                kind: ProcessorErrorKind::Other,
-                                                error: format!("Filter error: {e}"),
-                                                source_detail,
-                                            }
-                                        },
-                                    )?;
-                                Ok((filtered, consumed, filtered_count))
-                            }
-                        }
-                    })?;
-
-                let metric = self.metrics.with(SignalAttributes { signal });
-                metric.dropped_items.add(dropped_items);
-
-                // Record the drop flow-metric. A no-op unless this node is
-                // a decision node in a flow that enables `dropped.items`.
-                // `dropped_items` is the dropped count.
-                effect_handler.record_flow_dropped_items(signal, dropped_items);
-
-                let kept_items = filtered_arrow_records.num_items();
-                let mut pdata = OtapPdata::new(context, filtered_arrow_records.into());
-                if kept_items == 0 {
-                    pdata.complete_processor_without_output(effect_handler);
-                    effect_handler.notify_ack(AckMsg::new(pdata)).await?;
-                } else {
-                    effect_handler.send_message_with_source_node(pdata).await?;
-                }
-                Ok(())
-            }
+    async fn process_control(
+        &mut self,
+        control: NodeControlMsg<OtapPdata>,
+        _effect_handler: &mut local::EffectHandler<OtapPdata>,
+    ) -> Result<(), Error> {
+        if let NodeControlMsg::CollectTelemetry {
+            mut metrics_reporter,
+        } = control
+        {
+            _ = metrics_reporter.report_measurement(&mut self.metrics);
+            self.compute_duration.report(&mut metrics_reporter);
         }
+        Ok(())
+    }
+
+    async fn process_native(
+        &mut self,
+        arrow_pdata: OtapArrowPdata,
+        effect_handler: &mut local::EffectHandler<OtapPdata>,
+    ) -> Result<(), Error> {
+        let signal = arrow_pdata.signal_type();
+        let (context, mut arrow_records) = arrow_pdata.into_parts();
+        arrow_records.decode_transport_optimized_ids()?;
+
+        let (filtered_arrow_records, _signals_consumed, dropped_items): (
+            OtapArrowRecords,
+            u64,
+            u64,
+        ) = effect_handler.timed(&self.compute_duration, || -> Result<_, Error> {
+            match signal {
+                SignalType::Metrics => {
+                    let (filtered, consumed, filtered_count) = self
+                        .config
+                        .metric_filters()
+                        .filter(arrow_records, &mut self.metric_id_pool)
+                        .map_err(|e| {
+                            let source_detail = format_error_sources(&e);
+                            Error::ProcessorError {
+                                processor: effect_handler.processor_id(),
+                                kind: ProcessorErrorKind::Other,
+                                error: format!("Filter error: {e}"),
+                                source_detail,
+                            }
+                        })?;
+                    Ok((filtered, consumed, filtered_count))
+                }
+                SignalType::Logs => {
+                    let (filtered, consumed, filtered_count) = self
+                        .config
+                        .log_filters()
+                        .filter(arrow_records)
+                        .map_err(|e| {
+                            let source_detail = format_error_sources(&e);
+                            Error::ProcessorError {
+                                processor: effect_handler.processor_id(),
+                                kind: ProcessorErrorKind::Other,
+                                error: format!("Filter error: {e}"),
+                                source_detail,
+                            }
+                        })?;
+                    Ok((filtered, consumed, filtered_count))
+                }
+                SignalType::Traces => {
+                    let (filtered, consumed, filtered_count) = self
+                        .config
+                        .trace_filters()
+                        .filter(arrow_records)
+                        .map_err(|e| {
+                            let source_detail = format_error_sources(&e);
+                            Error::ProcessorError {
+                                processor: effect_handler.processor_id(),
+                                kind: ProcessorErrorKind::Other,
+                                error: format!("Filter error: {e}"),
+                                source_detail,
+                            }
+                        })?;
+                    Ok((filtered, consumed, filtered_count))
+                }
+            }
+        })?;
+
+        let metric = self.metrics.with(SignalAttributes { signal });
+        metric.dropped_items.add(dropped_items);
+
+        // Record the drop flow-metric. A no-op unless this node is
+        // a decision node in a flow that enables `dropped.items`.
+        // `dropped_items` is the dropped count.
+        effect_handler.record_flow_dropped_items(signal, dropped_items);
+
+        let kept_items = filtered_arrow_records.num_items();
+        let mut pdata = OtapPdata::new(context, filtered_arrow_records.into());
+        if kept_items == 0 {
+            pdata.complete_processor_without_output(effect_handler);
+            effect_handler.notify_ack(AckMsg::new(pdata)).await?;
+        } else {
+            effect_handler.send_message_with_source_node(pdata).await?;
+        }
+        Ok(())
     }
 }
 
@@ -243,6 +259,7 @@ mod tests {
     use crate::processors::filter_processor::{
         FILTER_PROCESSOR_URN, FilterProcessor, config::Config,
     };
+    use bytes::Bytes;
     use otel_arrow_dfe_config::SignalType;
     use otel_arrow_dfe_config::node::NodeUserConfig;
     use otel_arrow_dfe_engine::Interests;
@@ -258,6 +275,7 @@ mod tests {
     use otel_arrow_dfe_otap::pdata::OtapPdata;
     use otel_arrow_dfe_pdata::OtlpProtoBytes;
     use otel_arrow_dfe_pdata::TryIntoWithOptions;
+    use otel_arrow_dfe_pdata::codec::ResolvedCodec;
     use otel_arrow_dfe_pdata::otap::filter::{
         AnyValue as AnyValueFilter, KeyValue as KeyValueFilter, MatchType,
         logs::{LogFilter, LogMatchProperties, LogSeverityNumberMatchProperties},
@@ -914,6 +932,55 @@ mod tests {
                 assert_fully_filtered(&mut ctx, otlp_traces_bytes, SignalType::Traces).await;
             })
         }
+    }
+
+    /// Scenario: the native processor adapter receives malformed generalized OTLP input.
+    /// Guarantees: the filter permanently Nacks the exact bytes instead of returning a node error.
+    #[test]
+    fn malformed_encoded_input_is_recoverable() {
+        let test_runtime = TestRuntime::<OtapPdata>::new();
+        let controller = ControllerContext::new(test_runtime.metrics_registry());
+        let pipeline_ctx =
+            controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        let processor = ProcessorWrapper::local(
+            FilterProcessor::from_config(pipeline_ctx, &json!({})).unwrap(),
+            test_node(test_runtime.config().name.clone()),
+            Arc::new(NodeUserConfig::new_processor_config(FILTER_PROCESSOR_URN)),
+            test_runtime.config(),
+        );
+        let bytes = Bytes::from_static(&[0x0a, 0x05, 0x01]);
+        let pointer = bytes.as_ptr();
+        let pdata = OtapPdata::new_default(
+            ResolvedCodec::OTLP
+                .admit(SignalType::Logs, bytes.clone())
+                .unwrap()
+                .into(),
+        )
+        .test_subscribe_to(
+            Interests::NACKS | Interests::RETURN_DATA,
+            CallData::new(),
+            11,
+        );
+
+        test_runtime
+            .set_processor(processor)
+            .run_test(move |mut ctx| async move {
+                let (completion_tx, mut completion_rx) = pipeline_completion_msg_channel(1);
+                ctx.set_pipeline_completion_sender(completion_tx);
+                ctx.process(Message::PData(pdata)).await.unwrap();
+                assert!(ctx.drain_pdata().await.is_empty());
+                match completion_rx.recv().await.unwrap() {
+                    PipelineCompletionMsg::DeliverNack { nack } => {
+                        assert!(nack.permanent);
+                        assert!(nack.reason.contains("otlp-bytes"));
+                        let recovered = nack.refused.payload_ref().encoded_bytes().unwrap();
+                        assert_eq!(recovered.as_ptr(), pointer);
+                        assert_eq!(recovered, &bytes);
+                    }
+                    other => panic!("expected codec Nack, got {other:?}"),
+                }
+            })
+            .validate(|_| async {});
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/log_sampling_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/log_sampling_processor/mod.rs
@@ -324,6 +324,7 @@ mod tests {
                 let output_otap = match output_payload.into_data() {
                     PayloadData::OtlpBytes(_) => panic!("Unexpected otlp bytes"),
                     PayloadData::OtapArrowRecords(otap_arrow_records) => otap_arrow_records,
+                    PayloadData::Encoded(_) => panic!("Unexpected encoded bytes"),
                 };
 
                 let output_attrs = output_otap.get(ArrowPayloadType::LogAttrs).unwrap();

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
@@ -641,6 +641,9 @@ impl TemporalReaggregationProcessor {
                 let view = RawMetricsData::new(otlp.as_bytes());
                 self.process_view(effect_handler, &view).await
             }
+            PayloadData::Encoded(_) => {
+                unreachable!("encoded payloads are not admitted during the storage transition")
+            }
         };
 
         match result {

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/testing.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/testing.rs
@@ -350,6 +350,7 @@ fn payload_to_otlp(payload: &OtapPayload) -> otel_arrow_dfe_pdata::proto::OtlpPr
         PayloadData::OtlpBytes(bytes) => {
             otel_arrow_dfe_pdata::testing::round_trip::otlp_bytes_to_message(bytes.clone())
         }
+        PayloadData::Encoded(_) => panic!("unexpected encoded payload in legacy test helper"),
     }
 }
 

--- a/rust/otap-dataflow/crates/engine/src/exporter.rs
+++ b/rust/otap-dataflow/crates/engine/src/exporter.rs
@@ -29,6 +29,7 @@ use otel_arrow_dfe_channel::error::SendError;
 use otel_arrow_dfe_channel::mpsc;
 use otel_arrow_dfe_config::node::NodeUserConfig;
 use otel_arrow_dfe_config::transport_headers_policy::HeaderPropagationPolicy;
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
 use std::sync::Arc;
 
@@ -297,6 +298,7 @@ impl<PData> ExporterWrapper<PData> {
             metrics_reporter,
             node_interests,
             None,
+            CodecExecutor::default(),
         )
         .await
     }
@@ -308,6 +310,7 @@ impl<PData> ExporterWrapper<PData> {
         metrics_reporter: MetricsReporter,
         node_interests: Interests,
         completion_emission_metrics: Option<CompletionEmissionMetricsHandle>,
+        codec_executor: CodecExecutor,
     ) -> Result<TerminalState, Error> {
         match (self, metrics_reporter) {
             (
@@ -323,6 +326,7 @@ impl<PData> ExporterWrapper<PData> {
             ) => {
                 let mut effect_handler =
                     local::EffectHandler::new(node_id.clone(), metrics_reporter);
+                effect_handler.set_codec_executor(codec_executor.clone());
                 let pdata_rx = pdata_receiver.ok_or_else(|| Error::ExporterError {
                     exporter: effect_handler.exporter_id(),
                     kind: ExporterErrorKind::Configuration,
@@ -361,6 +365,7 @@ impl<PData> ExporterWrapper<PData> {
             ) => {
                 let mut effect_handler =
                     shared::EffectHandler::new(node_id.clone(), metrics_reporter);
+                effect_handler.set_codec_executor(codec_executor);
                 let pdata_rx = pdata_receiver.ok_or_else(|| Error::ExporterError {
                     exporter: effect_handler.exporter_id(),
                     kind: ExporterErrorKind::Configuration,

--- a/rust/otap-dataflow/crates/engine/src/local/exporter.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/exporter.rs
@@ -42,6 +42,7 @@ use crate::node::NodeId;
 use crate::terminal_state::TerminalState;
 use async_trait::async_trait;
 use otel_arrow_dfe_config::transport_headers_policy::HeaderPropagationPolicy;
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::error::Error as TelemetryError;
 use otel_arrow_dfe_telemetry::metrics::{MetricSet, MetricSetHandler};
 use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
@@ -96,6 +97,7 @@ pub trait Exporter<PData> {
 #[derive(Clone)]
 pub struct EffectHandler<PData> {
     pub(crate) core: EffectHandlerCore<PData>,
+    codec_executor: CodecExecutor,
     _pd: PhantomData<PData>,
     /// Propagation policy for filtering captured headers on egress.
     /// `None` when no propagation policy is configured (zero overhead).
@@ -109,9 +111,21 @@ impl<PData> EffectHandler<PData> {
     pub fn new(node_id: NodeId, metrics_reporter: MetricsReporter) -> Self {
         EffectHandler {
             core: EffectHandlerCore::new(node_id, metrics_reporter),
+            codec_executor: CodecExecutor::default(),
             _pd: PhantomData,
             propagation_policy: None,
         }
+    }
+
+    /// Returns the runtime-owned pdata codec service.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn codec_executor(&self) -> &CodecExecutor {
+        &self.codec_executor
+    }
+
+    pub(crate) fn set_codec_executor(&mut self, codec_executor: CodecExecutor) {
+        self.codec_executor = codec_executor;
     }
 
     /// Returns the id of the exporter associated with this handler.

--- a/rust/otap-dataflow/crates/engine/src/local/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/processor.rs
@@ -54,6 +54,7 @@ use crate::processor::ProcessorRuntimeRequirements;
 use crate::{WakeupError, WakeupSetOutcome};
 use async_trait::async_trait;
 use otel_arrow_dfe_config::{PortName, SignalType};
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::common_attributes::SignalAttributes;
 use otel_arrow_dfe_telemetry::error::Error as TelemetryError;
 use otel_arrow_dfe_telemetry::instrument::HistogramNormal;
@@ -131,6 +132,7 @@ pub trait Processor<PData> {
 #[derive(Clone)]
 pub struct EffectHandler<PData> {
     pub(crate) core: EffectHandlerCore<PData>,
+    codec_executor: CodecExecutor,
     /// Output-port router.
     pub router: OutputRouter<Sender<PData>>,
     /// Per-handler flow_metric state. See [`LocalFlowMetricState`] /
@@ -152,9 +154,21 @@ impl<PData> EffectHandler<PData> {
         let router = OutputRouter::new(node_id, msg_senders, default_port);
         EffectHandler {
             core,
+            codec_executor: CodecExecutor::default(),
             router,
             flow: LocalFlowMetricState::default(),
         }
+    }
+
+    /// Returns the runtime-owned pdata codec service.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn codec_executor(&self) -> &CodecExecutor {
+        &self.codec_executor
+    }
+
+    pub(crate) fn set_codec_executor(&mut self, codec_executor: CodecExecutor) {
+        self.codec_executor = codec_executor;
     }
 
     /// Returns the id of the processor associated with this handler.

--- a/rust/otap-dataflow/crates/engine/src/local/receiver.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/receiver.rs
@@ -46,6 +46,7 @@ use async_trait::async_trait;
 use otel_arrow_dfe_channel::error::RecvError;
 use otel_arrow_dfe_config::PortName;
 use otel_arrow_dfe_config::transport_headers_policy::HeaderCapturePolicy;
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::error::Error as TelemetryError;
 use otel_arrow_dfe_telemetry::metrics::{MetricSet, MetricSetHandler};
 use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
@@ -133,6 +134,7 @@ impl<PData> ControlChannel<PData> {
 #[derive(Clone)]
 pub struct EffectHandler<PData> {
     pub(crate) core: EffectHandlerCore<PData>,
+    codec_executor: CodecExecutor,
     /// Output-port router.
     pub router: OutputRouter<Sender<PData>>,
     /// Capture policy for extracting transport headers from inbound metadata.
@@ -156,9 +158,21 @@ impl<PData> EffectHandler<PData> {
         let router = OutputRouter::new(node_id, msg_senders, default_port);
         EffectHandler {
             core,
+            codec_executor: CodecExecutor::default(),
             router,
             capture_policy: None,
         }
+    }
+
+    /// Returns the runtime-owned pdata codec service.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn codec_executor(&self) -> &CodecExecutor {
+        &self.codec_executor
+    }
+
+    pub(crate) fn set_codec_executor(&mut self, codec_executor: CodecExecutor) {
+        self.codec_executor = codec_executor;
     }
 
     /// Returns the id of the receiver associated with this handler.

--- a/rust/otap-dataflow/crates/engine/src/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/processor.rs
@@ -36,6 +36,7 @@ use otel_arrow_dfe_channel::error::SendError;
 use otel_arrow_dfe_channel::mpsc;
 use otel_arrow_dfe_config::node::NodeUserConfig;
 use otel_arrow_dfe_config::{PortName, SignalType};
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::metrics::MeasurementMetricSet;
 use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
 use std::collections::HashMap;
@@ -613,6 +614,7 @@ impl<PData> ProcessorWrapper<PData> {
             false,
             false,
             TerminalMetricsDeadline::default(),
+            CodecExecutor::default(),
         )
         .await
     }
@@ -637,6 +639,7 @@ impl<PData> ProcessorWrapper<PData> {
         flow_metrics_active: bool,
         flow_needs_timing: bool,
         terminal_metrics_deadline: TerminalMetricsDeadline,
+        codec_executor: CodecExecutor,
     ) -> Result<(), Error>
     where
         PData: ReceivedAtNode + FlowMetricHook,
@@ -651,6 +654,7 @@ impl<PData> ProcessorWrapper<PData> {
                 mut inbox,
                 mut effect_handler,
             } => {
+                effect_handler.set_codec_executor(codec_executor.clone());
                 effect_handler
                     .core
                     .set_runtime_ctrl_msg_sender(runtime_ctrl_msg_tx);
@@ -750,6 +754,7 @@ impl<PData> ProcessorWrapper<PData> {
                 mut inbox,
                 mut effect_handler,
             } => {
+                effect_handler.set_codec_executor(codec_executor);
                 effect_handler
                     .core
                     .set_runtime_ctrl_msg_sender(runtime_ctrl_msg_tx);
@@ -1021,6 +1026,7 @@ mod tests {
     use crate::testing::{CtrlMsgCounters, TestMsg, test_node};
     use async_trait::async_trait;
     use otel_arrow_dfe_config::{SignalType, node::NodeUserConfig};
+    use otel_arrow_dfe_pdata::codec::CodecExecutor;
     use otel_arrow_dfe_telemetry::common_attributes::SignalAttributes;
     use otel_arrow_dfe_telemetry::metrics::{MeasurementMetricSet, MetricValue};
     use serde_json::Value;
@@ -1541,6 +1547,7 @@ mod tests {
                             true,
                             true,
                             crate::terminal_state::TerminalMetricsDeadline::default(),
+                            CodecExecutor::default(),
                         )
                         .await
                 });
@@ -1758,6 +1765,7 @@ mod tests {
                 true, // flow_metrics_active
                 false,
                 crate::terminal_state::TerminalMetricsDeadline::default(),
+                CodecExecutor::default(),
             )
             .await;
 
@@ -1999,6 +2007,7 @@ mod tests {
                 true,
                 false,
                 crate::terminal_state::TerminalMetricsDeadline::default(),
+                CodecExecutor::default(),
             )
             .await;
 

--- a/rust/otap-dataflow/crates/engine/src/receiver.rs
+++ b/rust/otap-dataflow/crates/engine/src/receiver.rs
@@ -30,6 +30,7 @@ use otel_arrow_dfe_channel::mpsc;
 use otel_arrow_dfe_config::PortName;
 use otel_arrow_dfe_config::node::NodeUserConfig;
 use otel_arrow_dfe_config::transport_headers_policy::HeaderCapturePolicy;
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -323,6 +324,24 @@ impl<PData> ReceiverWrapper<PData> {
         metrics_reporter: MetricsReporter,
         node_interests: Interests,
     ) -> Result<TerminalState, Error> {
+        self.start_with_codec_executor(
+            runtime_ctrl_msg_tx,
+            pipeline_completion_msg_tx,
+            metrics_reporter,
+            node_interests,
+            CodecExecutor::default(),
+        )
+        .await
+    }
+
+    pub(crate) async fn start_with_codec_executor(
+        self,
+        runtime_ctrl_msg_tx: RuntimeCtrlMsgSender<PData>,
+        pipeline_completion_msg_tx: PipelineCompletionMsgSender<PData>,
+        metrics_reporter: MetricsReporter,
+        node_interests: Interests,
+        codec_executor: CodecExecutor,
+    ) -> Result<TerminalState, Error> {
         match (self, metrics_reporter) {
             (
                 ReceiverWrapper::Local {
@@ -356,6 +375,7 @@ impl<PData> ReceiverWrapper<PData> {
                     runtime_ctrl_msg_tx,
                     metrics_reporter,
                 );
+                effect_handler.set_codec_executor(codec_executor.clone());
                 effect_handler.set_source_tagging(source_tag);
                 effect_handler.set_capture_policy(capture_policy);
                 effect_handler
@@ -396,6 +416,7 @@ impl<PData> ReceiverWrapper<PData> {
                     runtime_ctrl_msg_tx,
                     metrics_reporter,
                 );
+                effect_handler.set_codec_executor(codec_executor);
                 effect_handler.set_source_tagging(source_tag);
                 effect_handler.set_capture_policy(capture_policy);
                 effect_handler

--- a/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
+++ b/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
@@ -39,6 +39,7 @@ use crate::{exporter::ExporterWrapper, processor::ProcessorWrapper, receiver::Re
 use otel_arrow_dfe_config::DeployedPipelineKey;
 use otel_arrow_dfe_config::pipeline::PipelineConfig;
 use otel_arrow_dfe_config::policy::TelemetryPolicy;
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::event::ObservedEventReporter;
 use otel_arrow_dfe_telemetry::metrics::{MeasurementMetricSet, MetricSetSnapshot};
 use otel_arrow_dfe_telemetry::reporter::{MetricsReporter, ReportOutcome};
@@ -470,6 +471,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
             .build()
             .expect("Failed to create runtime");
         let local_tasks = LocalSet::new();
+        let codec_executor = CodecExecutor::default();
         // ToDo create an optimized version of FuturesUnordered that can be used for !Send, !Sync tasks
         let mut futures = FuturesUnordered::new();
 
@@ -613,6 +615,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
             let effect_metrics_reporter = metrics_reporter.clone();
             let final_metrics_reporter = metrics_reporter.clone();
             let exporter_terminal_metrics_deadline = terminal_metrics_deadline.clone();
+            let exporter_codec_executor = codec_executor.clone();
             let fut = async move {
                 match exporter
                     .start_with_completion_metrics(
@@ -621,6 +624,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
                         effect_metrics_reporter,
                         node_interests,
                         completion_emission_metrics,
+                        exporter_codec_executor,
                     )
                     .await
                 {
@@ -695,6 +699,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
             let metrics_reporter = metrics_reporter.clone();
             let final_metrics_reporter = metrics_reporter.clone();
             let processor_terminal_metrics_deadline = terminal_metrics_deadline.clone();
+            let processor_codec_executor = codec_executor.clone();
             // Extract flow metric roles for this processor node.
             // Compute pipeline-wide flags before moving metric sets into handlers.
             let flow_active = flow_metric_state.is_active();
@@ -774,6 +779,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
                         flow_active,
                         flow_needs_timing,
                         processor_terminal_metrics_deadline.clone(),
+                        processor_codec_executor,
                     )
                     .await;
                 flush_metrics_reporter(
@@ -833,13 +839,15 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
             let effect_metrics_reporter = metrics_reporter.clone();
             let final_metrics_reporter = metrics_reporter.clone();
             let receiver_terminal_metrics_deadline = terminal_metrics_deadline.clone();
+            let receiver_codec_executor = codec_executor.clone();
             let fut = async move {
                 match receiver
-                    .start(
+                    .start_with_codec_executor(
                         runtime_ctrl_msg_tx,
                         pipeline_completion_msg_tx,
                         effect_metrics_reporter,
                         node_interests,
+                        receiver_codec_executor,
                     )
                     .await
                 {

--- a/rust/otap-dataflow/crates/engine/src/shared/exporter.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/exporter.rs
@@ -43,6 +43,7 @@ use crate::{Interests, ReceivedAtNode};
 use async_trait::async_trait;
 use otel_arrow_dfe_channel::error::RecvError;
 use otel_arrow_dfe_config::transport_headers_policy::HeaderPropagationPolicy;
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::error::Error as TelemetryError;
 use otel_arrow_dfe_telemetry::metrics::{MetricSet, MetricSetHandler};
 use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
@@ -97,6 +98,7 @@ pub trait Exporter<PData> {
 #[derive(Clone)]
 pub struct EffectHandler<PData> {
     pub(crate) core: EffectHandlerCore<PData>,
+    codec_executor: CodecExecutor,
     _pd: PhantomData<PData>,
     /// Propagation policy for filtering captured headers on egress.
     /// `None` when no propagation policy is configured (zero overhead).
@@ -110,9 +112,21 @@ impl<PData> EffectHandler<PData> {
     pub fn new(node_id: NodeId, metrics_reporter: MetricsReporter) -> Self {
         EffectHandler {
             core: EffectHandlerCore::new(node_id, metrics_reporter),
+            codec_executor: CodecExecutor::default(),
             _pd: PhantomData,
             propagation_policy: None,
         }
+    }
+
+    /// Returns the runtime-owned pdata codec service.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn codec_executor(&self) -> &CodecExecutor {
+        &self.codec_executor
+    }
+
+    pub(crate) fn set_codec_executor(&mut self, codec_executor: CodecExecutor) {
+        self.codec_executor = codec_executor;
     }
 
     /// Returns the id of the exporter associated with this handler.

--- a/rust/otap-dataflow/crates/engine/src/shared/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/processor.rs
@@ -53,6 +53,7 @@ use crate::shared::message::SharedSender;
 use crate::{WakeupError, WakeupSetOutcome};
 use async_trait::async_trait;
 use otel_arrow_dfe_config::{PortName, SignalType};
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::common_attributes::SignalAttributes;
 use otel_arrow_dfe_telemetry::error::Error as TelemetryError;
 use otel_arrow_dfe_telemetry::instrument::HistogramNormal;
@@ -130,6 +131,7 @@ pub trait Processor<PData> {
 #[derive(Clone)]
 pub struct EffectHandler<PData> {
     pub(crate) core: EffectHandlerCore<PData>,
+    codec_executor: CodecExecutor,
     /// Output-port router.
     pub router: OutputRouter<SharedSender<PData>>,
     /// Per-handler flow_metric state. See [`SharedFlowMetricState`] /
@@ -156,9 +158,21 @@ impl<PData> EffectHandler<PData> {
         let router = OutputRouter::new(node_id, msg_senders, default_port);
         EffectHandler {
             core,
+            codec_executor: CodecExecutor::default(),
             router,
             flow: SharedFlowMetricState::default(),
         }
+    }
+
+    /// Returns the runtime-owned pdata codec service.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn codec_executor(&self) -> &CodecExecutor {
+        &self.codec_executor
+    }
+
+    pub(crate) fn set_codec_executor(&mut self, codec_executor: CodecExecutor) {
+        self.codec_executor = codec_executor;
     }
 
     /// Returns the id of the processor associated with this handler.

--- a/rust/otap-dataflow/crates/engine/src/shared/receiver.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/receiver.rs
@@ -46,6 +46,7 @@ use async_trait::async_trait;
 use otel_arrow_dfe_channel::error::RecvError;
 use otel_arrow_dfe_config::PortName;
 use otel_arrow_dfe_config::transport_headers_policy::HeaderCapturePolicy;
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::error::Error as TelemetryError;
 use otel_arrow_dfe_telemetry::metrics::{MetricSet, MetricSetHandler};
 use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
@@ -101,6 +102,7 @@ impl<PData> ControlChannel<PData> {
 #[derive(Clone)]
 pub struct EffectHandler<PData> {
     pub(crate) core: EffectHandlerCore<PData>,
+    codec_executor: CodecExecutor,
     /// Output-port router.
     pub router: OutputRouter<SharedSender<PData>>,
     /// Capture policy for extracting transport headers from inbound metadata.
@@ -127,9 +129,21 @@ impl<PData> EffectHandler<PData> {
         let router = OutputRouter::new(node_id, msg_senders, default_port);
         EffectHandler {
             core,
+            codec_executor: CodecExecutor::default(),
             router,
             capture_policy: None,
         }
+    }
+
+    /// Returns the runtime-owned pdata codec service.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn codec_executor(&self) -> &CodecExecutor {
+        &self.codec_executor
+    }
+
+    pub(crate) fn set_codec_executor(&mut self, codec_executor: CodecExecutor) {
+        self.codec_executor = codec_executor;
     }
 
     /// Returns the name of the receiver associated with this handler.

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -1172,7 +1172,16 @@ mod test {
     use pretty_assertions::assert_eq;
     use std::cell::Cell;
     use std::collections::HashMap;
+    use std::mem::size_of;
     use tokio::sync::mpsc;
+
+    /// Scenario: Queued OTAP pdata is built for a 64-bit target before codec integration.
+    /// Guarantees: The baseline queued-message layout remains fixed for later comparisons.
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn legacy_otap_pdata_layout_is_stable() {
+        assert_eq!(size_of::<OtapPdata>(), 152);
+    }
 
     fn create_test() -> (TestCallData, OtapPdata) {
         (TestCallData::default(), create_test_pdata())

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -31,7 +31,7 @@ use otel_arrow_dfe_engine::{
     MessageSourceLocalEffectHandlerExtension, MessageSourceSharedEffectHandlerExtension,
     ProducerEffectHandlerExtension,
 };
-use otel_arrow_dfe_pdata::OtapPayload;
+use otel_arrow_dfe_pdata::{CodecState, OtapArrowRecords, OtapPayload};
 
 use crate::transport_headers::TransportHeaders;
 
@@ -605,6 +605,95 @@ pub struct OtapPdata {
     payload: OtapPayload,
 }
 
+/// Owned capability proving that pdata is available as native Arrow records.
+#[derive(Clone, Debug)]
+pub struct OtapArrowPdata {
+    context: Context,
+    records: OtapArrowRecords,
+}
+
+impl OtapArrowPdata {
+    /// Constructs native pdata from its delivery context and records.
+    #[must_use]
+    pub const fn new(context: Context, records: OtapArrowRecords) -> Self {
+        Self { context, records }
+    }
+
+    /// Borrows the delivery context.
+    #[must_use]
+    pub const fn context(&self) -> &Context {
+        &self.context
+    }
+
+    /// Returns a mutable delivery context.
+    pub const fn context_mut(&mut self) -> &mut Context {
+        &mut self.context
+    }
+
+    /// Borrows native records.
+    #[must_use]
+    pub const fn records(&self) -> &OtapArrowRecords {
+        &self.records
+    }
+
+    /// Returns mutable native records.
+    pub const fn records_mut(&mut self) -> &mut OtapArrowRecords {
+        &mut self.records
+    }
+
+    /// Splits delivery context and native records without cloning.
+    #[must_use]
+    pub fn into_parts(self) -> (Context, OtapArrowRecords) {
+        (self.context, self.records)
+    }
+
+    /// Converts back to dynamically represented pipeline pdata.
+    #[must_use]
+    pub fn into_pdata(self) -> OtapPdata {
+        OtapPdata::new(self.context, self.records.into())
+    }
+}
+
+impl From<OtapArrowPdata> for OtapPdata {
+    fn from(value: OtapArrowPdata) -> Self {
+        value.into_pdata()
+    }
+}
+
+/// A failed codec conversion carrying the exact original pdata for Nack or retry.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct OtapPdataDecodeError(Box<OtapPdataDecodeErrorInner>);
+
+#[derive(Debug, thiserror::Error)]
+#[error("{source}")]
+struct OtapPdataDecodeErrorInner {
+    #[source]
+    source: otel_arrow_dfe_pdata::encode::Error,
+    pdata: OtapPdata,
+}
+
+impl OtapPdataDecodeError {
+    /// Returns the codec or conversion error.
+    #[must_use]
+    pub const fn error(&self) -> &otel_arrow_dfe_pdata::encode::Error {
+        &self.0.source
+    }
+
+    /// Borrows the exact original pdata retained for recovery.
+    #[must_use]
+    pub const fn pdata(&self) -> &OtapPdata {
+        &self.0.pdata
+    }
+
+    /// Splits the error and recoverable original pdata.
+    #[must_use]
+    pub fn into_parts(self) -> (otel_arrow_dfe_pdata::encode::Error, OtapPdata) {
+        let inner = *self.0;
+        (inner.source, inner.pdata)
+    }
+}
+
 /* -------- Signal type -------- */
 
 impl OtapPdata {
@@ -633,6 +722,25 @@ impl OtapPdata {
     #[must_use]
     pub const fn new(context: Context, payload: OtapPayload) -> Self {
         Self { context, payload }
+    }
+
+    /// Extracts native records through reusable codec state while retaining
+    /// the exact original pdata on failure.
+    pub fn try_into_otap(
+        self,
+        state: &mut CodecState,
+    ) -> Result<OtapArrowPdata, OtapPdataDecodeError> {
+        let Self { context, payload } = self;
+        match payload.try_into_otap(state) {
+            Ok(records) => Ok(OtapArrowPdata::new(context, records)),
+            Err(error) => {
+                let (source, payload) = error.into_parts();
+                Err(OtapPdataDecodeError(Box::new(OtapPdataDecodeErrorInner {
+                    source,
+                    pdata: Self { context, payload },
+                })))
+            }
+        }
     }
 
     /// Returns the type of signal represented by this `OtapPdata` instance.
@@ -1175,12 +1283,48 @@ mod test {
     use std::mem::size_of;
     use tokio::sync::mpsc;
 
-    /// Scenario: Queued OTAP pdata is built for a 64-bit target before codec integration.
-    /// Guarantees: The baseline queued-message layout remains fixed for later comparisons.
+    /// Scenario: Queued and native-capability pdata are built for a 64-bit target.
+    /// Guarantees: Transitional encoded storage reduces the queue below the 152-byte baseline.
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn legacy_otap_pdata_layout_is_stable() {
-        assert_eq!(size_of::<OtapPdata>(), 152);
+        assert_eq!(size_of::<OtapPdata>(), 144);
+        assert!(size_of::<OtapArrowPdata>() <= size_of::<OtapPdata>());
+    }
+
+    /// Scenario: Malformed encoded pdata carries delivery context through failed conversion.
+    /// Guarantees: Recovery preserves peer address, codec identity, bytes, signal, and item count.
+    #[test]
+    fn encoded_conversion_failure_preserves_delivery_ownership() {
+        use bytes::Bytes;
+        use otel_arrow_dfe_pdata::{PdataFormat, ResolvedCodec};
+
+        let peer = "127.0.0.1:4317".parse().expect("peer address");
+        let bytes = Bytes::from_static(&[0x0a, 0x05, 0x01]);
+        let pointer = bytes.as_ptr();
+        let payload = OtapPayload::from_encoded(
+            ResolvedCodec::OTLP
+                .admit(SignalType::Logs, bytes)
+                .expect("lazy admission"),
+        )
+        .with_item_count(9);
+        let pdata = OtapPdata::new(Context::default(), payload).with_peer_addr(peer);
+
+        let error = pdata
+            .try_into_otap(&mut CodecState::default())
+            .expect_err("malformed OTLP must fail");
+        let (_, recovered) = error.into_parts();
+        assert_eq!(recovered.peer_addr(), Some(peer));
+        assert_eq!(
+            recovered.payload_ref().format(),
+            PdataFormat::encoded(ResolvedCodec::OTLP)
+        );
+        assert_eq!(recovered.payload_ref().known_item_count(), Some(9));
+        assert_eq!(
+            recovered.payload_ref().encoded_bytes().unwrap().as_ptr(),
+            pointer
+        );
+        assert_eq!(recovered.signal_type(), SignalType::Logs);
     }
 
     fn create_test() -> (TestCallData, OtapPdata) {

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -21,17 +21,20 @@ use otel_arrow_dfe_config::PortName;
 use otel_arrow_dfe_config::{SignalFormat, SignalType};
 use otel_arrow_dfe_engine::_private::AckNackRouting;
 use otel_arrow_dfe_engine::control::{
-    AckMsg, CallData, Frame, NackMsg, RouteData, nanos_since_birth,
+    AckMsg, CallData, Frame, NackMsg, NodeControlMsg, RouteData, nanos_since_birth,
 };
 use otel_arrow_dfe_engine::error::{Error, TypedError};
 use otel_arrow_dfe_engine::flow_metrics::FlowMetricInterests;
-use otel_arrow_dfe_engine::processor::{FlowMetricEffectHandler, FlowMetricHook};
+use otel_arrow_dfe_engine::processor::{
+    FlowMetricEffectHandler, FlowMetricHook, ProcessorRuntimeRequirements,
+};
 use otel_arrow_dfe_engine::{
     ConsumerEffectHandlerExtension, FlowMetricAccumulation, Interests,
     MessageSourceLocalEffectHandlerExtension, MessageSourceSharedEffectHandlerExtension,
     ProducerEffectHandlerExtension,
 };
-use otel_arrow_dfe_pdata::{CodecState, OtapArrowRecords, OtapPayload};
+use otel_arrow_dfe_pdata::codec::{CodecView, EncodingPlan};
+use otel_arrow_dfe_pdata::{CodecState, OtapArrowRecords, OtapPayload, OtapPayloadHelpers};
 
 use crate::transport_headers::TransportHeaders;
 
@@ -641,6 +644,12 @@ impl OtapArrowPdata {
         &mut self.records
     }
 
+    /// Returns the signal represented by the native records.
+    #[must_use]
+    pub fn signal_type(&self) -> SignalType {
+        self.records.signal_type()
+    }
+
     /// Splits delivery context and native records without cloning.
     #[must_use]
     pub fn into_parts(self) -> (Context, OtapArrowRecords) {
@@ -1045,6 +1054,167 @@ impl_consumer_ext!(otel_arrow_dfe_engine::local::processor::EffectHandler<OtapPd
 impl_consumer_ext!(otel_arrow_dfe_engine::local::exporter::EffectHandler<OtapPdata>);
 impl_consumer_ext!(otel_arrow_dfe_engine::shared::processor::EffectHandler<OtapPdata>);
 impl_consumer_ext!(otel_arrow_dfe_engine::shared::exporter::EffectHandler<OtapPdata>);
+
+/* -------- Pdata codec effect handler extensions -------- */
+
+/// Representation-independent pdata operations supplied by an effect handler.
+///
+/// Codec state belongs to the pipeline runtime. These methods are async at the
+/// node boundary so codecs that need an offloaded or asynchronous executor can
+/// be added later without storing codec state in nodes. The current operations
+/// scope their synchronous state borrow entirely before returning.
+#[allow(async_fn_in_trait)]
+pub trait PdataEffectHandlerExtension {
+    /// Moves native records or decodes encoded pdata with recoverable failure.
+    async fn try_into_otap(&self, pdata: OtapPdata)
+    -> Result<OtapArrowPdata, OtapPdataDecodeError>;
+
+    /// Moves native records or decodes a payload with recoverable failure.
+    async fn try_payload_into_otap(
+        &self,
+        payload: OtapPayload,
+    ) -> Result<OtapArrowRecords, otel_arrow_dfe_pdata::OtapPayloadDecodeError>;
+
+    /// Borrows a read-only view through runtime-owned codec state.
+    async fn view<'a>(
+        &self,
+        payload: &'a OtapPayload,
+    ) -> Result<CodecView<'a>, otel_arrow_dfe_pdata::encode::Error>;
+
+    /// Encodes inside a scope that cannot cross an await point.
+    async fn with_encoded<R>(
+        &self,
+        payload: &mut OtapPayload,
+        plan: &EncodingPlan,
+        consume: impl FnOnce(&[u8]) -> R,
+    ) -> Result<R, otel_arrow_dfe_pdata::error::Error>;
+
+    /// Encodes to owned bytes suitable for asynchronous delivery.
+    async fn encode_owned(
+        &self,
+        payload: &mut OtapPayload,
+        plan: &EncodingPlan,
+    ) -> Result<bytes::Bytes, otel_arrow_dfe_pdata::error::Error>;
+}
+
+/// Processor capability for algorithms that always require mutable native OTAP.
+///
+/// Implementors only receive typed Arrow pdata. The adapter owns conversion
+/// and the permanent Nack policy for malformed encoded input.
+#[async_trait(?Send)]
+pub trait NativePdataProcessor {
+    /// Processes one successfully materialized native batch.
+    async fn process_native(
+        &mut self,
+        pdata: OtapArrowPdata,
+        effect_handler: &mut otel_arrow_dfe_engine::local::processor::EffectHandler<OtapPdata>,
+    ) -> Result<(), Error>;
+
+    /// Processes a control message without forcing pdata conversion.
+    async fn process_control(
+        &mut self,
+        _control: NodeControlMsg<OtapPdata>,
+        _effect_handler: &mut otel_arrow_dfe_engine::local::processor::EffectHandler<OtapPdata>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
+    /// Declares runtime services required by the native processor.
+    fn runtime_requirements(&self) -> ProcessorRuntimeRequirements {
+        ProcessorRuntimeRequirements::none()
+    }
+}
+
+/// Runs a [`NativePdataProcessor`] behind the dynamic pdata boundary.
+pub struct NativeProcessorAdapter;
+
+impl NativeProcessorAdapter {
+    /// Converts pdata, permanently Nacks codec failures, and invokes the
+    /// processor only after native access has been established.
+    pub async fn process<P: NativePdataProcessor>(
+        processor: &mut P,
+        msg: otel_arrow_dfe_engine::message::Message<OtapPdata>,
+        effect_handler: &mut otel_arrow_dfe_engine::local::processor::EffectHandler<OtapPdata>,
+    ) -> Result<(), Error> {
+        match msg {
+            otel_arrow_dfe_engine::message::Message::Control(control) => {
+                processor.process_control(control, effect_handler).await
+            }
+            otel_arrow_dfe_engine::message::Message::PData(pdata) => {
+                match effect_handler.try_into_otap(pdata).await {
+                    Ok(pdata) => processor.process_native(pdata, effect_handler).await,
+                    Err(error) => {
+                        let (error, pdata) = error.into_parts();
+                        effect_handler
+                            .notify_nack(NackMsg::new_permanent(error.to_string(), pdata))
+                            .await
+                    }
+                }
+            }
+        }
+    }
+}
+
+macro_rules! impl_pdata_effect_handler_ext {
+    ($handler:ty) => {
+        impl PdataEffectHandlerExtension for $handler {
+            async fn try_into_otap(
+                &self,
+                pdata: OtapPdata,
+            ) -> Result<OtapArrowPdata, OtapPdataDecodeError> {
+                let (context, payload) = pdata.into_parts();
+                match self.codec_executor().try_into_otap(payload) {
+                    Ok(records) => Ok(OtapArrowPdata::new(context, records)),
+                    Err(error) => {
+                        let (source, payload) = error.into_parts();
+                        Err(OtapPdataDecodeError(Box::new(OtapPdataDecodeErrorInner {
+                            source,
+                            pdata: OtapPdata::new(context, payload),
+                        })))
+                    }
+                }
+            }
+
+            async fn try_payload_into_otap(
+                &self,
+                payload: OtapPayload,
+            ) -> Result<OtapArrowRecords, otel_arrow_dfe_pdata::OtapPayloadDecodeError> {
+                self.codec_executor().try_into_otap(payload)
+            }
+
+            async fn view<'a>(
+                &self,
+                payload: &'a OtapPayload,
+            ) -> Result<CodecView<'a>, otel_arrow_dfe_pdata::encode::Error> {
+                self.codec_executor().view(payload)
+            }
+
+            async fn with_encoded<R>(
+                &self,
+                payload: &mut OtapPayload,
+                plan: &EncodingPlan,
+                consume: impl FnOnce(&[u8]) -> R,
+            ) -> Result<R, otel_arrow_dfe_pdata::error::Error> {
+                self.codec_executor().with_encoded(payload, plan, consume)
+            }
+
+            async fn encode_owned(
+                &self,
+                payload: &mut OtapPayload,
+                plan: &EncodingPlan,
+            ) -> Result<bytes::Bytes, otel_arrow_dfe_pdata::error::Error> {
+                self.codec_executor().encode_owned(payload, plan)
+            }
+        }
+    };
+}
+
+impl_pdata_effect_handler_ext!(otel_arrow_dfe_engine::local::processor::EffectHandler<OtapPdata>);
+impl_pdata_effect_handler_ext!(otel_arrow_dfe_engine::local::exporter::EffectHandler<OtapPdata>);
+impl_pdata_effect_handler_ext!(otel_arrow_dfe_engine::local::receiver::EffectHandler<OtapPdata>);
+impl_pdata_effect_handler_ext!(otel_arrow_dfe_engine::shared::processor::EffectHandler<OtapPdata>);
+impl_pdata_effect_handler_ext!(otel_arrow_dfe_engine::shared::exporter::EffectHandler<OtapPdata>);
+impl_pdata_effect_handler_ext!(otel_arrow_dfe_engine::shared::receiver::EffectHandler<OtapPdata>);
 
 /* --------  effect handler extensions (shared, local) -------- */
 

--- a/rust/otap-dataflow/crates/pdata/Cargo.toml
+++ b/rust/otap-dataflow/crates/pdata/Cargo.toml
@@ -21,6 +21,7 @@ arrow-schema = { workspace = true }
 datafusion = { workspace = true }
 ciborium = { workspace = true }
 itertools = { workspace = true }
+linkme = { workspace = true }
 otel-arrow-dfe-config = { workspace = true }
 otel-arrow-dfe-pdata-otlp-macros = { workspace = true }
 otel-arrow-dfe-pdata-otlp-model = { workspace = true }

--- a/rust/otap-dataflow/crates/pdata/src/codec.rs
+++ b/rust/otap-dataflow/crates/pdata/src/codec.rs
@@ -10,6 +10,7 @@
 
 use std::borrow::{Borrow, Cow};
 use std::fmt;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use bytes::Bytes;
 use otel_arrow_dfe_config::{EncodeOptions, SignalType};
@@ -338,6 +339,83 @@ impl EncodingPlan {
 #[derive(Default)]
 pub struct CodecState {
     codecs: Vec<(ResolvedCodec, Box<dyn PdataCodec>)>,
+}
+
+/// Scoped handle to the codec state owned by one pipeline runtime.
+///
+/// Cloning this value only clones the `Arc`. The closure boundary prevents a
+/// mutable codec borrow from escaping the operation or crossing an async
+/// suspension point. The mutex also lets shared nodes use the same pipeline
+/// service as local nodes. A future blocking or async executor can replace this
+/// implementation without putting codec state into node structs.
+#[derive(Clone, Default)]
+pub struct CodecExecutor {
+    state: Arc<Mutex<CodecState>>,
+}
+
+impl CodecExecutor {
+    fn lock(&self) -> MutexGuard<'_, CodecState> {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Runs one synchronous operation against runtime-owned codec state.
+    ///
+    /// This is an implementation hook for pdata-aware effect handlers. Nodes
+    /// should use the higher-level effect-handler capabilities instead.
+    #[doc(hidden)]
+    pub fn execute<R>(&self, operation: impl FnOnce(&mut CodecState) -> R) -> R {
+        operation(&mut self.lock())
+    }
+
+    /// Extracts or decodes native records while retaining failed input.
+    pub fn try_into_otap(
+        &self,
+        payload: crate::OtapPayload,
+    ) -> Result<OtapArrowRecords, crate::OtapPayloadDecodeError> {
+        self.execute(|state| payload.try_into_otap(state))
+    }
+
+    /// Borrows a representation-independent view of a payload.
+    pub fn view<'a>(
+        &self,
+        payload: &'a crate::OtapPayload,
+    ) -> Result<CodecView<'a>, crate::encode::Error> {
+        self.execute(|state| payload.view(state))
+    }
+
+    /// Encodes inside a scope that cannot outlive reusable codec storage.
+    pub fn with_encoded<R>(
+        &self,
+        payload: &mut crate::OtapPayload,
+        plan: &EncodingPlan,
+        consume: impl FnOnce(&[u8]) -> R,
+    ) -> Result<R, Error> {
+        self.execute(|state| {
+            let output = payload.prepare_encoded(state, plan)?;
+            Ok(consume(output.as_ref()))
+        })
+    }
+
+    /// Encodes to owned bytes suitable for an asynchronous send.
+    pub fn encode_owned(
+        &self,
+        payload: &mut crate::OtapPayload,
+        plan: &EncodingPlan,
+    ) -> Result<Bytes, Error> {
+        self.execute(|state| {
+            payload
+                .prepare_encoded(state, plan)
+                .map(EncodeOutput::into_bytes)
+        })
+    }
+
+    /// Returns whether two handles address the same pipeline-owned state.
+    #[must_use]
+    pub fn shares_state_with(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.state, &other.state)
+    }
 }
 
 impl CodecState {
@@ -783,6 +861,21 @@ mod tests {
         assert_eq!(codec, ResolvedCodec::OTLP);
         assert_eq!(codec.count_items(SignalType::Logs, &bytes), Some(4));
         assert_eq!(CodecState::default().test_instance_count(), 0);
+    }
+
+    /// Scenario: two runtime handles execute codec work for one pipeline.
+    /// Guarantees: cloned handles share the same lazily created codec instance.
+    #[test]
+    fn executor_clones_share_lazy_state() {
+        let first = CodecExecutor::default();
+        let second = first.clone();
+        assert!(first.shares_state_with(&second));
+        first.execute(|state| {
+            _ = state
+                .decode(ResolvedCodec::OTLP, SignalType::Logs, &logs_bytes())
+                .unwrap();
+        });
+        second.execute(|state| assert_eq!(state.test_instance_count(), 1));
     }
 
     /// Scenario: OTLP bytes are viewed and then decoded through reusable codec state.

--- a/rust/otap-dataflow/crates/pdata/src/codec.rs
+++ b/rust/otap-dataflow/crates/pdata/src/codec.rs
@@ -68,6 +68,67 @@ impl fmt::Display for PdataEncoding {
     }
 }
 
+/// Inline envelope for an independently encoded telemetry batch.
+///
+/// It contains immutable codec identity, signal, and shared bytes only. Item
+/// counts and other measurements remain in the owning payload wrapper so this
+/// envelope stays compact enough for allocation-free admission.
+#[derive(Clone, Debug)]
+pub struct EncodedPdata {
+    codec: ResolvedCodec,
+    signal: SignalType,
+    bytes: Bytes,
+}
+
+impl EncodedPdata {
+    /// Resolves and admits bytes without parsing their contents.
+    pub fn new(encoding: &PdataEncoding, signal: SignalType, bytes: Bytes) -> Result<Self, Error> {
+        resolve(encoding, signal, CodecDirection::Decode)?.admit(signal, bytes)
+    }
+
+    pub(crate) const fn from_resolved(
+        codec: ResolvedCodec,
+        signal: SignalType,
+        bytes: Bytes,
+    ) -> Self {
+        Self {
+            codec,
+            signal,
+            bytes,
+        }
+    }
+
+    /// Stable representation identity.
+    #[must_use]
+    pub fn encoding(&self) -> &PdataEncoding {
+        &self.codec.metadata().encoding
+    }
+
+    /// Resolved codec identity.
+    #[must_use]
+    pub const fn codec(&self) -> ResolvedCodec {
+        self.codec
+    }
+
+    /// Signal carried outside the encoded bytes.
+    #[must_use]
+    pub const fn signal_type(&self) -> SignalType {
+        self.signal
+    }
+
+    /// Borrows the original shared buffer.
+    #[must_use]
+    pub const fn bytes(&self) -> &Bytes {
+        &self.bytes
+    }
+
+    /// Takes ownership of the shared buffer without copying it.
+    #[must_use]
+    pub fn into_bytes(self) -> Bytes {
+        self.bytes
+    }
+}
+
 /// Immutable capabilities advertised by a codec extension.
 #[derive(Debug)]
 pub struct PdataCodecMetadata {
@@ -220,6 +281,12 @@ impl ResolvedCodec {
             .count_items
             .and_then(|counter| counter(signal, bytes))
     }
+
+    /// Admits supported input without decoding or creating mutable codec state.
+    pub fn admit(self, signal: SignalType, bytes: Bytes) -> Result<EncodedPdata, Error> {
+        self.require(signal, CodecDirection::Decode)?;
+        Ok(EncodedPdata::from_resolved(self, signal, bytes))
+    }
 }
 
 /// Startup-resolved output representation and output-specific options.
@@ -308,6 +375,14 @@ impl CodecState {
         Ok(records)
     }
 
+    /// Decodes an admitted envelope using reusable runtime state.
+    pub fn decode_encoded(
+        &mut self,
+        encoded: &EncodedPdata,
+    ) -> Result<OtapArrowRecords, crate::encode::Error> {
+        self.decode(encoded.codec, encoded.signal, &encoded.bytes)
+    }
+
     /// Creates a view through the same reusable codec instance.
     pub fn view<'a>(
         &mut self,
@@ -326,6 +401,14 @@ impl CodecState {
             );
         }
         Ok(view)
+    }
+
+    /// Creates a view over an admitted envelope.
+    pub fn view_encoded<'a>(
+        &mut self,
+        encoded: &'a EncodedPdata,
+    ) -> Result<CodecView<'a>, crate::encode::Error> {
+        self.view(encoded.codec, encoded.signal, &encoded.bytes)
     }
 
     /// Encodes with a startup-resolved output plan.

--- a/rust/otap-dataflow/crates/pdata/src/codec.rs
+++ b/rust/otap-dataflow/crates/pdata/src/codec.rs
@@ -1,0 +1,813 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pluggable codecs between independent encoded batches and native OTAP.
+//!
+//! Registrations are immutable and linked into the binary. Mutable codec state
+//! is created lazily by a pipeline-owned [`CodecState`]. This module deliberately
+//! does not participate in payload storage yet; the legacy OTLP representation
+//! remains the runtime default while codec behavior is characterized in isolation.
+
+use std::borrow::{Borrow, Cow};
+use std::fmt;
+
+use bytes::Bytes;
+use otel_arrow_dfe_config::{EncodeOptions, SignalType};
+
+use crate::error::Error;
+use crate::otap::OtapArrowRecords;
+use crate::otlp::logs::LogsProtoBytesEncoder;
+use crate::otlp::metrics::MetricsProtoBytesEncoder;
+use crate::otlp::traces::TracesProtoBytesEncoder;
+use crate::otlp::{BoundedBuf, ProtoBuffer, ProtoBytesEncoder};
+use crate::views::otlp::bytes::logs::RawLogsData;
+use crate::views::otlp::bytes::metrics::RawMetricsData;
+use crate::views::otlp::bytes::traces::RawTraceData;
+use crate::{OtapPayloadHelpers, OtlpProtoBytes, TryIntoWithOptions};
+
+/// Stable identity of an independently decodable byte representation.
+///
+/// Incompatible format versions and intrinsic compression use different names.
+/// HTTP and gRPC compression are transport properties and are not part of this
+/// identity.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct PdataEncoding(Cow<'static, str>);
+
+impl PdataEncoding {
+    /// OTLP protobuf service-request bytes without transport compression.
+    pub const OTLP: Self = Self::new("otlp-bytes");
+
+    /// Declares a compile-time encoding identity.
+    #[must_use]
+    pub const fn new(name: &'static str) -> Self {
+        Self(Cow::Borrowed(name))
+    }
+
+    /// Returns the stable configuration and diagnostic name.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Borrow<str> for PdataEncoding {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<String> for PdataEncoding {
+    fn from(name: String) -> Self {
+        Self(Cow::Owned(name))
+    }
+}
+
+impl fmt::Display for PdataEncoding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Immutable capabilities advertised by a codec extension.
+#[derive(Debug)]
+pub struct PdataCodecMetadata {
+    /// Globally stable representation name.
+    pub encoding: PdataEncoding,
+    /// Signals understood by this codec.
+    pub signals: &'static [SignalType],
+    /// Informational version. Incompatible versions require different identities.
+    pub format_version: Option<&'static str>,
+    /// Compression intrinsic to the representation, if any.
+    pub compression: Option<&'static str>,
+    /// Whether encoded bytes can be converted to native OTAP.
+    pub can_decode: bool,
+    /// Whether native OTAP can be converted to this representation.
+    pub can_encode: bool,
+}
+
+/// A read-only view returned directly by a codec.
+///
+/// Views may borrow the input bytes, but never mutable codec state. The default
+/// implementation owns decoded OTAP records.
+pub enum CodecView<'a> {
+    /// Borrowed OTLP protobuf service-request bytes.
+    OtlpBytes {
+        /// Signal carried outside the bytes.
+        signal: SignalType,
+        /// Uncompressed service-request bytes.
+        bytes: &'a [u8],
+    },
+    /// Native OTAP records, either borrowed or decoded for this view.
+    OtapArrowRecords(Cow<'a, OtapArrowRecords>),
+}
+
+impl CodecView<'_> {
+    /// Signal exposed by this view.
+    #[must_use]
+    pub fn signal_type(&self) -> SignalType {
+        match self {
+            Self::OtlpBytes { signal, .. } => *signal,
+            Self::OtapArrowRecords(records) => records.signal_type(),
+        }
+    }
+}
+
+/// Reusable synchronous codec implementation owned by one pipeline runtime.
+///
+/// Every encoded input and output is a complete independently decodable batch.
+/// Stream-relative dictionary state is not an encoded pdata representation.
+pub trait PdataCodec: Send {
+    /// Decodes one complete batch while the caller retains the original bytes.
+    fn decode(
+        &mut self,
+        signal: SignalType,
+        bytes: &Bytes,
+    ) -> Result<OtapArrowRecords, crate::encode::Error>;
+
+    /// Encodes native records into an independently owned complete batch.
+    fn encode(&mut self, records: OtapArrowRecords, options: EncodeOptions)
+    -> Result<Bytes, Error>;
+
+    /// Prepares output that may borrow reusable encoder storage.
+    ///
+    /// The default implementation delegates to [`Self::encode`]. Codecs with a
+    /// scratch buffer can return it through [`EncodeOutput::buffer`].
+    fn prepare_encode<'a>(
+        &'a mut self,
+        records: &mut OtapArrowRecords,
+        options: EncodeOptions,
+    ) -> Result<EncodeOutput<'a>, Error> {
+        self.encode(records.clone(), options)
+            .map(EncodeOutput::bytes)
+    }
+
+    /// Returns a representation-specific borrowed view when available.
+    fn view<'a>(
+        &mut self,
+        signal: SignalType,
+        bytes: &'a Bytes,
+    ) -> Result<CodecView<'a>, crate::encode::Error> {
+        self.decode(signal, bytes)
+            .map(|records| CodecView::OtapArrowRecords(Cow::Owned(records)))
+    }
+}
+
+/// Optional allocation-free item scan that needs no mutable codec instance.
+pub type ItemCounter = fn(SignalType, &[u8]) -> Option<usize>;
+
+/// Link-time codec registration. Only immutable factories are shared globally.
+#[derive(Debug)]
+pub struct PdataCodecRegistration {
+    /// Representation identity and capabilities.
+    pub metadata: &'static PdataCodecMetadata,
+    /// Creates independent mutable state for one pipeline runtime.
+    pub create: fn() -> Box<dyn PdataCodec>,
+    /// Optional stateless item scan used by flow metrics.
+    pub count_items: Option<ItemCounter>,
+}
+
+/// Trusted codec extensions compiled into this binary.
+#[allow(unsafe_code)]
+#[linkme::distributed_slice]
+pub static PDATA_CODEC_FACTORIES: [PdataCodecRegistration];
+
+/// An immutable codec resolved from the link-time registry.
+#[derive(Clone, Copy, Debug)]
+pub struct ResolvedCodec(&'static PdataCodecRegistration);
+
+impl PartialEq for ResolvedCodec {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::eq(self.0, other.0)
+    }
+}
+
+impl Eq for ResolvedCodec {}
+
+impl ResolvedCodec {
+    /// Built-in OTLP, available without a registry scan.
+    pub const OTLP: Self = Self(&OTLP_CODEC);
+
+    /// Immutable capabilities and canonical encoding name.
+    #[must_use]
+    pub const fn metadata(self) -> &'static PdataCodecMetadata {
+        self.0.metadata
+    }
+
+    /// Checks signal and direction without another registry lookup.
+    pub fn require(self, signal: SignalType, direction: CodecDirection) -> Result<(), Error> {
+        let metadata = self.metadata();
+        if !metadata.signals.contains(&signal) {
+            return Err(codec_error(
+                &metadata.encoding,
+                format!("unsupported signal {signal:?}"),
+            ));
+        }
+        match direction {
+            CodecDirection::Decode if !metadata.can_decode => {
+                Err(codec_error(&metadata.encoding, "decoder unavailable"))
+            }
+            CodecDirection::Encode if !metadata.can_encode => {
+                Err(codec_error(&metadata.encoding, "encoder unavailable"))
+            }
+            _ => Ok(()),
+        }
+    }
+
+    /// Counts items without instantiating mutable codec state when supported.
+    #[must_use]
+    pub fn count_items(self, signal: SignalType, bytes: &[u8]) -> Option<usize> {
+        self.0
+            .count_items
+            .and_then(|counter| counter(signal, bytes))
+    }
+}
+
+/// Startup-resolved output representation and output-specific options.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct EncodingPlan {
+    codec: ResolvedCodec,
+    options: EncodeOptions,
+}
+
+impl EncodingPlan {
+    /// Default OTLP protobuf output.
+    pub const OTLP: Self = Self {
+        codec: ResolvedCodec::OTLP,
+        options: EncodeOptions {
+            otlp_size_limit: None,
+        },
+    };
+
+    /// Builds a plan from an already resolved codec.
+    pub fn new(codec: ResolvedCodec, options: EncodeOptions) -> Result<Self, Error> {
+        if !codec.metadata().can_encode {
+            return Err(codec_error(
+                &codec.metadata().encoding,
+                "encoder unavailable",
+            ));
+        }
+        Ok(Self { codec, options })
+    }
+
+    /// Resolves an output name once while constructing a node.
+    pub fn resolve(encoding: &PdataEncoding, options: EncodeOptions) -> Result<Self, Error> {
+        Self::new(find(encoding)?, options)
+    }
+
+    /// Resolved output codec.
+    #[must_use]
+    pub const fn codec(self) -> ResolvedCodec {
+        self.codec
+    }
+
+    /// Output-specific options.
+    #[must_use]
+    pub const fn options(self) -> EncodeOptions {
+        self.options
+    }
+}
+
+/// Mutable codec instances cached by one pipeline runtime.
+#[derive(Default)]
+pub struct CodecState {
+    codecs: Vec<(ResolvedCodec, Box<dyn PdataCodec>)>,
+}
+
+impl CodecState {
+    fn instance(&mut self, codec: ResolvedCodec) -> &mut dyn PdataCodec {
+        let index = match self.codecs.iter().position(|(key, _)| *key == codec) {
+            Some(index) => index,
+            None => {
+                let index = self.codecs.len();
+                self.codecs.push((codec, (codec.0.create)()));
+                index
+            }
+        };
+        self.codecs[index].1.as_mut()
+    }
+
+    /// Decodes with reusable runtime state and verifies signal preservation.
+    pub fn decode(
+        &mut self,
+        codec: ResolvedCodec,
+        signal: SignalType,
+        bytes: &Bytes,
+    ) -> Result<OtapArrowRecords, crate::encode::Error> {
+        codec.require(signal, CodecDirection::Decode)?;
+        let records = self
+            .instance(codec)
+            .decode(signal, bytes)
+            .map_err(|error| codec_error(&codec.metadata().encoding, error.to_string()))?;
+        if records.signal_type() != signal {
+            return Err(codec_error(
+                &codec.metadata().encoding,
+                "decoder changed the signal type",
+            )
+            .into());
+        }
+        Ok(records)
+    }
+
+    /// Creates a view through the same reusable codec instance.
+    pub fn view<'a>(
+        &mut self,
+        codec: ResolvedCodec,
+        signal: SignalType,
+        bytes: &'a Bytes,
+    ) -> Result<CodecView<'a>, crate::encode::Error> {
+        codec.require(signal, CodecDirection::Decode)?;
+        let view = self
+            .instance(codec)
+            .view(signal, bytes)
+            .map_err(|error| codec_error(&codec.metadata().encoding, error.to_string()))?;
+        if view.signal_type() != signal {
+            return Err(
+                codec_error(&codec.metadata().encoding, "view changed the signal type").into(),
+            );
+        }
+        Ok(view)
+    }
+
+    /// Encodes with a startup-resolved output plan.
+    pub fn prepare_encode<'a>(
+        &'a mut self,
+        records: &mut OtapArrowRecords,
+        plan: &EncodingPlan,
+    ) -> Result<EncodeOutput<'a>, Error> {
+        plan.codec
+            .require(records.signal_type(), CodecDirection::Encode)?;
+        self.instance(plan.codec)
+            .prepare_encode(records, plan.options)
+    }
+
+    /// Number of mutable codec instances created so far.
+    #[cfg(any(test, feature = "testing"))]
+    #[must_use]
+    pub fn test_instance_count(&self) -> usize {
+        self.codecs.len()
+    }
+}
+
+enum OutputStorage<'a> {
+    Bytes(Bytes),
+    Buffer(BufferOutput<'a>),
+}
+
+struct BufferOutput<'a> {
+    buffer: &'a mut ProtoBuffer,
+    max_retained_capacity: usize,
+}
+
+impl Drop for BufferOutput<'_> {
+    fn drop(&mut self) {
+        self.buffer.retain_capacity(self.max_retained_capacity);
+    }
+}
+
+/// Prepared encoded output backed by owned bytes or reusable scratch storage.
+pub struct EncodeOutput<'a>(OutputStorage<'a>);
+
+impl<'a> EncodeOutput<'a> {
+    /// Wraps independently owned bytes.
+    #[must_use]
+    pub fn bytes(bytes: Bytes) -> Self {
+        Self(OutputStorage::Bytes(bytes))
+    }
+
+    /// Borrows reusable codec storage for synchronous consumption.
+    #[must_use]
+    pub fn buffer(buffer: &'a mut ProtoBuffer, max_retained_capacity: usize) -> Self {
+        Self(OutputStorage::Buffer(BufferOutput {
+            buffer,
+            max_retained_capacity,
+        }))
+    }
+
+    /// Detaches bytes for an asynchronous send without copying their contents.
+    #[must_use]
+    pub fn into_bytes(self) -> Bytes {
+        match self.0 {
+            OutputStorage::Bytes(bytes) => bytes,
+            OutputStorage::Buffer(output) => {
+                let (bytes, capacity) = output.buffer.take_into_bytes();
+                output
+                    .buffer
+                    .ensure_capacity(capacity.min(output.max_retained_capacity));
+                bytes
+            }
+        }
+    }
+
+    /// Keeps scratch attached and copies only when output uses that scratch.
+    #[must_use]
+    pub fn copy_into_bytes(self) -> Bytes {
+        match self.0 {
+            OutputStorage::Bytes(bytes) => bytes,
+            OutputStorage::Buffer(output) => Bytes::copy_from_slice(output.buffer.as_ref()),
+        }
+    }
+}
+
+impl AsRef<[u8]> for EncodeOutput<'_> {
+    fn as_ref(&self) -> &[u8] {
+        match &self.0 {
+            OutputStorage::Bytes(bytes) => bytes,
+            OutputStorage::Buffer(output) => output.buffer.as_ref(),
+        }
+    }
+}
+
+/// The operation required by a codec consumer.
+#[derive(Clone, Copy, Debug)]
+pub enum CodecDirection {
+    /// Encoded bytes to native OTAP.
+    Decode,
+    /// Native OTAP to encoded bytes.
+    Encode,
+}
+
+/// Finds a unique codec without creating mutable state.
+pub fn find(encoding: &PdataEncoding) -> Result<ResolvedCodec, Error> {
+    let mut matches = PDATA_CODEC_FACTORIES
+        .iter()
+        .filter(|registration| &registration.metadata.encoding == encoding);
+    let registration = matches
+        .next()
+        .ok_or_else(|| codec_error(encoding, "no codec registered"))?;
+    if matches.next().is_some() {
+        return Err(codec_error(encoding, "duplicate encoding registration"));
+    }
+    Ok(ResolvedCodec(registration))
+}
+
+/// Resolves a codec and validates its signal and direction.
+pub fn resolve(
+    encoding: &PdataEncoding,
+    signal: SignalType,
+    direction: CodecDirection,
+) -> Result<ResolvedCodec, Error> {
+    let codec = find(encoding)?;
+    codec.require(signal, direction)?;
+    Ok(codec)
+}
+
+/// Iterates all compiled-in codec identities without creating mutable state.
+pub fn registered_codecs() -> impl Iterator<Item = ResolvedCodec> {
+    PDATA_CODEC_FACTORIES.iter().map(ResolvedCodec)
+}
+
+/// Validates names, capabilities, and uniqueness of linked registrations.
+pub fn validate_registrations() -> Result<(), Error> {
+    validate_factories(&PDATA_CODEC_FACTORIES)
+}
+
+fn validate_factories(factories: &[PdataCodecRegistration]) -> Result<(), Error> {
+    for (index, registration) in factories.iter().enumerate() {
+        let metadata = registration.metadata;
+        let name = metadata.encoding.as_str();
+        if ["otap", "otlp", "preserve"].contains(&name) {
+            return Err(codec_error(&metadata.encoding, "reserved format name"));
+        }
+        if name.is_empty()
+            || !name.bytes().all(|byte| {
+                byte.is_ascii_lowercase() || byte.is_ascii_digit() || b"._-:".contains(&byte)
+            })
+        {
+            return Err(codec_error(
+                &metadata.encoding,
+                "identity must use lowercase ASCII letters, digits, '.', '_', '-', or ':'",
+            ));
+        }
+        if metadata.signals.is_empty() || (!metadata.can_decode && !metadata.can_encode) {
+            return Err(codec_error(
+                &metadata.encoding,
+                "must advertise a signal and an encoder or decoder",
+            ));
+        }
+        if factories[..index]
+            .iter()
+            .any(|other| other.metadata.encoding == metadata.encoding)
+        {
+            return Err(codec_error(
+                &metadata.encoding,
+                "duplicate encoding registration",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn codec_error(encoding: &PdataEncoding, reason: impl Into<String>) -> Error {
+    Error::PdataCodec {
+        encoding: encoding.clone(),
+        reason: reason.into(),
+    }
+}
+
+const OTLP_INITIAL_BUFFER_CAPACITY: usize = 8 * 1024;
+const OTLP_MAX_RETAINED_BUFFER_CAPACITY: usize = 256 * 1024;
+
+struct OtlpSignalEncoder<E> {
+    encoder: E,
+    buffer: ProtoBuffer,
+}
+
+impl<E: Default> Default for OtlpSignalEncoder<E> {
+    fn default() -> Self {
+        Self {
+            encoder: E::default(),
+            buffer: ProtoBuffer::with_capacity(OTLP_INITIAL_BUFFER_CAPACITY),
+        }
+    }
+}
+
+#[derive(Default)]
+struct OtlpEncoderState {
+    logs: Option<Box<OtlpSignalEncoder<LogsProtoBytesEncoder>>>,
+    metrics: Option<Box<OtlpSignalEncoder<MetricsProtoBytesEncoder>>>,
+    traces: Option<Box<OtlpSignalEncoder<TracesProtoBytesEncoder>>>,
+}
+
+/// Built-in OTLP protobuf codec.
+#[derive(Default)]
+pub struct OtlpCodec {
+    encoder: Option<Box<OtlpEncoderState>>,
+}
+
+impl OtlpCodec {
+    fn output_limit(options: EncodeOptions) -> usize {
+        options
+            .otlp_size_limit
+            .map_or(crate::otlp::common::MAX_OTLP_SIZE_LIMIT, |limit| {
+                limit.get().min(crate::otlp::common::MAX_OTLP_SIZE_LIMIT)
+            })
+    }
+
+    #[inline(never)]
+    fn prepare_logs<'a>(
+        state: &'a mut OtlpEncoderState,
+        records: &mut OtapArrowRecords,
+        options: EncodeOptions,
+    ) -> Result<EncodeOutput<'a>, Error> {
+        let state = state
+            .logs
+            .get_or_insert_with(|| Box::new(OtlpSignalEncoder::default()));
+        prepare_signal(&mut state.encoder, &mut state.buffer, records, options)
+    }
+
+    #[inline(never)]
+    fn prepare_metrics<'a>(
+        state: &'a mut OtlpEncoderState,
+        records: &mut OtapArrowRecords,
+        options: EncodeOptions,
+    ) -> Result<EncodeOutput<'a>, Error> {
+        let state = state
+            .metrics
+            .get_or_insert_with(|| Box::new(OtlpSignalEncoder::default()));
+        prepare_signal(&mut state.encoder, &mut state.buffer, records, options)
+    }
+
+    #[inline(never)]
+    fn prepare_traces<'a>(
+        state: &'a mut OtlpEncoderState,
+        records: &mut OtapArrowRecords,
+        options: EncodeOptions,
+    ) -> Result<EncodeOutput<'a>, Error> {
+        let state = state
+            .traces
+            .get_or_insert_with(|| Box::new(OtlpSignalEncoder::default()));
+        prepare_signal(&mut state.encoder, &mut state.buffer, records, options)
+    }
+}
+
+fn prepare_signal<'a, E: ProtoBytesEncoder>(
+    encoder: &mut E,
+    buffer: &'a mut ProtoBuffer,
+    records: &mut OtapArrowRecords,
+    options: EncodeOptions,
+) -> Result<EncodeOutput<'a>, Error> {
+    buffer.clear();
+    buffer.set_limit(OtlpCodec::output_limit(options));
+    if let Err(error) = encoder.encode(records, buffer) {
+        buffer.retain_capacity(OTLP_MAX_RETAINED_BUFFER_CAPACITY);
+        return Err(error);
+    }
+    Ok(EncodeOutput::buffer(
+        buffer,
+        OTLP_MAX_RETAINED_BUFFER_CAPACITY,
+    ))
+}
+
+impl PdataCodec for OtlpCodec {
+    fn decode(
+        &mut self,
+        signal: SignalType,
+        bytes: &Bytes,
+    ) -> Result<OtapArrowRecords, crate::encode::Error> {
+        match signal {
+            SignalType::Logs => {
+                let _ = RawLogsData::try_new(bytes)?;
+            }
+            SignalType::Metrics => {
+                let _ = RawMetricsData::try_new(bytes)?;
+            }
+            SignalType::Traces => {
+                let _ = RawTraceData::try_new(bytes)?;
+            }
+        }
+        OtlpProtoBytes::new_from_bytes(signal, bytes.clone()).try_into_with_default()
+    }
+
+    fn encode(
+        &mut self,
+        mut records: OtapArrowRecords,
+        options: EncodeOptions,
+    ) -> Result<Bytes, Error> {
+        Ok(self.prepare_encode(&mut records, options)?.into_bytes())
+    }
+
+    fn prepare_encode<'a>(
+        &'a mut self,
+        records: &mut OtapArrowRecords,
+        options: EncodeOptions,
+    ) -> Result<EncodeOutput<'a>, Error> {
+        let state = self
+            .encoder
+            .get_or_insert_with(|| Box::new(OtlpEncoderState::default()));
+        match records.signal_type() {
+            SignalType::Logs => Self::prepare_logs(state, records, options),
+            SignalType::Metrics => Self::prepare_metrics(state, records, options),
+            SignalType::Traces => Self::prepare_traces(state, records, options),
+        }
+    }
+
+    fn view<'a>(
+        &mut self,
+        signal: SignalType,
+        bytes: &'a Bytes,
+    ) -> Result<CodecView<'a>, crate::encode::Error> {
+        Ok(CodecView::OtlpBytes { signal, bytes })
+    }
+}
+
+/// Metadata for the built-in OTLP codec.
+pub static OTLP_METADATA: PdataCodecMetadata = PdataCodecMetadata {
+    encoding: PdataEncoding::OTLP,
+    signals: &[SignalType::Logs, SignalType::Metrics, SignalType::Traces],
+    format_version: None,
+    compression: None,
+    can_decode: true,
+    can_encode: true,
+};
+
+#[allow(unsafe_code)]
+#[linkme::distributed_slice(PDATA_CODEC_FACTORIES)]
+static OTLP_CODEC: PdataCodecRegistration = PdataCodecRegistration {
+    metadata: &OTLP_METADATA,
+    create: || Box::new(OtlpCodec::default()),
+    count_items: Some(|signal, bytes| Some(crate::payload::count_otlp_items(signal, bytes))),
+};
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use prost::Message;
+
+    use super::*;
+    use crate::testing::codec_conformance::{DecodeConformanceCase, assert_decode_conformance};
+    use crate::testing::fixtures::{
+        logs_with_full_resource_and_scope, metrics_sum_with_full_resource_and_scope,
+        traces_with_full_resource_and_scope,
+    };
+
+    fn logs_bytes() -> Bytes {
+        logs_with_full_resource_and_scope().encode_to_vec().into()
+    }
+
+    /// Scenario: the built-in registry is resolved without constructing mutable state.
+    /// Guarantees: OTLP metadata and the stateless item counter are available eagerly.
+    #[test]
+    fn resolves_otlp_without_codec_instance() {
+        validate_registrations().unwrap();
+        let codec = resolve(
+            &PdataEncoding::OTLP,
+            SignalType::Logs,
+            CodecDirection::Decode,
+        )
+        .unwrap();
+        let bytes = logs_bytes();
+        assert_eq!(codec, ResolvedCodec::OTLP);
+        assert_eq!(codec.count_items(SignalType::Logs, &bytes), Some(4));
+        assert_eq!(CodecState::default().test_instance_count(), 0);
+    }
+
+    /// Scenario: OTLP bytes are viewed and then decoded through reusable codec state.
+    /// Guarantees: the view borrows the original buffer and decoding preserves signal and items.
+    #[test]
+    fn otlp_view_and_decode_preserve_input() {
+        let bytes = logs_bytes();
+        let pointer = bytes.as_ptr();
+        let mut state = CodecState::default();
+        let view = state
+            .view(ResolvedCodec::OTLP, SignalType::Logs, &bytes)
+            .unwrap();
+        match view {
+            CodecView::OtlpBytes { signal, bytes } => {
+                assert_eq!(signal, SignalType::Logs);
+                assert_eq!(bytes.as_ptr(), pointer);
+            }
+            CodecView::OtapArrowRecords(_) => panic!("OTLP should expose a borrowed byte view"),
+        }
+        let records = state
+            .decode(ResolvedCodec::OTLP, SignalType::Logs, &bytes)
+            .unwrap();
+        assert_eq!(records.signal_type(), SignalType::Logs);
+        assert_eq!(records.num_items(), 4);
+        assert_eq!(state.test_instance_count(), 1);
+    }
+
+    /// Scenario: native logs are encoded repeatedly through one startup-resolved plan.
+    /// Guarantees: output remains independently decodable and the codec instance is reused.
+    #[test]
+    fn otlp_prepared_output_reuses_codec_state() {
+        let bytes = logs_bytes();
+        let mut decode_state = CodecState::default();
+        let original = decode_state
+            .decode(ResolvedCodec::OTLP, SignalType::Logs, &bytes)
+            .unwrap();
+        let mut encode_state = CodecState::default();
+        for _ in 0..2 {
+            let mut records = original.clone();
+            let encoded = encode_state
+                .prepare_encode(&mut records, &EncodingPlan::OTLP)
+                .unwrap()
+                .into_bytes();
+            let decoded = decode_state
+                .decode(ResolvedCodec::OTLP, SignalType::Logs, &encoded)
+                .unwrap();
+            assert_eq!(decoded.num_items(), 4);
+        }
+        assert_eq!(encode_state.test_instance_count(), 1);
+    }
+
+    /// Scenario: an output plan sets an OTLP limit smaller than the encoded batch.
+    /// Guarantees: the limit reaches the reusable encoder and later encodes recover.
+    #[test]
+    fn otlp_encoder_recovers_after_limit_error() {
+        let bytes = logs_bytes();
+        let mut state = CodecState::default();
+        let records = state
+            .decode(ResolvedCodec::OTLP, SignalType::Logs, &bytes)
+            .unwrap();
+        let limited = EncodingPlan::new(
+            ResolvedCodec::OTLP,
+            EncodeOptions {
+                otlp_size_limit: NonZeroUsize::new(1),
+            },
+        )
+        .unwrap();
+        assert!(
+            state
+                .prepare_encode(&mut records.clone(), &limited)
+                .is_err()
+        );
+        let encoded = state
+            .prepare_encode(&mut records.clone(), &EncodingPlan::OTLP)
+            .unwrap()
+            .into_bytes();
+        assert!(!encoded.is_empty());
+    }
+
+    /// Scenario: OTLP logs, metrics, and traces run through the shared codec contract.
+    /// Guarantees: every signal preserves items, rejects malformed input, and round-trips independently.
+    #[test]
+    fn otlp_codec_conforms_for_all_signals() {
+        let cases = [
+            (
+                SignalType::Logs,
+                Bytes::from(logs_with_full_resource_and_scope().encode_to_vec()),
+                4,
+            ),
+            (
+                SignalType::Metrics,
+                Bytes::from(metrics_sum_with_full_resource_and_scope().encode_to_vec()),
+                2,
+            ),
+            (
+                SignalType::Traces,
+                Bytes::from(traces_with_full_resource_and_scope().encode_to_vec()),
+                2,
+            ),
+        ];
+        for (signal, valid, expected_items) in cases {
+            assert_decode_conformance(DecodeConformanceCase {
+                codec: ResolvedCodec::OTLP,
+                signal,
+                valid,
+                malformed: Some(Bytes::from_static(&[0x0a, 0x05, 0x01])),
+                expected_items,
+            });
+        }
+    }
+}

--- a/rust/otap-dataflow/crates/pdata/src/error.rs
+++ b/rust/otap-dataflow/crates/pdata/src/error.rs
@@ -235,6 +235,12 @@ pub enum Error {
     #[error("Format error: {}", error)]
     Format { error: String },
 
+    #[error("PData codec `{encoding}` failed: {reason}")]
+    PdataCodec {
+        encoding: crate::codec::PdataEncoding,
+        reason: String,
+    },
+
     #[error("Invalid schema for payload {payload_type:?}: {source}")]
     InvalidSchemaForPayload {
         payload_type: ArrowPayloadType,

--- a/rust/otap-dataflow/crates/pdata/src/lib.rs
+++ b/rust/otap-dataflow/crates/pdata/src/lib.rs
@@ -18,10 +18,15 @@ pub mod otap;
 pub mod schema;
 
 pub mod arrays;
+pub mod codec;
 pub(crate) mod decode;
 pub mod encode;
 pub(crate) mod payload;
 
+pub use codec::{
+    CodecDirection, CodecState, CodecView, EncodeOutput, EncodingPlan, PdataCodec,
+    PdataCodecMetadata, PdataCodecRegistration, PdataEncoding, ResolvedCodec,
+};
 pub use otap::OtapArrowRecords;
 pub use otlp::OtlpProtoBytes;
 pub use payload::{OtapPayload, OtapPayloadHelpers, PayloadData};

--- a/rust/otap-dataflow/crates/pdata/src/lib.rs
+++ b/rust/otap-dataflow/crates/pdata/src/lib.rs
@@ -24,12 +24,14 @@ pub mod encode;
 pub(crate) mod payload;
 
 pub use codec::{
-    CodecDirection, CodecState, CodecView, EncodeOutput, EncodingPlan, PdataCodec,
+    CodecDirection, CodecState, CodecView, EncodeOutput, EncodedPdata, EncodingPlan, PdataCodec,
     PdataCodecMetadata, PdataCodecRegistration, PdataEncoding, ResolvedCodec,
 };
 pub use otap::OtapArrowRecords;
 pub use otlp::OtlpProtoBytes;
-pub use payload::{OtapPayload, OtapPayloadHelpers, PayloadData};
+pub use payload::{
+    OtapPayload, OtapPayloadDecodeError, OtapPayloadHelpers, PayloadData, PdataFormat,
+};
 
 /// Testing support
 #[cfg(any(test, feature = "testing"))]

--- a/rust/otap-dataflow/crates/pdata/src/lib.rs
+++ b/rust/otap-dataflow/crates/pdata/src/lib.rs
@@ -24,8 +24,8 @@ pub mod encode;
 pub(crate) mod payload;
 
 pub use codec::{
-    CodecDirection, CodecState, CodecView, EncodeOutput, EncodedPdata, EncodingPlan, PdataCodec,
-    PdataCodecMetadata, PdataCodecRegistration, PdataEncoding, ResolvedCodec,
+    CodecDirection, CodecExecutor, CodecState, CodecView, EncodeOutput, EncodedPdata, EncodingPlan,
+    PdataCodec, PdataCodecMetadata, PdataCodecRegistration, PdataEncoding, ResolvedCodec,
 };
 pub use otap::OtapArrowRecords;
 pub use otlp::OtlpProtoBytes;

--- a/rust/otap-dataflow/crates/pdata/src/otap/memory.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/memory.rs
@@ -407,7 +407,7 @@ mod tests {
         assert_eq!(
             match arrow_payload.into_data() {
                 PayloadData::OtapArrowRecords(records) => records.root_payload_type(),
-                PayloadData::OtlpBytes(_) => unreachable!(),
+                PayloadData::OtlpBytes(_) | PayloadData::Encoded(_) => unreachable!(),
             },
             ArrowPayloadType::Logs
         );

--- a/rust/otap-dataflow/crates/pdata/src/otlp/common.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/common.rs
@@ -829,6 +829,14 @@ impl ProtoBuffer {
             self.buffer.reserve(capacity - self.buffer.capacity());
         }
     }
+
+    /// Clears the buffer and bounds the allocation retained for later encodes.
+    pub fn retain_capacity(&mut self, maximum: usize) {
+        self.buffer.clear();
+        if self.buffer.capacity() > maximum {
+            self.buffer = Vec::with_capacity(maximum.min(self.limit));
+        }
+    }
 }
 
 impl BoundedBuf for ProtoBuffer {

--- a/rust/otap-dataflow/crates/pdata/src/otlp/mod.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/mod.rs
@@ -103,6 +103,16 @@ impl OtlpProtoBytes {
         }
     }
 
+    /// Borrows the shared encoded buffer.
+    #[must_use]
+    pub const fn bytes(&self) -> &Bytes {
+        match self {
+            Self::ExportLogsRequest(bytes)
+            | Self::ExportMetricsRequest(bytes)
+            | Self::ExportTracesRequest(bytes) => bytes,
+        }
+    }
+
     /// Return the byte-size of this message.
     #[must_use]
     pub fn num_bytes(&self) -> usize {

--- a/rust/otap-dataflow/crates/pdata/src/otlp/mod.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/mod.rs
@@ -53,9 +53,9 @@ impl OtlpProtoBytes {
     #[must_use]
     pub fn new_from_bytes<B>(signal: SignalType, b: B) -> Self
     where
-        B: Into<Vec<u8>>,
+        B: Into<Bytes>,
     {
-        let bytes: Bytes = b.into().into();
+        let bytes: Bytes = b.into();
         match signal {
             SignalType::Logs => Self::ExportLogsRequest(bytes),
             SignalType::Metrics => Self::ExportMetricsRequest(bytes),

--- a/rust/otap-dataflow/crates/pdata/src/payload.rs
+++ b/rust/otap-dataflow/crates/pdata/src/payload.rs
@@ -455,73 +455,86 @@ impl OtapPayloadHelpers for OtlpProtoBytes {
     }
 
     fn num_items(&self) -> usize {
-        // Counting requires traversing the encoded protobuf record hierarchy.
-        match self {
-            Self::ExportLogsRequest(bytes) => {
-                let logs_data_view = RawLogsData::new(bytes.as_ref());
-                use otel_arrow_dfe_pdata_views::views::logs::{
-                    LogsDataView, ResourceLogsView, ScopeLogsView,
-                };
-                logs_data_view
-                    .resources()
-                    .map(|rl| {
-                        rl.scopes()
-                            .map(|sl| sl.log_records().count())
-                            .sum::<usize>()
-                    })
-                    .sum()
-            }
-            Self::ExportTracesRequest(bytes) => {
-                let traces_data_view = RawTraceData::new(bytes.as_ref());
-                use otel_arrow_dfe_pdata_views::views::trace::{
-                    ResourceSpansView, ScopeSpansView, TracesView,
-                };
-                traces_data_view
-                    .resources()
-                    .map(|rs| rs.scopes().map(|ss| ss.spans().count()).sum::<usize>())
-                    .sum()
-            }
-            Self::ExportMetricsRequest(bytes) => {
-                let metrics_data_view = RawMetricsData::new(bytes.as_ref());
-                use otel_arrow_dfe_pdata_views::views::metrics::{
-                    DataView, ExponentialHistogramView, GaugeView, HistogramView, MetricView,
-                    MetricsView, ResourceMetricsView, ScopeMetricsView, SumView, SummaryView,
-                };
-                metrics_data_view
-                    .resources()
-                    .map(|rm| {
-                        rm.scopes()
-                            .map(|sm| {
-                                sm.metrics()
-                                    .map(|metric| {
-                                        metric
-                                            .data()
-                                            .map(|data| {
-                                                let mut count = 0;
-                                                if let Some(gauge) = data.as_gauge() {
-                                                    count += gauge.data_points().count();
-                                                } else if let Some(sum) = data.as_sum() {
-                                                    count += sum.data_points().count();
-                                                } else if let Some(histogram) = data.as_histogram()
-                                                {
-                                                    count += histogram.data_points().count();
-                                                } else if let Some(exp_histogram) =
-                                                    data.as_exponential_histogram()
-                                                {
-                                                    count += exp_histogram.data_points().count();
-                                                } else if let Some(summary) = data.as_summary() {
-                                                    count += summary.data_points().count();
-                                                }
-                                                count
-                                            })
-                                            .unwrap_or(0)
-                                    })
-                                    .sum::<usize>()
-                            })
-                            .sum::<usize>()
-                    })
-                    .sum()
-            }
+        count_otlp_items(self.signal_type(), self.as_bytes())
+    }
+}
+
+/// Stateless OTLP item scan shared by the codec and compatibility storage.
+pub(crate) fn count_otlp_items(signal: SignalType, bytes: &[u8]) -> usize {
+    // Counting traverses the encoded protobuf record hierarchy without
+    // constructing an owned request or a mutable codec instance.
+    match signal {
+        SignalType::Logs => {
+            let logs_data_view = RawLogsData::new(bytes);
+            use otel_arrow_dfe_pdata_views::views::logs::{
+                LogsDataView, ResourceLogsView, ScopeLogsView,
+            };
+            logs_data_view
+                .resources()
+                .map(|resource| {
+                    resource
+                        .scopes()
+                        .map(|scope| scope.log_records().count())
+                        .sum::<usize>()
+                })
+                .sum()
+        }
+        SignalType::Traces => {
+            let traces_data_view = RawTraceData::new(bytes);
+            use otel_arrow_dfe_pdata_views::views::trace::{
+                ResourceSpansView, ScopeSpansView, TracesView,
+            };
+            traces_data_view
+                .resources()
+                .map(|resource| {
+                    resource
+                        .scopes()
+                        .map(|scope| scope.spans().count())
+                        .sum::<usize>()
+                })
+                .sum()
+        }
+        SignalType::Metrics => {
+            let metrics_data_view = RawMetricsData::new(bytes);
+            use otel_arrow_dfe_pdata_views::views::metrics::{
+                DataView, ExponentialHistogramView, GaugeView, HistogramView, MetricView,
+                MetricsView, ResourceMetricsView, ScopeMetricsView, SumView, SummaryView,
+            };
+            metrics_data_view
+                .resources()
+                .map(|resource| {
+                    resource
+                        .scopes()
+                        .map(|scope| {
+                            scope
+                                .metrics()
+                                .map(|metric| {
+                                    metric
+                                        .data()
+                                        .map(|data| {
+                                            if let Some(gauge) = data.as_gauge() {
+                                                gauge.data_points().count()
+                                            } else if let Some(sum) = data.as_sum() {
+                                                sum.data_points().count()
+                                            } else if let Some(histogram) = data.as_histogram() {
+                                                histogram.data_points().count()
+                                            } else if let Some(histogram) =
+                                                data.as_exponential_histogram()
+                                            {
+                                                histogram.data_points().count()
+                                            } else if let Some(summary) = data.as_summary() {
+                                                summary.data_points().count()
+                                            } else {
+                                                0
+                                            }
+                                        })
+                                        .unwrap_or(0)
+                                })
+                                .sum::<usize>()
+                        })
+                        .sum::<usize>()
+                })
+                .sum()
         }
     }
 }

--- a/rust/otap-dataflow/crates/pdata/src/payload.rs
+++ b/rust/otap-dataflow/crates/pdata/src/payload.rs
@@ -691,6 +691,29 @@ mod test {
     use bytes::Bytes;
     use pretty_assertions::assert_eq;
     use prost::Message;
+    use std::mem::size_of;
+
+    /// Scenario: The legacy payload representation is built for a 64-bit target.
+    /// Guarantees: The baseline payload layout remains fixed for codec comparisons.
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn legacy_payload_layout_is_stable() {
+        assert_eq!(size_of::<PayloadData>(), 40);
+        assert_eq!(size_of::<OtapPayload>(), 72);
+    }
+
+    /// Scenario: An OTLP payload is converted back to its matching legacy representation.
+    /// Guarantees: Forwarding retains the original shared byte buffer without copying it.
+    #[test]
+    fn matching_otlp_forwarding_preserves_buffer() {
+        let original = Bytes::from_static(b"legacy-otlp");
+        let pointer = original.as_ptr();
+        let payload = OtapPayload::from(OtlpProtoBytes::ExportLogsRequest(original));
+        let forwarded: OtlpProtoBytes = payload
+            .try_into_with_default()
+            .expect("matching OTLP forwarding");
+        assert_eq!(forwarded.as_bytes().as_ptr(), pointer);
+    }
 
     #[test]
     fn test_conversion_logs() {

--- a/rust/otap-dataflow/crates/pdata/src/payload.rs
+++ b/rust/otap-dataflow/crates/pdata/src/payload.rs
@@ -82,6 +82,9 @@
 // directly from OTAP -> OTLP bytes. The utility functions we use might change as part of
 // this diagram may need to be updated (https://github.com/open-telemetry/otel-arrow/issues/1095)
 
+use crate::codec::{
+    CodecState, CodecView, EncodeOutput, EncodedPdata, EncodingPlan, PdataEncoding, ResolvedCodec,
+};
 use crate::encode::{encode_logs_otap_batch, encode_metrics_otap_batch, encode_spans_otap_batch};
 use crate::error::Error;
 use crate::otap::{OtapArrowRecords, OtapBatchStore};
@@ -94,7 +97,7 @@ use crate::views::otlp::bytes::logs::RawLogsData;
 use crate::views::otlp::bytes::metrics::RawMetricsData;
 use crate::views::otlp::bytes::traces::RawTraceData;
 use crate::{TryFromWithOptions, TryIntoWithOptions};
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use otel_arrow_dfe_config::{ConversionOptions, SignalFormat, SignalType};
 use prost::{EncodeError, Message};
 
@@ -110,6 +113,9 @@ pub enum PayloadData {
     /// data is serialized as a protobuf service message for one of the OTLP GRPC services
     OtlpBytes(OtlpProtoBytes),
 
+    /// Independently encoded bytes with a resolved codec identity.
+    Encoded(EncodedPdata),
+
     /// data is contained in `OtapBatch` which contains Arrow `RecordBatches` for OTAP payload type
     /// TODO: Remove "Arrow" from this case name, it stutters; follow SignalFormat.
     OtapArrowRecords(OtapArrowRecords),
@@ -119,6 +125,7 @@ impl PayloadData {
     fn signal_type(&self) -> SignalType {
         match self {
             Self::OtlpBytes(value) => value.signal_type(),
+            Self::Encoded(value) => value.signal_type(),
             Self::OtapArrowRecords(value) => value.signal_type(),
         }
     }
@@ -127,12 +134,14 @@ impl PayloadData {
         match self {
             Self::OtapArrowRecords(_) => SignalFormat::OtapRecords,
             Self::OtlpBytes(_) => SignalFormat::OtlpBytes,
+            Self::Encoded(_) => SignalFormat::Encoded,
         }
     }
 
     fn is_empty(&self) -> bool {
         match self {
             Self::OtlpBytes(value) => value.is_empty(),
+            Self::Encoded(value) => value.bytes().is_empty(),
             Self::OtapArrowRecords(value) => value.is_empty(),
         }
     }
@@ -141,6 +150,11 @@ impl PayloadData {
     fn take_payload(&mut self) -> Self {
         match self {
             Self::OtlpBytes(value) => Self::OtlpBytes(value.take_payload()),
+            Self::Encoded(value) => {
+                let empty =
+                    EncodedPdata::from_resolved(value.codec(), value.signal_type(), Bytes::new());
+                Self::Encoded(std::mem::replace(value, empty))
+            }
             Self::OtapArrowRecords(value) => Self::OtapArrowRecords(value.take_payload()),
         }
     }
@@ -148,6 +162,10 @@ impl PayloadData {
     fn num_items(&self) -> usize {
         match self {
             Self::OtlpBytes(value) => value.num_items(),
+            Self::Encoded(value) => value
+                .codec()
+                .count_items(value.signal_type(), value.bytes())
+                .unwrap_or(0),
             Self::OtapArrowRecords(value) => value.num_items(),
         }
     }
@@ -155,6 +173,7 @@ impl PayloadData {
     fn num_bytes(&self) -> Option<usize> {
         match self {
             Self::OtlpBytes(value) => Some(value.num_bytes()),
+            Self::Encoded(value) => Some(value.bytes().len()),
             Self::OtapArrowRecords(value) => value.num_bytes(),
         }
     }
@@ -162,8 +181,66 @@ impl PayloadData {
     fn retained_memory_bytes(&self) -> usize {
         match self {
             Self::OtlpBytes(value) => value.retained_memory_bytes(),
+            Self::Encoded(value) => value.bytes().len(),
             Self::OtapArrowRecords(value) => value.retained_memory_bytes(),
         }
+    }
+}
+
+/// Logical pdata representation identity, independent of compatibility storage.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PdataFormat {
+    /// Native mutable OTAP records.
+    Otap,
+    /// Independently encoded bytes understood by a registered codec.
+    Encoded(ResolvedCodec),
+}
+
+impl PdataFormat {
+    /// Native OTAP representation.
+    pub const OTAP: Self = Self::Otap;
+
+    /// Builds an encoded representation identity.
+    #[must_use]
+    pub const fn encoded(codec: ResolvedCodec) -> Self {
+        Self::Encoded(codec)
+    }
+
+    /// Returns the encoded codec identity, if this is a byte representation.
+    #[must_use]
+    pub const fn codec(self) -> Option<ResolvedCodec> {
+        match self {
+            Self::Otap => None,
+            Self::Encoded(codec) => Some(codec),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CachedMeasurement(usize);
+
+impl CachedMeasurement {
+    const UNKNOWN: usize = usize::MAX;
+
+    const fn unknown() -> Self {
+        Self(Self::UNKNOWN)
+    }
+
+    const fn get(self) -> Option<usize> {
+        if self.0 == Self::UNKNOWN {
+            None
+        } else {
+            Some(self.0)
+        }
+    }
+
+    fn set(&mut self, value: usize) {
+        debug_assert_ne!(value, Self::UNKNOWN, "measurement exceeds supported range");
+        self.0 = value;
+    }
+
+    fn take(&mut self) -> Self {
+        std::mem::replace(self, Self::unknown())
     }
 }
 
@@ -189,8 +266,42 @@ impl PayloadData {
 #[derive(Clone, Debug)]
 pub struct OtapPayload {
     data: PayloadData,
-    item_count: Option<usize>,
-    size: Option<usize>,
+    item_count: CachedMeasurement,
+    size: CachedMeasurement,
+}
+
+/// A failed native conversion together with the exact recoverable input.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct OtapPayloadDecodeError(Box<OtapPayloadDecodeErrorInner>);
+
+#[derive(Debug, thiserror::Error)]
+#[error("{source}")]
+struct OtapPayloadDecodeErrorInner {
+    #[source]
+    source: crate::encode::Error,
+    payload: OtapPayload,
+}
+
+impl OtapPayloadDecodeError {
+    /// Returns the codec or conversion error.
+    #[must_use]
+    pub const fn error(&self) -> &crate::encode::Error {
+        &self.0.source
+    }
+
+    /// Returns the exact payload retained for retry or Nack.
+    #[must_use]
+    pub const fn payload(&self) -> &OtapPayload {
+        &self.0.payload
+    }
+
+    /// Splits the conversion error and recoverable payload.
+    #[must_use]
+    pub fn into_parts(self) -> (crate::encode::Error, OtapPayload) {
+        let inner = *self.0;
+        (inner.source, inner.payload)
+    }
 }
 
 impl OtapPayload {
@@ -199,8 +310,8 @@ impl OtapPayload {
     fn from_data(data: PayloadData) -> Self {
         Self {
             data,
-            item_count: None,
-            size: None,
+            item_count: CachedMeasurement::unknown(),
+            size: CachedMeasurement::unknown(),
         }
     }
 
@@ -214,6 +325,67 @@ impl OtapPayload {
     #[must_use]
     pub fn from_otap(payload: OtapArrowRecords) -> Self {
         Self::from_data(PayloadData::OtapArrowRecords(payload))
+    }
+
+    /// Wraps admitted encoded bytes without copying or decoding them.
+    #[must_use]
+    pub fn from_encoded(payload: EncodedPdata) -> Self {
+        Self::from_data(PayloadData::Encoded(payload))
+    }
+
+    /// Supplies a receiver-known item count without parsing encoded bytes.
+    #[must_use]
+    pub fn with_item_count(mut self, item_count: usize) -> Self {
+        self.item_count.set(item_count);
+        self
+    }
+
+    /// Logical representation identity.
+    #[must_use]
+    pub fn format(&self) -> PdataFormat {
+        match &self.data {
+            PayloadData::OtlpBytes(_) => PdataFormat::encoded(ResolvedCodec::OTLP),
+            PayloadData::Encoded(encoded) => PdataFormat::encoded(encoded.codec()),
+            PayloadData::OtapArrowRecords(_) => PdataFormat::OTAP,
+        }
+    }
+
+    /// Encoding identity for byte representations.
+    #[must_use]
+    pub fn encoding(&self) -> Option<&PdataEncoding> {
+        match &self.data {
+            PayloadData::OtlpBytes(_) => Some(&ResolvedCodec::OTLP.metadata().encoding),
+            PayloadData::Encoded(encoded) => Some(encoded.encoding()),
+            PayloadData::OtapArrowRecords(_) => None,
+        }
+    }
+
+    /// Borrows existing encoded bytes without conversion.
+    #[must_use]
+    pub fn encoded_bytes(&self) -> Option<&Bytes> {
+        match &self.data {
+            PayloadData::OtlpBytes(bytes) => Some(bytes.bytes()),
+            PayloadData::Encoded(encoded) => Some(encoded.bytes()),
+            PayloadData::OtapArrowRecords(_) => None,
+        }
+    }
+
+    /// Borrows native records only when already materialized.
+    #[must_use]
+    pub fn otap_ref(&self) -> Option<&OtapArrowRecords> {
+        match &self.data {
+            PayloadData::OtapArrowRecords(records) => Some(records),
+            _ => None,
+        }
+    }
+
+    /// Known item count, keeping unknown distinct from an empty batch.
+    #[must_use]
+    pub fn known_item_count(&self) -> Option<usize> {
+        match &self.data {
+            PayloadData::OtapArrowRecords(records) => Some(records.num_items()),
+            _ => self.item_count.get(),
+        }
     }
 
     /// Borrows the concrete payload data for pattern matching.
@@ -234,7 +406,111 @@ impl OtapPayload {
 
     /// Consumes this payload and extracts or converts it to OTAP records.
     pub fn into_otap(self) -> Result<OtapArrowRecords, crate::encode::Error> {
-        self.try_into_with_default()
+        match self.try_into_otap(&mut CodecState::default()) {
+            Ok(records) => Ok(records),
+            Err(error) => Err(error.into_parts().0),
+        }
+    }
+
+    /// Extracts native records or decodes encoded input through reusable state.
+    ///
+    /// A failure retains the exact original representation, bytes, and caches.
+    pub fn try_into_otap(
+        self,
+        state: &mut CodecState,
+    ) -> Result<OtapArrowRecords, OtapPayloadDecodeError> {
+        let Self {
+            data,
+            item_count,
+            size,
+        } = self;
+        match data {
+            PayloadData::OtapArrowRecords(records) => Ok(records),
+            PayloadData::OtlpBytes(bytes) => {
+                let payload = Self {
+                    data: PayloadData::OtlpBytes(bytes.clone()),
+                    item_count,
+                    size,
+                };
+                bytes.try_into_with_default().map_err(|source| {
+                    OtapPayloadDecodeError(Box::new(OtapPayloadDecodeErrorInner {
+                        source,
+                        payload,
+                    }))
+                })
+            }
+            PayloadData::Encoded(encoded) => {
+                let payload = Self {
+                    data: PayloadData::Encoded(encoded.clone()),
+                    item_count,
+                    size,
+                };
+                state.decode_encoded(&encoded).map_err(|source| {
+                    OtapPayloadDecodeError(Box::new(OtapPayloadDecodeErrorInner {
+                        source,
+                        payload,
+                    }))
+                })
+            }
+        }
+    }
+
+    /// Returns a read-only representation-independent view.
+    pub fn view<'a>(
+        &'a self,
+        state: &mut CodecState,
+    ) -> Result<CodecView<'a>, crate::encode::Error> {
+        match &self.data {
+            PayloadData::OtlpBytes(bytes) => Ok(CodecView::OtlpBytes {
+                signal: bytes.signal_type(),
+                bytes: bytes.as_bytes(),
+            }),
+            PayloadData::Encoded(encoded) => state.view_encoded(encoded),
+            PayloadData::OtapArrowRecords(records) => Ok(CodecView::OtapArrowRecords(
+                std::borrow::Cow::Borrowed(records),
+            )),
+        }
+    }
+
+    /// Prepares output using a startup-resolved encoding plan.
+    pub fn prepare_encoded<'a>(
+        &'a mut self,
+        state: &'a mut CodecState,
+        plan: &EncodingPlan,
+    ) -> Result<EncodeOutput<'a>, Error> {
+        plan.codec()
+            .require(self.signal_type(), crate::codec::CodecDirection::Encode)?;
+        match &mut self.data {
+            PayloadData::OtlpBytes(bytes) if plan.codec() == ResolvedCodec::OTLP => {
+                Ok(EncodeOutput::bytes(bytes.clone_bytes()))
+            }
+            PayloadData::Encoded(encoded) if encoded.codec() == plan.codec() => {
+                Ok(EncodeOutput::bytes(encoded.bytes().clone()))
+            }
+            PayloadData::OtapArrowRecords(records) => state.prepare_encode(records, plan),
+            PayloadData::OtlpBytes(bytes) => {
+                let mut records: OtapArrowRecords = bytes.clone().try_into_with_default().map_err(
+                    |error: crate::encode::Error| Error::Format {
+                        error: error.to_string(),
+                    },
+                )?;
+                state
+                    .prepare_encode(&mut records, plan)
+                    .map(EncodeOutput::copy_into_bytes)
+                    .map(EncodeOutput::bytes)
+            }
+            PayloadData::Encoded(encoded) => {
+                let mut records = state
+                    .decode_encoded(encoded)
+                    .map_err(|error| Error::Format {
+                        error: error.to_string(),
+                    })?;
+                state
+                    .prepare_encode(&mut records, plan)
+                    .map(EncodeOutput::copy_into_bytes)
+                    .map(EncodeOutput::bytes)
+            }
+        }
     }
 
     /// Returns the type of signal represented by this `OtapPdata` instance.
@@ -278,11 +554,24 @@ impl OtapPayload {
         match &self.data {
             // Cache OTLP counts because counting traverses protobuf records.
             PayloadData::OtlpBytes(_) => {
-                if let Some(item_count) = self.item_count {
+                if let Some(item_count) = self.item_count.get() {
                     return item_count;
                 }
                 let item_count = self.data.num_items();
-                self.item_count = Some(item_count);
+                self.item_count.set(item_count);
+                item_count
+            }
+            PayloadData::Encoded(encoded) => {
+                if let Some(item_count) = self.item_count.get() {
+                    return item_count;
+                }
+                let Some(item_count) = encoded
+                    .codec()
+                    .count_items(encoded.signal_type(), encoded.bytes())
+                else {
+                    return 0;
+                };
+                self.item_count.set(item_count);
                 item_count
             }
             // Bypass the cache for OTAP because Arrow batches store row counts.
@@ -299,14 +588,14 @@ impl OtapPayload {
     pub fn num_bytes(&mut self) -> Option<usize> {
         match &self.data {
             // OTLP already stores the exact encoded length in Bytes metadata.
-            PayloadData::OtlpBytes(_) => self.data.num_bytes(),
+            PayloadData::OtlpBytes(_) | PayloadData::Encoded(_) => self.data.num_bytes(),
             // Cache OTAP sizing because it walks every Arrow array and buffer.
             PayloadData::OtapArrowRecords(_) => {
-                if let Some(size) = self.size {
+                if let Some(size) = self.size.get() {
                     return Some(size);
                 }
                 let size = self.data.num_bytes()?;
-                self.size = Some(size);
+                self.size.set(size);
                 Some(size)
             }
         }
@@ -328,8 +617,8 @@ impl OtapPayload {
     pub const fn empty(signal: SignalType) -> Self {
         Self {
             data: PayloadData::OtlpBytes(OtlpProtoBytes::empty(signal)),
-            item_count: None,
-            size: None,
+            item_count: CachedMeasurement::unknown(),
+            size: CachedMeasurement::unknown(),
         }
     }
 
@@ -338,14 +627,14 @@ impl OtapPayload {
     #[cfg(any(test, feature = "testing"))]
     #[must_use]
     pub fn test_has_cached_item_count(&self) -> bool {
-        self.item_count.is_some()
+        self.item_count.get().is_some()
     }
 
     /// Test-only introspection: true if the OTAP size cache has been computed.
     #[cfg(any(test, feature = "testing"))]
     #[must_use]
     pub fn test_has_cached_size(&self) -> bool {
-        self.size.is_some()
+        self.size.get().is_some()
     }
 }
 
@@ -553,6 +842,12 @@ impl From<OtlpProtoBytes> for OtapPayload {
     }
 }
 
+impl From<EncodedPdata> for OtapPayload {
+    fn from(value: EncodedPdata) -> Self {
+        Self::from_encoded(value)
+    }
+}
+
 impl From<PayloadData> for OtapPayload {
     fn from(value: PayloadData) -> Self {
         Self::from_data(value)
@@ -569,6 +864,7 @@ impl TryFromWithOptions<OtapPayload> for OtapArrowRecords {
         match value.into_data() {
             PayloadData::OtapArrowRecords(value) => Ok(value),
             PayloadData::OtlpBytes(value) => value.try_into_with_options(opts),
+            PayloadData::Encoded(value) => CodecState::default().decode_encoded(&value),
         }
     }
 }
@@ -583,6 +879,17 @@ impl TryFromWithOptions<OtapPayload> for OtlpProtoBytes {
         match value.into_data() {
             PayloadData::OtapArrowRecords(value) => value.try_into_with_options(opts),
             PayloadData::OtlpBytes(value) => Ok(value),
+            PayloadData::Encoded(value) if value.codec() == ResolvedCodec::OTLP => Ok(
+                OtlpProtoBytes::new_from_bytes(value.signal_type(), value.into_bytes()),
+            ),
+            PayloadData::Encoded(value) => {
+                let records = CodecState::default()
+                    .decode_encoded(&value)
+                    .map_err(|error| Error::Format {
+                        error: error.to_string(),
+                    })?;
+                records.try_into_with_options(opts)
+            }
         }
     }
 }
@@ -706,13 +1013,14 @@ mod test {
     use prost::Message;
     use std::mem::size_of;
 
-    /// Scenario: The legacy payload representation is built for a 64-bit target.
-    /// Guarantees: The baseline payload layout remains fixed for codec comparisons.
+    /// Scenario: Transitional legacy, encoded, and native storage is built for a 64-bit target.
+    /// Guarantees: Inline admission reduces the wrapper below the 72-byte upstream baseline.
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn legacy_payload_layout_is_stable() {
-        assert_eq!(size_of::<PayloadData>(), 40);
-        assert_eq!(size_of::<OtapPayload>(), 72);
+        assert_eq!(size_of::<EncodedPdata>(), 48);
+        assert_eq!(size_of::<PayloadData>(), 48);
+        assert_eq!(size_of::<OtapPayload>(), 64);
     }
 
     /// Scenario: An OTLP payload is converted back to its matching legacy representation.
@@ -726,6 +1034,98 @@ mod test {
             .try_into_with_default()
             .expect("matching OTLP forwarding");
         assert_eq!(forwarded.as_bytes().as_ptr(), pointer);
+    }
+
+    /// Scenario: OTLP bytes are admitted explicitly into generalized transitional storage.
+    /// Guarantees: Admission and matching output preserve the buffer and create no codec instance.
+    #[test]
+    fn encoded_admission_and_matching_forward_are_lazy() {
+        let original = Bytes::from_static(b"deliberately-not-protobuf");
+        let pointer = original.as_ptr();
+        let encoded = ResolvedCodec::OTLP
+            .admit(SignalType::Logs, original)
+            .expect("OTLP admission validates metadata only");
+        let mut payload = OtapPayload::from_encoded(encoded);
+        assert_eq!(payload.signal_format(), SignalFormat::Encoded);
+        assert_eq!(payload.format(), PdataFormat::encoded(ResolvedCodec::OTLP));
+        assert_eq!(payload.encoded_bytes().unwrap().as_ptr(), pointer);
+
+        let mut state = CodecState::default();
+        let output = payload
+            .prepare_encoded(&mut state, &EncodingPlan::OTLP)
+            .expect("matching output forwards bytes");
+        assert_eq!(output.as_ref().as_ptr(), pointer);
+        drop(output);
+        assert_eq!(state.test_instance_count(), 0);
+    }
+
+    /// Scenario: Malformed generalized OTLP is converted with receiver-known measurements.
+    /// Guarantees: Failure returns the same bytes, identity, signal, count, and reusable state.
+    #[test]
+    fn encoded_decode_failure_recovers_exact_input() {
+        let original = Bytes::from_static(&[0x0a, 0x05, 0x01]);
+        let pointer = original.as_ptr();
+        let payload = OtapPayload::from_encoded(
+            ResolvedCodec::OTLP
+                .admit(SignalType::Logs, original)
+                .expect("lazy OTLP admission"),
+        )
+        .with_item_count(7);
+        let mut state = CodecState::default();
+        let error = payload
+            .try_into_otap(&mut state)
+            .expect_err("malformed OTLP must fail native conversion");
+        let (_, recovered) = error.into_parts();
+        assert_eq!(recovered.signal_type(), SignalType::Logs);
+        assert_eq!(
+            recovered.format(),
+            PdataFormat::encoded(ResolvedCodec::OTLP)
+        );
+        assert_eq!(recovered.known_item_count(), Some(7));
+        assert_eq!(recovered.encoded_bytes().unwrap().as_ptr(), pointer);
+        assert_eq!(
+            recovered.encoded_bytes().unwrap().as_ref(),
+            &[0x0a, 0x05, 0x01]
+        );
+        assert_eq!(state.test_instance_count(), 1);
+    }
+
+    /// Scenario: Native OTAP is consumed through the recoverable codec capability.
+    /// Guarantees: Records move directly and no codec instance is constructed.
+    #[test]
+    fn native_try_into_otap_needs_no_codec() {
+        let expected: OtapArrowRecords = OtlpProtoBytes::new_from_bytes(
+            SignalType::Logs,
+            logs_with_full_resource_and_scope().encode_to_vec(),
+        )
+        .try_into_with_default()
+        .expect("fixture conversion");
+        let mut state = CodecState::default();
+        let actual = OtapPayload::from_otap(expected.clone())
+            .try_into_otap(&mut state)
+            .expect("native move");
+        assert_eq!(actual, expected);
+        assert_eq!(state.test_instance_count(), 0);
+    }
+
+    /// Scenario: A read-only consumer views admitted OTLP before materialization.
+    /// Guarantees: The borrowed view preserves the byte pointer and leaves storage encoded.
+    #[test]
+    fn encoded_view_does_not_materialize_payload() {
+        let original = Bytes::from(logs_with_full_resource_and_scope().encode_to_vec());
+        let pointer = original.as_ptr();
+        let payload = OtapPayload::from_encoded(
+            ResolvedCodec::OTLP
+                .admit(SignalType::Logs, original)
+                .expect("OTLP admission"),
+        );
+        let mut state = CodecState::default();
+        let view = payload.view(&mut state).expect("OTLP borrowed view");
+        match view {
+            CodecView::OtlpBytes { bytes, .. } => assert_eq!(bytes.as_ptr(), pointer),
+            CodecView::OtapArrowRecords(_) => panic!("OTLP should remain a borrowed byte view"),
+        }
+        assert_eq!(payload.encoded_bytes().unwrap().as_ptr(), pointer);
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/pdata/src/testing/codec_conformance.rs
+++ b/rust/otap-dataflow/crates/pdata/src/testing/codec_conformance.rs
@@ -1,0 +1,75 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Reusable behavioral checks for pdata codecs before payload integration.
+
+use bytes::Bytes;
+use otel_arrow_dfe_config::SignalType;
+
+use crate::OtapPayloadHelpers;
+use crate::codec::{CodecState, EncodingPlan, ResolvedCodec};
+
+/// One codec and byte sample used by the decode conformance checks.
+pub struct DecodeConformanceCase {
+    /// Resolved codec under test.
+    pub codec: ResolvedCodec,
+    /// Signal carried outside the encoded bytes.
+    pub signal: SignalType,
+    /// Complete independently decodable batch.
+    pub valid: Bytes,
+    /// Malformed bytes that strict decoders must reject.
+    pub malformed: Option<Bytes>,
+    /// Expected primary-signal item count.
+    pub expected_items: usize,
+}
+
+/// Checks signal preservation, borrowed views, stateless counts, state reuse,
+/// repeated malformed input, and independent output decoding.
+pub fn assert_decode_conformance(case: DecodeConformanceCase) {
+    let pointer = case.valid.as_ptr();
+    assert_eq!(
+        case.codec.count_items(case.signal, &case.valid),
+        Some(case.expected_items)
+    );
+
+    let mut state = CodecState::default();
+    let view = state
+        .view(case.codec, case.signal, &case.valid)
+        .expect("valid codec bytes must produce a view");
+    assert_eq!(view.signal_type(), case.signal);
+    assert_eq!(case.valid.as_ptr(), pointer);
+
+    let records = state
+        .decode(case.codec, case.signal, &case.valid)
+        .expect("valid codec bytes must decode");
+    assert_eq!(records.signal_type(), case.signal);
+    assert_eq!(records.num_items(), case.expected_items);
+    assert_eq!(state.test_instance_count(), 1);
+
+    if let Some(malformed) = case.malformed {
+        let malformed_pointer = malformed.as_ptr();
+        for _ in 0..2 {
+            assert!(state.decode(case.codec, case.signal, &malformed).is_err());
+            assert_eq!(malformed.as_ptr(), malformed_pointer);
+        }
+        let recovered = state
+            .decode(case.codec, case.signal, &case.valid)
+            .expect("valid decode must recover after repeated failures");
+        assert_eq!(recovered.num_items(), case.expected_items);
+    }
+
+    if case.codec.metadata().can_encode {
+        let plan = EncodingPlan::new(case.codec, Default::default())
+            .expect("conforming output codec must resolve");
+        let mut records = records;
+        let output = state
+            .prepare_encode(&mut records, &plan)
+            .expect("conforming codec must encode")
+            .into_bytes();
+        let independently_decoded = CodecState::default()
+            .decode(case.codec, case.signal, &output)
+            .expect("each encoded output must decode independently");
+        assert_eq!(independently_decoded.signal_type(), case.signal);
+        assert_eq!(independently_decoded.num_items(), case.expected_items);
+    }
+}

--- a/rust/otap-dataflow/crates/pdata/src/testing/mod.rs
+++ b/rust/otap-dataflow/crates/pdata/src/testing/mod.rs
@@ -3,6 +3,7 @@
 
 //! Testing utilities for OTLP and OTAP verification.
 
+pub mod codec_conformance;
 pub mod equiv;
 pub mod fixtures;
 pub mod record_batch;

--- a/rust/otap-dataflow/docs/pdata-codec-benchmarks.md
+++ b/rust/otap-dataflow/docs/pdata-codec-benchmarks.md
@@ -1,0 +1,22 @@
+# PData Codec Benchmark Method
+
+Use the `payload_measurements` and `syslog_cef_receiver` Criterion benchmarks to
+compare representation changes with the legacy implementation.
+
+## Controlled comparison
+
+1. Build release benchmark executables for the baseline and candidate commits.
+2. Select an otherwise idle logical CPU and confirm that its SMT sibling is idle.
+3. Pin every benchmark process to that CPU.
+4. Alternate baseline and candidate runs to reduce temperature and run-order bias.
+5. Use identical warm-up, measurement, sample-count, and input-size settings.
+6. Retain Criterion confidence intervals and record the tested commit IDs.
+
+Matching-representation forwarding must preserve the original `Bytes` buffer and
+must not allocate a representation wrapper. Native OTAP conversion must move the
+records directly. If confidence intervals do not overlap, repeat the interleaved
+runs and use CPU counters or allocation profiling before attributing a regression
+to the codec abstraction.
+
+HTTP compression measurements include encoding directly from the reusable output
+buffer. Keep transport compression separate from codec encoding in reports.


### PR DESCRIPTION
# Change summary

This is PR 2 of the pluggable PData codec series introduced in #3452. It builds on the codec foundation by integrating codec access into the pipeline runtime and migrating existing consumers to representation-independent APIs.

Existing receivers continue producing their current representations. This allows the runtime and node migrations to be reviewed before activating the generalized codec path for OTLP.

### Payload capabilities

This PR adds transitional `EncodedPdata` storage alongside the existing `OtlpBytes` and native OTAP representations.

It introduces:

- Representation-independent format, encoding, byte, and native-record inspection.
- Recoverable conversion from owned PData into `OtapArrowPdata`.
- `OtapArrowPdata` as proof that a processor owns native Arrow records.
- Decode errors that retain the original payload and delivery context.
- Read-only codec views that avoid materializing compatible encoded input.
- Output preparation through a startup-resolved `EncodingPlan`.
- Layout and zero-copy assertions for encoded and native paths.

`From<OtlpProtoBytes>` continues producing the legacy representation. Generalized encoded storage is exercised explicitly in tests until the OTLP receiver cutover.

### Runtime integration

The pipeline runtime creates one lazy codec service and exposes it through receiver, processor, and exporter effect handlers. Nodes do not store their own codec state.

A native processor adapter centralizes conversion and error handling:

1. Convert incoming PData through runtime-owned codec state.
2. Permanently Nack codec failures using the recovered original message.
3. Invoke the processor only with `OtapArrowPdata`.

The filter processor uses this adapter as the first native processor implementation.

### Node migration

Core, contrib, and WASM consumers are migrated according to their data requirements:

- Transparent processors forward the original representation.
- Read-only processors use codec views.
- Native processors use recoverable OTAP conversion.
- Exporters use startup-resolved encoding plans.
- The transform processor preserves encoded input when no transformation applies.

The migration covers core processors and exporters together with Kafka, Geneva, KQL, ClickHouse, Azure Monitor, resource validation, attribute condensation, and the WASM bridge.

### Scope boundary

This PR does not:

- Change OTLP receiver admission.
- Remove `OtlpBytes` or `SignalFormat`.
- Introduce codec-aware batching.
- Add syslog, Parquet, or other codecs.
- Change wire protocols, configuration aliases, durable-storage formats, or transport compression.

## Related issue

- Part of #3452
- Depends on the codec foundation PR

## Validation

- `cargo xtask check`

## User-facing changes

None. This PR changes internal payload and node APIs without changing receiver output, pipeline configuration, wire protocols, or observable behavior.