### PR TITLE
Pdata codec series 04 batching

### DIFF
--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -7797,6 +7797,7 @@ dependencies = [
  "datafusion",
  "hex",
  "itertools 0.15.0",
+ "linkme",
  "nix 0.31.3",
  "num_enum",
  "otel-arrow-dfe-config",

--- a/rust/otap-dataflow/benchmarks/benches/payload_measurements/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/payload_measurements/main.rs
@@ -8,15 +8,19 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 
+use otel_arrow_dfe_config::SignalType;
+use otel_arrow_dfe_otap::compression::CompressionMethod;
 use otel_arrow_dfe_otap::pdata::{Context, OtapPdata};
-use otel_arrow_dfe_pdata::OtapPayload;
 use otel_arrow_dfe_pdata::otap::OtapArrowRecords;
+use otel_arrow_dfe_pdata::otap::batching::make_item_batches;
 use otel_arrow_dfe_pdata::otlp::OtlpProtoBytes;
+use otel_arrow_dfe_pdata::otlp::batching::make_bytes_batches_owned;
 use otel_arrow_dfe_pdata::proto::OtlpProtoMessage;
 use otel_arrow_dfe_pdata::proto::opentelemetry::common::v1::*;
 use otel_arrow_dfe_pdata::proto::opentelemetry::logs::v1::*;
 use otel_arrow_dfe_pdata::proto::opentelemetry::resource::v1::*;
 use otel_arrow_dfe_pdata::testing::round_trip::{otlp_message_to_bytes, otlp_to_otap};
+use otel_arrow_dfe_pdata::{OtapPayload, TryIntoWithOptions};
 
 #[cfg(not(windows))]
 use tikv_jemallocator::Jemalloc;
@@ -179,10 +183,112 @@ fn measure_payload_size(c: &mut Criterion) {
     group.finish();
 }
 
+fn legacy_representation_paths(c: &mut Criterion) {
+    let mut group = c.benchmark_group("PData legacy representation paths");
+
+    for record_count in [10, 100, 1_000] {
+        let message = OtlpProtoMessage::Logs(create_logs_data(record_count));
+        let otlp_bytes: OtlpProtoBytes = otlp_message_to_bytes(&message);
+        let otap_records: OtapArrowRecords = otlp_to_otap(&message);
+
+        _ = group.bench_function(BenchmarkId::new("OTLP/forward", record_count), |b| {
+            b.iter_batched(
+                || OtapPayload::from(otlp_bytes.clone()),
+                |payload| {
+                    let forwarded: OtlpProtoBytes = payload
+                        .try_into_with_default()
+                        .expect("matching OTLP forwarding");
+                    black_box(forwarded)
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        _ = group.bench_function(BenchmarkId::new("OTLP/decode", record_count), |b| {
+            b.iter_batched(
+                || OtapPayload::from(otlp_bytes.clone()),
+                |payload| {
+                    let records: OtapArrowRecords =
+                        payload.try_into_with_default().expect("OTLP decode");
+                    black_box(records)
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        _ = group.bench_function(BenchmarkId::new("OTAP/encode_otlp", record_count), |b| {
+            b.iter_batched(
+                || otap_records.clone(),
+                |records| {
+                    let encoded: OtlpProtoBytes =
+                        records.try_into_with_default().expect("OTLP encode");
+                    black_box(encoded)
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        _ = group.bench_function(BenchmarkId::new("OTAP/native_move", record_count), |b| {
+            b.iter_batched(
+                || OtapPayload::from(otap_records.clone()),
+                |payload| {
+                    let records: OtapArrowRecords = payload
+                        .try_into_with_default()
+                        .expect("native payload move");
+                    black_box(records)
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        _ = group.bench_function(BenchmarkId::new("OTLP/batch", record_count), |b| {
+            b.iter_batched(
+                || vec![otlp_bytes.clone(), otlp_bytes.clone()],
+                |inputs| {
+                    black_box(
+                        make_bytes_batches_owned(SignalType::Logs, None, None, None, None, inputs)
+                            .expect("OTLP byte batching"),
+                    )
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        _ = group.bench_function(BenchmarkId::new("OTAP/batch", record_count), |b| {
+            b.iter_batched(
+                || vec![otap_records.clone(), otap_records.clone()],
+                |inputs| {
+                    black_box(
+                        make_item_batches(SignalType::Logs, None, inputs)
+                            .expect("OTAP item batching"),
+                    )
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        _ = group.bench_function(BenchmarkId::new("OTLP/zstd", record_count), |b| {
+            b.iter_batched_ref(
+                Vec::new,
+                |scratch| {
+                    CompressionMethod::Zstd
+                        .encode(black_box(otlp_bytes.as_bytes()), scratch)
+                        .expect("OTLP HTTP compression");
+                    _ = black_box(scratch.len());
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     payload_measurements,
     count_logs,
     count_payload_items,
-    measure_payload_size
+    measure_payload_size,
+    legacy_representation_paths
 );
 criterion_main!(payload_measurements);

--- a/rust/otap-dataflow/benchmarks/benches/payload_measurements/main.rs
+++ b/rust/otap-dataflow/benchmarks/benches/payload_measurements/main.rs
@@ -20,7 +20,9 @@ use otel_arrow_dfe_pdata::proto::opentelemetry::common::v1::*;
 use otel_arrow_dfe_pdata::proto::opentelemetry::logs::v1::*;
 use otel_arrow_dfe_pdata::proto::opentelemetry::resource::v1::*;
 use otel_arrow_dfe_pdata::testing::round_trip::{otlp_message_to_bytes, otlp_to_otap};
-use otel_arrow_dfe_pdata::{OtapPayload, TryIntoWithOptions};
+use otel_arrow_dfe_pdata::{
+    CodecState, EncodingPlan, OtapPayload, ResolvedCodec, TryIntoWithOptions,
+};
 
 #[cfg(not(windows))]
 use tikv_jemallocator::Jemalloc;
@@ -284,11 +286,84 @@ fn legacy_representation_paths(c: &mut Criterion) {
     group.finish();
 }
 
+fn direct_codec_paths(c: &mut Criterion) {
+    let mut group = c.benchmark_group("PData direct codec paths");
+
+    for record_count in [10, 100, 1_000] {
+        let message = OtlpProtoMessage::Logs(create_logs_data(record_count));
+        let otlp_bytes: OtlpProtoBytes = otlp_message_to_bytes(&message);
+        let encoded = otlp_bytes.clone_bytes();
+        let otap_records: OtapArrowRecords = otlp_to_otap(&message);
+
+        _ = group.bench_function(BenchmarkId::new("OTLP/count", record_count), |b| {
+            b.iter(|| black_box(ResolvedCodec::OTLP.count_items(SignalType::Logs, &encoded)))
+        });
+
+        _ = group.bench_function(BenchmarkId::new("OTLP/view", record_count), |b| {
+            let mut state = CodecState::default();
+            b.iter(|| {
+                black_box(
+                    state
+                        .view(ResolvedCodec::OTLP, SignalType::Logs, &encoded)
+                        .expect("OTLP codec view"),
+                )
+            })
+        });
+
+        _ = group.bench_function(BenchmarkId::new("OTLP/decode", record_count), |b| {
+            let mut state = CodecState::default();
+            b.iter(|| {
+                black_box(
+                    state
+                        .decode(ResolvedCodec::OTLP, SignalType::Logs, &encoded)
+                        .expect("OTLP codec decode"),
+                )
+            })
+        });
+
+        _ = group.bench_function(
+            BenchmarkId::new("OTAP/encode_prepared", record_count),
+            |b| {
+                let mut state = CodecState::default();
+                b.iter_batched(
+                    || otap_records.clone(),
+                    |mut records| {
+                        let output = state
+                            .prepare_encode(&mut records, &EncodingPlan::OTLP)
+                            .expect("OTLP prepared output");
+                        black_box(output.as_ref().len())
+                    },
+                    BatchSize::SmallInput,
+                )
+            },
+        );
+
+        _ = group.bench_function(BenchmarkId::new("OTAP/encode_owned", record_count), |b| {
+            let mut state = CodecState::default();
+            b.iter_batched(
+                || otap_records.clone(),
+                |mut records| {
+                    black_box(
+                        state
+                            .prepare_encode(&mut records, &EncodingPlan::OTLP)
+                            .expect("OTLP owned output")
+                            .into_bytes(),
+                    )
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     payload_measurements,
     count_logs,
     count_payload_items,
     measure_payload_size,
-    legacy_representation_paths
+    legacy_representation_paths,
+    direct_codec_paths
 );
 criterion_main!(payload_measurements);

--- a/rust/otap-dataflow/crates/config/src/conversion.rs
+++ b/rust/otap-dataflow/crates/config/src/conversion.rs
@@ -1,16 +1,22 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Options for protocol conversion.
+//! Options for encoded output.
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::num::NonZeroUsize;
 
-/// Options for protocol conversion.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+/// Output-specific options applied while encoding telemetry.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
 #[serde(deny_unknown_fields)]
-pub struct ConversionOptions {
-    /// default applies.
+pub struct EncodeOptions {
+    /// Maximum size of an encoded OTLP protobuf message.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub otlp_size_limit: Option<NonZeroUsize>,
 }
+
+/// Transitional alias for code that still passes the former conversion options.
+///
+/// Decoding has no configurable policy. New code should use [`EncodeOptions`]
+/// only at an output boundary.
+pub type ConversionOptions = EncodeOptions;

--- a/rust/otap-dataflow/crates/config/src/lib.rs
+++ b/rust/otap-dataflow/crates/config/src/lib.rs
@@ -73,6 +73,8 @@ pub enum SignalFormat {
     OtapRecords,
     /// OTLP protobuf bytes
     OtlpBytes,
+    /// Independently encoded bytes identified by a registered pdata codec.
+    Encoded,
     // TODO: maybe add types not included in OtapPdata including
     // OtlpProtoMessage, OtapArrowBytes, and possible opaque.
 }

--- a/rust/otap-dataflow/crates/config/src/lib.rs
+++ b/rust/otap-dataflow/crates/config/src/lib.rs
@@ -53,7 +53,7 @@ pub use topic::{
 /// Validation helpers for node configuration.
 pub mod validation;
 
-pub use conversion::ConversionOptions;
+pub use conversion::{ConversionOptions, EncodeOptions};
 
 /// Signal types
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
@@ -12,10 +12,11 @@ use otel_arrow_dfe_engine::local::capability::auth::bearer_token_provider::Beare
 use otel_arrow_dfe_engine::local::exporter::{EffectHandler, Exporter};
 use otel_arrow_dfe_engine::message::{ExporterInbox, Message};
 use otel_arrow_dfe_engine::terminal_state::TerminalState;
+#[cfg(test)]
 use otel_arrow_dfe_pdata::otlp::OtlpProtoBytes;
 use otel_arrow_dfe_pdata::views::otap::OtapLogsView;
 use otel_arrow_dfe_pdata::views::otlp::bytes::logs::RawLogsData;
-use otel_arrow_dfe_pdata::{OtapArrowRecords, OtapPayload, PayloadData};
+use otel_arrow_dfe_pdata::{CodecView, OtapArrowRecords, OtapPayload};
 
 use super::client::LogsIngestionClientPool;
 use super::config::Config;
@@ -28,7 +29,7 @@ use super::metrics::AzureMonitorExporterMetricsRc;
 use super::state::AzureMonitorExporterState;
 use super::transformer::Transformer;
 use otel_arrow_dfe_otap::bearer_auth::{BearerAuth, BearerAuthEvents};
-use otel_arrow_dfe_otap::pdata::{Context, OtapPdata};
+use otel_arrow_dfe_otap::pdata::{Context, OtapPdata, PdataEffectHandlerExtension};
 
 use otel_arrow_dfe_telemetry::common_attributes::{HttpResponse, Outcome};
 
@@ -456,15 +457,28 @@ impl AzureMonitorExporter {
                 *msg_id += 1;
                 let (context, payload) = pdata.into_parts();
 
-                let log_entries = match payload.data() {
-                    PayloadData::OtapArrowRecords(otap_records) => match otap_records {
+                let view = match effect_handler.view(&payload).await {
+                    Ok(view) => view,
+                    Err(error) => {
+                        effect_handler
+                            .notify_nack(NackMsg::new_permanent(
+                                error.to_string(),
+                                OtapPdata::new(context, payload),
+                            ))
+                            .await?;
+                        return Ok(());
+                    }
+                };
+                let log_entries = match view {
+                    CodecView::OtapArrowRecords(otap_records) => match otap_records.as_ref() {
                         OtapArrowRecords::Logs(_) => {
-                            let logs_view = OtapLogsView::try_from(otap_records).map_err(|e| {
-                                let error = Error::LogsViewCreationFailed { source: e };
-                                EngineError::InternalError {
-                                    message: error.to_string(),
-                                }
-                            })?;
+                            let logs_view =
+                                OtapLogsView::try_from(otap_records.as_ref()).map_err(|e| {
+                                    let error = Error::LogsViewCreationFailed { source: e };
+                                    EngineError::InternalError {
+                                        message: error.to_string(),
+                                    }
+                                })?;
                             Some(self.transformer.convert_to_log_analytics(&logs_view))
                         }
                         OtapArrowRecords::Metrics(_) | OtapArrowRecords::Traces(_) => {
@@ -476,13 +490,12 @@ impl AzureMonitorExporter {
                             None
                         }
                     },
-                    PayloadData::OtlpBytes(otlp_bytes) => match otlp_bytes {
-                        OtlpProtoBytes::ExportLogsRequest(bytes) => {
-                            let logs_view = RawLogsData::new(bytes.as_ref());
+                    CodecView::OtlpBytes { signal, bytes } => match signal {
+                        SignalType::Logs => {
+                            let logs_view = RawLogsData::new(bytes);
                             Some(self.transformer.convert_to_log_analytics(&logs_view))
                         }
-                        OtlpProtoBytes::ExportMetricsRequest(_)
-                        | OtlpProtoBytes::ExportTracesRequest(_) => {
+                        SignalType::Metrics | SignalType::Traces => {
                             otel_warn!(
                                 "azure_monitor_exporter.message.unsupported_signal",
                                 signal = "metrics_or_traces",

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
@@ -35,9 +35,9 @@ otel_arrow_dfe_telemetry::otel_component_scope!(
 use async_trait::async_trait;
 use futures::future::LocalBoxFuture;
 use linkme::distributed_slice;
+use otel_arrow_dfe_config::SignalType;
 use otel_arrow_dfe_config::node::NodeUserConfig;
 use otel_arrow_dfe_config::validation::validate_typed_config;
-use otel_arrow_dfe_config::{SignalFormat, SignalType};
 use otel_arrow_dfe_engine::config::ExporterConfig;
 use otel_arrow_dfe_engine::context::PipelineContext;
 use otel_arrow_dfe_engine::control::{AckMsg, NackMsg, NodeControlMsg};
@@ -50,12 +50,12 @@ use otel_arrow_dfe_engine::terminal_state::TerminalState;
 use otel_arrow_dfe_engine::{ConsumerEffectHandlerExtension, ExporterFactory};
 use otel_arrow_dfe_otap::OTAP_EXPORTER_FACTORIES;
 use otel_arrow_dfe_otap::metrics::ExporterExportMetrics;
-use otel_arrow_dfe_otap::pdata::OtapPdata;
+use otel_arrow_dfe_otap::pdata::{OtapPdata, PdataEffectHandlerExtension};
+#[cfg(test)]
+use otel_arrow_dfe_pdata::OtlpProtoBytes;
 use otel_arrow_dfe_pdata::error::Error as PdataError;
 use otel_arrow_dfe_pdata::proto::opentelemetry::arrow::v1::ArrowPayloadType;
-use otel_arrow_dfe_pdata::{
-    OtapArrowRecords, OtapPayload, OtlpProtoBytes, PayloadData, TryIntoWithOptions,
-};
+use otel_arrow_dfe_pdata::{OtapArrowRecords, OtapPayload};
 use otel_arrow_dfe_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
 use otel_arrow_dfe_telemetry::metrics::MetricSetHandler;
 use otel_arrow_dfe_telemetry::metrics::{MeasurementMetricSet, MetricSet};
@@ -208,11 +208,19 @@ fn transform_raw_otlp_logs(
     payload: &OtapPayload,
     transformer: &mut OtlpLogsTransformer,
 ) -> Option<Result<Option<arrow::array::RecordBatch>, error::ClickhouseExporterError>> {
-    match payload.data() {
-        PayloadData::OtlpBytes(OtlpProtoBytes::ExportLogsRequest(bytes)) => {
-            Some(transformer.transform(bytes))
-        }
-        _ => None,
+    if payload.signal_type() == SignalType::Logs
+        && payload.format()
+            == otel_arrow_dfe_pdata::PdataFormat::encoded(otel_arrow_dfe_pdata::ResolvedCodec::OTLP)
+    {
+        Some(
+            transformer.transform(
+                payload
+                    .encoded_bytes()
+                    .expect("OTLP format has encoded bytes"),
+            ),
+        )
+    } else {
+        None
     }
 }
 
@@ -358,7 +366,8 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
                 Message::PData(pdata) => {
                     let export_started_at = Instant::now();
                     let signal_type = pdata.signal_type();
-                    let signal_format = pdata.signal_format();
+                    let input_was_native =
+                        pdata.payload_ref().format() == otel_arrow_dfe_pdata::PdataFormat::OTAP;
 
                     if is_unsupported_non_empty_signal(&pdata) {
                         let reason =
@@ -428,8 +437,9 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
                     let write_batches = if let Some(batches) = direct_otlp_batches {
                         batches
                     } else {
-                        let mut arrow_records: OtapArrowRecords = match payload
-                            .try_into_with_default()
+                        let mut arrow_records: OtapArrowRecords = match effect_handler
+                            .try_payload_into_otap(payload)
+                            .await
                         {
                             Ok(arrow_records) => arrow_records,
                             Err(e) => {
@@ -470,26 +480,25 @@ impl Exporter<OtapPdata> for ClickhouseExporter {
                             continue;
                         }
 
-                        let transform_result = if signal_type == SignalType::Logs
-                            && signal_format == SignalFormat::OtapRecords
-                        {
-                            match logs_fast_transformer.try_apply(&arrow_records) {
-                                Ok(LogsFastTransform::Applied(batch)) => {
-                                    self.ch_metrics.record_log_fast_path();
-                                    Ok(HashMap::from([(ArrowPayloadType::Logs, batch)]))
+                        let transform_result =
+                            if signal_type == SignalType::Logs && input_was_native {
+                                match logs_fast_transformer.try_apply(&arrow_records) {
+                                    Ok(LogsFastTransform::Applied(batch)) => {
+                                        self.ch_metrics.record_log_fast_path();
+                                        Ok(HashMap::from([(ArrowPayloadType::Logs, batch)]))
+                                    }
+                                    Ok(LogsFastTransform::NotApplicable(_)) => {
+                                        self.ch_metrics.record_log_transform_fallback();
+                                        batch_transformer.apply_plan(arrow_records)
+                                    }
+                                    Err(error) => Err(error),
                                 }
-                                Ok(LogsFastTransform::NotApplicable(_)) => {
+                            } else {
+                                if signal_type == SignalType::Logs {
                                     self.ch_metrics.record_log_transform_fallback();
-                                    batch_transformer.apply_plan(arrow_records)
                                 }
-                                Err(error) => Err(error),
-                            }
-                        } else {
-                            if signal_type == SignalType::Logs {
-                                self.ch_metrics.record_log_transform_fallback();
-                            }
-                            batch_transformer.apply_plan(arrow_records)
-                        };
+                                batch_transformer.apply_plan(arrow_records)
+                            };
 
                         match transform_result {
                             Ok(batches) => batches,

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
@@ -48,11 +48,10 @@ use otel_arrow_dfe_engine::local::exporter::{EffectHandler, Exporter};
 use otel_arrow_dfe_engine::message::{ExporterInbox, Message};
 use otel_arrow_dfe_engine::node::NodeId;
 use otel_arrow_dfe_engine::terminal_state::TerminalState;
-use otel_arrow_dfe_pdata::TryIntoWithOptions;
 use otel_arrow_dfe_pdata::otlp::OtlpProtoBytes;
 use otel_arrow_dfe_pdata::views::otap::OtapLogsView;
 use otel_arrow_dfe_pdata::views::otlp::bytes::logs::RawLogsData;
-use otel_arrow_dfe_pdata::{OtapArrowRecords, OtapPayload, PayloadData};
+use otel_arrow_dfe_pdata::{EncodingPlan, OtapArrowRecords, OtapPayload};
 use otel_arrow_dfe_telemetry::instrument::{Counter, Mmsc};
 use otel_arrow_dfe_telemetry::metrics::{MeasurementMetricSet, MetricSet};
 use otel_arrow_dfe_telemetry_macros::metric_set;
@@ -76,7 +75,7 @@ use prost::Message as ProstMessage;
 // Use crate-relative paths since we're now a module within otap
 use otel_arrow_dfe_otap::OTAP_EXPORTER_FACTORIES;
 use otel_arrow_dfe_otap::metrics::ExporterExportMetrics;
-use otel_arrow_dfe_otap::pdata::OtapPdata;
+use otel_arrow_dfe_otap::pdata::{OtapPdata, PdataEffectHandlerExtension};
 use otel_arrow_dfe_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
 
 mod agent_fed_source;
@@ -1384,7 +1383,7 @@ impl GenevaExporter {
     async fn export_payload(
         &mut self,
         payload: OtapPayload,
-        _effect_handler: &EffectHandler<OtapPdata>,
+        effect_handler: &EffectHandler<OtapPdata>,
     ) -> Result<usize, String> {
         if payload.is_empty() {
             self.metrics.empty_payloads_skipped.inc();
@@ -1395,178 +1394,185 @@ impl GenevaExporter {
             return Ok(0);
         }
 
-        // Handle based on payload type
-        match payload.into_data() {
-            // OTAP Arrow path: encode logs through LogsDataView without converting back to OTLP.
-            PayloadData::OtapArrowRecords(otap_records) => {
-                match otap_records {
-                    mut otap_records @ OtapArrowRecords::Logs(_) => {
-                        otel_info!(
-                            "geneva_exporter.upload",
-                            message = "Uploading log batches to Geneva using OTAP record views"
-                        );
+        if payload.format()
+            != otel_arrow_dfe_pdata::PdataFormat::encoded(otel_arrow_dfe_pdata::ResolvedCodec::OTLP)
+        {
+            let otap_records = effect_handler
+                .try_payload_into_otap(payload)
+                .await
+                .map_err(|error| {
+                    self.metrics.conversion_errors.inc();
+                    error.to_string()
+                })?;
 
-                        otap_records.decode_transport_optimized_ids().map_err(|e| {
+            match otap_records {
+                mut otap_records @ OtapArrowRecords::Logs(_) => {
+                    otel_info!(
+                        "geneva_exporter.upload",
+                        message = "Uploading log batches to Geneva using OTAP record views"
+                    );
+
+                    otap_records.decode_transport_optimized_ids().map_err(|e| {
+                        self.metrics.conversion_errors.inc();
+                        format!("Failed to decode OTAP transport-optimized log IDs: {}", e)
+                    })?;
+
+                    let logs_view = OtapLogsView::try_from(&otap_records).map_err(|e| {
+                        self.metrics.conversion_errors.inc();
+                        format!("Failed to build OTAP logs view: {}", e)
+                    })?;
+
+                    let encode_start = Instant::now();
+                    let batches = self
+                        .geneva_client
+                        .encode_and_compress_logs(&logs_view)
+                        .map_err(|e| format!("Failed to encode logs: {}", e))?;
+                    let encode_ms = encode_start.elapsed().as_secs_f64() * 1000.0;
+                    self.metrics.log_encode_duration.record(encode_ms);
+
+                    let batches_uploaded = self
+                        .upload_batches_concurrent(&batches, SignalType::Logs)
+                        .await?;
+
+                    otel_info!(
+                        "geneva_exporter.upload",
+                        count = batches_uploaded,
+                        message =
+                            "Successfully uploaded log batches to Geneva using OTAP record views"
+                    );
+
+                    Ok(batches_uploaded)
+                }
+                OtapArrowRecords::Traces(otap_records) => {
+                    // TODO: Zero-copy view path for future optimization (when TracesView is ready)
+
+                    // Fallback path: Convert OTAP Arrow -> OTLP bytes
+                    otel_info!(
+                        "geneva_exporter.convert",
+                        message = "Converting OTAP traces to OTLP bytes (fallback path)"
+                    );
+
+                    let mut trace_payload =
+                        OtapPayload::from(OtapArrowRecords::Traces(otap_records));
+                    let bytes = effect_handler
+                        .encode_owned(&mut trace_payload, &EncodingPlan::OTLP)
+                        .await
+                        .map_err(|e| {
                             self.metrics.conversion_errors.inc();
-                            format!("Failed to decode OTAP transport-optimized log IDs: {}", e)
+                            format!("Failed to convert OTAP to OTLP: {e:?}")
                         })?;
 
-                        let logs_view = OtapLogsView::try_from(&otap_records).map_err(|e| {
+                    // Decode OTLP bytes to ResourceSpans
+                    let traces_request =
+                        ExportTraceServiceRequest::decode(&bytes[..]).map_err(|e| {
                             self.metrics.conversion_errors.inc();
-                            format!("Failed to build OTAP logs view: {}", e)
+                            format!("Failed to decode traces request: {}", e)
                         })?;
 
-                        let encode_start = Instant::now();
-                        let batches = self
-                            .geneva_client
-                            .encode_and_compress_logs(&logs_view)
-                            .map_err(|e| format!("Failed to encode logs: {}", e))?;
-                        let encode_ms = encode_start.elapsed().as_secs_f64() * 1000.0;
-                        self.metrics.log_encode_duration.record(encode_ms);
+                    // Encode and compress using Geneva client
+                    let encode_start = Instant::now();
+                    let batches = self
+                        .geneva_client
+                        .encode_and_compress_spans(&traces_request.resource_spans[..])
+                        .map_err(|e| format!("Failed to encode spans: {}", e))?;
+                    let encode_ms = encode_start.elapsed().as_secs_f64() * 1000.0;
+                    self.metrics.trace_encode_duration.record(encode_ms);
 
-                        let batches_uploaded = self
-                            .upload_batches_concurrent(&batches, SignalType::Logs)
-                            .await?;
+                    let batches_uploaded = self
+                        .upload_batches_concurrent(&batches, SignalType::Traces)
+                        .await?;
 
-                        otel_info!(
-                            "geneva_exporter.upload",
-                            count = batches_uploaded,
-                            message = "Successfully uploaded log batches to Geneva using OTAP record views"
-                        );
+                    otel_info!(
+                        "geneva_exporter.upload",
+                        count = batches_uploaded,
+                        message = "Successfully uploaded trace batches to Geneva (OTAP fallback)"
+                    );
 
-                        Ok(batches_uploaded)
-                    }
-                    OtapArrowRecords::Traces(otap_records) => {
-                        // TODO: Zero-copy view path for future optimization (when TracesView is ready)
-
-                        // Fallback path: Convert OTAP Arrow -> OTLP bytes
-                        otel_info!(
-                            "geneva_exporter.convert",
-                            message = "Converting OTAP traces to OTLP bytes (fallback path)"
-                        );
-
-                        let otlp_bytes: OtlpProtoBytes =
-                            OtapPayload::from(OtapArrowRecords::Traces(otap_records))
-                                .try_into_with_default()
-                                .map_err(|e| {
-                                    self.metrics.conversion_errors.inc();
-                                    format!("Failed to convert OTAP to OTLP: {:?}", e)
-                                })?;
-
-                        let OtlpProtoBytes::ExportTracesRequest(bytes) = otlp_bytes else {
-                            self.metrics.conversion_errors.inc();
-                            return Err("Expected traces but got different signal type".to_string());
-                        };
-
-                        // Decode OTLP bytes to ResourceSpans
-                        let traces_request = ExportTraceServiceRequest::decode(&bytes[..])
-                            .map_err(|e| {
-                                self.metrics.conversion_errors.inc();
-                                format!("Failed to decode traces request: {}", e)
-                            })?;
-
-                        // Encode and compress using Geneva client
-                        let encode_start = Instant::now();
-                        let batches = self
-                            .geneva_client
-                            .encode_and_compress_spans(&traces_request.resource_spans[..])
-                            .map_err(|e| format!("Failed to encode spans: {}", e))?;
-                        let encode_ms = encode_start.elapsed().as_secs_f64() * 1000.0;
-                        self.metrics.trace_encode_duration.record(encode_ms);
-
-                        let batches_uploaded = self
-                            .upload_batches_concurrent(&batches, SignalType::Traces)
-                            .await?;
-
-                        otel_info!(
-                            "geneva_exporter.upload",
-                            count = batches_uploaded,
-                            message =
-                                "Successfully uploaded trace batches to Geneva (OTAP fallback)"
-                        );
-
-                        Ok(batches_uploaded)
-                    }
-                    OtapArrowRecords::Metrics(_) => {
-                        self.metrics.metrics_payloads_dropped.inc();
-                        Err("Geneva exporter does not support metrics signal".to_string())
-                    }
+                    Ok(batches_uploaded)
+                }
+                OtapArrowRecords::Metrics(_) => {
+                    self.metrics.metrics_payloads_dropped.inc();
+                    Err("Geneva exporter does not support metrics signal".to_string())
                 }
             }
+        } else {
+            let signal = payload.signal_type();
+            let otlp_bytes = OtlpProtoBytes::new_from_bytes(
+                signal,
+                payload.into_encoded_bytes().expect("OTLP view input"),
+            );
 
-            // OTLP path: Direct OTLP bytes from receivers without OTAP conversion (e.g., OTLP receiver -> Geneva exporter without batch processor)
-            PayloadData::OtlpBytes(otlp_bytes) => {
-                match otlp_bytes {
-                    OtlpProtoBytes::ExportLogsRequest(bytes) => {
-                        otel_info!(
-                            "geneva_exporter.upload",
-                            message = "Uploading log batches to Geneva using OTLP raw-byte view"
-                        );
+            match otlp_bytes {
+                OtlpProtoBytes::ExportLogsRequest(bytes) => {
+                    otel_info!(
+                        "geneva_exporter.upload",
+                        message = "Uploading log batches to Geneva using OTLP raw-byte view"
+                    );
 
-                        let logs_view = RawLogsData::try_new(bytes.as_ref()).map_err(|e| {
+                    let logs_view = RawLogsData::try_new(bytes.as_ref()).map_err(|e| {
+                        self.metrics.conversion_errors.inc();
+                        format!("Failed to decode logs request: {}", e)
+                    })?;
+
+                    // Encode and compress using Geneva client
+                    let encode_start = Instant::now();
+                    let batches = self
+                        .geneva_client
+                        .encode_and_compress_logs(&logs_view)
+                        .map_err(|e| format!("Failed to encode logs: {}", e))?;
+                    let encode_ms = encode_start.elapsed().as_secs_f64() * 1000.0;
+                    self.metrics.log_encode_duration.record(encode_ms);
+
+                    let batches_uploaded = self
+                        .upload_batches_concurrent(&batches, SignalType::Logs)
+                        .await?;
+
+                    otel_info!(
+                        "geneva_exporter.upload",
+                        count = batches_uploaded,
+                        message =
+                            "Successfully uploaded log batches to Geneva using OTLP raw-byte view"
+                    );
+
+                    Ok(batches_uploaded)
+                }
+                OtlpProtoBytes::ExportTracesRequest(bytes) => {
+                    otel_info!(
+                        "geneva_exporter.upload",
+                        message = "Uploading traces to Geneva using OTLP path"
+                    );
+
+                    // Decode OTLP bytes to ResourceSpans
+                    let traces_request =
+                        ExportTraceServiceRequest::decode(&bytes[..]).map_err(|e| {
                             self.metrics.conversion_errors.inc();
-                            format!("Failed to decode logs request: {}", e)
+                            format!("Failed to decode traces request: {}", e)
                         })?;
 
-                        // Encode and compress using Geneva client
-                        let encode_start = Instant::now();
-                        let batches = self
-                            .geneva_client
-                            .encode_and_compress_logs(&logs_view)
-                            .map_err(|e| format!("Failed to encode logs: {}", e))?;
-                        let encode_ms = encode_start.elapsed().as_secs_f64() * 1000.0;
-                        self.metrics.log_encode_duration.record(encode_ms);
+                    // Encode and compress using Geneva client
+                    let encode_start = Instant::now();
+                    let batches = self
+                        .geneva_client
+                        .encode_and_compress_spans(&traces_request.resource_spans[..])
+                        .map_err(|e| format!("Failed to encode spans: {}", e))?;
+                    let encode_ms = encode_start.elapsed().as_secs_f64() * 1000.0;
+                    self.metrics.trace_encode_duration.record(encode_ms);
 
-                        let batches_uploaded = self
-                            .upload_batches_concurrent(&batches, SignalType::Logs)
-                            .await?;
+                    let batches_uploaded = self
+                        .upload_batches_concurrent(&batches, SignalType::Traces)
+                        .await?;
 
-                        otel_info!(
-                            "geneva_exporter.upload",
-                            count = batches_uploaded,
-                            message = "Successfully uploaded log batches to Geneva using OTLP raw-byte view"
-                        );
+                    otel_info!(
+                        "geneva_exporter.upload",
+                        count = batches_uploaded,
+                        message = "Successfully uploaded trace batches to Geneva (OTLP path)"
+                    );
 
-                        Ok(batches_uploaded)
-                    }
-                    OtlpProtoBytes::ExportTracesRequest(bytes) => {
-                        otel_info!(
-                            "geneva_exporter.upload",
-                            message = "Uploading traces to Geneva using OTLP path"
-                        );
-
-                        // Decode OTLP bytes to ResourceSpans
-                        let traces_request = ExportTraceServiceRequest::decode(&bytes[..])
-                            .map_err(|e| {
-                                self.metrics.conversion_errors.inc();
-                                format!("Failed to decode traces request: {}", e)
-                            })?;
-
-                        // Encode and compress using Geneva client
-                        let encode_start = Instant::now();
-                        let batches = self
-                            .geneva_client
-                            .encode_and_compress_spans(&traces_request.resource_spans[..])
-                            .map_err(|e| format!("Failed to encode spans: {}", e))?;
-                        let encode_ms = encode_start.elapsed().as_secs_f64() * 1000.0;
-                        self.metrics.trace_encode_duration.record(encode_ms);
-
-                        let batches_uploaded = self
-                            .upload_batches_concurrent(&batches, SignalType::Traces)
-                            .await?;
-
-                        otel_info!(
-                            "geneva_exporter.upload",
-                            count = batches_uploaded,
-                            message = "Successfully uploaded trace batches to Geneva (OTLP path)"
-                        );
-
-                        Ok(batches_uploaded)
-                    }
-                    OtlpProtoBytes::ExportMetricsRequest(_) => {
-                        self.metrics.metrics_payloads_dropped.inc();
-                        Err("Geneva exporter does not support metrics signal".to_string())
-                    }
+                    Ok(batches_uploaded)
+                }
+                OtlpProtoBytes::ExportMetricsRequest(_) => {
+                    self.metrics.metrics_payloads_dropped.inc();
+                    Err("Geneva exporter does not support metrics signal".to_string())
                 }
             }
         }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/kafka_exporter/encoder.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/kafka_exporter/encoder.rs
@@ -5,6 +5,7 @@
 
 use super::error::KafkaExporterError;
 use otel_arrow_dfe_pdata::{OtapArrowRecords, Producer as PdataProducer};
+#[cfg(test)]
 use otel_arrow_dfe_pdata::{OtapPayload, OtlpProtoBytes, TryIntoWithOptions};
 
 use prost::Message as ProstMessage;
@@ -23,7 +24,8 @@ use prost::Message as ProstMessage;
 ///
 /// A vector of bytes containing the OTLP protobuf representation,
 /// ready to be sent to Kafka.
-pub fn encode_to_otlp_bytes(payload: OtapPayload) -> Result<Vec<u8>, KafkaExporterError> {
+#[cfg(test)]
+pub(crate) fn encode_to_otlp_bytes(payload: OtapPayload) -> Result<Vec<u8>, KafkaExporterError> {
     // Convert payload to OTLP protobuf bytes
     // This uses the built-in TryFrom implementation that handles both cases:
     // - OtlpProtoBytes -> return as-is
@@ -40,7 +42,7 @@ pub fn encode_to_otlp_bytes(payload: OtapPayload) -> Result<Vec<u8>, KafkaExport
 ///
 /// # Arguments
 ///
-/// * `payload` - The OTAP payload to encode
+/// * `otap_records` - Native OTAP records to encode
 /// * `producer` - The OTAP PdataProducer used to encode BatchArrowRecords
 ///
 /// # Returns
@@ -48,12 +50,9 @@ pub fn encode_to_otlp_bytes(payload: OtapPayload) -> Result<Vec<u8>, KafkaExport
 /// A vector of bytes containing the BatchArrowRecord byte representation,
 /// ready to be sent to Kafka.
 pub fn encode_to_batch_arrow_record_bytes(
-    payload: OtapPayload,
+    mut otap_records: OtapArrowRecords,
     producer: &mut PdataProducer,
 ) -> Result<Vec<u8>, KafkaExporterError> {
-    let mut otap_records: OtapArrowRecords = payload
-        .try_into_with_default()
-        .map_err(|e| KafkaExporterError::OtapArrowRecordsConversion(format!("{}", e)))?;
     let bar = producer
         .produce_bar(&mut otap_records)
         .map_err(|e| KafkaExporterError::BatchArrowRecordConversion(format!("{}", e)))?;

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/kafka_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/kafka_exporter/exporter.rs
@@ -50,7 +50,10 @@ use otel_arrow_dfe_engine::message::{ExporterInbox, Message};
 use otel_arrow_dfe_engine::node::NodeId;
 use otel_arrow_dfe_engine::terminal_state::TerminalState;
 use otel_arrow_dfe_otap::OTAP_EXPORTER_FACTORIES;
-use otel_arrow_dfe_otap::pdata::OtapPdata;
+use otel_arrow_dfe_otap::pdata::{OtapPdata, PdataEffectHandlerExtension};
+#[cfg(test)]
+use otel_arrow_dfe_pdata::CodecState;
+use otel_arrow_dfe_pdata::EncodingPlan;
 use otel_arrow_dfe_pdata::Producer as PdataProducer;
 use otel_arrow_dfe_telemetry::common_attributes::Outcome;
 use rdkafka::client::DefaultClientContext;
@@ -639,12 +642,36 @@ impl KafkaExporter {
         // This block borrows &mut self.pdata_producer so it must complete
         // before we borrow self.config again for the topic reference below.
         let encoding_start = Instant::now();
-        let encode_result = match encoding {
-            MessageFormat::OtlpProto => encoder::encode_to_otlp_bytes(payload.clone()),
-            MessageFormat::OtapProto => encoder::encode_to_batch_arrow_record_bytes(
-                payload.clone(),
-                &mut self.pdata_producer,
-            ),
+        let encode_result = match (encoding, effect_handler) {
+            (MessageFormat::OtlpProto, Some(effect_handler)) => {
+                let mut encoding_payload = payload.clone();
+                effect_handler
+                    .encode_owned(&mut encoding_payload, &EncodingPlan::OTLP)
+                    .await
+                    .map(|bytes| bytes.to_vec())
+                    .map_err(|error| KafkaExporterError::OtlpConversion(error.to_string()))
+            }
+            (MessageFormat::OtapProto, Some(effect_handler)) => effect_handler
+                .try_payload_into_otap(payload.clone())
+                .await
+                .map_err(|error| KafkaExporterError::OtapArrowRecordsConversion(error.to_string()))
+                .and_then(|records| {
+                    encoder::encode_to_batch_arrow_record_bytes(records, &mut self.pdata_producer)
+                }),
+            #[cfg(test)]
+            (MessageFormat::OtlpProto, None) => encoder::encode_to_otlp_bytes(payload.clone()),
+            #[cfg(test)]
+            (MessageFormat::OtapProto, None) => payload
+                .clone()
+                .try_into_otap(&mut CodecState::default())
+                .map_err(|error| KafkaExporterError::OtapArrowRecordsConversion(error.to_string()))
+                .and_then(|records| {
+                    encoder::encode_to_batch_arrow_record_bytes(records, &mut self.pdata_producer)
+                }),
+            #[cfg(not(test))]
+            (_, None) => Err(KafkaExporterError::OtlpConversion(
+                "runtime codec service unavailable".to_string(),
+            )),
         };
 
         // nack on failed encoding bytes

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/condense_attributes_processor/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/condense_attributes_processor/mod.rs
@@ -34,6 +34,7 @@ use otel_arrow_dfe_engine::message::Message;
 use otel_arrow_dfe_engine::node::NodeId;
 use otel_arrow_dfe_engine::process_duration::ComputeDuration;
 use otel_arrow_dfe_engine::processor::ProcessorWrapper;
+#[cfg(test)]
 use otel_arrow_dfe_pdata::TryIntoWithOptions;
 use otel_arrow_dfe_pdata::encode::record::attributes::StrKeysAttributesRecordBatchBuilder;
 use otel_arrow_dfe_pdata::otlp::attributes::AttributeValueType;
@@ -45,7 +46,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use otel_arrow_dfe_otap::OTAP_PROCESSOR_FACTORIES;
-use otel_arrow_dfe_otap::pdata::OtapPdata;
+use otel_arrow_dfe_otap::pdata::{OtapPdata, PdataEffectHandlerExtension};
 
 /// URN identifier for the Condense Attributes processor
 pub const CONDENSE_ATTRIBUTES_PROCESSOR_URN: &str = "urn:otel:processor:condense_attributes";
@@ -644,16 +645,26 @@ impl local::Processor<OtapPdata> for CondenseAttributesProcessor {
                     _ => Ok(()),
                 }
             }
-            Message::PData(pdata) => {
+            Message::PData(mut pdata) => {
                 let signal = pdata.signal_type();
-                let (context, payload) = pdata.into_parts();
-                let saved_payload = if context.may_return_payload() {
-                    payload.clone()
+                let may_return_payload = pdata.context_mut().may_return_payload();
+                let saved_payload = if may_return_payload {
+                    pdata.payload_ref().clone()
                 } else {
                     OtapPayload::empty(signal)
                 };
 
-                let mut records: OtapArrowRecords = payload.try_into_with_default()?;
+                let arrow_pdata = match effect_handler.try_into_otap(pdata).await {
+                    Ok(arrow_pdata) => arrow_pdata,
+                    Err(error) => {
+                        let (error, pdata) = error.into_parts();
+                        effect_handler
+                            .notify_nack(NackMsg::new_permanent(error.to_string(), pdata))
+                            .await?;
+                        return Ok(());
+                    }
+                };
+                let (context, mut records) = arrow_pdata.into_parts();
 
                 let input_items = records.num_items() as u64;
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/processor.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/processor.rs
@@ -3,7 +3,7 @@
 
 use super::config::RecordsetKqlProcessorConfig;
 use super::create_recordset_kql_processor;
-use otel_arrow_dfe_otap::pdata::OtapPdata;
+use otel_arrow_dfe_otap::pdata::{OtapPdata, PdataEffectHandlerExtension};
 
 use super::otlp_bridge::{
     BridgeDiagnosticOptions, BridgeError, BridgeOptions, BridgePipeline,
@@ -27,8 +27,9 @@ use otel_arrow_dfe_engine::{
     process_duration::ComputeDuration,
     processor::ProcessorRuntimeRequirements,
 };
+#[cfg(test)]
 use otel_arrow_dfe_pdata::TryIntoWithOptions;
-use otel_arrow_dfe_pdata::{OtapPayload, OtlpProtoBytes};
+use otel_arrow_dfe_pdata::{EncodingPlan, OtapPayload, OtlpProtoBytes};
 
 /// URN identifier for the processor
 pub const RECORDSET_KQL_PROCESSOR_URN: &str = "urn:microsoft:processor:recordset_kql";
@@ -149,20 +150,34 @@ impl RecordsetKqlProcessor {
         let signal = data.signal_type();
         let input_items = data.num_items() as u64;
 
-        // Extract context and payload, convert to OTLP bytes
-        let (ctx, payload) = data.into_parts();
-        let otlp_bytes: OtlpProtoBytes = payload.try_into_with_default()?;
+        // Encode through the pipeline runtime's reusable codec state.
+        let (ctx, mut payload) = data.into_parts();
+        let otlp_bytes = match effect_handler
+            .encode_owned(&mut payload, &EncodingPlan::OTLP)
+            .await
+        {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                effect_handler
+                    .notify_nack(NackMsg::new_permanent(
+                        error.to_string(),
+                        OtapPdata::new(ctx, payload),
+                    ))
+                    .await?;
+                return Ok(());
+            }
+        };
 
         // Process based on signal type (timed).
-        let result = effect_handler.timed(&self.compute_duration, || match otlp_bytes {
-            OtlpProtoBytes::ExportLogsRequest(bytes) => {
+        let result = effect_handler.timed(&self.compute_duration, || match signal {
+            SignalType::Logs => {
                 otel_debug!("recordset_kql_processor.processing_logs", input_items);
-                self.process_logs(bytes, signal)
+                self.process_logs(otlp_bytes, signal)
             }
-            OtlpProtoBytes::ExportMetricsRequest(_bytes) => Err(Error::InternalError {
+            SignalType::Metrics => Err(Error::InternalError {
                 message: "Metrics processing not yet implemented in KQL bridge".to_string(),
             }),
-            OtlpProtoBytes::ExportTracesRequest(_bytes) => Err(Error::InternalError {
+            SignalType::Traces => Err(Error::InternalError {
                 message: "Traces processing not yet implemented in KQL bridge".to_string(),
             }),
         });

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/resource_validator_processor/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/resource_validator_processor/mod.rs
@@ -64,8 +64,8 @@ use otel_arrow_dfe_engine::local::processor as local;
 use otel_arrow_dfe_engine::message::Message;
 use otel_arrow_dfe_engine::node::NodeId;
 use otel_arrow_dfe_engine::processor::ProcessorWrapper;
+use otel_arrow_dfe_pdata::CodecView;
 use otel_arrow_dfe_pdata::OtapArrowRecords;
-use otel_arrow_dfe_pdata::PayloadData;
 use otel_arrow_dfe_pdata::TryFromWithOptions;
 #[cfg(test)]
 use otel_arrow_dfe_pdata::TryIntoWithOptions;
@@ -86,7 +86,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use otel_arrow_dfe_otap::OTAP_PROCESSOR_FACTORIES;
-use otel_arrow_dfe_otap::pdata::OtapPdata;
+use otel_arrow_dfe_otap::pdata::{OtapPdata, PdataEffectHandlerExtension};
 
 /// URN identifier for the Resource Validator processor
 pub const RESOURCE_VALIDATOR_PROCESSOR_URN: &str = "urn:otel:processor:resource_validator";
@@ -488,38 +488,47 @@ impl local::Processor<OtapPdata> for ResourceValidatorProcessor {
             Message::PData(mut pdata) => {
                 let signal_type = pdata.signal_type();
 
+                let view = match effect_handler.view(pdata.payload_ref()).await {
+                    Ok(view) => view,
+                    Err(error) => {
+                        let failure = ValidationFailure::ConversionError;
+                        let result = Err((failure, error.to_string()));
+                        let count = pdata.num_items() as u64;
+                        self.update_metrics(&result, count);
+                        effect_handler
+                            .notify_nack(NackMsg::new_permanent(error.to_string(), pdata))
+                            .await?;
+                        return Ok(());
+                    }
+                };
+
                 // Get allowed values (extension point for future dynamic auth)
                 let allowed_values = self.get_allowed_values(&pdata);
 
-                // Validate based on payload type
-                let validation_result = match pdata.payload_ref().data() {
-                    PayloadData::OtlpBytes(otlp_bytes) => match (signal_type, otlp_bytes) {
-                        (SignalType::Logs, OtlpProtoBytes::ExportLogsRequest(bytes)) => {
-                            let logs_data = RawLogsData::new(bytes.as_ref());
+                let validation_result = match view {
+                    CodecView::OtlpBytes { signal, bytes } => match signal {
+                        SignalType::Logs => {
+                            let logs_data = RawLogsData::new(bytes);
                             self.validate_logs(&logs_data, &allowed_values)
                         }
-                        (SignalType::Metrics, OtlpProtoBytes::ExportMetricsRequest(bytes)) => {
-                            let metrics_data = RawMetricsData::new(bytes.as_ref());
+                        SignalType::Metrics => {
+                            let metrics_data = RawMetricsData::new(bytes);
                             self.validate_metrics(&metrics_data, &allowed_values)
                         }
-                        (SignalType::Traces, OtlpProtoBytes::ExportTracesRequest(bytes)) => {
-                            let trace_data = RawTraceData::new(bytes.as_ref());
+                        SignalType::Traces => {
+                            let trace_data = RawTraceData::new(bytes);
                             self.validate_traces(&trace_data, &allowed_values)
                         }
-                        _ => {
-                            // Signal type doesn't match payload type - this shouldn't happen
-                            // but pass through rather than fail
-                            Ok(())
-                        }
                     },
-                    PayloadData::OtapArrowRecords(arrow_records) => match signal_type {
+                    CodecView::OtapArrowRecords(arrow_records) => match signal_type {
                         SignalType::Logs => {
-                            self.validate_arrow_logs(arrow_records, &allowed_values)
+                            self.validate_arrow_logs(arrow_records.as_ref(), &allowed_values)
                         }
                         // Metrics/Traces Arrow views not yet available - convert to OTLP
                         // TODO: Implement OtapMetricsView/OtapTracesView to avoid clone + conversion
                         SignalType::Metrics | SignalType::Traces => {
-                            match OtlpProtoBytes::try_from_with_default(arrow_records.clone()) {
+                            match OtlpProtoBytes::try_from_with_default(arrow_records.into_owned())
+                            {
                                 Ok(OtlpProtoBytes::ExportMetricsRequest(bytes)) => {
                                     let data = RawMetricsData::new(bytes.as_ref());
                                     self.validate_metrics(&data, &allowed_values)

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/mod.rs
@@ -29,11 +29,11 @@ use otel_arrow_dfe_engine::node::NodeId;
 use otel_arrow_dfe_engine::terminal_state::TerminalState;
 use otel_arrow_dfe_engine::{ConsumerEffectHandlerExtension, ExporterFactory};
 use otel_arrow_dfe_otap::OTAP_EXPORTER_FACTORIES;
-use otel_arrow_dfe_otap::pdata::OtapPdata;
+use otel_arrow_dfe_otap::pdata::{OtapPdata, PdataEffectHandlerExtension};
 use otel_arrow_dfe_pdata::views::otap::{OtapLogsView, OtapMetricsView};
 use otel_arrow_dfe_pdata::views::otlp::bytes::logs::RawLogsData;
 use otel_arrow_dfe_pdata::views::otlp::bytes::metrics::RawMetricsData;
-use otel_arrow_dfe_pdata::{OtapPayload, PayloadData};
+use otel_arrow_dfe_pdata::{CodecView, OtapPayload};
 use otel_arrow_dfe_pdata_views::views::common::InstrumentationScopeView;
 use otel_arrow_dfe_pdata_views::views::logs::{
     LogRecordView, LogsDataView, ResourceLogsView, ScopeLogsView,
@@ -275,7 +275,7 @@ impl Exporter<OtapPdata> for ConsoleExporter {
                 Message::PData(data) => {
                     let export_start = Instant::now();
                     let signal = data.signal_type();
-                    match self.export(data.payload_ref()).await {
+                    match self.export(data.payload_ref(), &effect_handler).await {
                         Ok(()) => self.metrics.record_success(signal, export_start.elapsed()),
                         Err(error_type) => {
                             self.metrics
@@ -293,64 +293,74 @@ impl Exporter<OtapPdata> for ConsoleExporter {
 }
 
 impl ConsoleExporter {
-    async fn export(&self, payload: &OtapPayload) -> Result<(), ConsoleExportErrorType> {
+    async fn export(
+        &self,
+        payload: &OtapPayload,
+        effect_handler: &EffectHandler<OtapPdata>,
+    ) -> Result<(), ConsoleExportErrorType> {
         match payload.signal_type() {
-            SignalType::Logs => self.export_logs(payload).await,
+            SignalType::Logs => self.export_logs(payload, effect_handler).await,
             SignalType::Traces => self.unsupported_signal("traces"),
-            SignalType::Metrics => self.export_metrics(payload).await,
+            SignalType::Metrics => self.export_metrics(payload, effect_handler).await,
         }
     }
 
-    async fn export_logs(&self, payload: &OtapPayload) -> Result<(), ConsoleExportErrorType> {
-        match payload.data() {
-            PayloadData::OtlpBytes(bytes) => match RawLogsData::try_from(bytes) {
+    async fn export_logs(
+        &self,
+        payload: &OtapPayload,
+        effect_handler: &EffectHandler<OtapPdata>,
+    ) -> Result<(), ConsoleExportErrorType> {
+        match effect_handler.view(payload).await.map_err(|error| {
+            otel_error!("console.pdata.decode_failed", error = %error);
+            ConsoleExportErrorType::OtapViewCreation
+        })? {
+            CodecView::OtlpBytes { bytes, .. } => match RawLogsData::try_new(bytes) {
                 Ok(logs_view) => self.formatter.print_logs_data(&logs_view).await,
                 Err(e) => {
                     otel_error!("console.logs_view.otlp_create_failed", error = ?e, message = "Failed to create OTLP logs view");
                     Err(ConsoleExportErrorType::OtlpViewCreation)
                 }
             },
-            PayloadData::OtapArrowRecords(records) => match OtapLogsView::try_from(records) {
-                Ok(logs_view) => self.formatter.print_logs_data(&logs_view).await,
-                Err(e) => {
-                    otel_error!("console.logs_view.otap_create_failed", error = ?e, message = "Failed to create OTAP logs view");
-                    Err(ConsoleExportErrorType::OtapViewCreation)
+            CodecView::OtapArrowRecords(records) => {
+                match OtapLogsView::try_from(records.as_ref()) {
+                    Ok(logs_view) => self.formatter.print_logs_data(&logs_view).await,
+                    Err(e) => {
+                        otel_error!("console.logs_view.otap_create_failed", error = ?e, message = "Failed to create OTAP logs view");
+                        Err(ConsoleExportErrorType::OtapViewCreation)
+                    }
                 }
-            },
-            PayloadData::Encoded(_) => {
-                unreachable!("encoded payloads are not admitted during the storage transition")
             }
         }
     }
 
-    async fn export_metrics(&self, payload: &OtapPayload) -> Result<(), ConsoleExportErrorType> {
+    async fn export_metrics(
+        &self,
+        payload: &OtapPayload,
+        effect_handler: &EffectHandler<OtapPdata>,
+    ) -> Result<(), ConsoleExportErrorType> {
         if !self.formatter.supports_metrics() {
             return self.unsupported_signal("metrics");
         }
 
-        match payload.data() {
-            PayloadData::OtlpBytes(bytes) => {
-                let metrics_bytes = match bytes {
-                    otel_arrow_dfe_pdata::OtlpProtoBytes::ExportMetricsRequest(bytes) => bytes,
-                    _ => unreachable!("metrics payload must contain metrics OTLP bytes"),
-                };
-                match RawMetricsData::try_new(metrics_bytes) {
-                    Ok(metrics_view) => self.formatter.print_metrics_data(&metrics_view).await,
-                    Err(e) => {
-                        otel_warn!("console.metrics_view.otlp_create_failed", error = ?e);
-                        Err(ConsoleExportErrorType::OtlpViewCreation)
-                    }
-                }
-            }
-            PayloadData::OtapArrowRecords(records) => match OtapMetricsView::try_from(records) {
+        match effect_handler.view(payload).await.map_err(|error| {
+            otel_warn!("console.pdata.decode_failed", error = %error);
+            ConsoleExportErrorType::OtapViewCreation
+        })? {
+            CodecView::OtlpBytes { bytes, .. } => match RawMetricsData::try_new(bytes) {
                 Ok(metrics_view) => self.formatter.print_metrics_data(&metrics_view).await,
                 Err(e) => {
-                    otel_warn!("console.metrics_view.otap_create_failed", error = ?e);
-                    Err(ConsoleExportErrorType::OtapViewCreation)
+                    otel_warn!("console.metrics_view.otlp_create_failed", error = ?e);
+                    Err(ConsoleExportErrorType::OtlpViewCreation)
                 }
             },
-            PayloadData::Encoded(_) => {
-                unreachable!("encoded payloads are not admitted during the storage transition")
+            CodecView::OtapArrowRecords(records) => {
+                match OtapMetricsView::try_from(records.as_ref()) {
+                    Ok(metrics_view) => self.formatter.print_metrics_data(&metrics_view).await,
+                    Err(e) => {
+                        otel_warn!("console.metrics_view.otap_create_failed", error = ?e);
+                        Err(ConsoleExportErrorType::OtapViewCreation)
+                    }
+                }
             }
         }
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/mod.rs
@@ -317,6 +317,9 @@ impl ConsoleExporter {
                     Err(ConsoleExportErrorType::OtapViewCreation)
                 }
             },
+            PayloadData::Encoded(_) => {
+                unreachable!("encoded payloads are not admitted during the storage transition")
+            }
         }
     }
 
@@ -346,6 +349,9 @@ impl ConsoleExporter {
                     Err(ConsoleExportErrorType::OtapViewCreation)
                 }
             },
+            PayloadData::Encoded(_) => {
+                unreachable!("encoded payloads are not admitted during the storage transition")
+            }
         }
     }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/file_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/file_exporter/mod.rs
@@ -35,12 +35,14 @@ use otel_arrow_dfe_engine::node::NodeId;
 use otel_arrow_dfe_engine::terminal_state::TerminalState;
 use otel_arrow_dfe_engine::{ConsumerEffectHandlerExtension, ExporterFactory};
 use otel_arrow_dfe_otap::OTAP_EXPORTER_FACTORIES;
-use otel_arrow_dfe_otap::pdata::OtapPdata;
+use otel_arrow_dfe_otap::pdata::{OtapPdata, PdataEffectHandlerExtension};
+#[cfg(test)]
+use otel_arrow_dfe_pdata::OtapPayload;
 use otel_arrow_dfe_pdata::views::otap::{OtapLogsView, OtapMetricsView, OtapTracesView};
 use otel_arrow_dfe_pdata::views::otlp::bytes::logs::RawLogsData;
 use otel_arrow_dfe_pdata::views::otlp::bytes::metrics::RawMetricsData;
 use otel_arrow_dfe_pdata::views::otlp::bytes::traces::RawTraceData;
-use otel_arrow_dfe_pdata::{OtapPayload, OtapPayloadHelpers, PayloadData};
+use otel_arrow_dfe_pdata::{CodecView, OtapPayloadHelpers};
 use otel_arrow_dfe_telemetry::attributes::AttributeEnum as _;
 use otel_arrow_dfe_telemetry::common_attributes::{
     Outcome, SignalAttributes, SignalOutcomeAttributes,
@@ -160,11 +162,18 @@ impl FileExporter {
             self.record_export_outcome(signal, Outcome::Success);
             return Ok(());
         }
-        if let Err(error) = encode_payload(
-            pdata.payload_ref(),
-            &mut self.frame,
-            self.config.max_frame_bytes,
-        ) {
+        let view = match effect_handler.view(pdata.payload_ref()).await {
+            Ok(view) => view,
+            Err(error) => {
+                self.record_export_outcome(signal, Outcome::Failure);
+                let reason = format!("file exporter rejected invalid pdata: {error}");
+                effect_handler
+                    .notify_nack(NackMsg::new_permanent(reason, pdata))
+                    .await?;
+                return Ok(());
+            }
+        };
+        if let Err(error) = encode_payload(view, &mut self.frame, self.config.max_frame_bytes) {
             self.record_export_outcome(signal, Outcome::Failure);
             let reason = match error {
                 EncodeFailure::Frame(FrameEncodeError::FrameTooLarge { .. }) => {
@@ -363,49 +372,46 @@ enum EncodeFailure {
 }
 
 fn encode_payload(
-    payload: &OtapPayload,
+    view: CodecView<'_>,
     frame: &mut Vec<u8>,
     max_frame_bytes: usize,
 ) -> Result<(), EncodeFailure> {
     frame.clear();
-    match payload.data() {
-        PayloadData::OtlpBytes(bytes) => match bytes {
-            otel_arrow_dfe_pdata::OtlpProtoBytes::ExportLogsRequest(_) => {
-                let view = RawLogsData::try_from(bytes)
+    match view {
+        CodecView::OtlpBytes { signal, bytes } => match signal {
+            SignalType::Logs => {
+                let view = RawLogsData::try_new(bytes)
                     .map_err(|error| EncodeFailure::View(error.to_string()))?;
                 encode_logs(&view, frame, max_frame_bytes)?;
             }
-            otel_arrow_dfe_pdata::OtlpProtoBytes::ExportMetricsRequest(bytes) => {
+            SignalType::Metrics => {
                 let view = RawMetricsData::try_new(bytes)
                     .map_err(|error| EncodeFailure::View(error.to_string()))?;
                 encode_metrics(&view, frame, max_frame_bytes)?;
             }
-            otel_arrow_dfe_pdata::OtlpProtoBytes::ExportTracesRequest(bytes) => {
+            SignalType::Traces => {
                 let view = RawTraceData::try_new(bytes)
                     .map_err(|error| EncodeFailure::View(error.to_string()))?;
                 encode_traces(&view, frame, max_frame_bytes)?;
             }
         },
-        PayloadData::OtapArrowRecords(records) => match records.signal_type() {
+        CodecView::OtapArrowRecords(records) => match records.signal_type() {
             SignalType::Logs => {
-                let view = OtapLogsView::try_from(records)
+                let view = OtapLogsView::try_from(records.as_ref())
                     .map_err(|error| EncodeFailure::View(error.to_string()))?;
                 encode_logs(&view, frame, max_frame_bytes)?;
             }
             SignalType::Metrics => {
-                let view = OtapMetricsView::try_from(records)
+                let view = OtapMetricsView::try_from(records.as_ref())
                     .map_err(|error| EncodeFailure::View(error.to_string()))?;
                 encode_metrics(&view, frame, max_frame_bytes)?;
             }
             SignalType::Traces => {
-                let view = OtapTracesView::try_from(records)
+                let view = OtapTracesView::try_from(records.as_ref())
                     .map_err(|error| EncodeFailure::View(error.to_string()))?;
                 encode_traces(&view, frame, max_frame_bytes)?;
             }
         },
-        PayloadData::Encoded(_) => {
-            unreachable!("encoded payloads are not admitted during the storage transition")
-        }
     }
     Ok(())
 }
@@ -416,6 +422,19 @@ const fn signal_index(signal: SignalType) -> usize {
         SignalType::Metrics => 1,
         SignalType::Traces => 2,
     }
+}
+
+#[cfg(test)]
+fn encode_payload_for_test(
+    payload: &OtapPayload,
+    frame: &mut Vec<u8>,
+    max_frame_bytes: usize,
+) -> Result<(), EncodeFailure> {
+    let mut state = otel_arrow_dfe_pdata::CodecState::default();
+    let view = payload
+        .view(&mut state)
+        .map_err(|error| EncodeFailure::View(error.to_string()))?;
+    encode_payload(view, frame, max_frame_bytes)
 }
 
 fn exporter_error(
@@ -559,7 +578,7 @@ mod tests {
         let expected_fields = ["resourceLogs", "resourceMetrics", "resourceSpans"];
         let mut frame = Vec::new();
         for (payload, expected_field) in payloads.iter().zip(expected_fields) {
-            encode_payload(payload, &mut frame, 4096).unwrap();
+            encode_payload_for_test(payload, &mut frame, 4096).unwrap();
             let value: serde_json::Value = serde_json::from_slice(&frame).unwrap();
             assert!(value.get(expected_field).is_some());
         }
@@ -572,7 +591,7 @@ mod tests {
         let payload =
             OtapPayload::from(OtlpProtoBytes::new_from_bytes(SignalType::Logs, vec![0x80]));
         let mut frame = b"previous telemetry\n".to_vec();
-        assert!(encode_payload(&payload, &mut frame, 4096).is_err());
+        assert!(encode_payload_for_test(&payload, &mut frame, 4096).is_err());
         assert!(frame.is_empty());
     }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/file_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/file_exporter/mod.rs
@@ -403,6 +403,9 @@ fn encode_payload(
                 encode_traces(&view, frame, max_frame_bytes)?;
             }
         },
+        PayloadData::Encoded(_) => {
+            unreachable!("encoded payloads are not admitted during the storage transition")
+        }
     }
     Ok(())
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
@@ -29,9 +29,8 @@ use otel_arrow_dfe_engine::message::{ExporterInbox, Message};
 use otel_arrow_dfe_engine::node::NodeId;
 use otel_arrow_dfe_engine::terminal_state::TerminalState;
 use otel_arrow_dfe_otap::OTAP_EXPORTER_FACTORIES;
-use otel_arrow_dfe_otap::pdata::OtapPdata;
+use otel_arrow_dfe_otap::pdata::{OtapPdata, PdataEffectHandlerExtension};
 use otel_arrow_dfe_pdata::Producer;
-use otel_arrow_dfe_pdata::TryIntoWithOptions;
 use otel_arrow_dfe_pdata::encode::producer::ProducerOptions;
 use otel_arrow_dfe_pdata::otap::OtapArrowRecords;
 use otel_arrow_dfe_pdata::proto::opentelemetry::arrow::v1::{
@@ -717,9 +716,21 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                         let export_started_at = Instant::now();
                         let signal_type = pdata.signal_type();
 
-                        let payload = pdata.take_payload();
+                        // Keep encoded input recoverable until decoding succeeds. Native OTAP
+                        // without return-data interests is still moved directly.
+                        let return_payload = pdata.context_mut().may_return_payload();
+                        let retain_for_conversion =
+                            return_payload || pdata.payload_ref().encoding().is_some();
+                        let payload = if retain_for_conversion {
+                            pdata.payload_ref().clone()
+                        } else {
+                            pdata.take_payload()
+                        };
 
-                        let message: OtapArrowRecords = match payload.try_into_with_default() {
+                        let message: OtapArrowRecords = match effect_handler
+                            .try_payload_into_otap(payload)
+                            .await
+                        {
                             Ok(m) => m,
                             Err(e) => {
                                 self.metrics.record_failure(
@@ -727,10 +738,15 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                                     OtapExporterErrorType::PayloadConversion,
                                     export_started_at.elapsed(),
                                 );
-                                effect_handler.notify_nack(NackMsg::new("payload conversion failed", pdata)).await?;
-                                return Err(e.into());
+                                effect_handler
+                                    .notify_nack(NackMsg::new_permanent(e.to_string(), pdata))
+                                    .await?;
+                                continue;
                             }
                         };
+                        if retain_for_conversion && !return_payload {
+                            drop(pdata.take_payload());
+                        }
 
                         // Route each batch to the stream with the smallest
                         // local backlog. This is intentionally based on queue

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
@@ -631,6 +631,11 @@ impl Exporter<OtapPdata> for OTLPExporter {
                             let future = make_export_future(prepared, client);
                             inflight_exports.push(future);
                         }
+                        (_, PayloadData::Encoded(_)) => {
+                            unreachable!(
+                                "encoded payloads are not admitted during the storage transition"
+                            )
+                        }
                     }
                 }
                 _ => {

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
@@ -39,15 +39,13 @@ use otel_arrow_dfe_otap::otap_grpc::client_settings::GrpcClientSettings;
 use otel_arrow_dfe_otap::otap_grpc::otlp::client::{
     LogsServiceClient, MetricsServiceClient, TraceServiceClient,
 };
-use otel_arrow_dfe_otap::pdata::{Context, OtapPdata};
+use otel_arrow_dfe_otap::pdata::{Context, OtapPdata, PdataEffectHandlerExtension};
 use otel_arrow_dfe_otap::transport_headers::ValueKind;
-use otel_arrow_dfe_pdata::otlp::logs::LogsProtoBytesEncoder;
-use otel_arrow_dfe_pdata::otlp::metrics::MetricsProtoBytesEncoder;
-use otel_arrow_dfe_pdata::otlp::traces::TracesProtoBytesEncoder;
-use otel_arrow_dfe_pdata::otlp::{ProtoBuffer, ProtoBytesEncoder};
-use otel_arrow_dfe_pdata::{
-    OtapArrowRecords, OtapPayload, OtapPayloadHelpers, OtlpProtoBytes, PayloadData,
-};
+use otel_arrow_dfe_pdata::OtapPayload;
+#[cfg(test)]
+use otel_arrow_dfe_pdata::OtlpProtoBytes;
+#[cfg(test)]
+use otel_arrow_dfe_pdata::PayloadData;
 use serde::Deserialize;
 use std::collections::VecDeque;
 use std::future::Future;
@@ -250,15 +248,6 @@ impl Exporter<OtapPdata> for OTLPExporter {
         // Returns `None` when no static headers are configured, which preserves
         // the zero-allocation fast path in `build_grpc_metadata`.
         let static_metadata = self.config.grpc.build_static_metadata();
-
-        // reuse the encoder and the buffer across pdatas
-        let mut logs_proto_encoder = LogsProtoBytesEncoder::new();
-        let mut metrics_proto_encoder = MetricsProtoBytesEncoder::new();
-        let mut traces_proto_encoder = TracesProtoBytesEncoder::new();
-
-        let mut logs_proto_buffer = ProtoBuffer::with_capacity(8 * 1024);
-        let mut metrics_proto_buffer = ProtoBuffer::with_capacity(8 * 1024);
-        let mut traces_proto_buffer = ProtoBuffer::with_capacity(8 * 1024);
 
         let mut grpc_clients = GrpcClientPool::new(max_in_flight, channels, compression);
         grpc_clients.prepopulate_clients();
@@ -502,7 +491,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
                     }
 
                     let signal_type = pdata.signal_type();
-                    let (context, payload) = pdata.into_parts();
+                    let (context, mut payload) = pdata.into_parts();
 
                     // The cached bearer header, together with the generation of the
                     // token it was built from. The generation is echoed back on
@@ -529,114 +518,50 @@ impl Exporter<OtapPdata> for OTLPExporter {
                         token_generation,
                     };
 
-                    // Dispatch based on signal type and the concrete payload representation.
-                    match (signal_type, payload.into_data()) {
-                        (SignalType::Logs, PayloadData::OtapArrowRecords(otap_batch)) => {
-                            dispatch_otap_export(
-                                otap_batch,
-                                context,
-                                metadata,
-                                SignalType::Logs,
-                                export_started_at,
-                                &exporter_id,
-                                &mut logs_proto_buffer,
-                                &mut logs_proto_encoder,
-                                |encoded| {
-                                    let client = SignalClient::Logs(grpc_clients.take_logs());
-                                    make_export_future(encoded, client)
-                                },
-                                &mut inflight_exports,
-                                &mut self.metrics,
-                                &effect_handler,
-                            )
-                            .await;
+                    let bytes = match effect_handler
+                        .encode_owned(
+                            &mut payload,
+                            &otel_arrow_dfe_pdata::codec::EncodingPlan::OTLP,
+                        )
+                        .await
+                    {
+                        Ok(bytes) => bytes,
+                        Err(error) => {
+                            _ = effect_handler
+                                .notify_nack(NackMsg::new_permanent(
+                                    error.to_string(),
+                                    OtapPdata::new(context, payload),
+                                ))
+                                .await;
+                            self.metrics.record_failure(
+                                signal_type,
+                                OtlpGrpcExporterErrorType::Encoding,
+                                export_started_at.elapsed(),
+                            );
+                            continue;
                         }
-                        (SignalType::Metrics, PayloadData::OtapArrowRecords(otap_batch)) => {
-                            dispatch_otap_export(
-                                otap_batch,
-                                context,
-                                metadata,
-                                SignalType::Metrics,
-                                export_started_at,
-                                &exporter_id,
-                                &mut metrics_proto_buffer,
-                                &mut metrics_proto_encoder,
-                                |encoded| {
-                                    let client = SignalClient::Metrics(grpc_clients.take_metrics());
-                                    make_export_future(encoded, client)
-                                },
-                                &mut inflight_exports,
-                                &mut self.metrics,
-                                &effect_handler,
-                            )
-                            .await;
-                        }
-                        (SignalType::Traces, PayloadData::OtapArrowRecords(otap_batch)) => {
-                            dispatch_otap_export(
-                                otap_batch,
-                                context,
-                                metadata,
-                                SignalType::Traces,
-                                export_started_at,
-                                &exporter_id,
-                                &mut traces_proto_buffer,
-                                &mut traces_proto_encoder,
-                                |encoded| {
-                                    let client = SignalClient::Traces(grpc_clients.take_traces());
-                                    make_export_future(encoded, client)
-                                },
-                                &mut inflight_exports,
-                                &mut self.metrics,
-                                &effect_handler,
-                            )
-                            .await;
-                        }
-                        (_, PayloadData::OtlpBytes(service_req)) => {
-                            let prepared = match service_req {
-                                OtlpProtoBytes::ExportLogsRequest(bytes) => prepare_otlp_export(
-                                    bytes,
-                                    context,
-                                    metadata,
-                                    SignalType::Logs,
-                                    export_started_at,
-                                    |b| OtlpProtoBytes::ExportLogsRequest(b).into(),
-                                ),
-                                OtlpProtoBytes::ExportMetricsRequest(bytes) => prepare_otlp_export(
-                                    bytes,
-                                    context,
-                                    metadata,
-                                    SignalType::Metrics,
-                                    export_started_at,
-                                    |b| OtlpProtoBytes::ExportMetricsRequest(b).into(),
-                                ),
-                                OtlpProtoBytes::ExportTracesRequest(bytes) => prepare_otlp_export(
-                                    bytes,
-                                    context,
-                                    metadata,
-                                    SignalType::Traces,
-                                    export_started_at,
-                                    |b| OtlpProtoBytes::ExportTracesRequest(b).into(),
-                                ),
-                            };
-
-                            let client = match signal_type {
-                                SignalType::Logs => SignalClient::Logs(grpc_clients.take_logs()),
-                                SignalType::Metrics => {
-                                    SignalClient::Metrics(grpc_clients.take_metrics())
-                                }
-                                SignalType::Traces => {
-                                    SignalClient::Traces(grpc_clients.take_traces())
-                                }
-                            };
-                            let future = make_export_future(prepared, client);
-                            inflight_exports.push(future);
-                        }
-                        (_, PayloadData::Encoded(_)) => {
-                            unreachable!(
-                                "encoded payloads are not admitted during the storage transition"
-                            )
-                        }
-                    }
+                    };
+                    let saved_payload = if context.may_return_payload() {
+                        payload
+                    } else {
+                        // Release input buffers before allocating the in-flight export.
+                        drop(payload);
+                        OtapPayload::empty(signal_type)
+                    };
+                    let prepared = EncodedExport {
+                        bytes,
+                        context,
+                        metadata,
+                        signal_type,
+                        export_started_at,
+                        saved_payload,
+                    };
+                    let client = match signal_type {
+                        SignalType::Logs => SignalClient::Logs(grpc_clients.take_logs()),
+                        SignalType::Metrics => SignalClient::Metrics(grpc_clients.take_metrics()),
+                        SignalType::Traces => SignalClient::Traces(grpc_clients.take_traces()),
+                    };
+                    inflight_exports.push(make_export_future(prepared, client));
                 }
                 _ => {
                     // ignore unhandled messages
@@ -812,154 +737,6 @@ struct RequestMetadata {
     /// Generation of the bearer token stamped into `metadata`. `None` when no
     /// token provider is bound.
     token_generation: Option<u64>,
-}
-
-/// Encoding failed before the request was sent; we still need to surface a Nack with payload.
-struct EncodingFailure {
-    error: Error,
-    context: Context,
-    saved_payload: OtapPayload,
-}
-
-fn prepare_otap_export<Enc: ProtoBytesEncoder>(
-    mut otap_batch: OtapArrowRecords,
-    context: Context,
-    metadata: RequestMetadata,
-    proto_buffer: &mut ProtoBuffer,
-    encoder: &mut Enc,
-    exporter: &NodeId,
-    signal_type: SignalType,
-    export_started_at: Instant,
-) -> Result<EncodedExport, Box<EncodingFailure>> {
-    proto_buffer.clear();
-    if let Err(e) = encoder.encode(&mut otap_batch, proto_buffer) {
-        let error = Error::ExporterError {
-            exporter: exporter.clone(),
-            kind: ExporterErrorKind::Other,
-            error: format!("encoding error: {}", e),
-            source_detail: "".to_string(),
-        };
-
-        if !context.may_return_payload() {
-            let _drop = otap_batch.take_payload();
-        }
-        let saved_payload: OtapPayload = otap_batch.into();
-
-        return Err(Box::new(EncodingFailure {
-            error,
-            context,
-            saved_payload,
-        }));
-    }
-
-    // Maintain the buffer's capacity across repeated calls.
-    let (bytes, next_capacity) = proto_buffer.take_into_bytes();
-    proto_buffer.ensure_capacity(next_capacity);
-
-    if !context.may_return_payload() {
-        // drop before the export, payload not requested
-        let _drop = otap_batch.take_payload();
-    }
-    let saved_payload: OtapPayload = otap_batch.into();
-
-    Ok(EncodedExport {
-        bytes,
-        context,
-        saved_payload,
-        signal_type,
-        export_started_at,
-        metadata,
-    })
-}
-
-fn prepare_otlp_export(
-    bytes: Bytes,
-    context: Context,
-    metadata: RequestMetadata,
-    signal_type: SignalType,
-    export_started_at: Instant,
-    save_payload_fn: impl FnOnce(Bytes) -> OtapPayload,
-) -> EncodedExport {
-    let saved_payload = if context.may_return_payload() {
-        save_payload_fn(bytes.clone())
-    } else {
-        save_payload_fn(Bytes::new())
-    };
-
-    EncodedExport {
-        bytes,
-        context,
-        saved_payload,
-        signal_type,
-        export_started_at,
-        metadata,
-    }
-}
-
-/// Encode an OTAP Arrow batch and enqueue the export task; on encoding failure, emit a Nack.
-#[allow(clippy::too_many_arguments)]
-async fn dispatch_otap_export<Enc, Fut, MakeFuture>(
-    otap_batch: OtapArrowRecords,
-    context: Context,
-    metadata: RequestMetadata,
-    signal_type: SignalType,
-    export_started_at: Instant,
-    exporter_id: &NodeId,
-    proto_buffer: &mut ProtoBuffer,
-    encoder: &mut Enc,
-    make_future: MakeFuture,
-    inflight: &mut InFlightExports<Fut, CompletedExport>,
-    metrics: &mut OtlpGrpcExporterMetrics,
-    effect_handler: &EffectHandler<OtapPdata>,
-) where
-    Enc: ProtoBytesEncoder,
-    Fut: Future<Output = CompletedExport>,
-    MakeFuture: FnOnce(EncodedExport) -> Fut,
-{
-    match prepare_otap_export(
-        otap_batch,
-        context,
-        metadata,
-        proto_buffer,
-        encoder,
-        exporter_id,
-        signal_type,
-        export_started_at,
-    ) {
-        Ok(encoded) => {
-            inflight.push(make_future(encoded));
-        }
-        Err(error) => {
-            metrics.record_failure(
-                signal_type,
-                OtlpGrpcExporterErrorType::Encoding,
-                export_started_at.elapsed(),
-            );
-            _ = notify_prepare_error(error, effect_handler).await;
-        }
-    }
-}
-
-async fn notify_prepare_error(
-    error: Box<EncodingFailure>,
-    effect_handler: &EffectHandler<OtapPdata>,
-) -> Result<(), Error> {
-    let EncodingFailure {
-        error,
-        context,
-        saved_payload,
-    } = *error;
-
-    // Encoding failures are permanent: the data is malformed and retrying the
-    // same payload will not succeed.
-    effect_handler
-        .notify_nack(NackMsg::new_permanent(
-            error.to_string(),
-            OtapPdata::new(context, saved_payload),
-        ))
-        .await?;
-
-    Ok(())
 }
 
 /// Whether a completed export failed because the server rejected the bearer

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
@@ -549,6 +549,11 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
 
                             (Uncompressed::InProtoBuffer, otap_batch.into())
                         }
+                        PayloadData::Encoded(_) => {
+                            unreachable!(
+                                "encoded payloads are not admitted during the storage transition"
+                            )
+                        }
                     };
 
                     let body = match compression {

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
@@ -40,12 +40,11 @@ use otel_arrow_dfe_engine::node::NodeId;
 use otel_arrow_dfe_engine::terminal_state::TerminalState;
 use otel_arrow_dfe_engine::wiring_contract::WiringContract;
 use otel_arrow_dfe_engine::{ConsumerEffectHandlerExtension, ExporterFactory};
+use otel_arrow_dfe_pdata::OtapPayload;
+#[cfg(test)]
+use otel_arrow_dfe_pdata::PayloadData;
 #[cfg(test)]
 use otel_arrow_dfe_pdata::TryIntoWithOptions;
-use otel_arrow_dfe_pdata::otlp::logs::LogsProtoBytesEncoder;
-use otel_arrow_dfe_pdata::otlp::metrics::MetricsProtoBytesEncoder;
-use otel_arrow_dfe_pdata::otlp::traces::TracesProtoBytesEncoder;
-use otel_arrow_dfe_pdata::otlp::{ProtoBuffer, ProtoBytesEncoder};
 use otel_arrow_dfe_pdata::proto::opentelemetry::collector::logs::v1::{
     ExportLogsPartialSuccess, ExportLogsServiceResponse,
 };
@@ -55,7 +54,6 @@ use otel_arrow_dfe_pdata::proto::opentelemetry::collector::metrics::v1::{
 use otel_arrow_dfe_pdata::proto::opentelemetry::collector::trace::v1::{
     ExportTracePartialSuccess, ExportTraceServiceResponse,
 };
-use otel_arrow_dfe_pdata::{OtapPayload, OtapPayloadHelpers, PayloadData};
 use prost::Message as _;
 use reqwest::{Client, Response};
 use secrecy::ExposeSecret;
@@ -66,7 +64,7 @@ use otel_arrow_dfe_otap::OTAP_EXPORTER_FACTORIES;
 use otel_arrow_dfe_otap::bearer_auth::{BearerAuth, BearerAuthEvents, apply_auth_rejection};
 use otel_arrow_dfe_otap::otlp_http::client_settings::{HttpClientError, HttpClientSettings};
 use otel_arrow_dfe_otap::otlp_http::{LOGS_PATH, METRICS_PATH, PROTOBUF_CONTENT_TYPE, TRACES_PATH};
-use otel_arrow_dfe_otap::pdata::{Context, OtapPdata};
+use otel_arrow_dfe_otap::pdata::{Context, OtapPdata, PdataEffectHandlerExtension};
 
 mod config;
 mod metrics;
@@ -300,11 +298,6 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
 
         let mut inflight_exports = InFlightExports::new();
 
-        let mut logs_proto_encoder = LogsProtoBytesEncoder::new();
-        let mut metrics_proto_encoder = MetricsProtoBytesEncoder::new();
-        let mut traces_proto_encoder = TracesProtoBytesEncoder::new();
-        let mut proto_buffer = ProtoBuffer::default();
-
         let compression = self.config.http.compression();
         // Buffer to hold compressed bytes. We re-use this scratch space to place
         // the compressed bytes and then allocate an exact sized Bytes to copy
@@ -450,7 +443,7 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                 Message::PData(pdata) => {
                     let export_started_at = Instant::now();
                     let signal_type = pdata.signal_type();
-                    let (context, payload) = pdata.into_parts();
+                    let (context, mut payload) = pdata.into_parts();
 
                     // We normally only reach here with a usable token, since intake
                     // is gated on `accepting_pdata`. The exception is shutdown, which
@@ -486,107 +479,79 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                             None => (None, None),
                         };
 
-                    // For the OtapArrowRecords path we keep the uncompressed bytes in
-                    // `proto_buffer` rather than materializing them into a `Bytes` up front: when
-                    // compression is enabled we feed the slice directly into the encoder, avoiding
-                    // an alloc+memcpy of the full uncompressed payload.
-                    enum Uncompressed {
-                        // Already a refcounted Bytes (OtlpBytes path).
-                        Bytes(Bytes),
-                        // Lives in `proto_buffer` (OtapArrowRecords path).
-                        InProtoBuffer,
-                    }
-
-                    // proto encode the payload into the request body, while keeping a copy of the
-                    // original payload if the context allows it to be returned.
-                    let (uncompressed, saved_payload) = match payload.into_data() {
-                        PayloadData::OtlpBytes(mut otlp_bytes) => {
-                            if context.may_return_payload() {
-                                // use cheap clone of bytes as the request body
-                                let body = otlp_bytes.clone_bytes();
-                                (Uncompressed::Bytes(body), otlp_bytes.into())
-                            } else {
-                                // take the bytes and replace with empty bytes in original payload
-                                let body = otlp_bytes.replace_bytes(Bytes::new());
-                                (Uncompressed::Bytes(body), otlp_bytes.into())
-                            }
-                        }
-                        PayloadData::OtapArrowRecords(mut otap_batch) => {
-                            // encode the OTAP batch as protobuf request body
-                            proto_buffer.clear();
-                            let encode_result =
-                                match signal_type {
-                                    SignalType::Logs => logs_proto_encoder
-                                        .encode(&mut otap_batch, &mut proto_buffer),
-                                    SignalType::Metrics => metrics_proto_encoder
-                                        .encode(&mut otap_batch, &mut proto_buffer),
-                                    SignalType::Traces => traces_proto_encoder
-                                        .encode(&mut otap_batch, &mut proto_buffer),
-                                };
-
-                            if !context.may_return_payload() {
-                                // drop the original OTAP batch if the context indicates it
-                                // does not wish it to be returned
-                                _ = otap_batch.take_payload();
-                            }
-
-                            if let Err(e) = encode_result {
-                                let export_duration = export_started_at.elapsed();
-                                // encoding error, we must have received an invalid structured batch
-                                let mut nack = NackMsg::new(
-                                    e.to_string(),
-                                    OtapPdata::new(context, otap_batch.into()),
-                                );
-                                nack.permanent = true;
-                                _ = effect_handler.notify_nack(nack).await;
-                                self.metrics.record_failure(
-                                    signal_type,
-                                    OtlpHttpExporterErrorType::Encoding,
-                                    export_duration,
-                                );
-                                continue;
-                            }
-
-                            (Uncompressed::InProtoBuffer, otap_batch.into())
-                        }
-                        PayloadData::Encoded(_) => {
-                            unreachable!(
-                                "encoded payloads are not admitted during the storage transition"
+                    let body = if let Some(method) = compression {
+                        match effect_handler
+                            .with_encoded(
+                                &mut payload,
+                                &otel_arrow_dfe_pdata::codec::EncodingPlan::OTLP,
+                                |encoded| {
+                                    method.encode(encoded, &mut compressed_buffer)?;
+                                    Ok::<Bytes, std::io::Error>(Bytes::copy_from_slice(
+                                        &compressed_buffer,
+                                    ))
+                                },
                             )
-                        }
-                    };
-
-                    let body = match compression {
-                        Some(method) => {
-                            let uncompressed_slice: &[u8] = match &uncompressed {
-                                Uncompressed::Bytes(b) => b.as_ref(),
-                                Uncompressed::InProtoBuffer => proto_buffer.as_ref(),
-                            };
-                            if let Err(e) =
-                                method.encode(uncompressed_slice, &mut compressed_buffer)
-                            {
-                                let export_duration = export_started_at.elapsed();
-                                let mut nack = NackMsg::new(
-                                    e.to_string(),
-                                    OtapPdata::new(context, saved_payload),
-                                );
-                                nack.permanent = true;
-                                _ = effect_handler.notify_nack(nack).await;
+                            .await
+                        {
+                            Ok(Ok(body)) => body,
+                            Ok(Err(error)) => {
+                                _ = effect_handler
+                                    .notify_nack(NackMsg::new_permanent(
+                                        error.to_string(),
+                                        OtapPdata::new(context, payload),
+                                    ))
+                                    .await;
                                 self.metrics.record_failure(
                                     signal_type,
                                     OtlpHttpExporterErrorType::Compression,
-                                    export_duration,
+                                    export_started_at.elapsed(),
                                 );
                                 continue;
                             }
-                            Bytes::copy_from_slice(&compressed_buffer)
-                        }
-                        None => match uncompressed {
-                            Uncompressed::Bytes(b) => b,
-                            Uncompressed::InProtoBuffer => {
-                                Bytes::copy_from_slice(proto_buffer.as_ref())
+                            Err(error) => {
+                                _ = effect_handler
+                                    .notify_nack(NackMsg::new_permanent(
+                                        error.to_string(),
+                                        OtapPdata::new(context, payload),
+                                    ))
+                                    .await;
+                                self.metrics.record_failure(
+                                    signal_type,
+                                    OtlpHttpExporterErrorType::Encoding,
+                                    export_started_at.elapsed(),
+                                );
+                                continue;
                             }
-                        },
+                        }
+                    } else {
+                        match effect_handler
+                            .encode_owned(
+                                &mut payload,
+                                &otel_arrow_dfe_pdata::codec::EncodingPlan::OTLP,
+                            )
+                            .await
+                        {
+                            Ok(body) => body,
+                            Err(error) => {
+                                _ = effect_handler
+                                    .notify_nack(NackMsg::new_permanent(
+                                        error.to_string(),
+                                        OtapPdata::new(context, payload),
+                                    ))
+                                    .await;
+                                self.metrics.record_failure(
+                                    signal_type,
+                                    OtlpHttpExporterErrorType::Encoding,
+                                    export_started_at.elapsed(),
+                                );
+                                continue;
+                            }
+                        }
+                    };
+                    let saved_payload = if context.may_return_payload() {
+                        payload
+                    } else {
+                        OtapPayload::empty(signal_type)
                     };
 
                     let endpoint: Rc<String> = Rc::clone(match signal_type {

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
@@ -59,8 +59,8 @@ use otel_arrow_dfe_engine::node::NodeId;
 use otel_arrow_dfe_engine::terminal_state::TerminalState;
 use otel_arrow_dfe_otap::OTAP_EXPORTER_FACTORIES;
 use otel_arrow_dfe_otap::metrics::ExporterExportMetrics;
-use otel_arrow_dfe_otap::pdata::OtapPdata;
-use otel_arrow_dfe_pdata::TryIntoWithOptions;
+use otel_arrow_dfe_otap::pdata::{OtapPdata, PdataEffectHandlerExtension};
+#[cfg(test)]
 use otel_arrow_dfe_pdata::otap::OtapArrowRecords;
 use otel_arrow_dfe_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
 use otel_arrow_dfe_telemetry::metrics::{MeasurementMetricSet, MetricSet, MetricSetHandler};
@@ -328,11 +328,9 @@ impl Exporter<OtapPdata> for ParquetExporter {
                     // Capture signal type before moving pdata into try_from
                     let signal_type = pdata.signal_type();
 
-                    // Note: context is not used
-                    let (_context, payload) = pdata.into_parts();
-
-                    let mut otap_batch: OtapArrowRecords =
-                        payload.try_into_with_default().inspect_err(|_| {
+                    let arrow_pdata = match effect_handler.try_into_otap(pdata).await {
+                        Ok(arrow_pdata) => arrow_pdata,
+                        Err(error) => {
                             if let Some(metrics) = self.pdata_metrics.as_mut() {
                                 metrics
                                     .with(SignalOutcomeAttributes {
@@ -341,7 +339,12 @@ impl Exporter<OtapPdata> for ParquetExporter {
                                     })
                                     .record(export_start.elapsed());
                             }
-                        })?;
+                            let (error, _pdata) = error.into_parts();
+                            return Err(error.into());
+                        }
+                    };
+                    // Note: context is not used by this terminal exporter.
+                    let (_context, mut otap_batch) = arrow_pdata.into_parts();
 
                     // decode the transport optimized IDs before converting
                     // to unvalidated parquet records

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/mod.rs
@@ -45,18 +45,24 @@ use linkme::distributed_slice;
 use otel_arrow_dfe_config::SignalType;
 use otel_arrow_dfe_config::error::Error as ConfigError;
 use otel_arrow_dfe_config::node::NodeUserConfig;
-use otel_arrow_dfe_engine::MessageSourceLocalEffectHandlerExtension;
 use otel_arrow_dfe_engine::config::ProcessorConfig;
 use otel_arrow_dfe_engine::context::PipelineContext;
+use otel_arrow_dfe_engine::control::NackMsg;
 use otel_arrow_dfe_engine::error::Error as EngineError;
 use otel_arrow_dfe_engine::local::processor as local;
 use otel_arrow_dfe_engine::message::Message;
 use otel_arrow_dfe_engine::node::NodeId;
 use otel_arrow_dfe_engine::process_duration::ComputeDuration;
 use otel_arrow_dfe_engine::processor::ProcessorWrapper;
-use otel_arrow_dfe_otap::{
-    OTAP_PROCESSOR_FACTORIES, opaque_string::OpaqueString, pdata::OtapPdata,
+use otel_arrow_dfe_engine::{
+    ConsumerEffectHandlerExtension, MessageSourceLocalEffectHandlerExtension,
 };
+use otel_arrow_dfe_otap::{
+    OTAP_PROCESSOR_FACTORIES,
+    opaque_string::OpaqueString,
+    pdata::{OtapPdata, PdataEffectHandlerExtension},
+};
+#[cfg(test)]
 use otel_arrow_dfe_pdata::TryIntoWithOptions;
 use otel_arrow_dfe_pdata::otap::transform::apply_attribute_transform;
 use otel_arrow_dfe_pdata::otap::{
@@ -419,10 +425,18 @@ impl local::Processor<OtapPdata> for AttributesProcessor {
                     return res;
                 }
 
-                let signal = pdata.signal_type();
-                let (context, payload) = pdata.into_parts();
-
-                let mut records: OtapArrowRecords = payload.try_into_with_default()?;
+                let arrow_pdata = match effect_handler.try_into_otap(pdata).await {
+                    Ok(arrow_pdata) => arrow_pdata,
+                    Err(error) => {
+                        let (error, pdata) = error.into_parts();
+                        effect_handler
+                            .notify_nack(NackMsg::new_permanent(error.to_string(), pdata))
+                            .await?;
+                        return Ok(());
+                    }
+                };
+                let signal = arrow_pdata.signal_type();
+                let (context, mut records) = arrow_pdata.into_parts();
 
                 // Apply transform across selected domains and record per-(action, domain) stats.
                 let result = effect_handler.timed(&self.compute_duration, || {

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -34,11 +34,12 @@ otel_arrow_dfe_telemetry::otel_component_scope!(
 );
 
 use async_trait::async_trait;
+#[cfg(test)]
 use bytes::Bytes;
 use linkme::distributed_slice;
+use otel_arrow_dfe_config::SignalType;
 use otel_arrow_dfe_config::error::Error as ConfigError;
 use otel_arrow_dfe_config::node::NodeUserConfig;
-use otel_arrow_dfe_config::{SignalFormat, SignalType};
 use otel_arrow_dfe_engine::MessageSourceLocalEffectHandlerExtension;
 use otel_arrow_dfe_engine::{
     ConsumerEffectHandlerExtension, Interests, LocalWakeupRequirements,
@@ -53,21 +54,22 @@ use otel_arrow_dfe_engine::{
 };
 use otel_arrow_dfe_otap::OTAP_PROCESSOR_FACTORIES;
 use otel_arrow_dfe_otap::accessory::slots::{Key as SlotKey, State as SlotState};
-use otel_arrow_dfe_otap::pdata::{Context, OtapPdata, PeerAddrMerger};
-use otel_arrow_dfe_pdata::TryIntoWithOptions;
-use otel_arrow_dfe_pdata::{
-    OtapArrowRecords, OtapPayload, OtapPayloadHelpers, OtlpProtoBytes, PayloadData,
-    error::Error as PDataError,
-    otap::batching::make_item_batches,
-    otlp::batching::{BytesBatches, make_bytes_batches_owned},
-};
+use otel_arrow_dfe_otap::pdata::{Context, OtapPdata, PdataEffectHandlerExtension, PeerAddrMerger};
+pub use otel_arrow_dfe_pdata::batching::BatchSizer as Sizer;
+use otel_arrow_dfe_pdata::batching::{BatchPlan, BatchProfile, BatchingOutput, PdataFormat};
+#[cfg(test)]
+use otel_arrow_dfe_pdata::codec::CodecState;
+use otel_arrow_dfe_pdata::codec::registered_codecs;
+use otel_arrow_dfe_pdata::{OtapPayload, error::Error as PDataError};
+#[cfg(test)]
+use otel_arrow_dfe_pdata::{OtlpProtoBytes, TryIntoWithOptions};
 use otel_arrow_dfe_telemetry::instrument::{Counter, Mmsc};
 use otel_arrow_dfe_telemetry::metrics::MetricSet;
 use otel_arrow_dfe_telemetry_macros::metric_set;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::BTreeMap;
 use std::net::SocketAddr;
-use std::num::NonZeroU64;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -88,62 +90,25 @@ pub const DEFAULT_MAX_BATCH_DURATION_MS: u64 = 200;
 const LOG_MSG_BATCHING_FAILED_PREFIX: &str = "OTAP batch processor: low-level batching failed for";
 const LOG_MSG_BATCHING_FAILED_SUFFIX: &str = "; dropping";
 
-// Encodes each supported (format, signal) pair into a distinct batch-local
-// wakeup slot.
-const fn wakeup_slot(format: SignalFormat, signal: SignalType) -> WakeupSlot {
-    let format_base = match format {
-        SignalFormat::OtapRecords => 0,
-        SignalFormat::OtlpBytes => 3,
-        SignalFormat::Encoded => 6,
-    };
-    let signal_offset = match signal {
+// Each finite buffer owns three signal slots, independent of its codec.
+const fn wakeup_slot(buffer: usize, signal: SignalType) -> WakeupSlot {
+    let offset = match signal {
         SignalType::Logs => 0,
         SignalType::Metrics => 1,
         SignalType::Traces => 2,
     };
-    WakeupSlot(format_base + signal_offset)
+    WakeupSlot(buffer as u128 * 3 + offset)
 }
 
-const fn signal_from_wakeup_slot(slot: WakeupSlot) -> Option<(SignalFormat, SignalType)> {
-    match slot.0 {
-        0 => Some((SignalFormat::OtapRecords, SignalType::Logs)),
-        1 => Some((SignalFormat::OtapRecords, SignalType::Metrics)),
-        2 => Some((SignalFormat::OtapRecords, SignalType::Traces)),
-        3 => Some((SignalFormat::OtlpBytes, SignalType::Logs)),
-        4 => Some((SignalFormat::OtlpBytes, SignalType::Metrics)),
-        5 => Some((SignalFormat::OtlpBytes, SignalType::Traces)),
-        _ => None,
-    }
-}
-
-/// How to size a batch.
-///
-/// Note: these are not always supported. In the present code, the only
-/// supported Sizer value is Items. We expect future support for bytes and
-/// requests sizers.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
-pub enum Sizer {
-    /// Count requests. This metric counts one per OtapPdata message.
-    Requests,
-    /// Count items.  The number of log records, trace spans, or
-    /// metric data points.
-    Items,
-    /// Count bytes.
-    Bytes,
-}
-
-impl Sizer {
-    /// Returns Sizer-specific size logic.
-    fn batch_size<T: OtapPayloadHelpers>(&self, payload: &T) -> Result<usize, PDataError> {
-        match self {
-            Self::Requests => Ok(1),
-            Self::Items => Ok(payload.num_items()),
-            Self::Bytes => payload.num_bytes().ok_or_else(|| PDataError::Format {
-                error: "bytes encoding not known".into(),
-            }),
-        }
-    }
+#[cfg(test)]
+fn signal_from_wakeup_slot(slot: WakeupSlot) -> Option<(usize, SignalType)> {
+    let buffer = usize::try_from(slot.0 / 3).ok()?;
+    let signal = match slot.0 % 3 {
+        0 => SignalType::Logs,
+        1 => SignalType::Metrics,
+        _ => SignalType::Traces,
+    };
+    Some((buffer, signal))
 }
 
 /// Min/max size for a specific format
@@ -201,76 +166,103 @@ pub struct FormatConfig {
 }
 
 /// Batching format option.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
+#[derive(Debug, Clone, PartialEq)]
 pub enum BatchingFormat {
-    /// Force to OTAP (default).
+    /// Force to OTAP.
     Otap,
 
     /// Force to OTLP.
     Otlp,
 
-    /// Preserve format, support both independently.
+    /// Preserve when native batching is supported; otherwise emit OTAP.
     Preserve,
+
+    /// Force output to a registered codec.
+    Codec(String),
 }
 
-/// Output of a batching operation: the produced batches, each paired with the
-/// input-unit *ownership weight* it represents (in the active sizer's unit),
-/// plus the number of oversize entries emitted whole because splitting them
-/// would have exceeded the configured fragment budget.
-///
-/// Ownership weights sum to exactly the input total (even when byte-splitting
-/// duplicates wrapper headers across fragments), so the batch processor can
-/// apportion Ack/Nack subscribers by ownership and attribute every fragment of
-/// a split input back to that input.
-struct BatchingOutput<T> {
-    batches: Vec<(T, usize)>,
-    budget_fallbacks: u64,
+impl<'de> Deserialize<'de> for BatchingFormat {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(match String::deserialize(deserializer)?.as_str() {
+            "otap" => Self::Otap,
+            "otlp" | "otlp-bytes" => Self::Otlp,
+            "preserve" => Self::Preserve,
+            name => Self::Codec(name.to_owned()),
+        })
+    }
 }
 
-/// The common signature of the batching methods
-trait Batcher<T: OtapPayloadHelpers> {
-    fn make_batches(
-        fmtcfg: &FormatConfig,
-        signal: SignalType,
-        records: Vec<T>,
-    ) -> Result<BatchingOutput<T>, PDataError>;
-
-    fn wakeup_slot(signal: SignalType) -> WakeupSlot;
-
-    /// Returns the appropriate empty request payload for this signal.
-    fn empty(signal: SignalType) -> T;
+impl Serialize for BatchingFormat {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(match self {
+            Self::Otap => "otap",
+            Self::Otlp => "otlp",
+            Self::Preserve => "preserve",
+            Self::Codec(name) => name,
+        })
+    }
 }
 
-/// Batch processor configuration.
+/// Batch processor configuration, with compatible built-in profile aliases.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(try_from = "ConfigInput")]
 pub struct Config {
-    /// The OTAP configuration.
-    #[serde(default = "default_otap")]
+    /// Native OTAP profile (legacy alias for codecs.otap).
     pub otap: FormatConfig,
-
-    /// The OTLP configuration.
-    #[serde(default = "default_otlp")]
+    /// OTLP byte profile (legacy alias for codecs.otlp-bytes).
     pub otlp: FormatConfig,
-
-    /// Maximum time data can sit in a batch before being flushed.
-    /// The timer starts when the first item arrives into an empty batch.
-    /// Set to 0 for immediate flush on every input.
-    #[serde(with = "humantime_serde", default = "default_max_batch_duration")]
+    /// Explicit profiles indexed by canonical codec name.
+    pub codecs: BTreeMap<String, FormatConfig>,
+    /// Maximum age of pending input.
     pub max_batch_duration: Duration,
-
-    /// Limits the number of pending requests for completion tracking.
-    #[serde(default = "default_inbound_request_limit")]
+    /// Per-buffer inbound completion tracking limit.
     pub inbound_request_limit: NonZeroUsize,
-
-    /// Limits the number of outbound requests for completion tracking.
-    #[serde(default = "default_outbound_request_limit")]
+    /// Per-buffer outbound completion tracking limit.
     pub outbound_request_limit: NonZeroUsize,
-
-    /// Batching format choice. Default is to preserve format, meaning
-    /// to batch OTAP and OTLP separately.
-    #[serde(default = "default_batching_format")]
+    /// Desired output representation, or native batching with OTAP fallback.
     pub format: BatchingFormat,
+}
+
+#[derive(Deserialize)]
+struct ConfigInput {
+    otap: Option<FormatConfig>,
+    otlp: Option<FormatConfig>,
+    #[serde(default)]
+    codecs: BTreeMap<String, FormatConfig>,
+    #[serde(with = "humantime_serde", default = "default_max_batch_duration")]
+    max_batch_duration: Duration,
+    #[serde(default = "default_inbound_request_limit")]
+    inbound_request_limit: NonZeroUsize,
+    #[serde(default = "default_outbound_request_limit")]
+    outbound_request_limit: NonZeroUsize,
+    #[serde(default = "default_batching_format")]
+    format: BatchingFormat,
+}
+
+impl TryFrom<ConfigInput> for Config {
+    type Error = String;
+    fn try_from(input: ConfigInput) -> Result<Self, Self::Error> {
+        let mut codecs = BTreeMap::new();
+        for (name, profile) in input.codecs {
+            let format = PdataFormat::resolve(&name).map_err(|error| error.to_string())?;
+            let canonical = format.name().to_owned();
+            if (format == PdataFormat::OTAP && input.otap.is_some())
+                || (format == PdataFormat::OTLP && input.otlp.is_some())
+                || codecs.insert(canonical.clone(), profile).is_some()
+            {
+                return Err(format!("duplicate batching profile for {canonical}"));
+            }
+        }
+        Ok(Self {
+            otap: input.otap.unwrap_or_else(default_otap),
+            otlp: input.otlp.unwrap_or_else(default_otlp),
+            codecs,
+            max_batch_duration: input.max_batch_duration,
+            inbound_request_limit: input.inbound_request_limit,
+            outbound_request_limit: input.outbound_request_limit,
+            format: input.format,
+        })
+    }
 }
 
 const fn default_otap_min_size_items() -> Option<NonZeroUsize> {
@@ -376,32 +368,97 @@ impl Default for Config {
             inbound_request_limit: default_inbound_request_limit(),
             outbound_request_limit: default_outbound_request_limit(),
             format: default_batching_format(),
+            codecs: BTreeMap::new(),
         }
     }
 }
 
 impl Config {
-    /// Validates the configuration.
+    /// Validates all active batching plans and their capabilities.
     pub fn validate(&self) -> Result<(), ConfigError> {
-        let immediate_flush = self.max_batch_duration == Duration::ZERO;
-        match self.format {
-            BatchingFormat::Otap => {
-                self.otap
-                    .validate(SignalFormat::OtapRecords, immediate_flush)?;
-            }
-            BatchingFormat::Otlp => {
-                self.otlp
-                    .validate(SignalFormat::OtlpBytes, immediate_flush)?;
-            }
-            BatchingFormat::Preserve => {
-                self.otap
-                    .validate(SignalFormat::OtapRecords, immediate_flush)?;
-                self.otlp
-                    .validate(SignalFormat::OtlpBytes, immediate_flush)?;
-            }
-        };
+        self.plans().map(|_| ())
+    }
 
-        Ok(())
+    fn profile(&self, format: PdataFormat) -> BatchProfile {
+        if let Some(profile) = self.codecs.get(format.name()) {
+            return profile.into();
+        }
+        if format == PdataFormat::OTAP {
+            return (&self.otap).into();
+        }
+        if format == PdataFormat::OTLP {
+            return (&self.otlp).into();
+        }
+        let mut default = format.default_profile();
+        // A codec without native support uses the configured OTAP fallback profile.
+        if !format.has_native_batching() {
+            self.codecs.get("otap").unwrap_or(&self.otap).into()
+        } else {
+            // Adding a compiled-in codec must not invalidate existing immediate
+            // flush configurations. An implicit profile uses its native threshold
+            // as a split limit; explicit profiles still require valid split settings.
+            if self.max_batch_duration == Duration::ZERO {
+                default.max_size = default.max_size.or(default.min_size);
+                default.min_size = None;
+            }
+            default
+        }
+    }
+
+    fn plans(&self) -> Result<Vec<(PdataFormat, BatchPlan)>, ConfigError> {
+        let formats = if self.format == BatchingFormat::Preserve {
+            let mut formats = vec![PdataFormat::OTAP, PdataFormat::OTLP];
+            let mut extra: Vec<_> = registered_codecs()
+                .filter(|codec| codec.metadata().can_decode)
+                .map(PdataFormat::encoded)
+                .filter(|format| *format != PdataFormat::OTLP)
+                .collect();
+            extra.sort_by_key(|format| format.name());
+            formats.extend(extra);
+            formats
+        } else {
+            vec![match &self.format {
+                BatchingFormat::Otap => PdataFormat::OTAP,
+                BatchingFormat::Otlp => PdataFormat::OTLP,
+                BatchingFormat::Codec(name) => PdataFormat::resolve(name).map_err(config_error)?,
+                BatchingFormat::Preserve => unreachable!(),
+            }]
+        };
+        formats
+            .into_iter()
+            .map(|format| {
+                let profile = self.profile(format);
+                if self.max_batch_duration == Duration::ZERO
+                    && (profile.min_size.is_some() || profile.max_size.is_none())
+                {
+                    return Err(config_error(
+                        "immediate flushing requires max_size and no min_size",
+                    ));
+                }
+                BatchPlan::new(format, profile, self.format == BatchingFormat::Preserve)
+                    .map(|plan| (format, plan))
+                    .map_err(config_error)
+            })
+            .collect()
+    }
+}
+
+fn config_error(error: impl std::fmt::Display) -> ConfigError {
+    ConfigError::InvalidUserConfig {
+        error: error.to_string(),
+    }
+}
+
+impl From<&FormatConfig> for BatchProfile {
+    fn from(profile: &FormatConfig) -> Self {
+        Self {
+            min_size: profile.min_size,
+            max_size: profile.max_size,
+            sizer: profile.sizer,
+            max_split_fragments: profile.max_split_fragments,
+            max_split_overhead_bytes: profile.max_split_overhead_bytes,
+            max_split_fragments_per_flush: profile.max_split_fragments_per_flush,
+        }
     }
 }
 
@@ -429,78 +486,13 @@ impl FormatConfig {
             max_split_fragments_per_flush: default_max_split_fragments_per_flush(),
         }
     }
-
-    /// The lower of the two size limits.
-    fn lower_limit(&self) -> usize {
-        self.min_size.or(self.max_size).expect("valid").get()
-    }
-
-    /// Validate the config, given its format. `immediate_flush` indicates the
-    /// parent Config has max_batch_duration == 0.
-    pub fn validate(&self, format: SignalFormat, immediate_flush: bool) -> Result<(), ConfigError> {
-        // At least one size is set.
-        if self.min_size.or(self.max_size).is_none() {
-            return Err(ConfigError::InvalidUserConfig {
-                error: "max_size or min_size must be set".into(),
-            });
-        }
-
-        // Check for a supported sizer. Presently, OTAP supports only
-        // items, OTLP supports only bytes.
-        let (expect_sizer, with_msg) = match format {
-            SignalFormat::OtapRecords => (Sizer::Items, "OTAP batch sizer: must be items"),
-            SignalFormat::OtlpBytes => (Sizer::Bytes, "OTLP batch sizer: must be bytes"),
-            SignalFormat::Encoded => (
-                Sizer::Bytes,
-                "encoded batches require conversion before legacy batching",
-            ),
-        };
-        if self.sizer != expect_sizer {
-            return Err(ConfigError::InvalidUserConfig {
-                error: with_msg.into(),
-            });
-        }
-
-        // If both sizes are set, check max_size is >= the min_size.
-        if let (Some(max_size), Some(min_size)) = (self.max_size, self.min_size) {
-            if max_size < min_size {
-                return Err(ConfigError::InvalidUserConfig {
-                    error: format!(
-                        "max_size ({}) must be >= min_size ({}) or unset",
-                        max_size, min_size,
-                    ),
-                });
-            }
-        }
-
-        // immediate_flush indicates there is not a time-based flush criteria, which
-        // raises requirements:
-        if immediate_flush {
-            // If min_size is set, we need a max_batch_duration to avoid
-            // indefinite delay.
-            if self.min_size.is_some() {
-                return Err(ConfigError::InvalidUserConfig {
-                    error: "min_size set requires max_batch_duration is set".into(),
-                });
-            }
-            // If max_size is unset, we're doing nothing with a batch processor,
-            // so this is considered an error.
-            if self.max_size.is_none() {
-                return Err(ConfigError::InvalidUserConfig {
-                    error: "max_batch_duration unset requires max_size is set".into(),
-                });
-            }
-        }
-
-        Ok(())
-    }
 }
 
 /// Per-signal state
-struct SignalBatches<T: OtapPayloadHelpers> {
-    logs: SignalBuffer<T>,
-    metrics: SignalBuffer<T>,
-    traces: SignalBuffer<T>,
+struct SignalBatches {
+    logs: SignalBuffer,
+    metrics: SignalBuffer,
+    traces: SignalBuffer,
 }
 
 /// Per-input wait context, including the arriving request's context.
@@ -524,9 +516,10 @@ struct BatchPortion {
     weight: usize,
 }
 
-struct Inputs<T: OtapPayloadHelpers> {
+#[derive(Default)]
+struct Inputs {
     /// Input batches.
-    pending: Vec<T>,
+    pending: Vec<OtapPayload>,
 
     /// Waiter context
     context: Vec<BatchPortion>,
@@ -541,9 +534,9 @@ struct MultiContext {
 }
 
 /// Per-signal buffer state
-struct SignalBuffer<T: OtapPayloadHelpers> {
+struct SignalBuffer {
     /// Pending input state.
-    inputs: Inputs<T>,
+    inputs: Inputs,
 
     /// Map of inbound requests.  This contains a limited number of pending request
     /// contexts with details for the impl to notify after an outcome is available.
@@ -559,38 +552,36 @@ struct SignalBuffer<T: OtapPayloadHelpers> {
 
     /// Whether the local scheduler currently has a live wakeup for this signal.
     wakeup_armed: bool,
+    slot: WakeupSlot,
 }
 
 /// Local (!Send) batch processor
 pub struct BatchProcessor {
     config: Config,
-    otap_signals: Option<SignalBatches<OtapArrowRecords>>,
-    otlp_signals: Option<SignalBatches<OtlpProtoBytes>>,
+    formats: Vec<Option<FormatState>>,
+    routes: Vec<(PdataFormat, usize)>,
     metrics: MetricSet<BatchProcessorMetrics>,
 }
 
-struct BatchProcessorFormat<'a, T: OtapPayloadHelpers> {
+struct FormatState {
+    plan: BatchPlan,
+    signals: SignalBatches,
+}
+
+struct BatchProcessorFormat<'a> {
     config: &'a Config,
-    fmtcfg: &'a FormatConfig,
-    signals: &'a mut SignalBatches<T>,
+    plan: &'a BatchPlan,
+    signals: &'a mut SignalBatches,
     metrics: &'a mut MetricSet<BatchProcessorMetrics>,
 }
 
-struct BatchProcessorSignal<'a, T: OtapPayloadHelpers>
-where
-    SignalBuffer<T>: Batcher<T>,
-{
+struct BatchProcessorSignal<'a> {
     signal: SignalType,
     config: &'a Config,
-    fmtcfg: &'a FormatConfig,
-    buffer: &'a mut SignalBuffer<T>,
+    fmtcfg: &'a BatchProfile,
+    plan: &'a BatchPlan,
+    buffer: &'a mut SignalBuffer,
     metrics: &'a mut MetricSet<BatchProcessorMetrics>,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ActiveBatchProcessorFormatKind {
-    Otap,
-    Otlp,
 }
 
 /// There are three reasons to flush.
@@ -650,10 +641,6 @@ pub struct BatchProcessorMetrics {
     split_budget_fallbacks: Counter<u64>,
 }
 
-fn nzu_to_nz64(nz: Option<NonZeroUsize>) -> Option<NonZeroU64> {
-    nz.map(|nz| NonZeroU64::new(nz.get() as u64).expect("nonzero"))
-}
-
 async fn log_batching_failed(
     effect: &mut local::EffectHandler<OtapPdata>,
     signal: SignalType,
@@ -667,18 +654,8 @@ async fn log_batching_failed(
 }
 
 impl BatchProcessor {
-    fn no_active_format_error() -> EngineError {
-        EngineError::InternalError {
-            message: "batch processor has no active format state".to_owned(),
-        }
-    }
-
-    const fn local_wakeup_requirements(&self) -> LocalWakeupRequirements {
-        let live_slots = match self.config.format {
-            BatchingFormat::Otap | BatchingFormat::Otlp => 3,
-            BatchingFormat::Preserve => 6,
-        };
-        LocalWakeupRequirements::new(live_slots)
+    fn local_wakeup_requirements(&self) -> LocalWakeupRequirements {
+        LocalWakeupRequirements::new(self.formats.iter().flatten().count() * 3)
     }
 
     /// Parse JSON config and build the processor instance with the provided metrics set.
@@ -693,23 +670,37 @@ impl BatchProcessor {
                 error: format!("invalid OTAP batch processor config: {e}"),
             })?;
 
-        // This checks that if both are present, max_size >= min_size, and
-        // that at least one is present so that lower_limit is valid below.
-        config.validate()?;
-
-        let otap_signals: Option<SignalBatches<OtapArrowRecords>> = config
-            .format
-            .has_otap()
-            .then(|| SignalBatches::new(&config));
-        let otlp_signals: Option<SignalBatches<OtlpProtoBytes>> = config
-            .format
-            .has_otlp()
-            .then(|| SignalBatches::new(&config));
-
-        Ok(BatchProcessor {
+        let plans = config.plans()?;
+        let mut formats: Vec<Option<FormatState>> = vec![None, None];
+        let mut routes = Vec::new();
+        for (source, plan) in plans {
+            let existing = formats
+                .iter()
+                .position(|state| state.as_ref().is_some_and(|state| state.plan == plan));
+            let index = existing.unwrap_or_else(|| {
+                if source == PdataFormat::OTAP {
+                    0
+                } else if source == PdataFormat::OTLP {
+                    1
+                } else {
+                    formats.len()
+                }
+            });
+            if index == formats.len() {
+                formats.push(None);
+            }
+            if formats[index].is_none() {
+                formats[index] = Some(FormatState {
+                    plan,
+                    signals: SignalBatches::new(&config, index),
+                });
+            }
+            routes.push((source, index));
+        }
+        Ok(Self {
             config,
-            otap_signals,
-            otlp_signals,
+            formats,
+            routes,
             metrics,
         })
     }
@@ -730,133 +721,86 @@ impl BatchProcessor {
         Ok(ProcessorWrapper::local(proc, node, user_config, proc_cfg))
     }
 
-    /// Flush all per-signal buffers (logs, metrics, traces).
+    /// Flushes each registered buffer at shutdown.
     async fn flush_shutdown(
         &mut self,
         effect: &mut local::EffectHandler<OtapPdata>,
     ) -> Result<(), EngineError> {
-        for signal in [SignalType::Logs, SignalType::Traces, SignalType::Metrics] {
-            if let Some(mut otap_signals) = self.otap_format() {
-                otap_signals
-                    .for_signal(signal)
-                    .flush_signal_impl(effect, Instant::now(), FlushReason::Shutdown)
-                    .await?;
-            }
-            if let Some(mut otlp_signals) = self.otlp_format() {
-                otlp_signals
-                    .for_signal(signal)
-                    .flush_signal_impl(effect, Instant::now(), FlushReason::Shutdown)
-                    .await?;
+        for index in 0..self.formats.len() {
+            for signal in [SignalType::Logs, SignalType::Traces, SignalType::Metrics] {
+                if let Some(mut format) = self.format(index) {
+                    format
+                        .for_signal(signal)
+                        .flush_signal_impl(effect, Instant::now(), FlushReason::Shutdown)
+                        .await?;
+                }
             }
         }
         Ok(())
     }
 
-    fn otap_format(&mut self) -> Option<BatchProcessorFormat<'_, OtapArrowRecords>> {
-        self.otap_signals
+    fn format(&mut self, index: usize) -> Option<BatchProcessorFormat<'_>> {
+        self.formats
+            .get_mut(index)?
             .as_mut()
-            .map(|signals| BatchProcessorFormat {
+            .map(|state| BatchProcessorFormat {
                 config: &self.config,
-                fmtcfg: &self.config.otap,
-                signals,
+                plan: &state.plan,
+                signals: &mut state.signals,
                 metrics: &mut self.metrics,
             })
     }
 
-    fn otlp_format(&mut self) -> Option<BatchProcessorFormat<'_, OtlpProtoBytes>> {
-        self.otlp_signals
-            .as_mut()
-            .map(|signals| BatchProcessorFormat {
-                config: &self.config,
-                fmtcfg: &self.config.otlp,
-                signals,
-                metrics: &mut self.metrics,
-            })
-    }
-
-    fn format_for_signal_format(
-        &self,
-        signal_format: SignalFormat,
-    ) -> Option<ActiveBatchProcessorFormatKind> {
-        match signal_format {
-            SignalFormat::OtapRecords if self.otap_signals.is_some() => {
-                Some(ActiveBatchProcessorFormatKind::Otap)
-            }
-            SignalFormat::OtapRecords if self.otlp_signals.is_some() => {
-                Some(ActiveBatchProcessorFormatKind::Otlp)
-            }
-            SignalFormat::OtlpBytes if self.otlp_signals.is_some() => {
-                Some(ActiveBatchProcessorFormatKind::Otlp)
-            }
-            SignalFormat::OtlpBytes if self.otap_signals.is_some() => {
-                Some(ActiveBatchProcessorFormatKind::Otap)
-            }
-            _ => None,
-        }
-    }
-
-    /// Process one incoming batch. Immediately acks empty requests.
-    /// If this input causes pending data to exceed the lower bound, it will
-    /// flush at least one output.
+    /// The pdata plan owns preparation; the node owns scheduling and delivery.
     async fn process_signal_impl(
         &mut self,
         effect: &mut local::EffectHandler<OtapPdata>,
         request: OtapPdata,
     ) -> Result<(), EngineError> {
         let signal = request.signal_type();
-
-        let (ctx, payload) = request.into_parts();
-
-        match payload.into_data() {
-            PayloadData::OtapArrowRecords(otap) => {
-                if let Some(mut otap_format) = self.otap_format() {
-                    otap_format
-                        .for_signal(signal)
-                        .accept_payload(effect, ctx, otap)
-                        .await?
-                } else if let Some(mut otlp_format) = self.otlp_format() {
-                    let otlp_payload = otap.try_into_with_default()?;
-                    otlp_format
-                        .for_signal(signal)
-                        .accept_payload(effect, ctx, otlp_payload)
-                        .await?
-                } else {
-                    return Err(Self::no_active_format_error());
-                }
-            }
-            PayloadData::OtlpBytes(otlp) => {
-                if let Some(mut otlp_format) = self.otlp_format() {
-                    otlp_format
-                        .for_signal(signal)
-                        .accept_payload(effect, ctx, otlp)
-                        .await?
-                } else if let Some(mut otap_format) = self.otap_format() {
-                    let otap_payload = otlp.try_into_with_default()?;
-                    otap_format
-                        .for_signal(signal)
-                        .accept_payload(effect, ctx, otap_payload)
-                        .await?
-                } else {
-                    return Err(Self::no_active_format_error());
-                }
-            }
-            PayloadData::Encoded(_) => {
-                unreachable!("encoded payloads are not admitted during the storage transition")
-            }
+        let (ctx, mut payload) = request.into_parts();
+        let index = if self.config.format == BatchingFormat::Preserve {
+            self.routes
+                .iter()
+                .find(|(source, _)| *source == payload.format())
+                .map(|(_, index)| *index)
+        } else {
+            self.routes.first().map(|(_, index)| *index)
         };
-        Ok(())
+        let Some(index) = index else {
+            effect
+                .notify_nack(NackMsg::new_permanent(
+                    "no batching plan for admitted codec",
+                    OtapPdata::new(ctx, payload),
+                ))
+                .await?;
+            return Ok(());
+        };
+        let mut format = self.format(index).expect("configured route");
+        if let Err(error) = effect.prepare_batch(format.plan, &mut payload).await {
+            format.metrics.dropped_conversion.inc();
+            effect
+                .notify_nack(NackMsg::new_permanent(
+                    error.to_string(),
+                    OtapPdata::new(ctx, payload),
+                ))
+                .await?;
+            return Ok(());
+        }
+        format
+            .for_signal(signal)
+            .accept_payload(effect, ctx, payload)
+            .await
     }
 }
 
-impl<'a, T: OtapPayloadHelpers> BatchProcessorFormat<'a, T>
-where
-    SignalBuffer<T>: Batcher<T>,
-{
-    const fn for_signal(&mut self, signal: SignalType) -> BatchProcessorSignal<'_, T> {
+impl<'a> BatchProcessorFormat<'a> {
+    const fn for_signal(&mut self, signal: SignalType) -> BatchProcessorSignal<'_> {
         BatchProcessorSignal {
             signal,
             config: self.config,
-            fmtcfg: self.fmtcfg,
+            fmtcfg: self.plan.profile(),
+            plan: self.plan,
             buffer: match signal {
                 SignalType::Logs => &mut self.signals.logs,
                 SignalType::Traces => &mut self.signals.traces,
@@ -867,101 +811,19 @@ where
     }
 }
 
-impl Batcher<OtapArrowRecords> for SignalBuffer<OtapArrowRecords> {
-    fn make_batches(
-        fmtcfg: &FormatConfig,
-        signal: SignalType,
-        pending: Vec<OtapArrowRecords>,
-    ) -> Result<BatchingOutput<OtapArrowRecords>, PDataError> {
-        // OTAP only supports Sizer::Items (checked in validate)
-        debug_assert_eq!(fmtcfg.sizer, Sizer::Items);
-        let batches = make_item_batches(signal, nzu_to_nz64(fmtcfg.max_size), pending)?;
-        // Item batches never duplicate content, so each output's ownership
-        // weight is simply its item count.
-        let batches = batches
-            .into_iter()
-            .map(|b| {
-                let weight = fmtcfg.sizer.batch_size(&b)?;
-                Ok((b, weight))
-            })
-            .collect::<Result<Vec<_>, PDataError>>()?;
-        Ok(BatchingOutput {
-            batches,
-            budget_fallbacks: 0,
-        })
-    }
-
-    fn empty(signal: SignalType) -> OtapArrowRecords {
-        match signal {
-            SignalType::Logs => OtapArrowRecords::Logs(otel_arrow_dfe_pdata::otap::Logs::default()),
-            SignalType::Metrics => {
-                OtapArrowRecords::Metrics(otel_arrow_dfe_pdata::otap::Metrics::default())
-            }
-            SignalType::Traces => {
-                OtapArrowRecords::Traces(otel_arrow_dfe_pdata::otap::Traces::default())
-            }
-        }
-    }
-
-    fn wakeup_slot(signal: SignalType) -> WakeupSlot {
-        wakeup_slot(SignalFormat::OtapRecords, signal)
-    }
-}
-
-impl Batcher<OtlpProtoBytes> for SignalBuffer<OtlpProtoBytes> {
-    fn make_batches(
-        fmtcfg: &FormatConfig,
-        signal: SignalType,
-        pending: Vec<OtlpProtoBytes>,
-    ) -> Result<BatchingOutput<OtlpProtoBytes>, PDataError> {
-        // OTLP only supports Sizer::Bytes (checked in validate)
-        debug_assert_eq!(fmtcfg.sizer, Sizer::Bytes);
-        let BytesBatches {
-            batches,
-            budget_fallbacks,
-        } = make_bytes_batches_owned(
-            signal,
-            nzu_to_nz64(fmtcfg.max_size),
-            nzu_to_nz64(fmtcfg.max_split_fragments),
-            nzu_to_nz64(fmtcfg.max_split_overhead_bytes),
-            nzu_to_nz64(fmtcfg.max_split_fragments_per_flush),
-            pending,
-        )?;
-        Ok(BatchingOutput {
-            batches,
-            budget_fallbacks,
-        })
-    }
-
-    fn empty(signal: SignalType) -> OtlpProtoBytes {
-        match signal {
-            SignalType::Logs => OtlpProtoBytes::ExportLogsRequest(Bytes::new()),
-            SignalType::Metrics => OtlpProtoBytes::ExportMetricsRequest(Bytes::new()),
-            SignalType::Traces => OtlpProtoBytes::ExportTracesRequest(Bytes::new()),
-        }
-    }
-
-    fn wakeup_slot(signal: SignalType) -> WakeupSlot {
-        wakeup_slot(SignalFormat::OtlpBytes, signal)
-    }
-}
-
-impl<'a, T: OtapPayloadHelpers> BatchProcessorSignal<'a, T>
-where
-    SignalBuffer<T>: Batcher<T>,
-{
+impl<'a> BatchProcessorSignal<'a> {
     async fn accept_payload(
         &mut self,
         effect: &mut local::EffectHandler<OtapPdata>,
         ctx: Context,
-        payload: T,
+        payload: OtapPayload,
     ) -> Result<(), EngineError> {
         let weight = self.fmtcfg.sizer.batch_size(&payload)?;
         if weight == 0 {
             // Note: we do not check for empty envelopes, e.g., logs
             // requests with only a resource and no log records. We do
             // not count these.
-            let mut pdata = OtapPdata::new(ctx, payload.into());
+            let mut pdata = OtapPdata::new(ctx, payload);
             pdata.complete_processor_without_output(effect);
             effect.notify_ack(AckMsg::new(pdata)).await?;
             return Ok(());
@@ -983,7 +845,7 @@ where
             match slot {
                 Err(bctx) => {
                     self.metrics.nacked_inbound_slots.inc();
-                    let refused = OtapPdata::new(bctx.ctx, payload.into());
+                    let refused = OtapPdata::new(bctx.ctx, payload);
                     // Note: Failure to Ack/Nack is an engine-level error.
                     effect
                         .notify_nack(NackMsg::new("inbound routes exhausted", refused))
@@ -1058,7 +920,7 @@ where
         }
 
         if reason != FlushReason::Timer && self.buffer.wakeup_armed {
-            let _ = effect.cancel_wakeup(SignalBuffer::<T>::wakeup_slot(self.signal));
+            let _ = effect.cancel_wakeup(self.buffer.slot);
             self.buffer.wakeup_armed = false;
         }
 
@@ -1108,7 +970,7 @@ where
         let BatchingOutput {
             batches: mut output_batches,
             budget_fallbacks,
-        } = match SignalBuffer::<T>::make_batches(self.fmtcfg, self.signal, pending) {
+        } = match effect.batch(self.plan, self.signal, pending).await {
             Ok(v) => v,
             Err(e) => {
                 self.metrics.batching_errors.add(count as u64);
@@ -1119,7 +981,7 @@ where
                 self.buffer
                     .handle_partial_responses(self.signal, effect, &res, inputs.context)
                     .await?;
-                return Err(EngineError::InternalError { message: str });
+                return Ok(());
             }
         };
 
@@ -1190,16 +1052,31 @@ where
 
         let mut input_context = inputs.take_context();
 
-        for (records, ownership) in output_batches {
+        for (mut records, ownership) in output_batches {
             // Apportion ack/nack subscribers by the batch's ownership weight
             // (input units it represents), not its own encoded size, so every
             // fragment of a split input is attributed back to that input.
             let weight = ownership;
-            let mut pdata = OtapPdata::new(Context::default(), records.into());
 
             // If any inputs require completion tracking, get an outbound slot
             // and subscribe so their contexts can unwind after this output.
             let (routed_ctxs, merged_peer) = self.buffer.drain_context(weight, &mut input_context);
+            if let Err(error) = effect.finish_batch(self.plan, &mut records).await {
+                self.metrics.dropped_conversion.inc();
+                if let Some(parts) = routed_ctxs {
+                    self.buffer
+                        .handle_partial_responses(
+                            self.signal,
+                            effect,
+                            &Err(error.to_string()),
+                            parts,
+                        )
+                        .await?;
+                }
+                continue;
+            }
+            let mut pdata = OtapPdata::new(Context::default(), records);
+
             // Forward the receiver-observed peer address only when every
             // input merged into this output batch came from the same peer
             // (see Context::merge_peer_addr). Mixed-peer batches leave
@@ -1219,10 +1096,7 @@ where
                                 effect
                                     .notify_nack(NackMsg::new(
                                         "outbound routes exhausted",
-                                        OtapPdata::new(
-                                            batch.ctx,
-                                            SignalBuffer::empty(self.signal).into(),
-                                        ),
+                                        OtapPdata::new(batch.ctx, OtapPayload::empty(self.signal)),
                                     ))
                                     .await?;
                                 // Note: failure to get an outbound slot does not
@@ -1232,9 +1106,11 @@ where
                         }
                     }
                     Ok(outkey) => {
+                        let mut calldata: CallData = outkey.into();
+                        calldata.push((self.buffer.slot.0 as u64).into());
                         effect.subscribe_to(
                             Interests::NACKS | Interests::ACKS,
-                            outkey.into(),
+                            calldata,
                             &mut pdata,
                         );
                     }
@@ -1302,24 +1178,29 @@ impl BatchProcessor {
             return Ok(());
         }
 
-        let signal = retdata.signal_type();
-        match self.format_for_signal_format(retdata.signal_format()) {
-            Some(ActiveBatchProcessorFormatKind::Otap) => {
-                self.otap_format()
-                    .expect("otap batch state must exist when otap format kind is selected")
-                    .for_signal(signal)
-                    .handle(signal, calldata, effect, res)
-                    .await
-            }
-            Some(ActiveBatchProcessorFormatKind::Otlp) => {
-                self.otlp_format()
-                    .expect("otlp batch state must exist when otlp format kind is selected")
-                    .for_signal(signal)
-                    .handle(signal, calldata, effect, res)
-                    .await
-            }
-            None => Err(Self::no_active_format_error()),
+        let mut calldata = calldata;
+        if calldata.len() != 2 {
+            return Err(EngineError::InternalError {
+                message: "invalid batch completion token".into(),
+            });
         }
+        let slot = u64::from(calldata.pop().expect("checked token"));
+        let index = (slot / 3) as usize;
+        let signal = match slot % 3 {
+            0 => SignalType::Logs,
+            1 => SignalType::Metrics,
+            _ => SignalType::Traces,
+        };
+        let _ = retdata;
+        let mut format = self
+            .format(index)
+            .ok_or_else(|| EngineError::InternalError {
+                message: "unknown batch completion buffer".into(),
+            })?;
+        format
+            .for_signal(signal)
+            .handle(signal, calldata, effect, res)
+            .await
     }
 }
 
@@ -1377,33 +1258,20 @@ impl local::Processor<OtapPdata> for BatchProcessor {
                     Ok(())
                 }
                 NodeControlMsg::Wakeup { slot, when, .. } => {
-                    let Some((format, signal)) = signal_from_wakeup_slot(slot) else {
+                    let Ok(index) = usize::try_from(slot.0 / 3) else {
                         return Ok(());
                     };
-
-                    match format {
-                        SignalFormat::OtapRecords => {
-                            if let Some(mut otap_format) = self.otap_format() {
-                                otap_format
-                                    .for_signal(signal)
-                                    .flush_signal_impl(effect, when, FlushReason::Timer)
-                                    .await?;
-                            }
-                        }
-                        SignalFormat::OtlpBytes => {
-                            if let Some(mut otlp_format) = self.otlp_format() {
-                                otlp_format
-                                    .for_signal(signal)
-                                    .flush_signal_impl(effect, when, FlushReason::Timer)
-                                    .await?;
-                            }
-                        }
-                        SignalFormat::Encoded => {
-                            unreachable!(
-                                "encoded payloads are not admitted during the storage transition"
-                            )
-                        }
+                    let signal = match slot.0 % 3 {
+                        0 => SignalType::Logs,
+                        1 => SignalType::Metrics,
+                        _ => SignalType::Traces,
                     };
+                    if let Some(mut format) = self.format(index) {
+                        format
+                            .for_signal(signal)
+                            .flush_signal_impl(effect, when, FlushReason::Timer)
+                            .await?;
+                    }
 
                     Ok(())
                 }
@@ -1419,35 +1287,12 @@ impl local::Processor<OtapPdata> for BatchProcessor {
     }
 }
 
-impl<T: OtapPayloadHelpers> Default for Inputs<T> {
-    fn default() -> Self {
+impl SignalBatches {
+    fn new(config: &Config, index: usize) -> Self {
         Self {
-            pending: Vec::new(),
-            context: Vec::new(),
-            weight: 0,
-        }
-    }
-}
-
-impl BatchingFormat {
-    const fn has_otlp(&self) -> bool {
-        !matches!(self, Self::Otap)
-    }
-
-    const fn has_otap(&self) -> bool {
-        !matches!(self, Self::Otlp)
-    }
-}
-
-impl<T: OtapPayloadHelpers> SignalBatches<T>
-where
-    SignalBuffer<T>: Batcher<T>,
-{
-    fn new(config: &Config) -> Self {
-        Self {
-            logs: SignalBuffer::new(config),
-            traces: SignalBuffer::new(config),
-            metrics: SignalBuffer::new(config),
+            logs: SignalBuffer::new(config, wakeup_slot(index, SignalType::Logs)),
+            traces: SignalBuffer::new(config, wakeup_slot(index, SignalType::Traces)),
+            metrics: SignalBuffer::new(config, wakeup_slot(index, SignalType::Metrics)),
         }
     }
 }
@@ -1468,7 +1313,7 @@ impl MultiContext {
     }
 }
 
-impl<T: OtapPayloadHelpers> Inputs<T> {
+impl Inputs {
     fn drain(&mut self) -> Self {
         Self {
             pending: std::mem::take(&mut self.pending),
@@ -1498,13 +1343,13 @@ impl<T: OtapPayloadHelpers> Inputs<T> {
         }
     }
 
-    fn accept(&mut self, batch: T, part: BatchPortion) {
+    fn accept(&mut self, batch: OtapPayload, part: BatchPortion) {
         self.weight += part.weight;
         self.pending.push(batch);
         self.context.push(part);
     }
 
-    fn take_pending(&mut self) -> Vec<T> {
+    fn take_pending(&mut self) -> Vec<OtapPayload> {
         std::mem::take(&mut self.pending)
     }
 
@@ -1513,32 +1358,29 @@ impl<T: OtapPayloadHelpers> Inputs<T> {
     }
 }
 
-fn known_total_bytes<T: OtapPayloadHelpers>(payloads: &[T]) -> Option<usize> {
+fn known_total_bytes(payloads: &[OtapPayload]) -> Option<usize> {
     payloads.iter().try_fold(0usize, |total, payload| {
-        payload.num_bytes().map(|bytes| total + bytes)
+        payload.measured_bytes().map(|bytes| total + bytes)
     })
 }
 
 /// Like [`known_total_bytes`] but over output batches paired with ownership
 /// weights (the weight is ignored; only the real encoded size is summed).
-fn known_total_output_bytes<T: OtapPayloadHelpers>(payloads: &[(T, usize)]) -> Option<usize> {
+fn known_total_output_bytes(payloads: &[(OtapPayload, usize)]) -> Option<usize> {
     payloads.iter().try_fold(0usize, |total, (payload, _own)| {
-        payload.num_bytes().map(|bytes| total + bytes)
+        payload.measured_bytes().map(|bytes| total + bytes)
     })
 }
 
-impl<T: OtapPayloadHelpers> SignalBuffer<T>
-where
-    Inputs<T>: Default,
-    Self: Batcher<T>,
-{
-    fn new(cfg: &Config) -> Self {
+impl SignalBuffer {
+    fn new(cfg: &Config, slot: WakeupSlot) -> Self {
         Self {
             inputs: Inputs::default(),
             inbound: SlotState::new(cfg.inbound_request_limit.get()),
             outbound: SlotState::new(cfg.outbound_request_limit.get()),
             arrival: None,
             wakeup_armed: false,
+            slot,
         }
     }
 
@@ -1548,8 +1390,8 @@ where
     fn take_remaining(
         &mut self,
         sizer: Sizer,
-        from_inputs: &mut Inputs<T>,
-        output_batches: &mut Vec<(T, usize)>,
+        from_inputs: &mut Inputs,
+        output_batches: &mut Vec<(OtapPayload, usize)>,
     ) {
         // SAFETY: protected by output_batches.len() > 1. The caller only retains
         // a whole-input partial (ownership weight == real size), so recomputing
@@ -1671,13 +1513,13 @@ where
     /// should flush, where `now` is the current timestamp.
     async fn set_arrival(
         &mut self,
-        signal: SignalType,
+        _signal: SignalType,
         now: Instant,
         timeout: Duration,
         effect: &mut local::EffectHandler<OtapPdata>,
     ) -> Result<(), EngineError> {
         effect
-            .set_wakeup(Self::wakeup_slot(signal), now + timeout)
+            .set_wakeup(self.slot, now + timeout)
             .map(|_| {
                 self.arrival = Some(now);
                 self.wakeup_armed = true;
@@ -1730,7 +1572,6 @@ mod tests {
     use otel_arrow_dfe_otap::testing::TestCallData;
     use otel_arrow_dfe_otap::testing::{next_ack, next_nack};
     use otel_arrow_dfe_pdata::encode::{encode_logs_otap_batch, encode_spans_otap_batch};
-    use otel_arrow_dfe_pdata::otap::OtapArrowRecords;
     use otel_arrow_dfe_pdata::proto::OtlpProtoMessage;
     use otel_arrow_dfe_pdata::proto::opentelemetry::common::v1::InstrumentationScope;
     use otel_arrow_dfe_pdata::proto::opentelemetry::logs::v1::{
@@ -1846,9 +1687,170 @@ mod tests {
         assert_eq!(uc.default_output.as_deref(), Some("main_output"));
     }
 
+    /// Scenario: The batch processor is created with its default configuration.
+    /// Guarantees: Default codec profiles and duration limits are accepted.
     #[test]
     fn test_default_config_ok() {
         let _cfg: Config = serde_json::from_value(json!({})).unwrap_or_default();
+    }
+
+    /// Scenario: users configure built-in profiles through legacy aliases or
+    /// canonical codec names, or request ambiguous/unsupported configurations.
+    /// Guarantees: compatible YAML resolves identically and invalid capabilities
+    /// are rejected before the processor buffers any requests.
+    #[test]
+    fn codec_profiles_preserve_configuration_compatibility() {
+        let legacy: Config = serde_json::from_value(json!({
+            "format": "otlp", "otlp": { "min_size": 32, "max_size": 64, "sizer": "bytes" }
+        }))
+        .unwrap();
+        let canonical: Config = serde_json::from_value(json!({
+            "format": "otlp-bytes", "codecs": { "otlp-bytes": { "min_size": 32, "max_size": 64, "sizer": "bytes" } }
+        })).unwrap();
+        assert_eq!(legacy.plans().unwrap(), canonical.plans().unwrap());
+        let immediate: Config = serde_json::from_value(json!({
+            "max_batch_duration": "0s",
+            "otap": { "max_size": 100, "sizer": "items" },
+            "otlp": { "max_size": 10000, "sizer": "bytes" }
+        }))
+        .unwrap();
+        immediate.validate().unwrap();
+        assert!(
+            serde_json::from_value::<Config>(json!({
+                "otlp": { "min_size": 32, "sizer": "bytes" },
+                "codecs": { "otlp-bytes": { "min_size": 32, "sizer": "bytes" } }
+            }))
+            .unwrap_err()
+            .to_string()
+            .contains("duplicate")
+        );
+        assert!(
+            serde_json::from_value::<Config>(json!({
+                "codecs": { "not-registered": { "min_size": 1, "sizer": "items" } }
+            }))
+            .is_err()
+        );
+        let decode_only: Config = serde_json::from_value(json!({
+            "format": "test-otlp-decode-only"
+        }))
+        .unwrap();
+        assert!(
+            decode_only
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("encoder unavailable")
+        );
+        let unsupported: Config = serde_json::from_value(json!({
+            "codecs": { "test-otlp-codec": { "min_size": 1, "sizer": "bytes" } }
+        }))
+        .unwrap();
+        assert!(
+            unsupported
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("fallback requires items")
+        );
+    }
+
+    /// Scenario: preserve mode receives a native-batching extension and a
+    /// decoder-only extension, and downstream changes their output representation.
+    /// Guarantees: native output retains its codec, fallback emits OTAP, and both
+    /// Ack and Nack reach the correct input through explicit completion tokens.
+    #[test]
+    fn codec_batches_route_completions_after_downstream_conversion() {
+        use otel_arrow_dfe_pdata::codec::{EncodedPdata, PdataEncoding};
+        let (_, _, phase) = setup_test_runtime(json!({
+            "format": "preserve",
+            "otap": { "min_size": 1, "sizer": "items" },
+            "codecs": { "test-native-otlp": { "min_size": 1, "sizer": "bytes" } },
+            "max_batch_duration": "1s"
+        }));
+        phase
+            .run_test(move |mut ctx| async move {
+                let (completion_tx, mut completion_rx) = pipeline_completion_msg_channel(10);
+                ctx.set_pipeline_completion_sender(completion_tx);
+                let mut generator = DataGenerator::new(1);
+                for (index, name) in ["test-native-otlp", "test-otlp-decode-only"]
+                    .into_iter()
+                    .enumerate()
+                {
+                    let logs: OtlpProtoMessage = generator.generate_logs().into();
+                    let bytes = otlp_message_to_bytes(&logs).clone_bytes();
+                    let encoded = EncodedPdata::new(
+                        &PdataEncoding::from(name.to_owned()),
+                        SignalType::Logs,
+                        bytes,
+                    )
+                    .unwrap();
+                    let input = OtapPdata::new_default(encoded.into()).test_subscribe_to(
+                        Interests::ACKS | Interests::NACKS,
+                        TestCallData::new_with(index as u64, 0).into(),
+                        23,
+                    );
+                    ctx.process(Message::PData(input)).await.unwrap();
+                    let mut outputs = ctx.drain_pdata().await;
+                    assert_eq!(outputs.len(), 1);
+                    let output = outputs.pop().unwrap();
+                    assert_eq!(
+                        output.payload_ref().format().name(),
+                        if index == 0 { name } else { "otap" }
+                    );
+                    assert_equivalent(&[logs], &[otap_pdata_to_message(&output)]);
+                    // Both replies use a representation different from the emitted one.
+                    let returned = if index == 0 {
+                        output
+                            .try_into_otap(&mut CodecState::default())
+                            .unwrap()
+                            .into_pdata()
+                    } else {
+                        let (context, payload) = output.into_parts();
+                        OtapPdata::new(
+                            context,
+                            payload
+                                .into_encoded_for_test(PdataEncoding::OTLP, Default::default())
+                                .unwrap()
+                                .into(),
+                        )
+                    };
+                    if index == 0 {
+                        let (_, ack) = next_ack(AckMsg::new(returned)).unwrap();
+                        ctx.process(Message::Control(NodeControlMsg::Ack(ack)))
+                            .await
+                            .unwrap();
+                    } else {
+                        let (_, nack) =
+                            next_nack(NackMsg::new("test rejection", returned)).unwrap();
+                        ctx.process(Message::Control(NodeControlMsg::Nack(nack)))
+                            .await
+                            .unwrap();
+                    }
+                    let completion = next_completion(
+                        &mut completion_rx,
+                        Duration::from_secs(1),
+                        "codec batch completion",
+                    )
+                    .await;
+                    let (node, calldata) = match completion {
+                        PipelineCompletionMsg::DeliverAck { ack } if index == 0 => {
+                            let (node, ack) = next_ack(ack).unwrap();
+                            (node, ack.unwind.route.calldata)
+                        }
+                        PipelineCompletionMsg::DeliverNack { nack } if index == 1 => {
+                            let (node, nack) = next_nack(nack).unwrap();
+                            (node, nack.unwind.route.calldata)
+                        }
+                        other => panic!("unexpected completion: {other:?}"),
+                    };
+                    assert_eq!(node, 23);
+                    assert_eq!(
+                        TestCallData::try_from(calldata).unwrap(),
+                        TestCallData::new_with(index as u64, 0)
+                    );
+                }
+            })
+            .validate(|_| async {});
     }
 
     #[test]
@@ -1972,18 +1974,21 @@ mod tests {
     }
 
     fn otap_pdata_to_message(data: &OtapPdata) -> OtlpProtoMessage {
-        let rec: OtapArrowRecords = data.clone().payload().try_into_with_default().unwrap();
-        otap_to_otlp(&rec)
+        let rec = data
+            .clone()
+            .try_into_otap(&mut CodecState::default())
+            .unwrap();
+        otap_to_otlp(rec.records())
     }
 
     const fn all_wakeup_slots() -> [WakeupSlot; 6] {
         [
-            wakeup_slot(SignalFormat::OtapRecords, SignalType::Logs),
-            wakeup_slot(SignalFormat::OtapRecords, SignalType::Metrics),
-            wakeup_slot(SignalFormat::OtapRecords, SignalType::Traces),
-            wakeup_slot(SignalFormat::OtlpBytes, SignalType::Logs),
-            wakeup_slot(SignalFormat::OtlpBytes, SignalType::Metrics),
-            wakeup_slot(SignalFormat::OtlpBytes, SignalType::Traces),
+            wakeup_slot(0, SignalType::Logs),
+            wakeup_slot(0, SignalType::Metrics),
+            wakeup_slot(0, SignalType::Traces),
+            wakeup_slot(1, SignalType::Logs),
+            wakeup_slot(1, SignalType::Metrics),
+            wakeup_slot(1, SignalType::Traces),
         ]
     }
 
@@ -2318,12 +2323,12 @@ mod tests {
     #[test]
     fn test_wakeup_slot_round_trip_and_uniqueness() {
         let slots = [
-            (SignalFormat::OtapRecords, SignalType::Logs),
-            (SignalFormat::OtapRecords, SignalType::Metrics),
-            (SignalFormat::OtapRecords, SignalType::Traces),
-            (SignalFormat::OtlpBytes, SignalType::Logs),
-            (SignalFormat::OtlpBytes, SignalType::Metrics),
-            (SignalFormat::OtlpBytes, SignalType::Traces),
+            (0, SignalType::Logs),
+            (0, SignalType::Metrics),
+            (0, SignalType::Traces),
+            (1, SignalType::Logs),
+            (1, SignalType::Metrics),
+            (1, SignalType::Traces),
         ];
 
         for (expected_format, expected_signal) in slots {
@@ -2347,6 +2352,8 @@ mod tests {
     // The processor replaces wakeups per slot. This test proves that an early
     // wakeup is ignored and that the current wakeup still flushes the buffered
     // input later.
+    /// Scenario: A stale timer wakeup arrives before the current batch deadline.
+    /// Guarantees: The early wakeup leaves data buffered and the current wakeup flushes it once.
     #[test]
     fn test_timer_flush_ignores_stale_wakeup() {
         let (_telemetry_registry, metrics_reporter, phase) = setup_test_runtime(json!({
@@ -2394,7 +2401,7 @@ mod tests {
 
                 let stale_when = Instant::now();
                 ctx.process(Message::Control(NodeControlMsg::Wakeup {
-                    slot: wakeup_slot(SignalFormat::OtapRecords, SignalType::Logs),
+                    slot: wakeup_slot(0, SignalType::Logs),
                     when: stale_when,
                     revision: 0,
                 }))
@@ -2407,7 +2414,7 @@ mod tests {
 
                 let current_when = Instant::now() + Duration::from_secs(1);
                 ctx.process(Message::Control(NodeControlMsg::Wakeup {
-                    slot: wakeup_slot(SignalFormat::OtapRecords, SignalType::Logs),
+                    slot: wakeup_slot(0, SignalType::Logs),
                     when: current_when,
                     revision: 1,
                 }))
@@ -2548,7 +2555,7 @@ mod tests {
 
                 let current_when = Instant::now() + Duration::from_secs(1);
                 ctx.process(Message::Control(NodeControlMsg::Wakeup {
-                    slot: wakeup_slot(SignalFormat::OtapRecords, SignalType::Logs),
+                    slot: wakeup_slot(0, SignalType::Logs),
                     when: current_when,
                     revision: 1,
                 }))
@@ -3187,6 +3194,8 @@ mod tests {
 
     /// OTLP min_size is byte-based. The size flush decision must compare the
     /// configured threshold against pending bytes, not against log-record count.
+    /// Scenario: Encoded OTLP input reaches the configured byte threshold.
+    /// Guarantees: The processor flushes OTLP-encoded output without waiting for its timer.
     #[test]
     fn test_otlp_byte_min_size_triggers_size_flush() {
         let (_telemetry_registry, metrics_reporter, phase) = setup_test_runtime(json!({
@@ -3218,7 +3227,7 @@ mod tests {
                     1,
                     "byte min_size should trigger an immediate size flush"
                 );
-                assert_eq!(outputs[0].signal_format(), SignalFormat::OtlpBytes);
+                assert_eq!(outputs[0].payload_ref().format(), PdataFormat::OTLP);
 
                 let output_messages: Vec<_> = outputs.iter().map(otap_pdata_to_message).collect();
                 assert_equivalent(&[logs], &output_messages);
@@ -3329,8 +3338,8 @@ mod tests {
             });
     }
 
-    /// Test Preserve mode: this can't use the same test harness used above because it
-    /// arranges mixed-format inputs.
+    /// Scenario: preserve-mode batching receives interleaved OTLP and native OTAP batches.
+    /// Guarantees: each built-in representation is batched independently and keeps its output format.
     #[test]
     fn test_preserve_mode_mixed_formats() {
         let (_telemetry_registry, metrics_reporter, phase) = setup_test_runtime(json!({
@@ -3377,8 +3386,8 @@ mod tests {
                 // Trigger timeout for both active batching slots.
                 let when = Instant::now() + Duration::from_secs(1);
                 for slot in [
-                    wakeup_slot(SignalFormat::OtlpBytes, SignalType::Logs),
-                    wakeup_slot(SignalFormat::OtapRecords, SignalType::Logs),
+                    wakeup_slot(1, SignalType::Logs),
+                    wakeup_slot(0, SignalType::Logs),
                 ] {
                     ctx.process(Message::Control(NodeControlMsg::Wakeup {
                         slot,
@@ -3398,10 +3407,11 @@ mod tests {
                 let mut has_otap = false;
                 let mut has_otlp = false;
                 for output in &outputs {
-                    match output.signal_format() {
-                        SignalFormat::OtapRecords => has_otap = true,
-                        SignalFormat::OtlpBytes => has_otlp = true,
-                        SignalFormat::Encoded => panic!("unexpected encoded output"),
+                    if output.payload_ref().format() == PdataFormat::OTAP {
+                        has_otap = true;
+                    } else {
+                        assert_eq!(output.payload_ref().format(), PdataFormat::OTLP);
+                        has_otlp = true;
                     }
                 }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -94,6 +94,7 @@ const fn wakeup_slot(format: SignalFormat, signal: SignalType) -> WakeupSlot {
     let format_base = match format {
         SignalFormat::OtapRecords => 0,
         SignalFormat::OtlpBytes => 3,
+        SignalFormat::Encoded => 6,
     };
     let signal_offset = match signal {
         SignalType::Logs => 0,
@@ -449,6 +450,10 @@ impl FormatConfig {
         let (expect_sizer, with_msg) = match format {
             SignalFormat::OtapRecords => (Sizer::Items, "OTAP batch sizer: must be items"),
             SignalFormat::OtlpBytes => (Sizer::Bytes, "OTLP batch sizer: must be bytes"),
+            SignalFormat::Encoded => (
+                Sizer::Bytes,
+                "encoded batches require conversion before legacy batching",
+            ),
         };
         if self.sizer != expect_sizer {
             return Err(ConfigError::InvalidUserConfig {
@@ -834,6 +839,9 @@ impl BatchProcessor {
                 } else {
                     return Err(Self::no_active_format_error());
                 }
+            }
+            PayloadData::Encoded(_) => {
+                unreachable!("encoded payloads are not admitted during the storage transition")
             }
         };
         Ok(())
@@ -1389,6 +1397,11 @@ impl local::Processor<OtapPdata> for BatchProcessor {
                                     .flush_signal_impl(effect, when, FlushReason::Timer)
                                     .await?;
                             }
+                        }
+                        SignalFormat::Encoded => {
+                            unreachable!(
+                                "encoded payloads are not admitted during the storage transition"
+                            )
                         }
                     };
 
@@ -3388,6 +3401,7 @@ mod tests {
                     match output.signal_format() {
                         SignalFormat::OtapRecords => has_otap = true,
                         SignalFormat::OtlpBytes => has_otlp = true,
+                        SignalFormat::Encoded => panic!("unexpected encoded output"),
                     }
                 }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/content_router/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/content_router/mod.rs
@@ -604,6 +604,9 @@ impl ContentRouter {
                     },
                 }
             }
+            PayloadData::Encoded(_) => {
+                unreachable!("encoded payloads are not admitted during the storage transition")
+            }
         }
     }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/content_router/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/content_router/mod.rs
@@ -90,8 +90,8 @@ use otel_arrow_dfe_engine::{
     ProcessorRuntimeRequirements, RouteAdmission, WakeupError,
 };
 use otel_arrow_dfe_otap::OTAP_PROCESSOR_FACTORIES;
-use otel_arrow_dfe_otap::pdata::OtapPdata;
-use otel_arrow_dfe_pdata::PayloadData;
+use otel_arrow_dfe_otap::pdata::{OtapPdata, PdataEffectHandlerExtension};
+use otel_arrow_dfe_pdata::CodecView;
 use otel_arrow_dfe_pdata::TryFromWithOptions;
 use otel_arrow_dfe_pdata::otlp::OtlpProtoBytes;
 use otel_arrow_dfe_pdata::views::otap::OtapLogsView;
@@ -564,34 +564,39 @@ impl ContentRouter {
     }
 
     /// Resolves the output port for a given message payload.
-    fn resolve_route(&self, pdata: &OtapPdata) -> RouteResolution {
+    async fn resolve_route(
+        &self,
+        effect_handler: &local::EffectHandler<OtapPdata>,
+        pdata: &OtapPdata,
+    ) -> RouteResolution {
         let signal_type = pdata.signal_type();
 
-        match pdata.payload_ref().data() {
-            PayloadData::OtlpBytes(otlp_bytes) => match (signal_type, otlp_bytes) {
-                (SignalType::Logs, OtlpProtoBytes::ExportLogsRequest(bytes)) => {
-                    let data = RawLogsData::new(bytes.as_ref());
+        let view = match effect_handler.view(pdata.payload_ref()).await {
+            Ok(view) => view,
+            Err(_) => return RouteResolution::ConversionError,
+        };
+        match view {
+            CodecView::OtlpBytes { signal, bytes } => match signal {
+                SignalType::Logs => {
+                    let data = RawLogsData::new(bytes);
                     self.resolve_logs_route(&data)
                 }
-                (SignalType::Metrics, OtlpProtoBytes::ExportMetricsRequest(bytes)) => {
-                    let data = RawMetricsData::new(bytes.as_ref());
+                SignalType::Metrics => {
+                    let data = RawMetricsData::new(bytes);
                     self.resolve_metrics_route(&data)
                 }
-                (SignalType::Traces, OtlpProtoBytes::ExportTracesRequest(bytes)) => {
-                    let data = RawTraceData::new(bytes.as_ref());
+                SignalType::Traces => {
+                    let data = RawTraceData::new(bytes);
                     self.resolve_traces_route(&data)
                 }
-                // Defensive: signal_type/payload mismatch cannot occur for OtlpBytes
-                // since signal_type() is derived from the OtlpProtoBytes variant itself.
-                _ => RouteResolution::ConversionError,
             },
-            PayloadData::OtapArrowRecords(arrow_records) => {
+            CodecView::OtapArrowRecords(arrow_records) => {
                 match signal_type {
                     // Use native OTAP Arrow view for logs (avoids clone + OTLP round-trip)
-                    SignalType::Logs => self.resolve_arrow_logs_route(arrow_records),
+                    SignalType::Logs => self.resolve_arrow_logs_route(arrow_records.as_ref()),
                     // Metrics/Traces Arrow views not yet available -- convert to OTLP.
                     // TODO: Use OtapMetricsView/OtapTracesView when available.
-                    _ => match OtlpProtoBytes::try_from_with_default(arrow_records.clone()) {
+                    _ => match OtlpProtoBytes::try_from_with_default(arrow_records.into_owned()) {
                         Ok(OtlpProtoBytes::ExportMetricsRequest(bytes)) => {
                             let data = RawMetricsData::new(bytes.as_ref());
                             self.resolve_metrics_route(&data)
@@ -603,9 +608,6 @@ impl ContentRouter {
                         _ => RouteResolution::ConversionError,
                     },
                 }
-            }
-            PayloadData::Encoded(_) => {
-                unreachable!("encoded payloads are not admitted during the storage transition")
             }
         }
     }
@@ -874,7 +876,7 @@ impl local::Processor<OtapPdata> for ContentRouter {
             Message::PData(data) => {
                 // Resolve routing once up front, then handle route-selection
                 // failures separately from downstream admission failures.
-                let resolution = self.resolve_route(&data);
+                let resolution = self.resolve_route(effect_handler, &data).await;
 
                 match resolution {
                     RouteResolution::Matched(port) => {

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/debug_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/debug_processor/mod.rs
@@ -35,9 +35,12 @@ use otel_arrow_dfe_engine::{
     ConsumerEffectHandlerExtension, MessageSourceLocalEffectHandlerExtension,
 };
 use otel_arrow_dfe_engine::{Interests, ProducerEffectHandlerExtension};
-use otel_arrow_dfe_otap::{OTAP_PROCESSOR_FACTORIES, pdata::OtapPdata};
+use otel_arrow_dfe_otap::{
+    OTAP_PROCESSOR_FACTORIES,
+    pdata::{OtapPdata, PdataEffectHandlerExtension},
+};
+use otel_arrow_dfe_pdata::EncodingPlan;
 use otel_arrow_dfe_pdata::OtlpProtoBytes;
-use otel_arrow_dfe_pdata::TryIntoWithOptions;
 use otel_arrow_dfe_pdata::proto::opentelemetry::{
     logs::v1::LogsData,
     metrics::v1::{MetricsData, metric::Data},
@@ -346,8 +349,12 @@ impl local::Processor<OtapPdata> for DebugProcessor {
                         .await?;
                 }
 
-                let (_context, payload) = pdata.into_parts();
-                let otlp_bytes: OtlpProtoBytes = payload.try_into_with_default()?;
+                let (_context, mut payload) = pdata.into_parts();
+                let signal = payload.signal_type();
+                let bytes = effect_handler
+                    .encode_owned(&mut payload, &EncodingPlan::OTLP)
+                    .await?;
+                let otlp_bytes = OtlpProtoBytes::new_from_bytes(signal, bytes);
 
                 match otlp_bytes {
                     OtlpProtoBytes::ExportLogsRequest(bytes) => {

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -100,8 +100,7 @@ use otel_arrow_dfe_quiver::{
 use smallvec::smallvec;
 
 use otel_arrow_dfe_otap::OTAP_PROCESSOR_FACTORIES;
-use otel_arrow_dfe_otap::pdata::OtapPdata;
-use otel_arrow_dfe_pdata::TryIntoWithOptions;
+use otel_arrow_dfe_otap::pdata::{OtapPdata, PdataEffectHandlerExtension};
 
 use bundle_adapter::{
     OtapRecordBundleAdapter, OtlpBytesAdapter, convert_bundle_to_pdata, recover_item_count,
@@ -133,7 +132,7 @@ use otel_arrow_dfe_engine::{
     ConsumerEffectHandlerExtension, Interests, LocalWakeupRequirements, ProcessorFactory,
     ProcessorRuntimeRequirements, ProducerEffectHandlerExtension,
 };
-use otel_arrow_dfe_pdata::{OtapArrowRecords, OtapPayload, PayloadData};
+use otel_arrow_dfe_pdata::OtapPayload;
 #[cfg(test)]
 use otel_arrow_dfe_telemetry::common_attributes::SignalAttributes;
 
@@ -964,26 +963,19 @@ impl DurableBuffer {
         data: OtapPdata,
         effect_handler: &mut EffectHandler<OtapPdata>,
     ) -> Result<(), Error> {
-        let (context, payload) = data.into_parts();
-
-        // Capture signal type before consuming the payload
-        let signal_type = payload.signal_type();
+        let signal_type = data.signal_type();
 
         // Get the engine reference - NACK with original payload if unavailable
         let engine = match self.engine() {
-            Ok((engine, _)) => engine,
+            Ok((engine, _)) => Arc::clone(engine),
             Err(e) => {
                 self.metrics
                     .ingest_for(IngestFailure::Error)
                     .failures
                     .add(1);
                 otel_error!("durable_buffer.engine.unavailable", error = %e);
-                let nack_pdata = OtapPdata::new(context, payload);
                 effect_handler
-                    .notify_nack(NackMsg::new(
-                        format!("engine not available: {}", e),
-                        nack_pdata,
-                    ))
+                    .notify_nack(NackMsg::new(format!("engine not available: {}", e), data))
                     .await?;
                 return Ok(());
             }
@@ -991,98 +983,70 @@ impl DurableBuffer {
 
         // Ingest based on payload type and configuration.
         // Adapters preserve the original payload via into_inner() for NACK on failure.
-        // Returns (Result, item_count) - item count tracks individual items for all formats.
-        let (ingest_result, item_count): (Result<(), _>, u64) = match payload.into_data() {
-            PayloadData::OtlpBytes(otlp_bytes) => {
-                // OTLP bytes: check configuration for handling mode
-                match self.config.otlp_handling {
-                    OtlpHandling::PassThrough => {
-                        // Store as opaque binary for efficient pass-through.
-                        // Item count is computed once inside the adapter constructor
-                        // (protobuf wire-format scan, no full deserialization) and cached.
-                        match OtlpBytesAdapter::new(otlp_bytes) {
-                            Ok(adapter) => {
-                                let num_items = adapter.cached_item_count();
-                                let result = match engine.ingest(&adapter).await {
-                                    Ok(()) => Ok(()),
-                                    Err(e) => Err((e, OtapPayload::from(adapter.into_inner()))),
-                                };
-                                (result, num_items)
-                            }
-                            Err((e, original_bytes)) => {
-                                // Adapter creation failed - NACK with original bytes
-                                self.metrics
-                                    .ingest_for(IngestFailure::Error)
-                                    .failures
-                                    .add(1);
-                                otel_error!("durable_buffer.otlp.adapter_failed", error = %e);
-
-                                let nack_pdata =
-                                    OtapPdata::new(context, OtapPayload::from(original_bytes));
-                                effect_handler
-                                    .notify_nack(NackMsg::new(
-                                        format!("OTLP adapter creation failed: {}", e),
-                                        nack_pdata,
-                                    ))
-                                    .await?;
-                                return Ok(());
-                            }
-                        }
+        // Preserve the existing durable OTLP format in pass-through mode. Other
+        // inputs use recoverable native conversion before Arrow storage.
+        let (context, ingest_result, item_count): (_, Result<(), _>, u64) =
+            if matches!(self.config.otlp_handling, OtlpHandling::PassThrough)
+                && data.payload_ref().format()
+                    == otel_arrow_dfe_pdata::PdataFormat::encoded(
+                        otel_arrow_dfe_pdata::ResolvedCodec::OTLP,
+                    )
+            {
+                let (context, payload) = data.into_parts();
+                let otlp_bytes = otel_arrow_dfe_pdata::OtlpProtoBytes::new_from_bytes(
+                    signal_type,
+                    payload
+                        .into_encoded_bytes()
+                        .expect("OTLP format must contain encoded bytes"),
+                );
+                match OtlpBytesAdapter::new(otlp_bytes) {
+                    Ok(adapter) => {
+                        let num_items = adapter.cached_item_count();
+                        let result = engine
+                            .ingest(&adapter)
+                            .await
+                            .map_err(|error| (error, OtapPayload::from(adapter.into_inner())));
+                        (context, result, num_items)
                     }
-                    OtlpHandling::ConvertToArrow => {
-                        // Convert to Arrow for queryability.
-                        // Clone bytes for NACK on conversion failure (conversion consumes the input).
-                        let bytes_for_nack = otlp_bytes.clone();
-                        let conversion_result: Result<OtapArrowRecords, _> =
-                            OtapPayload::from(otlp_bytes).try_into_with_default();
-                        match conversion_result {
-                            Ok(records) => {
-                                // Count items from Arrow data (cheap - just num_rows)
-                                let num_items = records.num_items() as u64;
-                                let adapter = OtapRecordBundleAdapter::new(records);
-                                let result = match engine.ingest(&adapter).await {
-                                    Ok(()) => Ok(()),
-                                    // Ingest failed: NACK with the Arrow records we tried to store
-                                    Err(e) => Err((e, OtapPayload::from(adapter.into_inner()))),
-                                };
-                                (result, num_items)
-                            }
-                            Err(e) => {
-                                // Conversion failed - NACK with original bytes so upstream can retry
-                                self.metrics
-                                    .ingest_for(IngestFailure::Error)
-                                    .failures
-                                    .add(1);
-                                otel_error!("durable_buffer.otlp.conversion_failed", error = %e);
-
-                                let nack_pdata =
-                                    OtapPdata::new(context, OtapPayload::from(bytes_for_nack));
-                                effect_handler
-                                    .notify_nack(NackMsg::new(
-                                        format!("OTLP to Arrow conversion failed: {}", e),
-                                        nack_pdata,
-                                    ))
-                                    .await?;
-                                return Ok(());
-                            }
-                        }
+                    Err((error, original_bytes)) => {
+                        self.metrics
+                            .ingest_for(IngestFailure::Error)
+                            .failures
+                            .add(1);
+                        otel_error!("durable_buffer.otlp.adapter_failed", error = %error);
+                        effect_handler
+                            .notify_nack(NackMsg::new(
+                                format!("OTLP adapter creation failed: {error}"),
+                                OtapPdata::new(context, OtapPayload::from(original_bytes)),
+                            ))
+                            .await?;
+                        return Ok(());
                     }
                 }
-            }
-            PayloadData::OtapArrowRecords(records) => {
-                // Native Arrow data: count items (cheap) and store directly.
-                let num_items = records.num_items() as u64;
-                let adapter = OtapRecordBundleAdapter::new(records);
-                let result = match engine.ingest(&adapter).await {
-                    Ok(()) => Ok(()),
-                    Err(e) => Err((e, OtapPayload::from(adapter.into_inner()))),
+            } else {
+                let arrow_pdata = match effect_handler.try_into_otap(data).await {
+                    Ok(arrow_pdata) => arrow_pdata,
+                    Err(error) => {
+                        self.metrics
+                            .ingest_for(IngestFailure::Error)
+                            .failures
+                            .add(1);
+                        let (error, pdata) = error.into_parts();
+                        effect_handler
+                            .notify_nack(NackMsg::new_permanent(error.to_string(), pdata))
+                            .await?;
+                        return Ok(());
+                    }
                 };
-                (result, num_items)
-            }
-            PayloadData::Encoded(_) => {
-                unreachable!("encoded payloads are not admitted during the storage transition")
-            }
-        };
+                let (context, records) = arrow_pdata.into_parts();
+                let item_count = records.num_items() as u64;
+                let adapter = OtapRecordBundleAdapter::new(records);
+                let result = engine
+                    .ingest(&adapter)
+                    .await
+                    .map_err(|error| (error, OtapPayload::from(adapter.into_inner())));
+                (context, result, item_count)
+            };
 
         // Handle ingest result
         match ingest_result {

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/mod.rs
@@ -1079,6 +1079,9 @@ impl DurableBuffer {
                 };
                 (result, num_items)
             }
+            PayloadData::Encoded(_) => {
+                unreachable!("encoded payloads are not admitted during the storage transition")
+            }
         };
 
         // Handle ingest result

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/mod.rs
@@ -34,8 +34,10 @@ use otel_arrow_dfe_engine::processor::{
 use otel_arrow_dfe_engine::{
     ConsumerEffectHandlerExtension, MessageSourceLocalEffectHandlerExtension,
 };
-use otel_arrow_dfe_otap::{OTAP_PROCESSOR_FACTORIES, pdata::OtapPdata};
-use otel_arrow_dfe_pdata::TryIntoWithOptions;
+use otel_arrow_dfe_otap::{
+    OTAP_PROCESSOR_FACTORIES,
+    pdata::{NativePdataProcessor, NativeProcessorAdapter, OtapArrowPdata, OtapPdata},
+};
 use otel_arrow_dfe_pdata::otap::OtapArrowRecords;
 use otel_arrow_dfe_pdata::otap::filter::IdBitmapPool;
 use otel_arrow_dfe_telemetry::common_attributes::SignalAttributes;
@@ -131,9 +133,7 @@ impl FilterProcessor {
 #[async_trait(?Send)]
 impl local::Processor<OtapPdata> for FilterProcessor {
     fn runtime_requirements(&self) -> ProcessorRuntimeRequirements {
-        // The filter processor drops signal items, so it records
-        // `dropped.items` when it lies within a flow that enables it.
-        ProcessorRuntimeRequirements::none().with_drop_decisions()
+        NativePdataProcessor::runtime_requirements(self)
     }
 
     async fn process(
@@ -141,100 +141,116 @@ impl local::Processor<OtapPdata> for FilterProcessor {
         msg: Message<OtapPdata>,
         effect_handler: &mut local::EffectHandler<OtapPdata>,
     ) -> Result<(), Error> {
-        match msg {
-            Message::Control(control) => {
-                if let NodeControlMsg::CollectTelemetry {
-                    mut metrics_reporter,
-                } = control
-                {
-                    _ = metrics_reporter.report_measurement(&mut self.metrics);
-                    self.compute_duration.report(&mut metrics_reporter);
-                }
-                Ok(())
-            }
-            Message::PData(pdata) => {
-                let signal = pdata.signal_type();
-                // convert to arrow records
-                let (context, payload) = pdata.into_parts();
+        NativeProcessorAdapter::process(self, msg, effect_handler).await
+    }
+}
 
-                let mut arrow_records: OtapArrowRecords = payload.try_into_with_default()?;
-                arrow_records.decode_transport_optimized_ids()?;
+#[async_trait(?Send)]
+impl NativePdataProcessor for FilterProcessor {
+    fn runtime_requirements(&self) -> ProcessorRuntimeRequirements {
+        // The filter processor drops signal items, so it records
+        // `dropped.items` when it lies within a flow that enables it.
+        ProcessorRuntimeRequirements::none().with_drop_decisions()
+    }
 
-                let (filtered_arrow_records, _signals_consumed, dropped_items): (
-                    OtapArrowRecords,
-                    u64,
-                    u64,
-                ) =
-                    effect_handler.timed(&self.compute_duration, || -> Result<_, Error> {
-                        match signal {
-                            SignalType::Metrics => {
-                                let (filtered, consumed, filtered_count) = self
-                                    .config
-                                    .metric_filters()
-                                    .filter(arrow_records, &mut self.metric_id_pool)
-                                    .map_err(|e| {
-                                        let source_detail = format_error_sources(&e);
-                                        Error::ProcessorError {
-                                            processor: effect_handler.processor_id(),
-                                            kind: ProcessorErrorKind::Other,
-                                            error: format!("Filter error: {e}"),
-                                            source_detail,
-                                        }
-                                    })?;
-                                Ok((filtered, consumed, filtered_count))
-                            }
-                            SignalType::Logs => {
-                                let (filtered, consumed, filtered_count) =
-                                    self.config.log_filters().filter(arrow_records).map_err(
-                                        |e| {
-                                            let source_detail = format_error_sources(&e);
-                                            Error::ProcessorError {
-                                                processor: effect_handler.processor_id(),
-                                                kind: ProcessorErrorKind::Other,
-                                                error: format!("Filter error: {e}"),
-                                                source_detail,
-                                            }
-                                        },
-                                    )?;
-                                Ok((filtered, consumed, filtered_count))
-                            }
-                            SignalType::Traces => {
-                                let (filtered, consumed, filtered_count) =
-                                    self.config.trace_filters().filter(arrow_records).map_err(
-                                        |e| {
-                                            let source_detail = format_error_sources(&e);
-                                            Error::ProcessorError {
-                                                processor: effect_handler.processor_id(),
-                                                kind: ProcessorErrorKind::Other,
-                                                error: format!("Filter error: {e}"),
-                                                source_detail,
-                                            }
-                                        },
-                                    )?;
-                                Ok((filtered, consumed, filtered_count))
-                            }
-                        }
-                    })?;
-
-                let metric = self.metrics.with(SignalAttributes { signal });
-                metric.dropped_items.add(dropped_items);
-
-                // Record the drop flow-metric. A no-op unless this node is
-                // a decision node in a flow that enables `dropped.items`.
-                // `dropped_items` is the dropped count.
-                effect_handler.record_flow_dropped_items(signal, dropped_items);
-
-                let kept_items = filtered_arrow_records.num_items();
-                let mut pdata = OtapPdata::new(context, filtered_arrow_records.into());
-                if kept_items == 0 {
-                    pdata.complete_processor_without_output(effect_handler);
-                    effect_handler.notify_ack(AckMsg::new(pdata)).await?;
-                } else {
-                    effect_handler.send_message_with_source_node(pdata).await?;
-                }
-                Ok(())
-            }
+    async fn process_control(
+        &mut self,
+        control: NodeControlMsg<OtapPdata>,
+        _effect_handler: &mut local::EffectHandler<OtapPdata>,
+    ) -> Result<(), Error> {
+        if let NodeControlMsg::CollectTelemetry {
+            mut metrics_reporter,
+        } = control
+        {
+            _ = metrics_reporter.report_measurement(&mut self.metrics);
+            self.compute_duration.report(&mut metrics_reporter);
         }
+        Ok(())
+    }
+
+    async fn process_native(
+        &mut self,
+        arrow_pdata: OtapArrowPdata,
+        effect_handler: &mut local::EffectHandler<OtapPdata>,
+    ) -> Result<(), Error> {
+        let signal = arrow_pdata.signal_type();
+        let (context, mut arrow_records) = arrow_pdata.into_parts();
+        arrow_records.decode_transport_optimized_ids()?;
+
+        let (filtered_arrow_records, _signals_consumed, dropped_items): (
+            OtapArrowRecords,
+            u64,
+            u64,
+        ) = effect_handler.timed(&self.compute_duration, || -> Result<_, Error> {
+            match signal {
+                SignalType::Metrics => {
+                    let (filtered, consumed, filtered_count) = self
+                        .config
+                        .metric_filters()
+                        .filter(arrow_records, &mut self.metric_id_pool)
+                        .map_err(|e| {
+                            let source_detail = format_error_sources(&e);
+                            Error::ProcessorError {
+                                processor: effect_handler.processor_id(),
+                                kind: ProcessorErrorKind::Other,
+                                error: format!("Filter error: {e}"),
+                                source_detail,
+                            }
+                        })?;
+                    Ok((filtered, consumed, filtered_count))
+                }
+                SignalType::Logs => {
+                    let (filtered, consumed, filtered_count) = self
+                        .config
+                        .log_filters()
+                        .filter(arrow_records)
+                        .map_err(|e| {
+                            let source_detail = format_error_sources(&e);
+                            Error::ProcessorError {
+                                processor: effect_handler.processor_id(),
+                                kind: ProcessorErrorKind::Other,
+                                error: format!("Filter error: {e}"),
+                                source_detail,
+                            }
+                        })?;
+                    Ok((filtered, consumed, filtered_count))
+                }
+                SignalType::Traces => {
+                    let (filtered, consumed, filtered_count) = self
+                        .config
+                        .trace_filters()
+                        .filter(arrow_records)
+                        .map_err(|e| {
+                            let source_detail = format_error_sources(&e);
+                            Error::ProcessorError {
+                                processor: effect_handler.processor_id(),
+                                kind: ProcessorErrorKind::Other,
+                                error: format!("Filter error: {e}"),
+                                source_detail,
+                            }
+                        })?;
+                    Ok((filtered, consumed, filtered_count))
+                }
+            }
+        })?;
+
+        let metric = self.metrics.with(SignalAttributes { signal });
+        metric.dropped_items.add(dropped_items);
+
+        // Record the drop flow-metric. A no-op unless this node is
+        // a decision node in a flow that enables `dropped.items`.
+        // `dropped_items` is the dropped count.
+        effect_handler.record_flow_dropped_items(signal, dropped_items);
+
+        let kept_items = filtered_arrow_records.num_items();
+        let mut pdata = OtapPdata::new(context, filtered_arrow_records.into());
+        if kept_items == 0 {
+            pdata.complete_processor_without_output(effect_handler);
+            effect_handler.notify_ack(AckMsg::new(pdata)).await?;
+        } else {
+            effect_handler.send_message_with_source_node(pdata).await?;
+        }
+        Ok(())
     }
 }
 
@@ -243,6 +259,7 @@ mod tests {
     use crate::processors::filter_processor::{
         FILTER_PROCESSOR_URN, FilterProcessor, config::Config,
     };
+    use bytes::Bytes;
     use otel_arrow_dfe_config::SignalType;
     use otel_arrow_dfe_config::node::NodeUserConfig;
     use otel_arrow_dfe_engine::Interests;
@@ -258,6 +275,7 @@ mod tests {
     use otel_arrow_dfe_otap::pdata::OtapPdata;
     use otel_arrow_dfe_pdata::OtlpProtoBytes;
     use otel_arrow_dfe_pdata::TryIntoWithOptions;
+    use otel_arrow_dfe_pdata::codec::ResolvedCodec;
     use otel_arrow_dfe_pdata::otap::filter::{
         AnyValue as AnyValueFilter, KeyValue as KeyValueFilter, MatchType,
         logs::{LogFilter, LogMatchProperties, LogSeverityNumberMatchProperties},
@@ -914,6 +932,55 @@ mod tests {
                 assert_fully_filtered(&mut ctx, otlp_traces_bytes, SignalType::Traces).await;
             })
         }
+    }
+
+    /// Scenario: the native processor adapter receives malformed generalized OTLP input.
+    /// Guarantees: the filter permanently Nacks the exact bytes instead of returning a node error.
+    #[test]
+    fn malformed_encoded_input_is_recoverable() {
+        let test_runtime = TestRuntime::<OtapPdata>::new();
+        let controller = ControllerContext::new(test_runtime.metrics_registry());
+        let pipeline_ctx =
+            controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        let processor = ProcessorWrapper::local(
+            FilterProcessor::from_config(pipeline_ctx, &json!({})).unwrap(),
+            test_node(test_runtime.config().name.clone()),
+            Arc::new(NodeUserConfig::new_processor_config(FILTER_PROCESSOR_URN)),
+            test_runtime.config(),
+        );
+        let bytes = Bytes::from_static(&[0x0a, 0x05, 0x01]);
+        let pointer = bytes.as_ptr();
+        let pdata = OtapPdata::new_default(
+            ResolvedCodec::OTLP
+                .admit(SignalType::Logs, bytes.clone())
+                .unwrap()
+                .into(),
+        )
+        .test_subscribe_to(
+            Interests::NACKS | Interests::RETURN_DATA,
+            CallData::new(),
+            11,
+        );
+
+        test_runtime
+            .set_processor(processor)
+            .run_test(move |mut ctx| async move {
+                let (completion_tx, mut completion_rx) = pipeline_completion_msg_channel(1);
+                ctx.set_pipeline_completion_sender(completion_tx);
+                ctx.process(Message::PData(pdata)).await.unwrap();
+                assert!(ctx.drain_pdata().await.is_empty());
+                match completion_rx.recv().await.unwrap() {
+                    PipelineCompletionMsg::DeliverNack { nack } => {
+                        assert!(nack.permanent);
+                        assert!(nack.reason.contains("otlp-bytes"));
+                        let recovered = nack.refused.payload_ref().encoded_bytes().unwrap();
+                        assert_eq!(recovered.as_ptr(), pointer);
+                        assert_eq!(recovered, &bytes);
+                    }
+                    other => panic!("expected codec Nack, got {other:?}"),
+                }
+            })
+            .validate(|_| async {});
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/log_sampling_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/log_sampling_processor/mod.rs
@@ -40,9 +40,9 @@ use otel_arrow_dfe_engine::processor::{
     FlowMetricHook, ProcessorRuntimeRequirements, ProcessorWrapper,
 };
 use otel_arrow_dfe_otap::OTAP_PROCESSOR_FACTORIES;
-use otel_arrow_dfe_otap::pdata::OtapPdata;
+use otel_arrow_dfe_otap::pdata::{OtapPdata, PdataEffectHandlerExtension};
 use otel_arrow_dfe_pdata::OtapPayload;
-use otel_arrow_dfe_pdata::TryIntoWithOptions;
+#[cfg(test)]
 use otel_arrow_dfe_pdata::otap::OtapArrowRecords;
 use otel_arrow_dfe_pdata::otap::filter::{IdBitmapPool, filter_otap_batch};
 use otel_arrow_dfe_telemetry::metrics::MetricSet;
@@ -108,15 +108,22 @@ impl LogSamplingProcessor {
     /// Processes a log payload: sample, filter, and forward or ack.
     async fn process_logs(
         &mut self,
-        mut pdata: OtapPdata,
+        pdata: OtapPdata,
         effect_handler: &mut local::EffectHandler<OtapPdata>,
     ) -> Result<(), EngineError> {
-        let total = pdata.num_items();
-
-        // Convert to Arrow records (no-op if already Arrow)
-        let (context, payload) = pdata.into_parts();
-        let mut records: OtapArrowRecords = payload.try_into_with_default()?;
+        let arrow_pdata = match effect_handler.try_into_otap(pdata).await {
+            Ok(arrow_pdata) => arrow_pdata,
+            Err(error) => {
+                let (error, pdata) = error.into_parts();
+                effect_handler
+                    .notify_nack(NackMsg::new_permanent(error.to_string(), pdata))
+                    .await?;
+                return Ok(());
+            }
+        };
+        let (context, mut records) = arrow_pdata.into_parts();
         records.decode_transport_optimized_ids()?;
+        let total = records.num_items();
 
         // Prepare the filter buffer.
         //

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/log_sampling_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/log_sampling_processor/mod.rs
@@ -324,6 +324,7 @@ mod tests {
                 let output_otap = match output_payload.into_data() {
                     PayloadData::OtlpBytes(_) => panic!("Unexpected otlp bytes"),
                     PayloadData::OtapArrowRecords(otap_arrow_records) => otap_arrow_records,
+                    PayloadData::Encoded(_) => panic!("Unexpected encoded bytes"),
                 };
 
                 let output_attrs = output_otap.get(ArrowPayloadType::LogAttrs).unwrap();

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/partition_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/partition_processor/mod.rs
@@ -33,9 +33,11 @@ use otel_arrow_dfe_engine::{
 use otel_arrow_dfe_otap::OTAP_PROCESSOR_FACTORIES;
 use otel_arrow_dfe_otap::accessory::context::split_contexts::{Contexts, OutboundError};
 use otel_arrow_dfe_otap::accessory::slots::Key;
-use otel_arrow_dfe_otap::pdata::OtapPdata;
+use otel_arrow_dfe_otap::pdata::{OtapPdata, PdataEffectHandlerExtension};
 use otel_arrow_dfe_otap::transport_headers::{TransportHeader, ValueKind};
-use otel_arrow_dfe_pdata::{OtapArrowRecords, OtapPayload, TryIntoWithOptions};
+#[cfg(test)]
+use otel_arrow_dfe_pdata::OtapArrowRecords;
+use otel_arrow_dfe_pdata::OtapPayload;
 use otel_arrow_dfe_query_engine::parser::default_parser_options;
 use otel_arrow_dfe_query_engine::pipeline::partition::{PartitionValue, Partitioner};
 use otel_arrow_dfe_query_engine_languages::opl::parser::OplParser;
@@ -239,9 +241,18 @@ impl Processor<OtapPdata> for PartitionProcessor {
                     pdata.add_flow_compute(flow);
                 }
 
-                let (mut inbound_context, payload) = pdata.into_parts();
-                let signal_type = payload.signal_type();
-                let mut otap_batch: OtapArrowRecords = payload.try_into_with_default()?;
+                let arrow_pdata = match effect_handler.try_into_otap(pdata).await {
+                    Ok(arrow_pdata) => arrow_pdata,
+                    Err(error) => {
+                        let (error, pdata) = error.into_parts();
+                        effect_handler
+                            .notify_nack(NackMsg::new_permanent(error.to_string(), pdata))
+                            .await?;
+                        return Ok(());
+                    }
+                };
+                let signal_type = arrow_pdata.signal_type();
+                let (mut inbound_context, mut otap_batch) = arrow_pdata.into_parts();
                 otap_batch.decode_transport_optimized_ids()?;
                 let inbound_batch_num_items = otap_batch.num_items();
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
@@ -641,6 +641,9 @@ impl TemporalReaggregationProcessor {
                 let view = RawMetricsData::new(otlp.as_bytes());
                 self.process_view(effect_handler, &view).await
             }
+            PayloadData::Encoded(_) => {
+                unreachable!("encoded payloads are not admitted during the storage transition")
+            }
         };
 
         match result {

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
@@ -37,11 +37,13 @@ use otel_arrow_dfe_engine::processor::{ProcessorRuntimeRequirements, ProcessorWr
 use otel_arrow_dfe_engine::{ConsumerEffectHandlerExtension, Interests};
 use otel_arrow_dfe_otap::OTAP_PROCESSOR_FACTORIES;
 use otel_arrow_dfe_otap::accessory::slots::{Key as SlotKey, State as SlotState};
-use otel_arrow_dfe_otap::pdata::{Context, OtapPdata, PeerAddrMerger};
+use otel_arrow_dfe_otap::pdata::{Context, OtapPdata, PdataEffectHandlerExtension, PeerAddrMerger};
+#[cfg(test)]
+use otel_arrow_dfe_pdata::PayloadData;
 use otel_arrow_dfe_pdata::otap::OtapArrowRecords;
 use otel_arrow_dfe_pdata::views::otap::OtapMetricsView;
 use otel_arrow_dfe_pdata::views::otlp::bytes::metrics::RawMetricsData;
-use otel_arrow_dfe_pdata::{OtapPayload, OtapPayloadHelpers, PayloadData};
+use otel_arrow_dfe_pdata::{CodecView, OtapPayload, OtapPayloadHelpers};
 use otel_arrow_dfe_pdata_views::views::common::InstrumentationScopeView;
 use otel_arrow_dfe_pdata_views::views::metrics::{
     AggregationTemporality, DataType, DataView, ExponentialHistogramDataPointView,
@@ -623,26 +625,35 @@ impl TemporalReaggregationProcessor {
         effect_handler: &mut local::EffectHandler<OtapPdata>,
         pdata: OtapPdata,
     ) -> Result<(), Error> {
-        let result = match pdata.payload_ref().data() {
-            PayloadData::OtapArrowRecords(records) => match OtapMetricsView::try_from(records) {
-                Ok(view) => self.process_view(effect_handler, &view).await,
-                Err(e) => {
-                    otel_warn!(telemetry::VIEW_CREATION_FAILED_EVENT, error = %e);
-                    self.metrics.batches_rejected.inc();
-                    let msg = format!("Failed to create view: {:#}", e);
-                    effect_handler
-                        .notify_nack(NackMsg::new_permanent(msg, pdata))
-                        .await?;
-
-                    return Ok(());
-                }
-            },
-            PayloadData::OtlpBytes(otlp) => {
-                let view = RawMetricsData::new(otlp.as_bytes());
-                self.process_view(effect_handler, &view).await
+        let view = match effect_handler.view(pdata.payload_ref()).await {
+            Ok(view) => view,
+            Err(error) => {
+                self.metrics.batches_rejected.inc();
+                effect_handler
+                    .notify_nack(NackMsg::new_permanent(error.to_string(), pdata))
+                    .await?;
+                return Ok(());
             }
-            PayloadData::Encoded(_) => {
-                unreachable!("encoded payloads are not admitted during the storage transition")
+        };
+        let result = match view {
+            CodecView::OtapArrowRecords(records) => {
+                match OtapMetricsView::try_from(records.as_ref()) {
+                    Ok(view) => self.process_view(effect_handler, &view).await,
+                    Err(e) => {
+                        otel_warn!(telemetry::VIEW_CREATION_FAILED_EVENT, error = %e);
+                        self.metrics.batches_rejected.inc();
+                        let msg = format!("Failed to create view: {:#}", e);
+                        effect_handler
+                            .notify_nack(NackMsg::new_permanent(msg, pdata))
+                            .await?;
+
+                        return Ok(());
+                    }
+                }
+            }
+            CodecView::OtlpBytes { bytes, .. } => {
+                let view = RawMetricsData::new(bytes);
+                self.process_view(effect_handler, &view).await
             }
         };
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/testing.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/testing.rs
@@ -350,6 +350,7 @@ fn payload_to_otlp(payload: &OtapPayload) -> otel_arrow_dfe_pdata::proto::OtlpPr
         PayloadData::OtlpBytes(bytes) => {
             otel_arrow_dfe_pdata::testing::round_trip::otlp_bytes_to_message(bytes.clone())
         }
+        PayloadData::Encoded(_) => panic!("unexpected encoded payload in legacy test helper"),
     }
 }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/transform_processor/mod.rs
@@ -65,11 +65,14 @@ use otel_arrow_dfe_otap::{
         context::split_contexts::{Contexts, OutboundError},
         slots::Key,
     },
-    pdata::{Context, OtapPdata},
+    pdata::{Context, OtapPdata, PdataEffectHandlerExtension},
 };
+#[cfg(test)]
+use otel_arrow_dfe_pdata::PayloadData;
+#[cfg(test)]
 use otel_arrow_dfe_pdata::TryIntoWithOptions;
 use otel_arrow_dfe_pdata::{
-    OtapArrowRecords, OtapPayload, OtapPayloadHelpers, PayloadData,
+    OtapArrowRecords, OtapPayload, OtapPayloadHelpers,
     otap::transform::sanitize::sanitize_otap_batch,
 };
 use otel_arrow_dfe_query_engine::{
@@ -664,18 +667,24 @@ impl Processor<OtapPdata> for TransformProcessor {
                     // convert payload to OTAP & remove delta encoded IDs.
                     // safety: we know payload will have been initialized to Some either, before
                     // entering the loop, or during the previous iteration.
-                    let conversion_result: Result<OtapArrowRecords, _> = payload
-                        .take()
-                        .expect("payload initialized")
-                        .try_into_with_default();
+                    let conversion_result = effect_handler
+                        .try_payload_into_otap(payload.take().expect("payload initialized"))
+                        .await;
                     let mut otap_batch = match conversion_result {
                         Ok(otap_batch) => otap_batch,
                         Err(error) => {
-                            transform_error = Some(TransformOperationError::new(
+                            self.metrics.record_failure(
+                                pdata_signal_type,
                                 TransformErrorType::PayloadConversion,
-                                error.into(),
-                            ));
-                            break;
+                            );
+                            let (error, payload) = error.into_parts();
+                            effect_handler
+                                .notify_nack(NackMsg::new_permanent(
+                                    error.to_string(),
+                                    OtapPdata::new(context, payload),
+                                ))
+                                .await?;
+                            return Ok(());
                         }
                     };
                     if let Err(error) = otap_batch.decode_transport_optimized_ids() {
@@ -720,17 +729,22 @@ impl Processor<OtapPdata> for TransformProcessor {
                         None => {
                             // safety: since error is `None`, we know payload must be `Some` based
                             // on the logic in the loop above, so it is safe to expect here
-                            match payload
-                                .take()
-                                .expect("payload option initialized")
-                                .into_data()
+                            match effect_handler
+                                .try_payload_into_otap(
+                                    payload.take().expect("payload option initialized"),
+                                )
+                                .await
                             {
-                                PayloadData::OtapArrowRecords(otap_batch) => Ok(otap_batch),
-                                _ => {
-                                    // safety: if any transform applied then we'll have converted
-                                    // the payload the OTAP, so we know here that it must be this
-                                    // variant of OtapPayload
-                                    unreachable!("expected OTAP payload variant")
+                                Ok(otap_batch) => Ok(otap_batch),
+                                Err(error) => {
+                                    let (error, payload) = error.into_parts();
+                                    effect_handler
+                                        .notify_nack(NackMsg::new_permanent(
+                                            error.to_string(),
+                                            OtapPdata::new(context, payload),
+                                        ))
+                                        .await?;
+                                    return Ok(());
                                 }
                             }
                         }

--- a/rust/otap-dataflow/crates/engine/src/exporter.rs
+++ b/rust/otap-dataflow/crates/engine/src/exporter.rs
@@ -29,6 +29,7 @@ use otel_arrow_dfe_channel::error::SendError;
 use otel_arrow_dfe_channel::mpsc;
 use otel_arrow_dfe_config::node::NodeUserConfig;
 use otel_arrow_dfe_config::transport_headers_policy::HeaderPropagationPolicy;
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
 use std::sync::Arc;
 
@@ -297,6 +298,7 @@ impl<PData> ExporterWrapper<PData> {
             metrics_reporter,
             node_interests,
             None,
+            CodecExecutor::default(),
         )
         .await
     }
@@ -308,6 +310,7 @@ impl<PData> ExporterWrapper<PData> {
         metrics_reporter: MetricsReporter,
         node_interests: Interests,
         completion_emission_metrics: Option<CompletionEmissionMetricsHandle>,
+        codec_executor: CodecExecutor,
     ) -> Result<TerminalState, Error> {
         match (self, metrics_reporter) {
             (
@@ -323,6 +326,7 @@ impl<PData> ExporterWrapper<PData> {
             ) => {
                 let mut effect_handler =
                     local::EffectHandler::new(node_id.clone(), metrics_reporter);
+                effect_handler.set_codec_executor(codec_executor.clone());
                 let pdata_rx = pdata_receiver.ok_or_else(|| Error::ExporterError {
                     exporter: effect_handler.exporter_id(),
                     kind: ExporterErrorKind::Configuration,
@@ -361,6 +365,7 @@ impl<PData> ExporterWrapper<PData> {
             ) => {
                 let mut effect_handler =
                     shared::EffectHandler::new(node_id.clone(), metrics_reporter);
+                effect_handler.set_codec_executor(codec_executor);
                 let pdata_rx = pdata_receiver.ok_or_else(|| Error::ExporterError {
                     exporter: effect_handler.exporter_id(),
                     kind: ExporterErrorKind::Configuration,

--- a/rust/otap-dataflow/crates/engine/src/local/exporter.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/exporter.rs
@@ -42,6 +42,7 @@ use crate::node::NodeId;
 use crate::terminal_state::TerminalState;
 use async_trait::async_trait;
 use otel_arrow_dfe_config::transport_headers_policy::HeaderPropagationPolicy;
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::error::Error as TelemetryError;
 use otel_arrow_dfe_telemetry::metrics::{MetricSet, MetricSetHandler};
 use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
@@ -96,6 +97,7 @@ pub trait Exporter<PData> {
 #[derive(Clone)]
 pub struct EffectHandler<PData> {
     pub(crate) core: EffectHandlerCore<PData>,
+    codec_executor: CodecExecutor,
     _pd: PhantomData<PData>,
     /// Propagation policy for filtering captured headers on egress.
     /// `None` when no propagation policy is configured (zero overhead).
@@ -109,9 +111,21 @@ impl<PData> EffectHandler<PData> {
     pub fn new(node_id: NodeId, metrics_reporter: MetricsReporter) -> Self {
         EffectHandler {
             core: EffectHandlerCore::new(node_id, metrics_reporter),
+            codec_executor: CodecExecutor::default(),
             _pd: PhantomData,
             propagation_policy: None,
         }
+    }
+
+    /// Returns the runtime-owned pdata codec service.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn codec_executor(&self) -> &CodecExecutor {
+        &self.codec_executor
+    }
+
+    pub(crate) fn set_codec_executor(&mut self, codec_executor: CodecExecutor) {
+        self.codec_executor = codec_executor;
     }
 
     /// Returns the id of the exporter associated with this handler.

--- a/rust/otap-dataflow/crates/engine/src/local/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/processor.rs
@@ -54,6 +54,7 @@ use crate::processor::ProcessorRuntimeRequirements;
 use crate::{WakeupError, WakeupSetOutcome};
 use async_trait::async_trait;
 use otel_arrow_dfe_config::{PortName, SignalType};
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::common_attributes::SignalAttributes;
 use otel_arrow_dfe_telemetry::error::Error as TelemetryError;
 use otel_arrow_dfe_telemetry::instrument::HistogramNormal;
@@ -131,6 +132,7 @@ pub trait Processor<PData> {
 #[derive(Clone)]
 pub struct EffectHandler<PData> {
     pub(crate) core: EffectHandlerCore<PData>,
+    codec_executor: CodecExecutor,
     /// Output-port router.
     pub router: OutputRouter<Sender<PData>>,
     /// Per-handler flow_metric state. See [`LocalFlowMetricState`] /
@@ -152,9 +154,21 @@ impl<PData> EffectHandler<PData> {
         let router = OutputRouter::new(node_id, msg_senders, default_port);
         EffectHandler {
             core,
+            codec_executor: CodecExecutor::default(),
             router,
             flow: LocalFlowMetricState::default(),
         }
+    }
+
+    /// Returns the runtime-owned pdata codec service.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn codec_executor(&self) -> &CodecExecutor {
+        &self.codec_executor
+    }
+
+    pub(crate) fn set_codec_executor(&mut self, codec_executor: CodecExecutor) {
+        self.codec_executor = codec_executor;
     }
 
     /// Returns the id of the processor associated with this handler.

--- a/rust/otap-dataflow/crates/engine/src/local/receiver.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/receiver.rs
@@ -46,6 +46,7 @@ use async_trait::async_trait;
 use otel_arrow_dfe_channel::error::RecvError;
 use otel_arrow_dfe_config::PortName;
 use otel_arrow_dfe_config::transport_headers_policy::HeaderCapturePolicy;
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::error::Error as TelemetryError;
 use otel_arrow_dfe_telemetry::metrics::{MetricSet, MetricSetHandler};
 use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
@@ -133,6 +134,7 @@ impl<PData> ControlChannel<PData> {
 #[derive(Clone)]
 pub struct EffectHandler<PData> {
     pub(crate) core: EffectHandlerCore<PData>,
+    codec_executor: CodecExecutor,
     /// Output-port router.
     pub router: OutputRouter<Sender<PData>>,
     /// Capture policy for extracting transport headers from inbound metadata.
@@ -156,9 +158,21 @@ impl<PData> EffectHandler<PData> {
         let router = OutputRouter::new(node_id, msg_senders, default_port);
         EffectHandler {
             core,
+            codec_executor: CodecExecutor::default(),
             router,
             capture_policy: None,
         }
+    }
+
+    /// Returns the runtime-owned pdata codec service.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn codec_executor(&self) -> &CodecExecutor {
+        &self.codec_executor
+    }
+
+    pub(crate) fn set_codec_executor(&mut self, codec_executor: CodecExecutor) {
+        self.codec_executor = codec_executor;
     }
 
     /// Returns the id of the receiver associated with this handler.

--- a/rust/otap-dataflow/crates/engine/src/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/processor.rs
@@ -36,6 +36,7 @@ use otel_arrow_dfe_channel::error::SendError;
 use otel_arrow_dfe_channel::mpsc;
 use otel_arrow_dfe_config::node::NodeUserConfig;
 use otel_arrow_dfe_config::{PortName, SignalType};
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::metrics::MeasurementMetricSet;
 use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
 use std::collections::HashMap;
@@ -613,6 +614,7 @@ impl<PData> ProcessorWrapper<PData> {
             false,
             false,
             TerminalMetricsDeadline::default(),
+            CodecExecutor::default(),
         )
         .await
     }
@@ -637,6 +639,7 @@ impl<PData> ProcessorWrapper<PData> {
         flow_metrics_active: bool,
         flow_needs_timing: bool,
         terminal_metrics_deadline: TerminalMetricsDeadline,
+        codec_executor: CodecExecutor,
     ) -> Result<(), Error>
     where
         PData: ReceivedAtNode + FlowMetricHook,
@@ -651,6 +654,7 @@ impl<PData> ProcessorWrapper<PData> {
                 mut inbox,
                 mut effect_handler,
             } => {
+                effect_handler.set_codec_executor(codec_executor.clone());
                 effect_handler
                     .core
                     .set_runtime_ctrl_msg_sender(runtime_ctrl_msg_tx);
@@ -750,6 +754,7 @@ impl<PData> ProcessorWrapper<PData> {
                 mut inbox,
                 mut effect_handler,
             } => {
+                effect_handler.set_codec_executor(codec_executor);
                 effect_handler
                     .core
                     .set_runtime_ctrl_msg_sender(runtime_ctrl_msg_tx);
@@ -1021,6 +1026,7 @@ mod tests {
     use crate::testing::{CtrlMsgCounters, TestMsg, test_node};
     use async_trait::async_trait;
     use otel_arrow_dfe_config::{SignalType, node::NodeUserConfig};
+    use otel_arrow_dfe_pdata::codec::CodecExecutor;
     use otel_arrow_dfe_telemetry::common_attributes::SignalAttributes;
     use otel_arrow_dfe_telemetry::metrics::{MeasurementMetricSet, MetricValue};
     use serde_json::Value;
@@ -1541,6 +1547,7 @@ mod tests {
                             true,
                             true,
                             crate::terminal_state::TerminalMetricsDeadline::default(),
+                            CodecExecutor::default(),
                         )
                         .await
                 });
@@ -1758,6 +1765,7 @@ mod tests {
                 true, // flow_metrics_active
                 false,
                 crate::terminal_state::TerminalMetricsDeadline::default(),
+                CodecExecutor::default(),
             )
             .await;
 
@@ -1999,6 +2007,7 @@ mod tests {
                 true,
                 false,
                 crate::terminal_state::TerminalMetricsDeadline::default(),
+                CodecExecutor::default(),
             )
             .await;
 

--- a/rust/otap-dataflow/crates/engine/src/receiver.rs
+++ b/rust/otap-dataflow/crates/engine/src/receiver.rs
@@ -30,6 +30,7 @@ use otel_arrow_dfe_channel::mpsc;
 use otel_arrow_dfe_config::PortName;
 use otel_arrow_dfe_config::node::NodeUserConfig;
 use otel_arrow_dfe_config::transport_headers_policy::HeaderCapturePolicy;
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -323,6 +324,24 @@ impl<PData> ReceiverWrapper<PData> {
         metrics_reporter: MetricsReporter,
         node_interests: Interests,
     ) -> Result<TerminalState, Error> {
+        self.start_with_codec_executor(
+            runtime_ctrl_msg_tx,
+            pipeline_completion_msg_tx,
+            metrics_reporter,
+            node_interests,
+            CodecExecutor::default(),
+        )
+        .await
+    }
+
+    pub(crate) async fn start_with_codec_executor(
+        self,
+        runtime_ctrl_msg_tx: RuntimeCtrlMsgSender<PData>,
+        pipeline_completion_msg_tx: PipelineCompletionMsgSender<PData>,
+        metrics_reporter: MetricsReporter,
+        node_interests: Interests,
+        codec_executor: CodecExecutor,
+    ) -> Result<TerminalState, Error> {
         match (self, metrics_reporter) {
             (
                 ReceiverWrapper::Local {
@@ -356,6 +375,7 @@ impl<PData> ReceiverWrapper<PData> {
                     runtime_ctrl_msg_tx,
                     metrics_reporter,
                 );
+                effect_handler.set_codec_executor(codec_executor.clone());
                 effect_handler.set_source_tagging(source_tag);
                 effect_handler.set_capture_policy(capture_policy);
                 effect_handler
@@ -396,6 +416,7 @@ impl<PData> ReceiverWrapper<PData> {
                     runtime_ctrl_msg_tx,
                     metrics_reporter,
                 );
+                effect_handler.set_codec_executor(codec_executor);
                 effect_handler.set_source_tagging(source_tag);
                 effect_handler.set_capture_policy(capture_policy);
                 effect_handler

--- a/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
+++ b/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
@@ -39,6 +39,7 @@ use crate::{exporter::ExporterWrapper, processor::ProcessorWrapper, receiver::Re
 use otel_arrow_dfe_config::DeployedPipelineKey;
 use otel_arrow_dfe_config::pipeline::PipelineConfig;
 use otel_arrow_dfe_config::policy::TelemetryPolicy;
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::event::ObservedEventReporter;
 use otel_arrow_dfe_telemetry::metrics::{MeasurementMetricSet, MetricSetSnapshot};
 use otel_arrow_dfe_telemetry::reporter::{MetricsReporter, ReportOutcome};
@@ -470,6 +471,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
             .build()
             .expect("Failed to create runtime");
         let local_tasks = LocalSet::new();
+        let codec_executor = CodecExecutor::default();
         // ToDo create an optimized version of FuturesUnordered that can be used for !Send, !Sync tasks
         let mut futures = FuturesUnordered::new();
 
@@ -613,6 +615,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
             let effect_metrics_reporter = metrics_reporter.clone();
             let final_metrics_reporter = metrics_reporter.clone();
             let exporter_terminal_metrics_deadline = terminal_metrics_deadline.clone();
+            let exporter_codec_executor = codec_executor.clone();
             let fut = async move {
                 match exporter
                     .start_with_completion_metrics(
@@ -621,6 +624,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
                         effect_metrics_reporter,
                         node_interests,
                         completion_emission_metrics,
+                        exporter_codec_executor,
                     )
                     .await
                 {
@@ -695,6 +699,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
             let metrics_reporter = metrics_reporter.clone();
             let final_metrics_reporter = metrics_reporter.clone();
             let processor_terminal_metrics_deadline = terminal_metrics_deadline.clone();
+            let processor_codec_executor = codec_executor.clone();
             // Extract flow metric roles for this processor node.
             // Compute pipeline-wide flags before moving metric sets into handlers.
             let flow_active = flow_metric_state.is_active();
@@ -774,6 +779,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
                         flow_active,
                         flow_needs_timing,
                         processor_terminal_metrics_deadline.clone(),
+                        processor_codec_executor,
                     )
                     .await;
                 flush_metrics_reporter(
@@ -833,13 +839,15 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
             let effect_metrics_reporter = metrics_reporter.clone();
             let final_metrics_reporter = metrics_reporter.clone();
             let receiver_terminal_metrics_deadline = terminal_metrics_deadline.clone();
+            let receiver_codec_executor = codec_executor.clone();
             let fut = async move {
                 match receiver
-                    .start(
+                    .start_with_codec_executor(
                         runtime_ctrl_msg_tx,
                         pipeline_completion_msg_tx,
                         effect_metrics_reporter,
                         node_interests,
+                        receiver_codec_executor,
                     )
                     .await
                 {

--- a/rust/otap-dataflow/crates/engine/src/shared/exporter.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/exporter.rs
@@ -43,6 +43,7 @@ use crate::{Interests, ReceivedAtNode};
 use async_trait::async_trait;
 use otel_arrow_dfe_channel::error::RecvError;
 use otel_arrow_dfe_config::transport_headers_policy::HeaderPropagationPolicy;
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::error::Error as TelemetryError;
 use otel_arrow_dfe_telemetry::metrics::{MetricSet, MetricSetHandler};
 use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
@@ -97,6 +98,7 @@ pub trait Exporter<PData> {
 #[derive(Clone)]
 pub struct EffectHandler<PData> {
     pub(crate) core: EffectHandlerCore<PData>,
+    codec_executor: CodecExecutor,
     _pd: PhantomData<PData>,
     /// Propagation policy for filtering captured headers on egress.
     /// `None` when no propagation policy is configured (zero overhead).
@@ -110,9 +112,21 @@ impl<PData> EffectHandler<PData> {
     pub fn new(node_id: NodeId, metrics_reporter: MetricsReporter) -> Self {
         EffectHandler {
             core: EffectHandlerCore::new(node_id, metrics_reporter),
+            codec_executor: CodecExecutor::default(),
             _pd: PhantomData,
             propagation_policy: None,
         }
+    }
+
+    /// Returns the runtime-owned pdata codec service.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn codec_executor(&self) -> &CodecExecutor {
+        &self.codec_executor
+    }
+
+    pub(crate) fn set_codec_executor(&mut self, codec_executor: CodecExecutor) {
+        self.codec_executor = codec_executor;
     }
 
     /// Returns the id of the exporter associated with this handler.

--- a/rust/otap-dataflow/crates/engine/src/shared/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/processor.rs
@@ -53,6 +53,7 @@ use crate::shared::message::SharedSender;
 use crate::{WakeupError, WakeupSetOutcome};
 use async_trait::async_trait;
 use otel_arrow_dfe_config::{PortName, SignalType};
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::common_attributes::SignalAttributes;
 use otel_arrow_dfe_telemetry::error::Error as TelemetryError;
 use otel_arrow_dfe_telemetry::instrument::HistogramNormal;
@@ -130,6 +131,7 @@ pub trait Processor<PData> {
 #[derive(Clone)]
 pub struct EffectHandler<PData> {
     pub(crate) core: EffectHandlerCore<PData>,
+    codec_executor: CodecExecutor,
     /// Output-port router.
     pub router: OutputRouter<SharedSender<PData>>,
     /// Per-handler flow_metric state. See [`SharedFlowMetricState`] /
@@ -156,9 +158,21 @@ impl<PData> EffectHandler<PData> {
         let router = OutputRouter::new(node_id, msg_senders, default_port);
         EffectHandler {
             core,
+            codec_executor: CodecExecutor::default(),
             router,
             flow: SharedFlowMetricState::default(),
         }
+    }
+
+    /// Returns the runtime-owned pdata codec service.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn codec_executor(&self) -> &CodecExecutor {
+        &self.codec_executor
+    }
+
+    pub(crate) fn set_codec_executor(&mut self, codec_executor: CodecExecutor) {
+        self.codec_executor = codec_executor;
     }
 
     /// Returns the id of the processor associated with this handler.

--- a/rust/otap-dataflow/crates/engine/src/shared/receiver.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/receiver.rs
@@ -46,6 +46,7 @@ use async_trait::async_trait;
 use otel_arrow_dfe_channel::error::RecvError;
 use otel_arrow_dfe_config::PortName;
 use otel_arrow_dfe_config::transport_headers_policy::HeaderCapturePolicy;
+use otel_arrow_dfe_pdata::codec::CodecExecutor;
 use otel_arrow_dfe_telemetry::error::Error as TelemetryError;
 use otel_arrow_dfe_telemetry::metrics::{MetricSet, MetricSetHandler};
 use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
@@ -101,6 +102,7 @@ impl<PData> ControlChannel<PData> {
 #[derive(Clone)]
 pub struct EffectHandler<PData> {
     pub(crate) core: EffectHandlerCore<PData>,
+    codec_executor: CodecExecutor,
     /// Output-port router.
     pub router: OutputRouter<SharedSender<PData>>,
     /// Capture policy for extracting transport headers from inbound metadata.
@@ -127,9 +129,21 @@ impl<PData> EffectHandler<PData> {
         let router = OutputRouter::new(node_id, msg_senders, default_port);
         EffectHandler {
             core,
+            codec_executor: CodecExecutor::default(),
             router,
             capture_policy: None,
         }
+    }
+
+    /// Returns the runtime-owned pdata codec service.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn codec_executor(&self) -> &CodecExecutor {
+        &self.codec_executor
+    }
+
+    pub(crate) fn set_codec_executor(&mut self, codec_executor: CodecExecutor) {
+        self.codec_executor = codec_executor;
     }
 
     /// Returns the name of the receiver associated with this handler.

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -1172,7 +1172,16 @@ mod test {
     use pretty_assertions::assert_eq;
     use std::cell::Cell;
     use std::collections::HashMap;
+    use std::mem::size_of;
     use tokio::sync::mpsc;
+
+    /// Scenario: Queued OTAP pdata is built for a 64-bit target before codec integration.
+    /// Guarantees: The baseline queued-message layout remains fixed for later comparisons.
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn legacy_otap_pdata_layout_is_stable() {
+        assert_eq!(size_of::<OtapPdata>(), 152);
+    }
 
     fn create_test() -> (TestCallData, OtapPdata) {
         (TestCallData::default(), create_test_pdata())

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -31,7 +31,7 @@ use otel_arrow_dfe_engine::{
     MessageSourceLocalEffectHandlerExtension, MessageSourceSharedEffectHandlerExtension,
     ProducerEffectHandlerExtension,
 };
-use otel_arrow_dfe_pdata::OtapPayload;
+use otel_arrow_dfe_pdata::{CodecState, OtapArrowRecords, OtapPayload};
 
 use crate::transport_headers::TransportHeaders;
 
@@ -605,6 +605,95 @@ pub struct OtapPdata {
     payload: OtapPayload,
 }
 
+/// Owned capability proving that pdata is available as native Arrow records.
+#[derive(Clone, Debug)]
+pub struct OtapArrowPdata {
+    context: Context,
+    records: OtapArrowRecords,
+}
+
+impl OtapArrowPdata {
+    /// Constructs native pdata from its delivery context and records.
+    #[must_use]
+    pub const fn new(context: Context, records: OtapArrowRecords) -> Self {
+        Self { context, records }
+    }
+
+    /// Borrows the delivery context.
+    #[must_use]
+    pub const fn context(&self) -> &Context {
+        &self.context
+    }
+
+    /// Returns a mutable delivery context.
+    pub const fn context_mut(&mut self) -> &mut Context {
+        &mut self.context
+    }
+
+    /// Borrows native records.
+    #[must_use]
+    pub const fn records(&self) -> &OtapArrowRecords {
+        &self.records
+    }
+
+    /// Returns mutable native records.
+    pub const fn records_mut(&mut self) -> &mut OtapArrowRecords {
+        &mut self.records
+    }
+
+    /// Splits delivery context and native records without cloning.
+    #[must_use]
+    pub fn into_parts(self) -> (Context, OtapArrowRecords) {
+        (self.context, self.records)
+    }
+
+    /// Converts back to dynamically represented pipeline pdata.
+    #[must_use]
+    pub fn into_pdata(self) -> OtapPdata {
+        OtapPdata::new(self.context, self.records.into())
+    }
+}
+
+impl From<OtapArrowPdata> for OtapPdata {
+    fn from(value: OtapArrowPdata) -> Self {
+        value.into_pdata()
+    }
+}
+
+/// A failed codec conversion carrying the exact original pdata for Nack or retry.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct OtapPdataDecodeError(Box<OtapPdataDecodeErrorInner>);
+
+#[derive(Debug, thiserror::Error)]
+#[error("{source}")]
+struct OtapPdataDecodeErrorInner {
+    #[source]
+    source: otel_arrow_dfe_pdata::encode::Error,
+    pdata: OtapPdata,
+}
+
+impl OtapPdataDecodeError {
+    /// Returns the codec or conversion error.
+    #[must_use]
+    pub const fn error(&self) -> &otel_arrow_dfe_pdata::encode::Error {
+        &self.0.source
+    }
+
+    /// Borrows the exact original pdata retained for recovery.
+    #[must_use]
+    pub const fn pdata(&self) -> &OtapPdata {
+        &self.0.pdata
+    }
+
+    /// Splits the error and recoverable original pdata.
+    #[must_use]
+    pub fn into_parts(self) -> (otel_arrow_dfe_pdata::encode::Error, OtapPdata) {
+        let inner = *self.0;
+        (inner.source, inner.pdata)
+    }
+}
+
 /* -------- Signal type -------- */
 
 impl OtapPdata {
@@ -633,6 +722,25 @@ impl OtapPdata {
     #[must_use]
     pub const fn new(context: Context, payload: OtapPayload) -> Self {
         Self { context, payload }
+    }
+
+    /// Extracts native records through reusable codec state while retaining
+    /// the exact original pdata on failure.
+    pub fn try_into_otap(
+        self,
+        state: &mut CodecState,
+    ) -> Result<OtapArrowPdata, OtapPdataDecodeError> {
+        let Self { context, payload } = self;
+        match payload.try_into_otap(state) {
+            Ok(records) => Ok(OtapArrowPdata::new(context, records)),
+            Err(error) => {
+                let (source, payload) = error.into_parts();
+                Err(OtapPdataDecodeError(Box::new(OtapPdataDecodeErrorInner {
+                    source,
+                    pdata: Self { context, payload },
+                })))
+            }
+        }
     }
 
     /// Returns the type of signal represented by this `OtapPdata` instance.
@@ -1175,12 +1283,48 @@ mod test {
     use std::mem::size_of;
     use tokio::sync::mpsc;
 
-    /// Scenario: Queued OTAP pdata is built for a 64-bit target before codec integration.
-    /// Guarantees: The baseline queued-message layout remains fixed for later comparisons.
+    /// Scenario: Queued and native-capability pdata are built for a 64-bit target.
+    /// Guarantees: Transitional encoded storage reduces the queue below the 152-byte baseline.
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn legacy_otap_pdata_layout_is_stable() {
-        assert_eq!(size_of::<OtapPdata>(), 152);
+        assert_eq!(size_of::<OtapPdata>(), 144);
+        assert!(size_of::<OtapArrowPdata>() <= size_of::<OtapPdata>());
+    }
+
+    /// Scenario: Malformed encoded pdata carries delivery context through failed conversion.
+    /// Guarantees: Recovery preserves peer address, codec identity, bytes, signal, and item count.
+    #[test]
+    fn encoded_conversion_failure_preserves_delivery_ownership() {
+        use bytes::Bytes;
+        use otel_arrow_dfe_pdata::{PdataFormat, ResolvedCodec};
+
+        let peer = "127.0.0.1:4317".parse().expect("peer address");
+        let bytes = Bytes::from_static(&[0x0a, 0x05, 0x01]);
+        let pointer = bytes.as_ptr();
+        let payload = OtapPayload::from_encoded(
+            ResolvedCodec::OTLP
+                .admit(SignalType::Logs, bytes)
+                .expect("lazy admission"),
+        )
+        .with_item_count(9);
+        let pdata = OtapPdata::new(Context::default(), payload).with_peer_addr(peer);
+
+        let error = pdata
+            .try_into_otap(&mut CodecState::default())
+            .expect_err("malformed OTLP must fail");
+        let (_, recovered) = error.into_parts();
+        assert_eq!(recovered.peer_addr(), Some(peer));
+        assert_eq!(
+            recovered.payload_ref().format(),
+            PdataFormat::encoded(ResolvedCodec::OTLP)
+        );
+        assert_eq!(recovered.payload_ref().known_item_count(), Some(9));
+        assert_eq!(
+            recovered.payload_ref().encoded_bytes().unwrap().as_ptr(),
+            pointer
+        );
+        assert_eq!(recovered.signal_type(), SignalType::Logs);
     }
 
     fn create_test() -> (TestCallData, OtapPdata) {

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -33,6 +33,7 @@ use otel_arrow_dfe_engine::{
     MessageSourceLocalEffectHandlerExtension, MessageSourceSharedEffectHandlerExtension,
     ProducerEffectHandlerExtension,
 };
+use otel_arrow_dfe_pdata::batching::{BatchPlan, BatchingOutput};
 use otel_arrow_dfe_pdata::codec::{CodecView, EncodingPlan};
 use otel_arrow_dfe_pdata::{CodecState, OtapArrowRecords, OtapPayload, OtapPayloadHelpers};
 
@@ -1095,6 +1096,28 @@ pub trait PdataEffectHandlerExtension {
         payload: &mut OtapPayload,
         plan: &EncodingPlan,
     ) -> Result<bytes::Bytes, otel_arrow_dfe_pdata::error::Error>;
+
+    /// Prepares one payload for a startup-resolved batching plan.
+    async fn prepare_batch(
+        &self,
+        plan: &BatchPlan,
+        payload: &mut OtapPayload,
+    ) -> Result<(), otel_arrow_dfe_pdata::error::Error>;
+
+    /// Merges or splits prepared payloads through a batching plan.
+    async fn batch(
+        &self,
+        plan: &BatchPlan,
+        signal: SignalType,
+        inputs: Vec<OtapPayload>,
+    ) -> Result<BatchingOutput, otel_arrow_dfe_pdata::error::Error>;
+
+    /// Converts a flushed working batch to the plan's output representation.
+    async fn finish_batch(
+        &self,
+        plan: &BatchPlan,
+        payload: &mut OtapPayload,
+    ) -> Result<(), otel_arrow_dfe_pdata::error::Error>;
 }
 
 /// Processor capability for algorithms that always require mutable native OTAP.
@@ -1204,6 +1227,31 @@ macro_rules! impl_pdata_effect_handler_ext {
                 plan: &EncodingPlan,
             ) -> Result<bytes::Bytes, otel_arrow_dfe_pdata::error::Error> {
                 self.codec_executor().encode_owned(payload, plan)
+            }
+
+            async fn prepare_batch(
+                &self,
+                plan: &BatchPlan,
+                payload: &mut OtapPayload,
+            ) -> Result<(), otel_arrow_dfe_pdata::error::Error> {
+                plan.prepare_with(payload, self.codec_executor())
+            }
+
+            async fn batch(
+                &self,
+                plan: &BatchPlan,
+                signal: SignalType,
+                inputs: Vec<OtapPayload>,
+            ) -> Result<BatchingOutput, otel_arrow_dfe_pdata::error::Error> {
+                plan.batch_with(signal, inputs, self.codec_executor())
+            }
+
+            async fn finish_batch(
+                &self,
+                plan: &BatchPlan,
+                payload: &mut OtapPayload,
+            ) -> Result<(), otel_arrow_dfe_pdata::error::Error> {
+                plan.finish_with(payload, self.codec_executor())
             }
         }
     };

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -21,17 +21,20 @@ use otel_arrow_dfe_config::PortName;
 use otel_arrow_dfe_config::{SignalFormat, SignalType};
 use otel_arrow_dfe_engine::_private::AckNackRouting;
 use otel_arrow_dfe_engine::control::{
-    AckMsg, CallData, Frame, NackMsg, RouteData, nanos_since_birth,
+    AckMsg, CallData, Frame, NackMsg, NodeControlMsg, RouteData, nanos_since_birth,
 };
 use otel_arrow_dfe_engine::error::{Error, TypedError};
 use otel_arrow_dfe_engine::flow_metrics::FlowMetricInterests;
-use otel_arrow_dfe_engine::processor::{FlowMetricEffectHandler, FlowMetricHook};
+use otel_arrow_dfe_engine::processor::{
+    FlowMetricEffectHandler, FlowMetricHook, ProcessorRuntimeRequirements,
+};
 use otel_arrow_dfe_engine::{
     ConsumerEffectHandlerExtension, FlowMetricAccumulation, Interests,
     MessageSourceLocalEffectHandlerExtension, MessageSourceSharedEffectHandlerExtension,
     ProducerEffectHandlerExtension,
 };
-use otel_arrow_dfe_pdata::{CodecState, OtapArrowRecords, OtapPayload};
+use otel_arrow_dfe_pdata::codec::{CodecView, EncodingPlan};
+use otel_arrow_dfe_pdata::{CodecState, OtapArrowRecords, OtapPayload, OtapPayloadHelpers};
 
 use crate::transport_headers::TransportHeaders;
 
@@ -641,6 +644,12 @@ impl OtapArrowPdata {
         &mut self.records
     }
 
+    /// Returns the signal represented by the native records.
+    #[must_use]
+    pub fn signal_type(&self) -> SignalType {
+        self.records.signal_type()
+    }
+
     /// Splits delivery context and native records without cloning.
     #[must_use]
     pub fn into_parts(self) -> (Context, OtapArrowRecords) {
@@ -1045,6 +1054,167 @@ impl_consumer_ext!(otel_arrow_dfe_engine::local::processor::EffectHandler<OtapPd
 impl_consumer_ext!(otel_arrow_dfe_engine::local::exporter::EffectHandler<OtapPdata>);
 impl_consumer_ext!(otel_arrow_dfe_engine::shared::processor::EffectHandler<OtapPdata>);
 impl_consumer_ext!(otel_arrow_dfe_engine::shared::exporter::EffectHandler<OtapPdata>);
+
+/* -------- Pdata codec effect handler extensions -------- */
+
+/// Representation-independent pdata operations supplied by an effect handler.
+///
+/// Codec state belongs to the pipeline runtime. These methods are async at the
+/// node boundary so codecs that need an offloaded or asynchronous executor can
+/// be added later without storing codec state in nodes. The current operations
+/// scope their synchronous state borrow entirely before returning.
+#[allow(async_fn_in_trait)]
+pub trait PdataEffectHandlerExtension {
+    /// Moves native records or decodes encoded pdata with recoverable failure.
+    async fn try_into_otap(&self, pdata: OtapPdata)
+    -> Result<OtapArrowPdata, OtapPdataDecodeError>;
+
+    /// Moves native records or decodes a payload with recoverable failure.
+    async fn try_payload_into_otap(
+        &self,
+        payload: OtapPayload,
+    ) -> Result<OtapArrowRecords, otel_arrow_dfe_pdata::OtapPayloadDecodeError>;
+
+    /// Borrows a read-only view through runtime-owned codec state.
+    async fn view<'a>(
+        &self,
+        payload: &'a OtapPayload,
+    ) -> Result<CodecView<'a>, otel_arrow_dfe_pdata::encode::Error>;
+
+    /// Encodes inside a scope that cannot cross an await point.
+    async fn with_encoded<R>(
+        &self,
+        payload: &mut OtapPayload,
+        plan: &EncodingPlan,
+        consume: impl FnOnce(&[u8]) -> R,
+    ) -> Result<R, otel_arrow_dfe_pdata::error::Error>;
+
+    /// Encodes to owned bytes suitable for asynchronous delivery.
+    async fn encode_owned(
+        &self,
+        payload: &mut OtapPayload,
+        plan: &EncodingPlan,
+    ) -> Result<bytes::Bytes, otel_arrow_dfe_pdata::error::Error>;
+}
+
+/// Processor capability for algorithms that always require mutable native OTAP.
+///
+/// Implementors only receive typed Arrow pdata. The adapter owns conversion
+/// and the permanent Nack policy for malformed encoded input.
+#[async_trait(?Send)]
+pub trait NativePdataProcessor {
+    /// Processes one successfully materialized native batch.
+    async fn process_native(
+        &mut self,
+        pdata: OtapArrowPdata,
+        effect_handler: &mut otel_arrow_dfe_engine::local::processor::EffectHandler<OtapPdata>,
+    ) -> Result<(), Error>;
+
+    /// Processes a control message without forcing pdata conversion.
+    async fn process_control(
+        &mut self,
+        _control: NodeControlMsg<OtapPdata>,
+        _effect_handler: &mut otel_arrow_dfe_engine::local::processor::EffectHandler<OtapPdata>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
+    /// Declares runtime services required by the native processor.
+    fn runtime_requirements(&self) -> ProcessorRuntimeRequirements {
+        ProcessorRuntimeRequirements::none()
+    }
+}
+
+/// Runs a [`NativePdataProcessor`] behind the dynamic pdata boundary.
+pub struct NativeProcessorAdapter;
+
+impl NativeProcessorAdapter {
+    /// Converts pdata, permanently Nacks codec failures, and invokes the
+    /// processor only after native access has been established.
+    pub async fn process<P: NativePdataProcessor>(
+        processor: &mut P,
+        msg: otel_arrow_dfe_engine::message::Message<OtapPdata>,
+        effect_handler: &mut otel_arrow_dfe_engine::local::processor::EffectHandler<OtapPdata>,
+    ) -> Result<(), Error> {
+        match msg {
+            otel_arrow_dfe_engine::message::Message::Control(control) => {
+                processor.process_control(control, effect_handler).await
+            }
+            otel_arrow_dfe_engine::message::Message::PData(pdata) => {
+                match effect_handler.try_into_otap(pdata).await {
+                    Ok(pdata) => processor.process_native(pdata, effect_handler).await,
+                    Err(error) => {
+                        let (error, pdata) = error.into_parts();
+                        effect_handler
+                            .notify_nack(NackMsg::new_permanent(error.to_string(), pdata))
+                            .await
+                    }
+                }
+            }
+        }
+    }
+}
+
+macro_rules! impl_pdata_effect_handler_ext {
+    ($handler:ty) => {
+        impl PdataEffectHandlerExtension for $handler {
+            async fn try_into_otap(
+                &self,
+                pdata: OtapPdata,
+            ) -> Result<OtapArrowPdata, OtapPdataDecodeError> {
+                let (context, payload) = pdata.into_parts();
+                match self.codec_executor().try_into_otap(payload) {
+                    Ok(records) => Ok(OtapArrowPdata::new(context, records)),
+                    Err(error) => {
+                        let (source, payload) = error.into_parts();
+                        Err(OtapPdataDecodeError(Box::new(OtapPdataDecodeErrorInner {
+                            source,
+                            pdata: OtapPdata::new(context, payload),
+                        })))
+                    }
+                }
+            }
+
+            async fn try_payload_into_otap(
+                &self,
+                payload: OtapPayload,
+            ) -> Result<OtapArrowRecords, otel_arrow_dfe_pdata::OtapPayloadDecodeError> {
+                self.codec_executor().try_into_otap(payload)
+            }
+
+            async fn view<'a>(
+                &self,
+                payload: &'a OtapPayload,
+            ) -> Result<CodecView<'a>, otel_arrow_dfe_pdata::encode::Error> {
+                self.codec_executor().view(payload)
+            }
+
+            async fn with_encoded<R>(
+                &self,
+                payload: &mut OtapPayload,
+                plan: &EncodingPlan,
+                consume: impl FnOnce(&[u8]) -> R,
+            ) -> Result<R, otel_arrow_dfe_pdata::error::Error> {
+                self.codec_executor().with_encoded(payload, plan, consume)
+            }
+
+            async fn encode_owned(
+                &self,
+                payload: &mut OtapPayload,
+                plan: &EncodingPlan,
+            ) -> Result<bytes::Bytes, otel_arrow_dfe_pdata::error::Error> {
+                self.codec_executor().encode_owned(payload, plan)
+            }
+        }
+    };
+}
+
+impl_pdata_effect_handler_ext!(otel_arrow_dfe_engine::local::processor::EffectHandler<OtapPdata>);
+impl_pdata_effect_handler_ext!(otel_arrow_dfe_engine::local::exporter::EffectHandler<OtapPdata>);
+impl_pdata_effect_handler_ext!(otel_arrow_dfe_engine::local::receiver::EffectHandler<OtapPdata>);
+impl_pdata_effect_handler_ext!(otel_arrow_dfe_engine::shared::processor::EffectHandler<OtapPdata>);
+impl_pdata_effect_handler_ext!(otel_arrow_dfe_engine::shared::exporter::EffectHandler<OtapPdata>);
+impl_pdata_effect_handler_ext!(otel_arrow_dfe_engine::shared::receiver::EffectHandler<OtapPdata>);
 
 /* --------  effect handler extensions (shared, local) -------- */
 

--- a/rust/otap-dataflow/crates/pdata/Cargo.toml
+++ b/rust/otap-dataflow/crates/pdata/Cargo.toml
@@ -21,6 +21,7 @@ arrow-schema = { workspace = true }
 datafusion = { workspace = true }
 ciborium = { workspace = true }
 itertools = { workspace = true }
+linkme = { workspace = true }
 otel-arrow-dfe-config = { workspace = true }
 otel-arrow-dfe-pdata-otlp-macros = { workspace = true }
 otel-arrow-dfe-pdata-otlp-model = { workspace = true }

--- a/rust/otap-dataflow/crates/pdata/src/batching.rs
+++ b/rust/otap-dataflow/crates/pdata/src/batching.rs
@@ -1,0 +1,453 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Representation-independent batching plans and codec batching contracts.
+//!
+//! This layer owns conversion, sizing, and in-line merge/split operations.
+//! Scheduling, bounded request tracking, and Ack/Nack routing belong to the node.
+
+use std::num::{NonZeroU64, NonZeroUsize};
+
+use bytes::Bytes;
+use otel_arrow_dfe_config::{EncodeOptions, SignalType};
+use serde::{Deserialize, Serialize};
+
+use crate::OtapPayload;
+pub use crate::PdataFormat;
+use crate::codec::{
+    self, CodecDirection, CodecExecutor, CodecState, EncodedPdata, EncodingPlan, PdataEncoding,
+    ResolvedCodec,
+};
+use crate::error::Error;
+
+/// Unit used for flush thresholds, splitting, and input ownership attribution.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum BatchSizer {
+    /// Original request count (reserved, not currently supported).
+    Requests,
+    /// Log records, spans, or metric data points.
+    Items,
+    /// Encoded bytes, including format wrappers.
+    Bytes,
+}
+
+impl BatchSizer {
+    /// Measures an input already prepared by its batching plan.
+    pub fn batch_size(&self, payload: &OtapPayload) -> Result<usize, Error> {
+        match self {
+            Self::Items => payload.known_item_count().ok_or_else(|| {
+                format_error("item count is unavailable; prepare the input before batching")
+            }),
+            Self::Bytes => payload
+                .encoded_bytes()
+                .map(Bytes::len)
+                .ok_or_else(|| format_error("encoded byte size is unavailable")),
+            Self::Requests => Err(format_error("request sizing is unsupported")),
+        }
+    }
+}
+
+/// Sizing and bounded split amplification policy shared by native batchers.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BatchProfile {
+    /// Flush threshold in the selected sizing unit.
+    pub min_size: Option<NonZeroUsize>,
+    /// Optional best-effort maximum output size in that same unit.
+    pub max_size: Option<NonZeroUsize>,
+    /// Unit supported by the selected native batcher or OTAP fallback.
+    pub sizer: BatchSizer,
+    /// Per-entry split fragment budget; indivisible/over-budget entries remain whole.
+    #[serde(default = "default_fragments")]
+    pub max_split_fragments: Option<NonZeroUsize>,
+    /// Maximum duplicated wrapper bytes per split entry.
+    #[serde(default = "default_overhead")]
+    pub max_split_overhead_bytes: Option<NonZeroUsize>,
+    /// Per-flush additional split fan-out budget, excluding mandatory whole entries.
+    #[serde(default = "default_fragments")]
+    pub max_split_fragments_per_flush: Option<NonZeroUsize>,
+}
+
+const fn default_fragments() -> Option<NonZeroUsize> {
+    NonZeroUsize::new(65536)
+}
+const fn default_overhead() -> Option<NonZeroUsize> {
+    NonZeroUsize::new(8 * 1024 * 1024)
+}
+
+impl BatchProfile {
+    /// Existing native OTAP defaults, also used by the item-based fallback.
+    #[must_use]
+    pub const fn otap() -> Self {
+        Self {
+            min_size: NonZeroUsize::new(8192),
+            max_size: None,
+            sizer: BatchSizer::Items,
+            max_split_fragments: None,
+            max_split_overhead_bytes: None,
+            max_split_fragments_per_flush: None,
+        }
+    }
+
+    /// Existing OTLP byte-batching defaults.
+    #[must_use]
+    pub const fn otlp() -> Self {
+        Self {
+            min_size: NonZeroUsize::new(262144),
+            max_size: None,
+            sizer: BatchSizer::Bytes,
+            max_split_fragments: default_fragments(),
+            max_split_overhead_bytes: default_overhead(),
+            max_split_fragments_per_flush: default_fragments(),
+        }
+    }
+
+    /// Checks representation-independent sizing constraints.
+    pub fn validate(&self) -> Result<(), Error> {
+        if self.min_size.or(self.max_size).is_none() {
+            return Err(format_error("max_size or min_size must be set"));
+        }
+        if let (Some(max), Some(min)) = (self.max_size, self.min_size)
+            && max < min
+        {
+            return Err(format_error("max_size must be >= min_size or unset"));
+        }
+        if self.sizer == BatchSizer::Requests {
+            return Err(format_error("request sizing is unsupported"));
+        }
+        Ok(())
+    }
+
+    /// The first size threshold reached by pending inputs.
+    #[must_use]
+    pub fn lower_limit(&self) -> usize {
+        self.min_size
+            .or(self.max_size)
+            .expect("validated batching profile")
+            .get()
+    }
+}
+
+/// A codec's optional native batching capabilities and default policy.
+#[derive(Debug)]
+pub struct BatchingSupport {
+    /// Supported units; declaring a unit promises in-line merge and split support.
+    pub sizers: &'static [BatchSizer],
+    /// Default policy when the node has no explicit codec profile.
+    pub default_profile: BatchProfile,
+}
+
+/// Codec-native outputs paired with input ownership weights, in input order.
+/// Weights must sum to the measured input total, even if wrapper bytes duplicate.
+pub struct CodecBatches {
+    /// Encoded independent output batches and their input-unit ownership.
+    pub batches: Vec<(Bytes, usize)>,
+    /// Entries emitted whole because of split amplification limits.
+    pub budget_fallbacks: u64,
+}
+
+impl PdataFormat {
+    /// Independently encoded OTLP protobuf bytes.
+    pub const OTLP: Self = Self::encoded(ResolvedCodec::OTLP);
+
+    /// Resolves a canonical format name or the legacy OTLP alias.
+    pub fn resolve(name: &str) -> Result<Self, Error> {
+        match name {
+            "otap" => Ok(Self::OTAP),
+            "otlp" => Ok(Self::OTLP),
+            name => codec::find(&PdataEncoding::from(name.to_owned())).map(Self::encoded),
+        }
+    }
+
+    /// Stable name for configuration and diagnostics.
+    #[must_use]
+    pub fn name(self) -> &'static str {
+        self.codec()
+            .map_or("otap", |codec| codec.metadata().encoding.as_str())
+    }
+
+    /// Supported signal types, known without examining any payload.
+    #[must_use]
+    pub fn signals(self) -> &'static [SignalType] {
+        self.codec().map_or(
+            &[SignalType::Logs, SignalType::Metrics, SignalType::Traces],
+            |codec| codec.metadata().signals,
+        )
+    }
+
+    /// Declared native profile, or the standard OTAP item fallback profile.
+    #[must_use]
+    pub fn default_profile(self) -> BatchProfile {
+        self.codec()
+            .and_then(|codec| codec.metadata().batching.as_ref())
+            .map_or_else(BatchProfile::otap, |support| {
+                support.default_profile.clone()
+            })
+    }
+
+    /// Whether this format declares native batching rather than relying on OTAP.
+    #[must_use]
+    pub fn has_native_batching(self) -> bool {
+        self.codec()
+            .is_none_or(|codec| codec.metadata().batching.is_some())
+    }
+
+    /// Converts only when necessary and retains the original payload on failure.
+    pub fn materialize(
+        self,
+        payload: &mut OtapPayload,
+        context: &mut CodecState,
+        encoding: Option<&EncodingPlan>,
+    ) -> Result<(), Error> {
+        if payload.format() == self {
+            return Ok(());
+        }
+        match self.codec() {
+            None => payload
+                .materialize_otap(context)
+                .map_err(|error| format_error(error.to_string())),
+            Some(codec) => {
+                let plan = encoding.ok_or_else(|| {
+                    format_error(format!(
+                        "missing startup encoding plan for {}",
+                        codec.metadata().encoding
+                    ))
+                })?;
+                payload.convert_encoding(context, plan)
+            }
+        }
+    }
+}
+
+/// A resolved batching operation. Working and output formats may differ when
+/// an explicitly requested encoding uses the item-based OTAP fallback.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BatchPlan {
+    working: PdataFormat,
+    output: PdataFormat,
+    encoding: Option<EncodingPlan>,
+    profile: BatchProfile,
+}
+
+impl BatchPlan {
+    /// Resolves native batching or the OTAP fallback before buffering input.
+    pub fn new(format: PdataFormat, profile: BatchProfile, preserve: bool) -> Result<Self, Error> {
+        profile.validate()?;
+        let native = match format.codec() {
+            None => profile.sizer == BatchSizer::Items,
+            Some(codec) => {
+                for signal in format.signals() {
+                    codec.require(*signal, CodecDirection::Decode)?;
+                }
+                codec
+                    .metadata()
+                    .batching
+                    .as_ref()
+                    .is_some_and(|support| support.sizers.contains(&profile.sizer))
+            }
+        };
+        if !native && profile.sizer != BatchSizer::Items {
+            return Err(format_error(format!(
+                "{} does not support {:?} batching; OTAP fallback requires items",
+                format.name(),
+                profile.sizer
+            )));
+        }
+        if !preserve && let Some(codec) = format.codec() {
+            for signal in format.signals() {
+                codec.require(*signal, CodecDirection::Encode)?;
+            }
+        }
+        let working = if native { format } else { PdataFormat::OTAP };
+        let output = if preserve { working } else { format };
+        let encoding = if preserve {
+            None
+        } else {
+            format
+                .codec()
+                .map(|codec| EncodingPlan::new(codec, EncodeOptions::default()))
+                .transpose()?
+        };
+        Ok(Self {
+            working,
+            output,
+            encoding,
+            profile,
+        })
+    }
+
+    /// The validated profile used for thresholds and output retention.
+    #[must_use]
+    pub const fn profile(&self) -> &BatchProfile {
+        &self.profile
+    }
+
+    /// Logical output format, also used to select a bounded buffer at startup.
+    #[must_use]
+    pub const fn output_format(&self) -> PdataFormat {
+        self.output
+    }
+
+    /// Prepares one input before its measurement and delivery context are buffered.
+    pub fn prepare(
+        &self,
+        payload: &mut OtapPayload,
+        context: &mut CodecState,
+    ) -> Result<(), Error> {
+        if !self.output.signals().contains(&payload.signal_type()) {
+            return Err(format_error(format!(
+                "{} does not support {:?}",
+                self.output.name(),
+                payload.signal_type()
+            )));
+        }
+        self.working
+            .materialize(payload, context, self.encoding.as_ref())?;
+        if self.profile.sizer == BatchSizer::Items && payload.known_item_count().is_none() {
+            let codec = self
+                .working
+                .codec()
+                .expect("native OTAP has known item counts");
+            let bytes = payload
+                .encoded_bytes()
+                .expect("encoded working format")
+                .clone();
+            let count =
+                context
+                    .instance(codec)
+                    .measure(payload.signal_type(), bytes, BatchSizer::Items)?;
+            payload.set_item_count(count);
+        }
+        Ok(())
+    }
+
+    /// Prepares one input using pipeline-runtime codec state.
+    pub fn prepare_with(
+        &self,
+        payload: &mut OtapPayload,
+        executor: &CodecExecutor,
+    ) -> Result<(), Error> {
+        executor.execute(|context| self.prepare(payload, context))
+    }
+
+    /// Finishes a flushed output. Retained tails stay in the working format so
+    /// their ownership units and measured sizes do not change between flushes.
+    pub fn finish(&self, payload: &mut OtapPayload, context: &mut CodecState) -> Result<(), Error> {
+        self.output
+            .materialize(payload, context, self.encoding.as_ref())
+    }
+
+    /// Finishes a flushed output using pipeline-runtime codec state.
+    pub fn finish_with(
+        &self,
+        payload: &mut OtapPayload,
+        executor: &CodecExecutor,
+    ) -> Result<(), Error> {
+        executor.execute(|context| self.finish(payload, context))
+    }
+
+    /// Merges/splits prepared inputs while preserving their in-line ownership.
+    pub fn batch(
+        &self,
+        signal: SignalType,
+        inputs: Vec<OtapPayload>,
+        context: &mut CodecState,
+    ) -> Result<BatchingOutput, Error> {
+        let total = inputs.iter().try_fold(0usize, |total, input| {
+            if input.format() != self.working || input.signal_type() != signal {
+                return Err(format_error("batch input was not prepared for this plan"));
+            }
+            total
+                .checked_add(self.profile.sizer.batch_size(input)?)
+                .ok_or_else(|| format_error("batch ownership overflow"))
+        })?;
+        let result = match self.working.codec() {
+            None => {
+                let records = inputs
+                    .into_iter()
+                    .map(|input| {
+                        input
+                            .try_into_otap(context)
+                            .expect("checked native OTAP working format")
+                    })
+                    .collect();
+                let limit = self
+                    .profile
+                    .max_size
+                    .map(|size| NonZeroU64::new(size.get() as u64).expect("nonzero"));
+                let batches = crate::otap::batching::make_item_batches(signal, limit, records)?;
+                BatchingOutput {
+                    batches: batches
+                        .into_iter()
+                        .map(|records| {
+                            let weight = records.num_items();
+                            (records.into(), weight)
+                        })
+                        .collect(),
+                    budget_fallbacks: 0,
+                }
+            }
+            Some(codec) => {
+                let inputs = inputs
+                    .into_iter()
+                    .map(|input| input.into_encoded_bytes().expect("checked working format"))
+                    .collect();
+                let result = context
+                    .instance(codec)
+                    .batch(signal, &self.profile, inputs)?;
+                BatchingOutput {
+                    batches: result
+                        .batches
+                        .into_iter()
+                        .map(|(bytes, weight)| {
+                            let encoded = EncodedPdata::from_resolved(codec, signal, bytes);
+                            let payload = OtapPayload::from_encoded(encoded);
+                            let payload = if self.profile.sizer == BatchSizer::Items {
+                                payload.with_item_count(weight)
+                            } else {
+                                payload
+                            };
+                            (payload, weight)
+                        })
+                        .collect(),
+                    budget_fallbacks: result.budget_fallbacks,
+                }
+            }
+        };
+        let output_total = result
+            .batches
+            .iter()
+            .try_fold(0usize, |total, (_, weight)| total.checked_add(*weight));
+        if output_total != Some(total) || result.batches.iter().any(|(_, weight)| *weight == 0) {
+            return Err(format_error(
+                "batcher did not partition input ownership exactly",
+            ));
+        }
+        Ok(result)
+    }
+
+    /// Batches prepared input using pipeline-runtime codec state.
+    pub fn batch_with(
+        &self,
+        signal: SignalType,
+        inputs: Vec<OtapPayload>,
+        executor: &CodecExecutor,
+    ) -> Result<BatchingOutput, Error> {
+        executor.execute(|context| self.batch(signal, inputs, context))
+    }
+}
+
+/// Re-batched working payloads and input ownership, not delivery contexts.
+pub struct BatchingOutput {
+    /// Outputs in input order, each paired with its input-unit ownership weight.
+    pub batches: Vec<(OtapPayload, usize)>,
+    /// Entries emitted whole after reaching split amplification budgets.
+    pub budget_fallbacks: u64,
+}
+
+fn format_error(error: impl Into<String>) -> Error {
+    Error::Format {
+        error: error.into(),
+    }
+}

--- a/rust/otap-dataflow/crates/pdata/src/codec.rs
+++ b/rust/otap-dataflow/crates/pdata/src/codec.rs
@@ -10,6 +10,7 @@
 
 use std::borrow::{Borrow, Cow};
 use std::fmt;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use bytes::Bytes;
 use otel_arrow_dfe_config::{EncodeOptions, SignalType};
@@ -338,6 +339,83 @@ impl EncodingPlan {
 #[derive(Default)]
 pub struct CodecState {
     codecs: Vec<(ResolvedCodec, Box<dyn PdataCodec>)>,
+}
+
+/// Scoped handle to the codec state owned by one pipeline runtime.
+///
+/// Cloning this value only clones the `Arc`. The closure boundary prevents a
+/// mutable codec borrow from escaping the operation or crossing an async
+/// suspension point. The mutex also lets shared nodes use the same pipeline
+/// service as local nodes. A future blocking or async executor can replace this
+/// implementation without putting codec state into node structs.
+#[derive(Clone, Default)]
+pub struct CodecExecutor {
+    state: Arc<Mutex<CodecState>>,
+}
+
+impl CodecExecutor {
+    fn lock(&self) -> MutexGuard<'_, CodecState> {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Runs one synchronous operation against runtime-owned codec state.
+    ///
+    /// This is an implementation hook for pdata-aware effect handlers. Nodes
+    /// should use the higher-level effect-handler capabilities instead.
+    #[doc(hidden)]
+    pub fn execute<R>(&self, operation: impl FnOnce(&mut CodecState) -> R) -> R {
+        operation(&mut self.lock())
+    }
+
+    /// Extracts or decodes native records while retaining failed input.
+    pub fn try_into_otap(
+        &self,
+        payload: crate::OtapPayload,
+    ) -> Result<OtapArrowRecords, crate::OtapPayloadDecodeError> {
+        self.execute(|state| payload.try_into_otap(state))
+    }
+
+    /// Borrows a representation-independent view of a payload.
+    pub fn view<'a>(
+        &self,
+        payload: &'a crate::OtapPayload,
+    ) -> Result<CodecView<'a>, crate::encode::Error> {
+        self.execute(|state| payload.view(state))
+    }
+
+    /// Encodes inside a scope that cannot outlive reusable codec storage.
+    pub fn with_encoded<R>(
+        &self,
+        payload: &mut crate::OtapPayload,
+        plan: &EncodingPlan,
+        consume: impl FnOnce(&[u8]) -> R,
+    ) -> Result<R, Error> {
+        self.execute(|state| {
+            let output = payload.prepare_encoded(state, plan)?;
+            Ok(consume(output.as_ref()))
+        })
+    }
+
+    /// Encodes to owned bytes suitable for an asynchronous send.
+    pub fn encode_owned(
+        &self,
+        payload: &mut crate::OtapPayload,
+        plan: &EncodingPlan,
+    ) -> Result<Bytes, Error> {
+        self.execute(|state| {
+            payload
+                .prepare_encoded(state, plan)
+                .map(EncodeOutput::into_bytes)
+        })
+    }
+
+    /// Returns whether two handles address the same pipeline-owned state.
+    #[must_use]
+    pub fn shares_state_with(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.state, &other.state)
+    }
 }
 
 impl CodecState {
@@ -783,6 +861,21 @@ mod tests {
         assert_eq!(codec, ResolvedCodec::OTLP);
         assert_eq!(codec.count_items(SignalType::Logs, &bytes), Some(4));
         assert_eq!(CodecState::default().test_instance_count(), 0);
+    }
+
+    /// Scenario: two runtime handles execute codec work for one pipeline.
+    /// Guarantees: cloned handles share the same lazily created codec instance.
+    #[test]
+    fn executor_clones_share_lazy_state() {
+        let first = CodecExecutor::default();
+        let second = first.clone();
+        assert!(first.shares_state_with(&second));
+        first.execute(|state| {
+            _ = state
+                .decode(ResolvedCodec::OTLP, SignalType::Logs, &logs_bytes())
+                .unwrap();
+        });
+        second.execute(|state| assert_eq!(state.test_instance_count(), 1));
     }
 
     /// Scenario: OTLP bytes are viewed and then decoded through reusable codec state.

--- a/rust/otap-dataflow/crates/pdata/src/codec.rs
+++ b/rust/otap-dataflow/crates/pdata/src/codec.rs
@@ -68,6 +68,67 @@ impl fmt::Display for PdataEncoding {
     }
 }
 
+/// Inline envelope for an independently encoded telemetry batch.
+///
+/// It contains immutable codec identity, signal, and shared bytes only. Item
+/// counts and other measurements remain in the owning payload wrapper so this
+/// envelope stays compact enough for allocation-free admission.
+#[derive(Clone, Debug)]
+pub struct EncodedPdata {
+    codec: ResolvedCodec,
+    signal: SignalType,
+    bytes: Bytes,
+}
+
+impl EncodedPdata {
+    /// Resolves and admits bytes without parsing their contents.
+    pub fn new(encoding: &PdataEncoding, signal: SignalType, bytes: Bytes) -> Result<Self, Error> {
+        resolve(encoding, signal, CodecDirection::Decode)?.admit(signal, bytes)
+    }
+
+    pub(crate) const fn from_resolved(
+        codec: ResolvedCodec,
+        signal: SignalType,
+        bytes: Bytes,
+    ) -> Self {
+        Self {
+            codec,
+            signal,
+            bytes,
+        }
+    }
+
+    /// Stable representation identity.
+    #[must_use]
+    pub fn encoding(&self) -> &PdataEncoding {
+        &self.codec.metadata().encoding
+    }
+
+    /// Resolved codec identity.
+    #[must_use]
+    pub const fn codec(&self) -> ResolvedCodec {
+        self.codec
+    }
+
+    /// Signal carried outside the encoded bytes.
+    #[must_use]
+    pub const fn signal_type(&self) -> SignalType {
+        self.signal
+    }
+
+    /// Borrows the original shared buffer.
+    #[must_use]
+    pub const fn bytes(&self) -> &Bytes {
+        &self.bytes
+    }
+
+    /// Takes ownership of the shared buffer without copying it.
+    #[must_use]
+    pub fn into_bytes(self) -> Bytes {
+        self.bytes
+    }
+}
+
 /// Immutable capabilities advertised by a codec extension.
 #[derive(Debug)]
 pub struct PdataCodecMetadata {
@@ -220,6 +281,12 @@ impl ResolvedCodec {
             .count_items
             .and_then(|counter| counter(signal, bytes))
     }
+
+    /// Admits supported input without decoding or creating mutable codec state.
+    pub fn admit(self, signal: SignalType, bytes: Bytes) -> Result<EncodedPdata, Error> {
+        self.require(signal, CodecDirection::Decode)?;
+        Ok(EncodedPdata::from_resolved(self, signal, bytes))
+    }
 }
 
 /// Startup-resolved output representation and output-specific options.
@@ -308,6 +375,14 @@ impl CodecState {
         Ok(records)
     }
 
+    /// Decodes an admitted envelope using reusable runtime state.
+    pub fn decode_encoded(
+        &mut self,
+        encoded: &EncodedPdata,
+    ) -> Result<OtapArrowRecords, crate::encode::Error> {
+        self.decode(encoded.codec, encoded.signal, &encoded.bytes)
+    }
+
     /// Creates a view through the same reusable codec instance.
     pub fn view<'a>(
         &mut self,
@@ -326,6 +401,14 @@ impl CodecState {
             );
         }
         Ok(view)
+    }
+
+    /// Creates a view over an admitted envelope.
+    pub fn view_encoded<'a>(
+        &mut self,
+        encoded: &'a EncodedPdata,
+    ) -> Result<CodecView<'a>, crate::encode::Error> {
+        self.view(encoded.codec, encoded.signal, &encoded.bytes)
     }
 
     /// Encodes with a startup-resolved output plan.

--- a/rust/otap-dataflow/crates/pdata/src/codec.rs
+++ b/rust/otap-dataflow/crates/pdata/src/codec.rs
@@ -15,6 +15,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use bytes::Bytes;
 use otel_arrow_dfe_config::{EncodeOptions, SignalType};
 
+use crate::batching::{BatchProfile, BatchSizer, BatchingSupport, CodecBatches};
 use crate::error::Error;
 use crate::otap::OtapArrowRecords;
 use crate::otlp::logs::LogsProtoBytesEncoder;
@@ -145,6 +146,8 @@ pub struct PdataCodecMetadata {
     pub can_decode: bool,
     /// Whether native OTAP can be converted to this representation.
     pub can_encode: bool,
+    /// Optional native batching support and its default policy.
+    pub batching: Option<BatchingSupport>,
 }
 
 /// A read-only view returned directly by a codec.
@@ -211,6 +214,44 @@ pub trait PdataCodec: Send {
     ) -> Result<CodecView<'a>, crate::encode::Error> {
         self.decode(signal, bytes)
             .map(|records| CodecView::OtapArrowRecords(Cow::Owned(records)))
+    }
+
+    /// Measures a complete encoded batch for a supported batching unit.
+    fn measure(
+        &mut self,
+        signal: SignalType,
+        bytes: Bytes,
+        sizer: BatchSizer,
+    ) -> Result<usize, Error> {
+        match sizer {
+            BatchSizer::Bytes => Ok(bytes.len()),
+            BatchSizer::Items => {
+                let records = self.decode(signal, &bytes).map_err(|error| Error::Format {
+                    error: error.to_string(),
+                })?;
+                if records.signal_type() != signal {
+                    return Err(Error::Format {
+                        error: "decoder changed the signal type".into(),
+                    });
+                }
+                Ok(records.num_items())
+            }
+            BatchSizer::Requests => Err(Error::Format {
+                error: "request sizing is unsupported".into(),
+            }),
+        }
+    }
+
+    /// Re-batches complete encoded inputs in order.
+    fn batch(
+        &mut self,
+        _signal: SignalType,
+        _profile: &BatchProfile,
+        _inputs: Vec<Bytes>,
+    ) -> Result<CodecBatches, Error> {
+        Err(Error::Format {
+            error: "native batching is unavailable".into(),
+        })
     }
 }
 
@@ -419,7 +460,7 @@ impl CodecExecutor {
 }
 
 impl CodecState {
-    fn instance(&mut self, codec: ResolvedCodec) -> &mut dyn PdataCodec {
+    pub(crate) fn instance(&mut self, codec: ResolvedCodec) -> &mut dyn PdataCodec {
         let index = match self.codecs.iter().position(|(key, _)| *key == codec) {
             Some(index) => index,
             None => {
@@ -645,6 +686,15 @@ fn validate_factories(factories: &[PdataCodecRegistration]) -> Result<(), Error>
                 "must advertise a signal and an encoder or decoder",
             ));
         }
+        if let Some(batching) = &metadata.batching {
+            batching.default_profile.validate()?;
+            if !metadata.can_decode || !batching.sizers.contains(&batching.default_profile.sizer) {
+                return Err(codec_error(
+                    &metadata.encoding,
+                    "native batching requires a decoder and a supported default sizer",
+                ));
+            }
+        }
         if factories[..index]
             .iter()
             .any(|other| other.metadata.encoding == metadata.encoding)
@@ -809,6 +859,36 @@ impl PdataCodec for OtlpCodec {
     ) -> Result<CodecView<'a>, crate::encode::Error> {
         Ok(CodecView::OtlpBytes { signal, bytes })
     }
+
+    fn batch(
+        &mut self,
+        signal: SignalType,
+        profile: &BatchProfile,
+        inputs: Vec<Bytes>,
+    ) -> Result<CodecBatches, Error> {
+        let limit = |value: Option<std::num::NonZeroUsize>| {
+            value.map(|value| std::num::NonZeroU64::new(value.get() as u64).expect("nonzero"))
+        };
+        let result = crate::otlp::batching::make_bytes_batches_owned(
+            signal,
+            limit(profile.max_size),
+            limit(profile.max_split_fragments),
+            limit(profile.max_split_overhead_bytes),
+            limit(profile.max_split_fragments_per_flush),
+            inputs
+                .into_iter()
+                .map(|bytes| OtlpProtoBytes::new_from_bytes(signal, bytes))
+                .collect(),
+        )?;
+        Ok(CodecBatches {
+            batches: result
+                .batches
+                .into_iter()
+                .map(|(mut bytes, weight)| (bytes.replace_bytes(Bytes::new()), weight))
+                .collect(),
+            budget_fallbacks: result.budget_fallbacks,
+        })
+    }
 }
 
 /// Metadata for the built-in OTLP codec.
@@ -819,6 +899,10 @@ pub static OTLP_METADATA: PdataCodecMetadata = PdataCodecMetadata {
     compression: None,
     can_decode: true,
     can_encode: true,
+    batching: Some(BatchingSupport {
+        sizers: &[BatchSizer::Bytes],
+        default_profile: BatchProfile::otlp(),
+    }),
 };
 
 #[allow(unsafe_code)]
@@ -984,6 +1068,83 @@ mod tests {
                 malformed: Some(Bytes::from_static(&[0x0a, 0x05, 0x01])),
                 expected_items,
             });
+        }
+    }
+
+    /// Scenario: a codec batcher drops, duplicates, or overflows input ownership weights.
+    /// Guarantees: BatchPlan rejects every output that cannot be attributed exactly to inputs.
+    #[test]
+    fn native_batcher_must_partition_input_ownership() {
+        use crate::batching::{BatchPlan, PdataFormat};
+
+        struct InvalidBatcher;
+
+        impl PdataCodec for InvalidBatcher {
+            fn decode(
+                &mut self,
+                signal: SignalType,
+                bytes: &Bytes,
+            ) -> Result<OtapArrowRecords, crate::encode::Error> {
+                OtlpCodec::default().decode(signal, bytes)
+            }
+
+            fn encode(
+                &mut self,
+                records: OtapArrowRecords,
+                options: EncodeOptions,
+            ) -> Result<Bytes, Error> {
+                OtlpCodec::default().encode(records, options)
+            }
+
+            fn batch(
+                &mut self,
+                _signal: SignalType,
+                _profile: &BatchProfile,
+                inputs: Vec<Bytes>,
+            ) -> Result<CodecBatches, Error> {
+                let bytes = &inputs[0];
+                let batches = match bytes[0] {
+                    0 => Vec::new(),
+                    1 => vec![(bytes.clone(), 0), (bytes.clone(), 1)],
+                    _ => vec![(bytes.clone(), usize::MAX), (bytes.clone(), 1)],
+                };
+                Ok(CodecBatches {
+                    batches,
+                    budget_fallbacks: 0,
+                })
+            }
+        }
+
+        static METADATA: PdataCodecMetadata = PdataCodecMetadata {
+            encoding: PdataEncoding::new("test-invalid-batcher"),
+            signals: &[SignalType::Logs],
+            format_version: None,
+            compression: None,
+            can_decode: true,
+            can_encode: true,
+            batching: Some(BatchingSupport {
+                sizers: &[BatchSizer::Bytes],
+                default_profile: BatchProfile::otlp(),
+            }),
+        };
+        static REGISTRATION: PdataCodecRegistration = PdataCodecRegistration {
+            count_items: None,
+            metadata: &METADATA,
+            create: || Box::new(InvalidBatcher),
+        };
+
+        let codec = ResolvedCodec(&REGISTRATION);
+        let plan = BatchPlan::new(PdataFormat::encoded(codec), BatchProfile::otlp(), true).unwrap();
+        let mut state = CodecState::default();
+        for bytes in [b"\0", b"\x01", b"\x02"] {
+            let payload = codec
+                .admit(SignalType::Logs, Bytes::from_static(bytes))
+                .unwrap();
+            let error = plan
+                .batch(SignalType::Logs, vec![payload.into()], &mut state)
+                .err()
+                .unwrap();
+            assert!(error.to_string().contains("partition input ownership"));
         }
     }
 }

--- a/rust/otap-dataflow/crates/pdata/src/codec.rs
+++ b/rust/otap-dataflow/crates/pdata/src/codec.rs
@@ -1,0 +1,813 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pluggable codecs between independent encoded batches and native OTAP.
+//!
+//! Registrations are immutable and linked into the binary. Mutable codec state
+//! is created lazily by a pipeline-owned [`CodecState`]. This module deliberately
+//! does not participate in payload storage yet; the legacy OTLP representation
+//! remains the runtime default while codec behavior is characterized in isolation.
+
+use std::borrow::{Borrow, Cow};
+use std::fmt;
+
+use bytes::Bytes;
+use otel_arrow_dfe_config::{EncodeOptions, SignalType};
+
+use crate::error::Error;
+use crate::otap::OtapArrowRecords;
+use crate::otlp::logs::LogsProtoBytesEncoder;
+use crate::otlp::metrics::MetricsProtoBytesEncoder;
+use crate::otlp::traces::TracesProtoBytesEncoder;
+use crate::otlp::{BoundedBuf, ProtoBuffer, ProtoBytesEncoder};
+use crate::views::otlp::bytes::logs::RawLogsData;
+use crate::views::otlp::bytes::metrics::RawMetricsData;
+use crate::views::otlp::bytes::traces::RawTraceData;
+use crate::{OtapPayloadHelpers, OtlpProtoBytes, TryIntoWithOptions};
+
+/// Stable identity of an independently decodable byte representation.
+///
+/// Incompatible format versions and intrinsic compression use different names.
+/// HTTP and gRPC compression are transport properties and are not part of this
+/// identity.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct PdataEncoding(Cow<'static, str>);
+
+impl PdataEncoding {
+    /// OTLP protobuf service-request bytes without transport compression.
+    pub const OTLP: Self = Self::new("otlp-bytes");
+
+    /// Declares a compile-time encoding identity.
+    #[must_use]
+    pub const fn new(name: &'static str) -> Self {
+        Self(Cow::Borrowed(name))
+    }
+
+    /// Returns the stable configuration and diagnostic name.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Borrow<str> for PdataEncoding {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<String> for PdataEncoding {
+    fn from(name: String) -> Self {
+        Self(Cow::Owned(name))
+    }
+}
+
+impl fmt::Display for PdataEncoding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Immutable capabilities advertised by a codec extension.
+#[derive(Debug)]
+pub struct PdataCodecMetadata {
+    /// Globally stable representation name.
+    pub encoding: PdataEncoding,
+    /// Signals understood by this codec.
+    pub signals: &'static [SignalType],
+    /// Informational version. Incompatible versions require different identities.
+    pub format_version: Option<&'static str>,
+    /// Compression intrinsic to the representation, if any.
+    pub compression: Option<&'static str>,
+    /// Whether encoded bytes can be converted to native OTAP.
+    pub can_decode: bool,
+    /// Whether native OTAP can be converted to this representation.
+    pub can_encode: bool,
+}
+
+/// A read-only view returned directly by a codec.
+///
+/// Views may borrow the input bytes, but never mutable codec state. The default
+/// implementation owns decoded OTAP records.
+pub enum CodecView<'a> {
+    /// Borrowed OTLP protobuf service-request bytes.
+    OtlpBytes {
+        /// Signal carried outside the bytes.
+        signal: SignalType,
+        /// Uncompressed service-request bytes.
+        bytes: &'a [u8],
+    },
+    /// Native OTAP records, either borrowed or decoded for this view.
+    OtapArrowRecords(Cow<'a, OtapArrowRecords>),
+}
+
+impl CodecView<'_> {
+    /// Signal exposed by this view.
+    #[must_use]
+    pub fn signal_type(&self) -> SignalType {
+        match self {
+            Self::OtlpBytes { signal, .. } => *signal,
+            Self::OtapArrowRecords(records) => records.signal_type(),
+        }
+    }
+}
+
+/// Reusable synchronous codec implementation owned by one pipeline runtime.
+///
+/// Every encoded input and output is a complete independently decodable batch.
+/// Stream-relative dictionary state is not an encoded pdata representation.
+pub trait PdataCodec: Send {
+    /// Decodes one complete batch while the caller retains the original bytes.
+    fn decode(
+        &mut self,
+        signal: SignalType,
+        bytes: &Bytes,
+    ) -> Result<OtapArrowRecords, crate::encode::Error>;
+
+    /// Encodes native records into an independently owned complete batch.
+    fn encode(&mut self, records: OtapArrowRecords, options: EncodeOptions)
+    -> Result<Bytes, Error>;
+
+    /// Prepares output that may borrow reusable encoder storage.
+    ///
+    /// The default implementation delegates to [`Self::encode`]. Codecs with a
+    /// scratch buffer can return it through [`EncodeOutput::buffer`].
+    fn prepare_encode<'a>(
+        &'a mut self,
+        records: &mut OtapArrowRecords,
+        options: EncodeOptions,
+    ) -> Result<EncodeOutput<'a>, Error> {
+        self.encode(records.clone(), options)
+            .map(EncodeOutput::bytes)
+    }
+
+    /// Returns a representation-specific borrowed view when available.
+    fn view<'a>(
+        &mut self,
+        signal: SignalType,
+        bytes: &'a Bytes,
+    ) -> Result<CodecView<'a>, crate::encode::Error> {
+        self.decode(signal, bytes)
+            .map(|records| CodecView::OtapArrowRecords(Cow::Owned(records)))
+    }
+}
+
+/// Optional allocation-free item scan that needs no mutable codec instance.
+pub type ItemCounter = fn(SignalType, &[u8]) -> Option<usize>;
+
+/// Link-time codec registration. Only immutable factories are shared globally.
+#[derive(Debug)]
+pub struct PdataCodecRegistration {
+    /// Representation identity and capabilities.
+    pub metadata: &'static PdataCodecMetadata,
+    /// Creates independent mutable state for one pipeline runtime.
+    pub create: fn() -> Box<dyn PdataCodec>,
+    /// Optional stateless item scan used by flow metrics.
+    pub count_items: Option<ItemCounter>,
+}
+
+/// Trusted codec extensions compiled into this binary.
+#[allow(unsafe_code)]
+#[linkme::distributed_slice]
+pub static PDATA_CODEC_FACTORIES: [PdataCodecRegistration];
+
+/// An immutable codec resolved from the link-time registry.
+#[derive(Clone, Copy, Debug)]
+pub struct ResolvedCodec(&'static PdataCodecRegistration);
+
+impl PartialEq for ResolvedCodec {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::eq(self.0, other.0)
+    }
+}
+
+impl Eq for ResolvedCodec {}
+
+impl ResolvedCodec {
+    /// Built-in OTLP, available without a registry scan.
+    pub const OTLP: Self = Self(&OTLP_CODEC);
+
+    /// Immutable capabilities and canonical encoding name.
+    #[must_use]
+    pub const fn metadata(self) -> &'static PdataCodecMetadata {
+        self.0.metadata
+    }
+
+    /// Checks signal and direction without another registry lookup.
+    pub fn require(self, signal: SignalType, direction: CodecDirection) -> Result<(), Error> {
+        let metadata = self.metadata();
+        if !metadata.signals.contains(&signal) {
+            return Err(codec_error(
+                &metadata.encoding,
+                format!("unsupported signal {signal:?}"),
+            ));
+        }
+        match direction {
+            CodecDirection::Decode if !metadata.can_decode => {
+                Err(codec_error(&metadata.encoding, "decoder unavailable"))
+            }
+            CodecDirection::Encode if !metadata.can_encode => {
+                Err(codec_error(&metadata.encoding, "encoder unavailable"))
+            }
+            _ => Ok(()),
+        }
+    }
+
+    /// Counts items without instantiating mutable codec state when supported.
+    #[must_use]
+    pub fn count_items(self, signal: SignalType, bytes: &[u8]) -> Option<usize> {
+        self.0
+            .count_items
+            .and_then(|counter| counter(signal, bytes))
+    }
+}
+
+/// Startup-resolved output representation and output-specific options.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct EncodingPlan {
+    codec: ResolvedCodec,
+    options: EncodeOptions,
+}
+
+impl EncodingPlan {
+    /// Default OTLP protobuf output.
+    pub const OTLP: Self = Self {
+        codec: ResolvedCodec::OTLP,
+        options: EncodeOptions {
+            otlp_size_limit: None,
+        },
+    };
+
+    /// Builds a plan from an already resolved codec.
+    pub fn new(codec: ResolvedCodec, options: EncodeOptions) -> Result<Self, Error> {
+        if !codec.metadata().can_encode {
+            return Err(codec_error(
+                &codec.metadata().encoding,
+                "encoder unavailable",
+            ));
+        }
+        Ok(Self { codec, options })
+    }
+
+    /// Resolves an output name once while constructing a node.
+    pub fn resolve(encoding: &PdataEncoding, options: EncodeOptions) -> Result<Self, Error> {
+        Self::new(find(encoding)?, options)
+    }
+
+    /// Resolved output codec.
+    #[must_use]
+    pub const fn codec(self) -> ResolvedCodec {
+        self.codec
+    }
+
+    /// Output-specific options.
+    #[must_use]
+    pub const fn options(self) -> EncodeOptions {
+        self.options
+    }
+}
+
+/// Mutable codec instances cached by one pipeline runtime.
+#[derive(Default)]
+pub struct CodecState {
+    codecs: Vec<(ResolvedCodec, Box<dyn PdataCodec>)>,
+}
+
+impl CodecState {
+    fn instance(&mut self, codec: ResolvedCodec) -> &mut dyn PdataCodec {
+        let index = match self.codecs.iter().position(|(key, _)| *key == codec) {
+            Some(index) => index,
+            None => {
+                let index = self.codecs.len();
+                self.codecs.push((codec, (codec.0.create)()));
+                index
+            }
+        };
+        self.codecs[index].1.as_mut()
+    }
+
+    /// Decodes with reusable runtime state and verifies signal preservation.
+    pub fn decode(
+        &mut self,
+        codec: ResolvedCodec,
+        signal: SignalType,
+        bytes: &Bytes,
+    ) -> Result<OtapArrowRecords, crate::encode::Error> {
+        codec.require(signal, CodecDirection::Decode)?;
+        let records = self
+            .instance(codec)
+            .decode(signal, bytes)
+            .map_err(|error| codec_error(&codec.metadata().encoding, error.to_string()))?;
+        if records.signal_type() != signal {
+            return Err(codec_error(
+                &codec.metadata().encoding,
+                "decoder changed the signal type",
+            )
+            .into());
+        }
+        Ok(records)
+    }
+
+    /// Creates a view through the same reusable codec instance.
+    pub fn view<'a>(
+        &mut self,
+        codec: ResolvedCodec,
+        signal: SignalType,
+        bytes: &'a Bytes,
+    ) -> Result<CodecView<'a>, crate::encode::Error> {
+        codec.require(signal, CodecDirection::Decode)?;
+        let view = self
+            .instance(codec)
+            .view(signal, bytes)
+            .map_err(|error| codec_error(&codec.metadata().encoding, error.to_string()))?;
+        if view.signal_type() != signal {
+            return Err(
+                codec_error(&codec.metadata().encoding, "view changed the signal type").into(),
+            );
+        }
+        Ok(view)
+    }
+
+    /// Encodes with a startup-resolved output plan.
+    pub fn prepare_encode<'a>(
+        &'a mut self,
+        records: &mut OtapArrowRecords,
+        plan: &EncodingPlan,
+    ) -> Result<EncodeOutput<'a>, Error> {
+        plan.codec
+            .require(records.signal_type(), CodecDirection::Encode)?;
+        self.instance(plan.codec)
+            .prepare_encode(records, plan.options)
+    }
+
+    /// Number of mutable codec instances created so far.
+    #[cfg(any(test, feature = "testing"))]
+    #[must_use]
+    pub fn test_instance_count(&self) -> usize {
+        self.codecs.len()
+    }
+}
+
+enum OutputStorage<'a> {
+    Bytes(Bytes),
+    Buffer(BufferOutput<'a>),
+}
+
+struct BufferOutput<'a> {
+    buffer: &'a mut ProtoBuffer,
+    max_retained_capacity: usize,
+}
+
+impl Drop for BufferOutput<'_> {
+    fn drop(&mut self) {
+        self.buffer.retain_capacity(self.max_retained_capacity);
+    }
+}
+
+/// Prepared encoded output backed by owned bytes or reusable scratch storage.
+pub struct EncodeOutput<'a>(OutputStorage<'a>);
+
+impl<'a> EncodeOutput<'a> {
+    /// Wraps independently owned bytes.
+    #[must_use]
+    pub fn bytes(bytes: Bytes) -> Self {
+        Self(OutputStorage::Bytes(bytes))
+    }
+
+    /// Borrows reusable codec storage for synchronous consumption.
+    #[must_use]
+    pub fn buffer(buffer: &'a mut ProtoBuffer, max_retained_capacity: usize) -> Self {
+        Self(OutputStorage::Buffer(BufferOutput {
+            buffer,
+            max_retained_capacity,
+        }))
+    }
+
+    /// Detaches bytes for an asynchronous send without copying their contents.
+    #[must_use]
+    pub fn into_bytes(self) -> Bytes {
+        match self.0 {
+            OutputStorage::Bytes(bytes) => bytes,
+            OutputStorage::Buffer(output) => {
+                let (bytes, capacity) = output.buffer.take_into_bytes();
+                output
+                    .buffer
+                    .ensure_capacity(capacity.min(output.max_retained_capacity));
+                bytes
+            }
+        }
+    }
+
+    /// Keeps scratch attached and copies only when output uses that scratch.
+    #[must_use]
+    pub fn copy_into_bytes(self) -> Bytes {
+        match self.0 {
+            OutputStorage::Bytes(bytes) => bytes,
+            OutputStorage::Buffer(output) => Bytes::copy_from_slice(output.buffer.as_ref()),
+        }
+    }
+}
+
+impl AsRef<[u8]> for EncodeOutput<'_> {
+    fn as_ref(&self) -> &[u8] {
+        match &self.0 {
+            OutputStorage::Bytes(bytes) => bytes,
+            OutputStorage::Buffer(output) => output.buffer.as_ref(),
+        }
+    }
+}
+
+/// The operation required by a codec consumer.
+#[derive(Clone, Copy, Debug)]
+pub enum CodecDirection {
+    /// Encoded bytes to native OTAP.
+    Decode,
+    /// Native OTAP to encoded bytes.
+    Encode,
+}
+
+/// Finds a unique codec without creating mutable state.
+pub fn find(encoding: &PdataEncoding) -> Result<ResolvedCodec, Error> {
+    let mut matches = PDATA_CODEC_FACTORIES
+        .iter()
+        .filter(|registration| &registration.metadata.encoding == encoding);
+    let registration = matches
+        .next()
+        .ok_or_else(|| codec_error(encoding, "no codec registered"))?;
+    if matches.next().is_some() {
+        return Err(codec_error(encoding, "duplicate encoding registration"));
+    }
+    Ok(ResolvedCodec(registration))
+}
+
+/// Resolves a codec and validates its signal and direction.
+pub fn resolve(
+    encoding: &PdataEncoding,
+    signal: SignalType,
+    direction: CodecDirection,
+) -> Result<ResolvedCodec, Error> {
+    let codec = find(encoding)?;
+    codec.require(signal, direction)?;
+    Ok(codec)
+}
+
+/// Iterates all compiled-in codec identities without creating mutable state.
+pub fn registered_codecs() -> impl Iterator<Item = ResolvedCodec> {
+    PDATA_CODEC_FACTORIES.iter().map(ResolvedCodec)
+}
+
+/// Validates names, capabilities, and uniqueness of linked registrations.
+pub fn validate_registrations() -> Result<(), Error> {
+    validate_factories(&PDATA_CODEC_FACTORIES)
+}
+
+fn validate_factories(factories: &[PdataCodecRegistration]) -> Result<(), Error> {
+    for (index, registration) in factories.iter().enumerate() {
+        let metadata = registration.metadata;
+        let name = metadata.encoding.as_str();
+        if ["otap", "otlp", "preserve"].contains(&name) {
+            return Err(codec_error(&metadata.encoding, "reserved format name"));
+        }
+        if name.is_empty()
+            || !name.bytes().all(|byte| {
+                byte.is_ascii_lowercase() || byte.is_ascii_digit() || b"._-:".contains(&byte)
+            })
+        {
+            return Err(codec_error(
+                &metadata.encoding,
+                "identity must use lowercase ASCII letters, digits, '.', '_', '-', or ':'",
+            ));
+        }
+        if metadata.signals.is_empty() || (!metadata.can_decode && !metadata.can_encode) {
+            return Err(codec_error(
+                &metadata.encoding,
+                "must advertise a signal and an encoder or decoder",
+            ));
+        }
+        if factories[..index]
+            .iter()
+            .any(|other| other.metadata.encoding == metadata.encoding)
+        {
+            return Err(codec_error(
+                &metadata.encoding,
+                "duplicate encoding registration",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn codec_error(encoding: &PdataEncoding, reason: impl Into<String>) -> Error {
+    Error::PdataCodec {
+        encoding: encoding.clone(),
+        reason: reason.into(),
+    }
+}
+
+const OTLP_INITIAL_BUFFER_CAPACITY: usize = 8 * 1024;
+const OTLP_MAX_RETAINED_BUFFER_CAPACITY: usize = 256 * 1024;
+
+struct OtlpSignalEncoder<E> {
+    encoder: E,
+    buffer: ProtoBuffer,
+}
+
+impl<E: Default> Default for OtlpSignalEncoder<E> {
+    fn default() -> Self {
+        Self {
+            encoder: E::default(),
+            buffer: ProtoBuffer::with_capacity(OTLP_INITIAL_BUFFER_CAPACITY),
+        }
+    }
+}
+
+#[derive(Default)]
+struct OtlpEncoderState {
+    logs: Option<Box<OtlpSignalEncoder<LogsProtoBytesEncoder>>>,
+    metrics: Option<Box<OtlpSignalEncoder<MetricsProtoBytesEncoder>>>,
+    traces: Option<Box<OtlpSignalEncoder<TracesProtoBytesEncoder>>>,
+}
+
+/// Built-in OTLP protobuf codec.
+#[derive(Default)]
+pub struct OtlpCodec {
+    encoder: Option<Box<OtlpEncoderState>>,
+}
+
+impl OtlpCodec {
+    fn output_limit(options: EncodeOptions) -> usize {
+        options
+            .otlp_size_limit
+            .map_or(crate::otlp::common::MAX_OTLP_SIZE_LIMIT, |limit| {
+                limit.get().min(crate::otlp::common::MAX_OTLP_SIZE_LIMIT)
+            })
+    }
+
+    #[inline(never)]
+    fn prepare_logs<'a>(
+        state: &'a mut OtlpEncoderState,
+        records: &mut OtapArrowRecords,
+        options: EncodeOptions,
+    ) -> Result<EncodeOutput<'a>, Error> {
+        let state = state
+            .logs
+            .get_or_insert_with(|| Box::new(OtlpSignalEncoder::default()));
+        prepare_signal(&mut state.encoder, &mut state.buffer, records, options)
+    }
+
+    #[inline(never)]
+    fn prepare_metrics<'a>(
+        state: &'a mut OtlpEncoderState,
+        records: &mut OtapArrowRecords,
+        options: EncodeOptions,
+    ) -> Result<EncodeOutput<'a>, Error> {
+        let state = state
+            .metrics
+            .get_or_insert_with(|| Box::new(OtlpSignalEncoder::default()));
+        prepare_signal(&mut state.encoder, &mut state.buffer, records, options)
+    }
+
+    #[inline(never)]
+    fn prepare_traces<'a>(
+        state: &'a mut OtlpEncoderState,
+        records: &mut OtapArrowRecords,
+        options: EncodeOptions,
+    ) -> Result<EncodeOutput<'a>, Error> {
+        let state = state
+            .traces
+            .get_or_insert_with(|| Box::new(OtlpSignalEncoder::default()));
+        prepare_signal(&mut state.encoder, &mut state.buffer, records, options)
+    }
+}
+
+fn prepare_signal<'a, E: ProtoBytesEncoder>(
+    encoder: &mut E,
+    buffer: &'a mut ProtoBuffer,
+    records: &mut OtapArrowRecords,
+    options: EncodeOptions,
+) -> Result<EncodeOutput<'a>, Error> {
+    buffer.clear();
+    buffer.set_limit(OtlpCodec::output_limit(options));
+    if let Err(error) = encoder.encode(records, buffer) {
+        buffer.retain_capacity(OTLP_MAX_RETAINED_BUFFER_CAPACITY);
+        return Err(error);
+    }
+    Ok(EncodeOutput::buffer(
+        buffer,
+        OTLP_MAX_RETAINED_BUFFER_CAPACITY,
+    ))
+}
+
+impl PdataCodec for OtlpCodec {
+    fn decode(
+        &mut self,
+        signal: SignalType,
+        bytes: &Bytes,
+    ) -> Result<OtapArrowRecords, crate::encode::Error> {
+        match signal {
+            SignalType::Logs => {
+                let _ = RawLogsData::try_new(bytes)?;
+            }
+            SignalType::Metrics => {
+                let _ = RawMetricsData::try_new(bytes)?;
+            }
+            SignalType::Traces => {
+                let _ = RawTraceData::try_new(bytes)?;
+            }
+        }
+        OtlpProtoBytes::new_from_bytes(signal, bytes.clone()).try_into_with_default()
+    }
+
+    fn encode(
+        &mut self,
+        mut records: OtapArrowRecords,
+        options: EncodeOptions,
+    ) -> Result<Bytes, Error> {
+        Ok(self.prepare_encode(&mut records, options)?.into_bytes())
+    }
+
+    fn prepare_encode<'a>(
+        &'a mut self,
+        records: &mut OtapArrowRecords,
+        options: EncodeOptions,
+    ) -> Result<EncodeOutput<'a>, Error> {
+        let state = self
+            .encoder
+            .get_or_insert_with(|| Box::new(OtlpEncoderState::default()));
+        match records.signal_type() {
+            SignalType::Logs => Self::prepare_logs(state, records, options),
+            SignalType::Metrics => Self::prepare_metrics(state, records, options),
+            SignalType::Traces => Self::prepare_traces(state, records, options),
+        }
+    }
+
+    fn view<'a>(
+        &mut self,
+        signal: SignalType,
+        bytes: &'a Bytes,
+    ) -> Result<CodecView<'a>, crate::encode::Error> {
+        Ok(CodecView::OtlpBytes { signal, bytes })
+    }
+}
+
+/// Metadata for the built-in OTLP codec.
+pub static OTLP_METADATA: PdataCodecMetadata = PdataCodecMetadata {
+    encoding: PdataEncoding::OTLP,
+    signals: &[SignalType::Logs, SignalType::Metrics, SignalType::Traces],
+    format_version: None,
+    compression: None,
+    can_decode: true,
+    can_encode: true,
+};
+
+#[allow(unsafe_code)]
+#[linkme::distributed_slice(PDATA_CODEC_FACTORIES)]
+static OTLP_CODEC: PdataCodecRegistration = PdataCodecRegistration {
+    metadata: &OTLP_METADATA,
+    create: || Box::new(OtlpCodec::default()),
+    count_items: Some(|signal, bytes| Some(crate::payload::count_otlp_items(signal, bytes))),
+};
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use prost::Message;
+
+    use super::*;
+    use crate::testing::codec_conformance::{DecodeConformanceCase, assert_decode_conformance};
+    use crate::testing::fixtures::{
+        logs_with_full_resource_and_scope, metrics_sum_with_full_resource_and_scope,
+        traces_with_full_resource_and_scope,
+    };
+
+    fn logs_bytes() -> Bytes {
+        logs_with_full_resource_and_scope().encode_to_vec().into()
+    }
+
+    /// Scenario: the built-in registry is resolved without constructing mutable state.
+    /// Guarantees: OTLP metadata and the stateless item counter are available eagerly.
+    #[test]
+    fn resolves_otlp_without_codec_instance() {
+        validate_registrations().unwrap();
+        let codec = resolve(
+            &PdataEncoding::OTLP,
+            SignalType::Logs,
+            CodecDirection::Decode,
+        )
+        .unwrap();
+        let bytes = logs_bytes();
+        assert_eq!(codec, ResolvedCodec::OTLP);
+        assert_eq!(codec.count_items(SignalType::Logs, &bytes), Some(4));
+        assert_eq!(CodecState::default().test_instance_count(), 0);
+    }
+
+    /// Scenario: OTLP bytes are viewed and then decoded through reusable codec state.
+    /// Guarantees: the view borrows the original buffer and decoding preserves signal and items.
+    #[test]
+    fn otlp_view_and_decode_preserve_input() {
+        let bytes = logs_bytes();
+        let pointer = bytes.as_ptr();
+        let mut state = CodecState::default();
+        let view = state
+            .view(ResolvedCodec::OTLP, SignalType::Logs, &bytes)
+            .unwrap();
+        match view {
+            CodecView::OtlpBytes { signal, bytes } => {
+                assert_eq!(signal, SignalType::Logs);
+                assert_eq!(bytes.as_ptr(), pointer);
+            }
+            CodecView::OtapArrowRecords(_) => panic!("OTLP should expose a borrowed byte view"),
+        }
+        let records = state
+            .decode(ResolvedCodec::OTLP, SignalType::Logs, &bytes)
+            .unwrap();
+        assert_eq!(records.signal_type(), SignalType::Logs);
+        assert_eq!(records.num_items(), 4);
+        assert_eq!(state.test_instance_count(), 1);
+    }
+
+    /// Scenario: native logs are encoded repeatedly through one startup-resolved plan.
+    /// Guarantees: output remains independently decodable and the codec instance is reused.
+    #[test]
+    fn otlp_prepared_output_reuses_codec_state() {
+        let bytes = logs_bytes();
+        let mut decode_state = CodecState::default();
+        let original = decode_state
+            .decode(ResolvedCodec::OTLP, SignalType::Logs, &bytes)
+            .unwrap();
+        let mut encode_state = CodecState::default();
+        for _ in 0..2 {
+            let mut records = original.clone();
+            let encoded = encode_state
+                .prepare_encode(&mut records, &EncodingPlan::OTLP)
+                .unwrap()
+                .into_bytes();
+            let decoded = decode_state
+                .decode(ResolvedCodec::OTLP, SignalType::Logs, &encoded)
+                .unwrap();
+            assert_eq!(decoded.num_items(), 4);
+        }
+        assert_eq!(encode_state.test_instance_count(), 1);
+    }
+
+    /// Scenario: an output plan sets an OTLP limit smaller than the encoded batch.
+    /// Guarantees: the limit reaches the reusable encoder and later encodes recover.
+    #[test]
+    fn otlp_encoder_recovers_after_limit_error() {
+        let bytes = logs_bytes();
+        let mut state = CodecState::default();
+        let records = state
+            .decode(ResolvedCodec::OTLP, SignalType::Logs, &bytes)
+            .unwrap();
+        let limited = EncodingPlan::new(
+            ResolvedCodec::OTLP,
+            EncodeOptions {
+                otlp_size_limit: NonZeroUsize::new(1),
+            },
+        )
+        .unwrap();
+        assert!(
+            state
+                .prepare_encode(&mut records.clone(), &limited)
+                .is_err()
+        );
+        let encoded = state
+            .prepare_encode(&mut records.clone(), &EncodingPlan::OTLP)
+            .unwrap()
+            .into_bytes();
+        assert!(!encoded.is_empty());
+    }
+
+    /// Scenario: OTLP logs, metrics, and traces run through the shared codec contract.
+    /// Guarantees: every signal preserves items, rejects malformed input, and round-trips independently.
+    #[test]
+    fn otlp_codec_conforms_for_all_signals() {
+        let cases = [
+            (
+                SignalType::Logs,
+                Bytes::from(logs_with_full_resource_and_scope().encode_to_vec()),
+                4,
+            ),
+            (
+                SignalType::Metrics,
+                Bytes::from(metrics_sum_with_full_resource_and_scope().encode_to_vec()),
+                2,
+            ),
+            (
+                SignalType::Traces,
+                Bytes::from(traces_with_full_resource_and_scope().encode_to_vec()),
+                2,
+            ),
+        ];
+        for (signal, valid, expected_items) in cases {
+            assert_decode_conformance(DecodeConformanceCase {
+                codec: ResolvedCodec::OTLP,
+                signal,
+                valid,
+                malformed: Some(Bytes::from_static(&[0x0a, 0x05, 0x01])),
+                expected_items,
+            });
+        }
+    }
+}

--- a/rust/otap-dataflow/crates/pdata/src/error.rs
+++ b/rust/otap-dataflow/crates/pdata/src/error.rs
@@ -235,6 +235,12 @@ pub enum Error {
     #[error("Format error: {}", error)]
     Format { error: String },
 
+    #[error("PData codec `{encoding}` failed: {reason}")]
+    PdataCodec {
+        encoding: crate::codec::PdataEncoding,
+        reason: String,
+    },
+
     #[error("Invalid schema for payload {payload_type:?}: {source}")]
     InvalidSchemaForPayload {
         payload_type: ArrowPayloadType,

--- a/rust/otap-dataflow/crates/pdata/src/lib.rs
+++ b/rust/otap-dataflow/crates/pdata/src/lib.rs
@@ -18,10 +18,15 @@ pub mod otap;
 pub mod schema;
 
 pub mod arrays;
+pub mod codec;
 pub(crate) mod decode;
 pub mod encode;
 pub(crate) mod payload;
 
+pub use codec::{
+    CodecDirection, CodecState, CodecView, EncodeOutput, EncodingPlan, PdataCodec,
+    PdataCodecMetadata, PdataCodecRegistration, PdataEncoding, ResolvedCodec,
+};
 pub use otap::OtapArrowRecords;
 pub use otlp::OtlpProtoBytes;
 pub use payload::{OtapPayload, OtapPayloadHelpers, PayloadData};

--- a/rust/otap-dataflow/crates/pdata/src/lib.rs
+++ b/rust/otap-dataflow/crates/pdata/src/lib.rs
@@ -24,12 +24,14 @@ pub mod encode;
 pub(crate) mod payload;
 
 pub use codec::{
-    CodecDirection, CodecState, CodecView, EncodeOutput, EncodingPlan, PdataCodec,
+    CodecDirection, CodecState, CodecView, EncodeOutput, EncodedPdata, EncodingPlan, PdataCodec,
     PdataCodecMetadata, PdataCodecRegistration, PdataEncoding, ResolvedCodec,
 };
 pub use otap::OtapArrowRecords;
 pub use otlp::OtlpProtoBytes;
-pub use payload::{OtapPayload, OtapPayloadHelpers, PayloadData};
+pub use payload::{
+    OtapPayload, OtapPayloadDecodeError, OtapPayloadHelpers, PayloadData, PdataFormat,
+};
 
 /// Testing support
 #[cfg(any(test, feature = "testing"))]

--- a/rust/otap-dataflow/crates/pdata/src/lib.rs
+++ b/rust/otap-dataflow/crates/pdata/src/lib.rs
@@ -18,6 +18,7 @@ pub mod otap;
 pub mod schema;
 
 pub mod arrays;
+pub mod batching;
 pub mod codec;
 pub(crate) mod decode;
 pub mod encode;

--- a/rust/otap-dataflow/crates/pdata/src/lib.rs
+++ b/rust/otap-dataflow/crates/pdata/src/lib.rs
@@ -24,8 +24,8 @@ pub mod encode;
 pub(crate) mod payload;
 
 pub use codec::{
-    CodecDirection, CodecState, CodecView, EncodeOutput, EncodedPdata, EncodingPlan, PdataCodec,
-    PdataCodecMetadata, PdataCodecRegistration, PdataEncoding, ResolvedCodec,
+    CodecDirection, CodecExecutor, CodecState, CodecView, EncodeOutput, EncodedPdata, EncodingPlan,
+    PdataCodec, PdataCodecMetadata, PdataCodecRegistration, PdataEncoding, ResolvedCodec,
 };
 pub use otap::OtapArrowRecords;
 pub use otlp::OtlpProtoBytes;

--- a/rust/otap-dataflow/crates/pdata/src/otap/memory.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/memory.rs
@@ -407,7 +407,7 @@ mod tests {
         assert_eq!(
             match arrow_payload.into_data() {
                 PayloadData::OtapArrowRecords(records) => records.root_payload_type(),
-                PayloadData::OtlpBytes(_) => unreachable!(),
+                PayloadData::OtlpBytes(_) | PayloadData::Encoded(_) => unreachable!(),
             },
             ArrowPayloadType::Logs
         );

--- a/rust/otap-dataflow/crates/pdata/src/otlp/common.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/common.rs
@@ -829,6 +829,14 @@ impl ProtoBuffer {
             self.buffer.reserve(capacity - self.buffer.capacity());
         }
     }
+
+    /// Clears the buffer and bounds the allocation retained for later encodes.
+    pub fn retain_capacity(&mut self, maximum: usize) {
+        self.buffer.clear();
+        if self.buffer.capacity() > maximum {
+            self.buffer = Vec::with_capacity(maximum.min(self.limit));
+        }
+    }
 }
 
 impl BoundedBuf for ProtoBuffer {

--- a/rust/otap-dataflow/crates/pdata/src/otlp/mod.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/mod.rs
@@ -113,6 +113,16 @@ impl OtlpProtoBytes {
         }
     }
 
+    /// Takes ownership of the shared encoded buffer.
+    #[must_use]
+    pub fn into_bytes(self) -> Bytes {
+        match self {
+            Self::ExportLogsRequest(bytes)
+            | Self::ExportMetricsRequest(bytes)
+            | Self::ExportTracesRequest(bytes) => bytes,
+        }
+    }
+
     /// Return the byte-size of this message.
     #[must_use]
     pub fn num_bytes(&self) -> usize {

--- a/rust/otap-dataflow/crates/pdata/src/otlp/mod.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/mod.rs
@@ -103,6 +103,16 @@ impl OtlpProtoBytes {
         }
     }
 
+    /// Borrows the shared encoded buffer.
+    #[must_use]
+    pub const fn bytes(&self) -> &Bytes {
+        match self {
+            Self::ExportLogsRequest(bytes)
+            | Self::ExportMetricsRequest(bytes)
+            | Self::ExportTracesRequest(bytes) => bytes,
+        }
+    }
+
     /// Return the byte-size of this message.
     #[must_use]
     pub fn num_bytes(&self) -> usize {

--- a/rust/otap-dataflow/crates/pdata/src/otlp/mod.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/mod.rs
@@ -53,9 +53,9 @@ impl OtlpProtoBytes {
     #[must_use]
     pub fn new_from_bytes<B>(signal: SignalType, b: B) -> Self
     where
-        B: Into<Vec<u8>>,
+        B: Into<Bytes>,
     {
-        let bytes: Bytes = b.into().into();
+        let bytes: Bytes = b.into();
         match signal {
             SignalType::Logs => Self::ExportLogsRequest(bytes),
             SignalType::Metrics => Self::ExportMetricsRequest(bytes),

--- a/rust/otap-dataflow/crates/pdata/src/payload.rs
+++ b/rust/otap-dataflow/crates/pdata/src/payload.rs
@@ -407,6 +407,16 @@ impl OtapPayload {
         }
     }
 
+    /// Returns a cached byte measurement or measures the current representation.
+    #[must_use]
+    pub fn measured_bytes(&self) -> Option<usize> {
+        self.data.num_bytes()
+    }
+
+    pub(crate) fn set_item_count(&mut self, count: usize) {
+        self.item_count.set(count);
+    }
+
     /// Borrows the concrete payload data for pattern matching.
     #[must_use]
     pub fn data(&self) -> &PayloadData {
@@ -472,6 +482,76 @@ impl OtapPayload {
                 })
             }
         }
+    }
+
+    /// Materializes native OTAP only after a successful decode.
+    pub(crate) fn materialize_otap(
+        &mut self,
+        state: &mut CodecState,
+    ) -> Result<(), crate::encode::Error> {
+        if !matches!(self.data, PayloadData::OtapArrowRecords(_)) {
+            let records = self
+                .clone()
+                .try_into_otap(state)
+                .map_err(|error| error.into_parts().0)?;
+            *self = records.into();
+        }
+        Ok(())
+    }
+
+    /// Converts to a generalized encoded representation through reusable state.
+    pub fn into_encoded(
+        mut self,
+        state: &mut CodecState,
+        plan: &EncodingPlan,
+    ) -> Result<EncodedPdata, Error> {
+        let signal = self.signal_type();
+        plan.codec()
+            .require(signal, crate::codec::CodecDirection::Encode)?;
+        if self.format() == PdataFormat::encoded(plan.codec()) {
+            return Ok(match self.data {
+                PayloadData::OtlpBytes(bytes) => {
+                    EncodedPdata::from_resolved(ResolvedCodec::OTLP, signal, bytes.into_bytes())
+                }
+                PayloadData::Encoded(encoded) => encoded,
+                PayloadData::OtapArrowRecords(_) => {
+                    unreachable!("native OTAP has no encoded representation")
+                }
+            });
+        }
+        let bytes = self.prepare_encoded(state, plan)?.into_bytes();
+        Ok(EncodedPdata::from_resolved(plan.codec(), signal, bytes))
+    }
+
+    /// Test helper for one-shot encoded representation conversion.
+    #[cfg(any(test, feature = "testing"))]
+    #[doc(hidden)]
+    pub fn into_encoded_for_test(
+        self,
+        encoding: PdataEncoding,
+        options: otel_arrow_dfe_config::EncodeOptions,
+    ) -> Result<EncodedPdata, Error> {
+        let plan = EncodingPlan::resolve(&encoding, options)?;
+        self.into_encoded(&mut CodecState::default(), &plan)
+    }
+
+    /// Atomically replaces the representation after successful encoding.
+    pub fn convert_encoding(
+        &mut self,
+        state: &mut CodecState,
+        plan: &EncodingPlan,
+    ) -> Result<(), Error> {
+        if self.format() != PdataFormat::encoded(plan.codec()) {
+            let item_count = self.known_item_count();
+            let encoded = self.clone().into_encoded(state, plan)?;
+            let converted = Self::from_encoded(encoded);
+            *self = if let Some(count) = item_count {
+                converted.with_item_count(count)
+            } else {
+                converted
+            };
+        }
+        Ok(())
     }
 
     /// Returns a read-only representation-independent view.

--- a/rust/otap-dataflow/crates/pdata/src/payload.rs
+++ b/rust/otap-dataflow/crates/pdata/src/payload.rs
@@ -455,73 +455,86 @@ impl OtapPayloadHelpers for OtlpProtoBytes {
     }
 
     fn num_items(&self) -> usize {
-        // Counting requires traversing the encoded protobuf record hierarchy.
-        match self {
-            Self::ExportLogsRequest(bytes) => {
-                let logs_data_view = RawLogsData::new(bytes.as_ref());
-                use otel_arrow_dfe_pdata_views::views::logs::{
-                    LogsDataView, ResourceLogsView, ScopeLogsView,
-                };
-                logs_data_view
-                    .resources()
-                    .map(|rl| {
-                        rl.scopes()
-                            .map(|sl| sl.log_records().count())
-                            .sum::<usize>()
-                    })
-                    .sum()
-            }
-            Self::ExportTracesRequest(bytes) => {
-                let traces_data_view = RawTraceData::new(bytes.as_ref());
-                use otel_arrow_dfe_pdata_views::views::trace::{
-                    ResourceSpansView, ScopeSpansView, TracesView,
-                };
-                traces_data_view
-                    .resources()
-                    .map(|rs| rs.scopes().map(|ss| ss.spans().count()).sum::<usize>())
-                    .sum()
-            }
-            Self::ExportMetricsRequest(bytes) => {
-                let metrics_data_view = RawMetricsData::new(bytes.as_ref());
-                use otel_arrow_dfe_pdata_views::views::metrics::{
-                    DataView, ExponentialHistogramView, GaugeView, HistogramView, MetricView,
-                    MetricsView, ResourceMetricsView, ScopeMetricsView, SumView, SummaryView,
-                };
-                metrics_data_view
-                    .resources()
-                    .map(|rm| {
-                        rm.scopes()
-                            .map(|sm| {
-                                sm.metrics()
-                                    .map(|metric| {
-                                        metric
-                                            .data()
-                                            .map(|data| {
-                                                let mut count = 0;
-                                                if let Some(gauge) = data.as_gauge() {
-                                                    count += gauge.data_points().count();
-                                                } else if let Some(sum) = data.as_sum() {
-                                                    count += sum.data_points().count();
-                                                } else if let Some(histogram) = data.as_histogram()
-                                                {
-                                                    count += histogram.data_points().count();
-                                                } else if let Some(exp_histogram) =
-                                                    data.as_exponential_histogram()
-                                                {
-                                                    count += exp_histogram.data_points().count();
-                                                } else if let Some(summary) = data.as_summary() {
-                                                    count += summary.data_points().count();
-                                                }
-                                                count
-                                            })
-                                            .unwrap_or(0)
-                                    })
-                                    .sum::<usize>()
-                            })
-                            .sum::<usize>()
-                    })
-                    .sum()
-            }
+        count_otlp_items(self.signal_type(), self.as_bytes())
+    }
+}
+
+/// Stateless OTLP item scan shared by the codec and compatibility storage.
+pub(crate) fn count_otlp_items(signal: SignalType, bytes: &[u8]) -> usize {
+    // Counting traverses the encoded protobuf record hierarchy without
+    // constructing an owned request or a mutable codec instance.
+    match signal {
+        SignalType::Logs => {
+            let logs_data_view = RawLogsData::new(bytes);
+            use otel_arrow_dfe_pdata_views::views::logs::{
+                LogsDataView, ResourceLogsView, ScopeLogsView,
+            };
+            logs_data_view
+                .resources()
+                .map(|resource| {
+                    resource
+                        .scopes()
+                        .map(|scope| scope.log_records().count())
+                        .sum::<usize>()
+                })
+                .sum()
+        }
+        SignalType::Traces => {
+            let traces_data_view = RawTraceData::new(bytes);
+            use otel_arrow_dfe_pdata_views::views::trace::{
+                ResourceSpansView, ScopeSpansView, TracesView,
+            };
+            traces_data_view
+                .resources()
+                .map(|resource| {
+                    resource
+                        .scopes()
+                        .map(|scope| scope.spans().count())
+                        .sum::<usize>()
+                })
+                .sum()
+        }
+        SignalType::Metrics => {
+            let metrics_data_view = RawMetricsData::new(bytes);
+            use otel_arrow_dfe_pdata_views::views::metrics::{
+                DataView, ExponentialHistogramView, GaugeView, HistogramView, MetricView,
+                MetricsView, ResourceMetricsView, ScopeMetricsView, SumView, SummaryView,
+            };
+            metrics_data_view
+                .resources()
+                .map(|resource| {
+                    resource
+                        .scopes()
+                        .map(|scope| {
+                            scope
+                                .metrics()
+                                .map(|metric| {
+                                    metric
+                                        .data()
+                                        .map(|data| {
+                                            if let Some(gauge) = data.as_gauge() {
+                                                gauge.data_points().count()
+                                            } else if let Some(sum) = data.as_sum() {
+                                                sum.data_points().count()
+                                            } else if let Some(histogram) = data.as_histogram() {
+                                                histogram.data_points().count()
+                                            } else if let Some(histogram) =
+                                                data.as_exponential_histogram()
+                                            {
+                                                histogram.data_points().count()
+                                            } else if let Some(summary) = data.as_summary() {
+                                                summary.data_points().count()
+                                            } else {
+                                                0
+                                            }
+                                        })
+                                        .unwrap_or(0)
+                                })
+                                .sum::<usize>()
+                        })
+                        .sum::<usize>()
+                })
+                .sum()
         }
     }
 }

--- a/rust/otap-dataflow/crates/pdata/src/payload.rs
+++ b/rust/otap-dataflow/crates/pdata/src/payload.rs
@@ -691,6 +691,29 @@ mod test {
     use bytes::Bytes;
     use pretty_assertions::assert_eq;
     use prost::Message;
+    use std::mem::size_of;
+
+    /// Scenario: The legacy payload representation is built for a 64-bit target.
+    /// Guarantees: The baseline payload layout remains fixed for codec comparisons.
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn legacy_payload_layout_is_stable() {
+        assert_eq!(size_of::<PayloadData>(), 40);
+        assert_eq!(size_of::<OtapPayload>(), 72);
+    }
+
+    /// Scenario: An OTLP payload is converted back to its matching legacy representation.
+    /// Guarantees: Forwarding retains the original shared byte buffer without copying it.
+    #[test]
+    fn matching_otlp_forwarding_preserves_buffer() {
+        let original = Bytes::from_static(b"legacy-otlp");
+        let pointer = original.as_ptr();
+        let payload = OtapPayload::from(OtlpProtoBytes::ExportLogsRequest(original));
+        let forwarded: OtlpProtoBytes = payload
+            .try_into_with_default()
+            .expect("matching OTLP forwarding");
+        assert_eq!(forwarded.as_bytes().as_ptr(), pointer);
+    }
 
     #[test]
     fn test_conversion_logs() {

--- a/rust/otap-dataflow/crates/pdata/src/payload.rs
+++ b/rust/otap-dataflow/crates/pdata/src/payload.rs
@@ -370,6 +370,25 @@ impl OtapPayload {
         }
     }
 
+    /// Takes existing encoded bytes without copying, returning the original
+    /// payload when it already contains native records.
+    pub fn into_encoded_bytes(self) -> Result<Bytes, Self> {
+        let Self {
+            data,
+            item_count,
+            size,
+        } = self;
+        match data {
+            PayloadData::OtlpBytes(bytes) => Ok(bytes.into_bytes()),
+            PayloadData::Encoded(encoded) => Ok(encoded.into_bytes()),
+            data @ PayloadData::OtapArrowRecords(_) => Err(Self {
+                data,
+                item_count,
+                size,
+            }),
+        }
+    }
+
     /// Borrows native records only when already materialized.
     #[must_use]
     pub fn otap_ref(&self) -> Option<&OtapArrowRecords> {

--- a/rust/otap-dataflow/crates/pdata/src/payload.rs
+++ b/rust/otap-dataflow/crates/pdata/src/payload.rs
@@ -82,6 +82,9 @@
 // directly from OTAP -> OTLP bytes. The utility functions we use might change as part of
 // this diagram may need to be updated (https://github.com/open-telemetry/otel-arrow/issues/1095)
 
+use crate::codec::{
+    CodecState, CodecView, EncodeOutput, EncodedPdata, EncodingPlan, PdataEncoding, ResolvedCodec,
+};
 use crate::encode::{encode_logs_otap_batch, encode_metrics_otap_batch, encode_spans_otap_batch};
 use crate::error::Error;
 use crate::otap::{OtapArrowRecords, OtapBatchStore};
@@ -94,7 +97,7 @@ use crate::views::otlp::bytes::logs::RawLogsData;
 use crate::views::otlp::bytes::metrics::RawMetricsData;
 use crate::views::otlp::bytes::traces::RawTraceData;
 use crate::{TryFromWithOptions, TryIntoWithOptions};
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use otel_arrow_dfe_config::{ConversionOptions, SignalFormat, SignalType};
 use prost::{EncodeError, Message};
 
@@ -110,6 +113,9 @@ pub enum PayloadData {
     /// data is serialized as a protobuf service message for one of the OTLP GRPC services
     OtlpBytes(OtlpProtoBytes),
 
+    /// Independently encoded bytes with a resolved codec identity.
+    Encoded(EncodedPdata),
+
     /// data is contained in `OtapBatch` which contains Arrow `RecordBatches` for OTAP payload type
     /// TODO: Remove "Arrow" from this case name, it stutters; follow SignalFormat.
     OtapArrowRecords(OtapArrowRecords),
@@ -119,6 +125,7 @@ impl PayloadData {
     fn signal_type(&self) -> SignalType {
         match self {
             Self::OtlpBytes(value) => value.signal_type(),
+            Self::Encoded(value) => value.signal_type(),
             Self::OtapArrowRecords(value) => value.signal_type(),
         }
     }
@@ -127,12 +134,14 @@ impl PayloadData {
         match self {
             Self::OtapArrowRecords(_) => SignalFormat::OtapRecords,
             Self::OtlpBytes(_) => SignalFormat::OtlpBytes,
+            Self::Encoded(_) => SignalFormat::Encoded,
         }
     }
 
     fn is_empty(&self) -> bool {
         match self {
             Self::OtlpBytes(value) => value.is_empty(),
+            Self::Encoded(value) => value.bytes().is_empty(),
             Self::OtapArrowRecords(value) => value.is_empty(),
         }
     }
@@ -141,6 +150,11 @@ impl PayloadData {
     fn take_payload(&mut self) -> Self {
         match self {
             Self::OtlpBytes(value) => Self::OtlpBytes(value.take_payload()),
+            Self::Encoded(value) => {
+                let empty =
+                    EncodedPdata::from_resolved(value.codec(), value.signal_type(), Bytes::new());
+                Self::Encoded(std::mem::replace(value, empty))
+            }
             Self::OtapArrowRecords(value) => Self::OtapArrowRecords(value.take_payload()),
         }
     }
@@ -148,6 +162,10 @@ impl PayloadData {
     fn num_items(&self) -> usize {
         match self {
             Self::OtlpBytes(value) => value.num_items(),
+            Self::Encoded(value) => value
+                .codec()
+                .count_items(value.signal_type(), value.bytes())
+                .unwrap_or(0),
             Self::OtapArrowRecords(value) => value.num_items(),
         }
     }
@@ -155,6 +173,7 @@ impl PayloadData {
     fn num_bytes(&self) -> Option<usize> {
         match self {
             Self::OtlpBytes(value) => Some(value.num_bytes()),
+            Self::Encoded(value) => Some(value.bytes().len()),
             Self::OtapArrowRecords(value) => value.num_bytes(),
         }
     }
@@ -162,8 +181,66 @@ impl PayloadData {
     fn retained_memory_bytes(&self) -> usize {
         match self {
             Self::OtlpBytes(value) => value.retained_memory_bytes(),
+            Self::Encoded(value) => value.bytes().len(),
             Self::OtapArrowRecords(value) => value.retained_memory_bytes(),
         }
+    }
+}
+
+/// Logical pdata representation identity, independent of compatibility storage.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PdataFormat {
+    /// Native mutable OTAP records.
+    Otap,
+    /// Independently encoded bytes understood by a registered codec.
+    Encoded(ResolvedCodec),
+}
+
+impl PdataFormat {
+    /// Native OTAP representation.
+    pub const OTAP: Self = Self::Otap;
+
+    /// Builds an encoded representation identity.
+    #[must_use]
+    pub const fn encoded(codec: ResolvedCodec) -> Self {
+        Self::Encoded(codec)
+    }
+
+    /// Returns the encoded codec identity, if this is a byte representation.
+    #[must_use]
+    pub const fn codec(self) -> Option<ResolvedCodec> {
+        match self {
+            Self::Otap => None,
+            Self::Encoded(codec) => Some(codec),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CachedMeasurement(usize);
+
+impl CachedMeasurement {
+    const UNKNOWN: usize = usize::MAX;
+
+    const fn unknown() -> Self {
+        Self(Self::UNKNOWN)
+    }
+
+    const fn get(self) -> Option<usize> {
+        if self.0 == Self::UNKNOWN {
+            None
+        } else {
+            Some(self.0)
+        }
+    }
+
+    fn set(&mut self, value: usize) {
+        debug_assert_ne!(value, Self::UNKNOWN, "measurement exceeds supported range");
+        self.0 = value;
+    }
+
+    fn take(&mut self) -> Self {
+        std::mem::replace(self, Self::unknown())
     }
 }
 
@@ -189,8 +266,42 @@ impl PayloadData {
 #[derive(Clone, Debug)]
 pub struct OtapPayload {
     data: PayloadData,
-    item_count: Option<usize>,
-    size: Option<usize>,
+    item_count: CachedMeasurement,
+    size: CachedMeasurement,
+}
+
+/// A failed native conversion together with the exact recoverable input.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct OtapPayloadDecodeError(Box<OtapPayloadDecodeErrorInner>);
+
+#[derive(Debug, thiserror::Error)]
+#[error("{source}")]
+struct OtapPayloadDecodeErrorInner {
+    #[source]
+    source: crate::encode::Error,
+    payload: OtapPayload,
+}
+
+impl OtapPayloadDecodeError {
+    /// Returns the codec or conversion error.
+    #[must_use]
+    pub const fn error(&self) -> &crate::encode::Error {
+        &self.0.source
+    }
+
+    /// Returns the exact payload retained for retry or Nack.
+    #[must_use]
+    pub const fn payload(&self) -> &OtapPayload {
+        &self.0.payload
+    }
+
+    /// Splits the conversion error and recoverable payload.
+    #[must_use]
+    pub fn into_parts(self) -> (crate::encode::Error, OtapPayload) {
+        let inner = *self.0;
+        (inner.source, inner.payload)
+    }
 }
 
 impl OtapPayload {
@@ -199,8 +310,8 @@ impl OtapPayload {
     fn from_data(data: PayloadData) -> Self {
         Self {
             data,
-            item_count: None,
-            size: None,
+            item_count: CachedMeasurement::unknown(),
+            size: CachedMeasurement::unknown(),
         }
     }
 
@@ -214,6 +325,67 @@ impl OtapPayload {
     #[must_use]
     pub fn from_otap(payload: OtapArrowRecords) -> Self {
         Self::from_data(PayloadData::OtapArrowRecords(payload))
+    }
+
+    /// Wraps admitted encoded bytes without copying or decoding them.
+    #[must_use]
+    pub fn from_encoded(payload: EncodedPdata) -> Self {
+        Self::from_data(PayloadData::Encoded(payload))
+    }
+
+    /// Supplies a receiver-known item count without parsing encoded bytes.
+    #[must_use]
+    pub fn with_item_count(mut self, item_count: usize) -> Self {
+        self.item_count.set(item_count);
+        self
+    }
+
+    /// Logical representation identity.
+    #[must_use]
+    pub fn format(&self) -> PdataFormat {
+        match &self.data {
+            PayloadData::OtlpBytes(_) => PdataFormat::encoded(ResolvedCodec::OTLP),
+            PayloadData::Encoded(encoded) => PdataFormat::encoded(encoded.codec()),
+            PayloadData::OtapArrowRecords(_) => PdataFormat::OTAP,
+        }
+    }
+
+    /// Encoding identity for byte representations.
+    #[must_use]
+    pub fn encoding(&self) -> Option<&PdataEncoding> {
+        match &self.data {
+            PayloadData::OtlpBytes(_) => Some(&ResolvedCodec::OTLP.metadata().encoding),
+            PayloadData::Encoded(encoded) => Some(encoded.encoding()),
+            PayloadData::OtapArrowRecords(_) => None,
+        }
+    }
+
+    /// Borrows existing encoded bytes without conversion.
+    #[must_use]
+    pub fn encoded_bytes(&self) -> Option<&Bytes> {
+        match &self.data {
+            PayloadData::OtlpBytes(bytes) => Some(bytes.bytes()),
+            PayloadData::Encoded(encoded) => Some(encoded.bytes()),
+            PayloadData::OtapArrowRecords(_) => None,
+        }
+    }
+
+    /// Borrows native records only when already materialized.
+    #[must_use]
+    pub fn otap_ref(&self) -> Option<&OtapArrowRecords> {
+        match &self.data {
+            PayloadData::OtapArrowRecords(records) => Some(records),
+            _ => None,
+        }
+    }
+
+    /// Known item count, keeping unknown distinct from an empty batch.
+    #[must_use]
+    pub fn known_item_count(&self) -> Option<usize> {
+        match &self.data {
+            PayloadData::OtapArrowRecords(records) => Some(records.num_items()),
+            _ => self.item_count.get(),
+        }
     }
 
     /// Borrows the concrete payload data for pattern matching.
@@ -234,7 +406,111 @@ impl OtapPayload {
 
     /// Consumes this payload and extracts or converts it to OTAP records.
     pub fn into_otap(self) -> Result<OtapArrowRecords, crate::encode::Error> {
-        self.try_into_with_default()
+        match self.try_into_otap(&mut CodecState::default()) {
+            Ok(records) => Ok(records),
+            Err(error) => Err(error.into_parts().0),
+        }
+    }
+
+    /// Extracts native records or decodes encoded input through reusable state.
+    ///
+    /// A failure retains the exact original representation, bytes, and caches.
+    pub fn try_into_otap(
+        self,
+        state: &mut CodecState,
+    ) -> Result<OtapArrowRecords, OtapPayloadDecodeError> {
+        let Self {
+            data,
+            item_count,
+            size,
+        } = self;
+        match data {
+            PayloadData::OtapArrowRecords(records) => Ok(records),
+            PayloadData::OtlpBytes(bytes) => {
+                let payload = Self {
+                    data: PayloadData::OtlpBytes(bytes.clone()),
+                    item_count,
+                    size,
+                };
+                bytes.try_into_with_default().map_err(|source| {
+                    OtapPayloadDecodeError(Box::new(OtapPayloadDecodeErrorInner {
+                        source,
+                        payload,
+                    }))
+                })
+            }
+            PayloadData::Encoded(encoded) => {
+                let payload = Self {
+                    data: PayloadData::Encoded(encoded.clone()),
+                    item_count,
+                    size,
+                };
+                state.decode_encoded(&encoded).map_err(|source| {
+                    OtapPayloadDecodeError(Box::new(OtapPayloadDecodeErrorInner {
+                        source,
+                        payload,
+                    }))
+                })
+            }
+        }
+    }
+
+    /// Returns a read-only representation-independent view.
+    pub fn view<'a>(
+        &'a self,
+        state: &mut CodecState,
+    ) -> Result<CodecView<'a>, crate::encode::Error> {
+        match &self.data {
+            PayloadData::OtlpBytes(bytes) => Ok(CodecView::OtlpBytes {
+                signal: bytes.signal_type(),
+                bytes: bytes.as_bytes(),
+            }),
+            PayloadData::Encoded(encoded) => state.view_encoded(encoded),
+            PayloadData::OtapArrowRecords(records) => Ok(CodecView::OtapArrowRecords(
+                std::borrow::Cow::Borrowed(records),
+            )),
+        }
+    }
+
+    /// Prepares output using a startup-resolved encoding plan.
+    pub fn prepare_encoded<'a>(
+        &'a mut self,
+        state: &'a mut CodecState,
+        plan: &EncodingPlan,
+    ) -> Result<EncodeOutput<'a>, Error> {
+        plan.codec()
+            .require(self.signal_type(), crate::codec::CodecDirection::Encode)?;
+        match &mut self.data {
+            PayloadData::OtlpBytes(bytes) if plan.codec() == ResolvedCodec::OTLP => {
+                Ok(EncodeOutput::bytes(bytes.clone_bytes()))
+            }
+            PayloadData::Encoded(encoded) if encoded.codec() == plan.codec() => {
+                Ok(EncodeOutput::bytes(encoded.bytes().clone()))
+            }
+            PayloadData::OtapArrowRecords(records) => state.prepare_encode(records, plan),
+            PayloadData::OtlpBytes(bytes) => {
+                let mut records: OtapArrowRecords = bytes.clone().try_into_with_default().map_err(
+                    |error: crate::encode::Error| Error::Format {
+                        error: error.to_string(),
+                    },
+                )?;
+                state
+                    .prepare_encode(&mut records, plan)
+                    .map(EncodeOutput::copy_into_bytes)
+                    .map(EncodeOutput::bytes)
+            }
+            PayloadData::Encoded(encoded) => {
+                let mut records = state
+                    .decode_encoded(encoded)
+                    .map_err(|error| Error::Format {
+                        error: error.to_string(),
+                    })?;
+                state
+                    .prepare_encode(&mut records, plan)
+                    .map(EncodeOutput::copy_into_bytes)
+                    .map(EncodeOutput::bytes)
+            }
+        }
     }
 
     /// Returns the type of signal represented by this `OtapPdata` instance.
@@ -278,11 +554,24 @@ impl OtapPayload {
         match &self.data {
             // Cache OTLP counts because counting traverses protobuf records.
             PayloadData::OtlpBytes(_) => {
-                if let Some(item_count) = self.item_count {
+                if let Some(item_count) = self.item_count.get() {
                     return item_count;
                 }
                 let item_count = self.data.num_items();
-                self.item_count = Some(item_count);
+                self.item_count.set(item_count);
+                item_count
+            }
+            PayloadData::Encoded(encoded) => {
+                if let Some(item_count) = self.item_count.get() {
+                    return item_count;
+                }
+                let Some(item_count) = encoded
+                    .codec()
+                    .count_items(encoded.signal_type(), encoded.bytes())
+                else {
+                    return 0;
+                };
+                self.item_count.set(item_count);
                 item_count
             }
             // Bypass the cache for OTAP because Arrow batches store row counts.
@@ -299,14 +588,14 @@ impl OtapPayload {
     pub fn num_bytes(&mut self) -> Option<usize> {
         match &self.data {
             // OTLP already stores the exact encoded length in Bytes metadata.
-            PayloadData::OtlpBytes(_) => self.data.num_bytes(),
+            PayloadData::OtlpBytes(_) | PayloadData::Encoded(_) => self.data.num_bytes(),
             // Cache OTAP sizing because it walks every Arrow array and buffer.
             PayloadData::OtapArrowRecords(_) => {
-                if let Some(size) = self.size {
+                if let Some(size) = self.size.get() {
                     return Some(size);
                 }
                 let size = self.data.num_bytes()?;
-                self.size = Some(size);
+                self.size.set(size);
                 Some(size)
             }
         }
@@ -328,8 +617,8 @@ impl OtapPayload {
     pub const fn empty(signal: SignalType) -> Self {
         Self {
             data: PayloadData::OtlpBytes(OtlpProtoBytes::empty(signal)),
-            item_count: None,
-            size: None,
+            item_count: CachedMeasurement::unknown(),
+            size: CachedMeasurement::unknown(),
         }
     }
 
@@ -338,14 +627,14 @@ impl OtapPayload {
     #[cfg(any(test, feature = "testing"))]
     #[must_use]
     pub fn test_has_cached_item_count(&self) -> bool {
-        self.item_count.is_some()
+        self.item_count.get().is_some()
     }
 
     /// Test-only introspection: true if the OTAP size cache has been computed.
     #[cfg(any(test, feature = "testing"))]
     #[must_use]
     pub fn test_has_cached_size(&self) -> bool {
-        self.size.is_some()
+        self.size.get().is_some()
     }
 }
 
@@ -553,6 +842,12 @@ impl From<OtlpProtoBytes> for OtapPayload {
     }
 }
 
+impl From<EncodedPdata> for OtapPayload {
+    fn from(value: EncodedPdata) -> Self {
+        Self::from_encoded(value)
+    }
+}
+
 impl From<PayloadData> for OtapPayload {
     fn from(value: PayloadData) -> Self {
         Self::from_data(value)
@@ -569,6 +864,7 @@ impl TryFromWithOptions<OtapPayload> for OtapArrowRecords {
         match value.into_data() {
             PayloadData::OtapArrowRecords(value) => Ok(value),
             PayloadData::OtlpBytes(value) => value.try_into_with_options(opts),
+            PayloadData::Encoded(value) => CodecState::default().decode_encoded(&value),
         }
     }
 }
@@ -583,6 +879,17 @@ impl TryFromWithOptions<OtapPayload> for OtlpProtoBytes {
         match value.into_data() {
             PayloadData::OtapArrowRecords(value) => value.try_into_with_options(opts),
             PayloadData::OtlpBytes(value) => Ok(value),
+            PayloadData::Encoded(value) if value.codec() == ResolvedCodec::OTLP => Ok(
+                OtlpProtoBytes::new_from_bytes(value.signal_type(), value.into_bytes()),
+            ),
+            PayloadData::Encoded(value) => {
+                let records = CodecState::default()
+                    .decode_encoded(&value)
+                    .map_err(|error| Error::Format {
+                        error: error.to_string(),
+                    })?;
+                records.try_into_with_options(opts)
+            }
         }
     }
 }
@@ -706,13 +1013,14 @@ mod test {
     use prost::Message;
     use std::mem::size_of;
 
-    /// Scenario: The legacy payload representation is built for a 64-bit target.
-    /// Guarantees: The baseline payload layout remains fixed for codec comparisons.
+    /// Scenario: Transitional legacy, encoded, and native storage is built for a 64-bit target.
+    /// Guarantees: Inline admission reduces the wrapper below the 72-byte upstream baseline.
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn legacy_payload_layout_is_stable() {
-        assert_eq!(size_of::<PayloadData>(), 40);
-        assert_eq!(size_of::<OtapPayload>(), 72);
+        assert_eq!(size_of::<EncodedPdata>(), 48);
+        assert_eq!(size_of::<PayloadData>(), 48);
+        assert_eq!(size_of::<OtapPayload>(), 64);
     }
 
     /// Scenario: An OTLP payload is converted back to its matching legacy representation.
@@ -726,6 +1034,98 @@ mod test {
             .try_into_with_default()
             .expect("matching OTLP forwarding");
         assert_eq!(forwarded.as_bytes().as_ptr(), pointer);
+    }
+
+    /// Scenario: OTLP bytes are admitted explicitly into generalized transitional storage.
+    /// Guarantees: Admission and matching output preserve the buffer and create no codec instance.
+    #[test]
+    fn encoded_admission_and_matching_forward_are_lazy() {
+        let original = Bytes::from_static(b"deliberately-not-protobuf");
+        let pointer = original.as_ptr();
+        let encoded = ResolvedCodec::OTLP
+            .admit(SignalType::Logs, original)
+            .expect("OTLP admission validates metadata only");
+        let mut payload = OtapPayload::from_encoded(encoded);
+        assert_eq!(payload.signal_format(), SignalFormat::Encoded);
+        assert_eq!(payload.format(), PdataFormat::encoded(ResolvedCodec::OTLP));
+        assert_eq!(payload.encoded_bytes().unwrap().as_ptr(), pointer);
+
+        let mut state = CodecState::default();
+        let output = payload
+            .prepare_encoded(&mut state, &EncodingPlan::OTLP)
+            .expect("matching output forwards bytes");
+        assert_eq!(output.as_ref().as_ptr(), pointer);
+        drop(output);
+        assert_eq!(state.test_instance_count(), 0);
+    }
+
+    /// Scenario: Malformed generalized OTLP is converted with receiver-known measurements.
+    /// Guarantees: Failure returns the same bytes, identity, signal, count, and reusable state.
+    #[test]
+    fn encoded_decode_failure_recovers_exact_input() {
+        let original = Bytes::from_static(&[0x0a, 0x05, 0x01]);
+        let pointer = original.as_ptr();
+        let payload = OtapPayload::from_encoded(
+            ResolvedCodec::OTLP
+                .admit(SignalType::Logs, original)
+                .expect("lazy OTLP admission"),
+        )
+        .with_item_count(7);
+        let mut state = CodecState::default();
+        let error = payload
+            .try_into_otap(&mut state)
+            .expect_err("malformed OTLP must fail native conversion");
+        let (_, recovered) = error.into_parts();
+        assert_eq!(recovered.signal_type(), SignalType::Logs);
+        assert_eq!(
+            recovered.format(),
+            PdataFormat::encoded(ResolvedCodec::OTLP)
+        );
+        assert_eq!(recovered.known_item_count(), Some(7));
+        assert_eq!(recovered.encoded_bytes().unwrap().as_ptr(), pointer);
+        assert_eq!(
+            recovered.encoded_bytes().unwrap().as_ref(),
+            &[0x0a, 0x05, 0x01]
+        );
+        assert_eq!(state.test_instance_count(), 1);
+    }
+
+    /// Scenario: Native OTAP is consumed through the recoverable codec capability.
+    /// Guarantees: Records move directly and no codec instance is constructed.
+    #[test]
+    fn native_try_into_otap_needs_no_codec() {
+        let expected: OtapArrowRecords = OtlpProtoBytes::new_from_bytes(
+            SignalType::Logs,
+            logs_with_full_resource_and_scope().encode_to_vec(),
+        )
+        .try_into_with_default()
+        .expect("fixture conversion");
+        let mut state = CodecState::default();
+        let actual = OtapPayload::from_otap(expected.clone())
+            .try_into_otap(&mut state)
+            .expect("native move");
+        assert_eq!(actual, expected);
+        assert_eq!(state.test_instance_count(), 0);
+    }
+
+    /// Scenario: A read-only consumer views admitted OTLP before materialization.
+    /// Guarantees: The borrowed view preserves the byte pointer and leaves storage encoded.
+    #[test]
+    fn encoded_view_does_not_materialize_payload() {
+        let original = Bytes::from(logs_with_full_resource_and_scope().encode_to_vec());
+        let pointer = original.as_ptr();
+        let payload = OtapPayload::from_encoded(
+            ResolvedCodec::OTLP
+                .admit(SignalType::Logs, original)
+                .expect("OTLP admission"),
+        );
+        let mut state = CodecState::default();
+        let view = payload.view(&mut state).expect("OTLP borrowed view");
+        match view {
+            CodecView::OtlpBytes { bytes, .. } => assert_eq!(bytes.as_ptr(), pointer),
+            CodecView::OtapArrowRecords(_) => panic!("OTLP should remain a borrowed byte view"),
+        }
+        assert_eq!(payload.encoded_bytes().unwrap().as_ptr(), pointer);
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/pdata/src/testing/codec.rs
+++ b/rust/otap-dataflow/crates/pdata/src/testing/codec.rs
@@ -1,0 +1,135 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Registered OTLP-compatible test codecs for exercising generic pdata paths.
+
+use crate::batching::CodecBatches;
+use crate::batching::{BatchProfile, BatchSizer, BatchingSupport};
+use crate::codec::{
+    OtlpCodec, PDATA_CODEC_FACTORIES, PdataCodec, PdataCodecMetadata, PdataCodecRegistration,
+    PdataEncoding,
+};
+use crate::{OtapArrowRecords, error::Error};
+use bytes::Bytes;
+use otel_arrow_dfe_config::{EncodeOptions, SignalType};
+
+// The native OTLP conversion uses trusted byte views. Test extensions validate
+// their input so malformed test messages exercise the generic codec error path.
+#[derive(Default)]
+struct TestCodec(OtlpCodec);
+
+impl PdataCodec for TestCodec {
+    fn decode(
+        &mut self,
+        signal: SignalType,
+        bytes: &Bytes,
+    ) -> Result<OtapArrowRecords, crate::encode::Error> {
+        use crate::views::otlp::bytes::{
+            logs::RawLogsData, metrics::RawMetricsData, traces::RawTraceData,
+        };
+        match signal {
+            SignalType::Logs => RawLogsData::try_new(bytes).map(|_| ()),
+            SignalType::Metrics => RawMetricsData::try_new(bytes).map(|_| ()),
+            SignalType::Traces => RawTraceData::try_new(bytes).map(|_| ()),
+        }
+        .map_err(|error| Error::Format {
+            error: error.to_string(),
+        })?;
+        self.0.decode(signal, bytes)
+    }
+
+    fn encode(
+        &mut self,
+        records: OtapArrowRecords,
+        options: EncodeOptions,
+    ) -> Result<Bytes, Error> {
+        self.0.encode(records, options)
+    }
+
+    fn batch(
+        &mut self,
+        signal: SignalType,
+        profile: &BatchProfile,
+        inputs: Vec<Bytes>,
+    ) -> Result<CodecBatches, Error> {
+        self.0.batch(signal, profile, inputs)
+    }
+}
+
+/// A registered encoding with OTAP fallback batching.
+pub const TEST_ENCODING: PdataEncoding = PdataEncoding::new("test-otlp-codec");
+/// A registered input encoding without an output encoder.
+pub const DECODE_ONLY_ENCODING: PdataEncoding = PdataEncoding::new("test-otlp-decode-only");
+/// A codec with native byte batching, independent of the built-in identity.
+pub const NATIVE_ENCODING: PdataEncoding = PdataEncoding::new("test-native-otlp");
+/// An output-only codec that must never be admitted into the pipeline.
+pub const ENCODE_ONLY_ENCODING: PdataEncoding = PdataEncoding::new("test-otlp-encode-only");
+
+static FALLBACK_METADATA: PdataCodecMetadata = PdataCodecMetadata {
+    encoding: TEST_ENCODING,
+    signals: &[SignalType::Logs, SignalType::Metrics, SignalType::Traces],
+    format_version: None,
+    compression: None,
+    can_decode: true,
+    can_encode: true,
+    batching: None,
+};
+static DECODE_METADATA: PdataCodecMetadata = PdataCodecMetadata {
+    encoding: DECODE_ONLY_ENCODING,
+    signals: &[SignalType::Logs, SignalType::Metrics, SignalType::Traces],
+    format_version: None,
+    compression: None,
+    can_decode: true,
+    can_encode: false,
+    batching: None,
+};
+static NATIVE_METADATA: PdataCodecMetadata = PdataCodecMetadata {
+    encoding: NATIVE_ENCODING,
+    signals: &[SignalType::Logs, SignalType::Metrics, SignalType::Traces],
+    format_version: None,
+    compression: None,
+    can_decode: true,
+    can_encode: true,
+    batching: Some(BatchingSupport {
+        sizers: &[BatchSizer::Bytes],
+        default_profile: BatchProfile::otlp(),
+    }),
+};
+static ENCODE_METADATA: PdataCodecMetadata = PdataCodecMetadata {
+    encoding: ENCODE_ONLY_ENCODING,
+    signals: &[SignalType::Logs],
+    format_version: None,
+    compression: None,
+    can_decode: false,
+    can_encode: true,
+    batching: None,
+};
+
+#[allow(unsafe_code)]
+#[linkme::distributed_slice(PDATA_CODEC_FACTORIES)]
+static FALLBACK: PdataCodecRegistration = PdataCodecRegistration {
+    count_items: None,
+    metadata: &FALLBACK_METADATA,
+    create: || Box::<TestCodec>::default(),
+};
+#[allow(unsafe_code)]
+#[linkme::distributed_slice(PDATA_CODEC_FACTORIES)]
+static DECODE: PdataCodecRegistration = PdataCodecRegistration {
+    count_items: None,
+    metadata: &DECODE_METADATA,
+    create: || Box::<TestCodec>::default(),
+};
+#[allow(unsafe_code)]
+#[linkme::distributed_slice(PDATA_CODEC_FACTORIES)]
+static NATIVE: PdataCodecRegistration = PdataCodecRegistration {
+    count_items: None,
+    metadata: &NATIVE_METADATA,
+    create: || Box::<TestCodec>::default(),
+};
+#[allow(unsafe_code)]
+#[linkme::distributed_slice(PDATA_CODEC_FACTORIES)]
+static ENCODE: PdataCodecRegistration = PdataCodecRegistration {
+    count_items: None,
+    metadata: &ENCODE_METADATA,
+    create: || Box::<TestCodec>::default(),
+};

--- a/rust/otap-dataflow/crates/pdata/src/testing/codec_conformance.rs
+++ b/rust/otap-dataflow/crates/pdata/src/testing/codec_conformance.rs
@@ -1,0 +1,75 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Reusable behavioral checks for pdata codecs before payload integration.
+
+use bytes::Bytes;
+use otel_arrow_dfe_config::SignalType;
+
+use crate::OtapPayloadHelpers;
+use crate::codec::{CodecState, EncodingPlan, ResolvedCodec};
+
+/// One codec and byte sample used by the decode conformance checks.
+pub struct DecodeConformanceCase {
+    /// Resolved codec under test.
+    pub codec: ResolvedCodec,
+    /// Signal carried outside the encoded bytes.
+    pub signal: SignalType,
+    /// Complete independently decodable batch.
+    pub valid: Bytes,
+    /// Malformed bytes that strict decoders must reject.
+    pub malformed: Option<Bytes>,
+    /// Expected primary-signal item count.
+    pub expected_items: usize,
+}
+
+/// Checks signal preservation, borrowed views, stateless counts, state reuse,
+/// repeated malformed input, and independent output decoding.
+pub fn assert_decode_conformance(case: DecodeConformanceCase) {
+    let pointer = case.valid.as_ptr();
+    assert_eq!(
+        case.codec.count_items(case.signal, &case.valid),
+        Some(case.expected_items)
+    );
+
+    let mut state = CodecState::default();
+    let view = state
+        .view(case.codec, case.signal, &case.valid)
+        .expect("valid codec bytes must produce a view");
+    assert_eq!(view.signal_type(), case.signal);
+    assert_eq!(case.valid.as_ptr(), pointer);
+
+    let records = state
+        .decode(case.codec, case.signal, &case.valid)
+        .expect("valid codec bytes must decode");
+    assert_eq!(records.signal_type(), case.signal);
+    assert_eq!(records.num_items(), case.expected_items);
+    assert_eq!(state.test_instance_count(), 1);
+
+    if let Some(malformed) = case.malformed {
+        let malformed_pointer = malformed.as_ptr();
+        for _ in 0..2 {
+            assert!(state.decode(case.codec, case.signal, &malformed).is_err());
+            assert_eq!(malformed.as_ptr(), malformed_pointer);
+        }
+        let recovered = state
+            .decode(case.codec, case.signal, &case.valid)
+            .expect("valid decode must recover after repeated failures");
+        assert_eq!(recovered.num_items(), case.expected_items);
+    }
+
+    if case.codec.metadata().can_encode {
+        let plan = EncodingPlan::new(case.codec, Default::default())
+            .expect("conforming output codec must resolve");
+        let mut records = records;
+        let output = state
+            .prepare_encode(&mut records, &plan)
+            .expect("conforming codec must encode")
+            .into_bytes();
+        let independently_decoded = CodecState::default()
+            .decode(case.codec, case.signal, &output)
+            .expect("each encoded output must decode independently");
+        assert_eq!(independently_decoded.signal_type(), case.signal);
+        assert_eq!(independently_decoded.num_items(), case.expected_items);
+    }
+}

--- a/rust/otap-dataflow/crates/pdata/src/testing/mod.rs
+++ b/rust/otap-dataflow/crates/pdata/src/testing/mod.rs
@@ -3,6 +3,7 @@
 
 //! Testing utilities for OTLP and OTAP verification.
 
+pub mod codec_conformance;
 pub mod equiv;
 pub mod fixtures;
 pub mod record_batch;

--- a/rust/otap-dataflow/crates/pdata/src/testing/mod.rs
+++ b/rust/otap-dataflow/crates/pdata/src/testing/mod.rs
@@ -3,6 +3,8 @@
 
 //! Testing utilities for OTLP and OTAP verification.
 
+#[cfg(any(test, feature = "testing"))]
+pub mod codec;
 pub mod codec_conformance;
 pub mod equiv;
 pub mod fixtures;

--- a/rust/otap-dataflow/crates/wasm-host/src/bridge.rs
+++ b/rust/otap-dataflow/crates/wasm-host/src/bridge.rs
@@ -10,9 +10,8 @@
 //! delivery semantics as unmodified data.
 
 use otel_arrow_dfe_engine::error::Error as EngineError;
-use otel_arrow_dfe_otap::pdata::OtapPdata;
+use otel_arrow_dfe_otap::pdata::{OtapArrowPdata, OtapPdata};
 use otel_arrow_dfe_pdata::OtapArrowRecords;
-use otel_arrow_dfe_pdata::TryIntoWithOptions;
 
 /// Run `run` on `pdata` converted to OTAP records, preserving the pdata context.
 ///
@@ -29,14 +28,13 @@ use otel_arrow_dfe_pdata::TryIntoWithOptions;
 /// OTAP records; add native OTLP handling and explicit per-`ArrowPayloadType`
 /// processing paths.
 pub(crate) fn run_on_otap_records<F>(
-    pdata: OtapPdata,
+    pdata: OtapArrowPdata,
     run: F,
 ) -> Result<Option<OtapPdata>, EngineError>
 where
     F: FnOnce(OtapArrowRecords) -> Result<Option<OtapArrowRecords>, EngineError>,
 {
-    let (context, payload) = pdata.into_parts();
-    let records: OtapArrowRecords = payload.try_into_with_default()?;
+    let (context, records) = pdata.into_parts();
     if records.root_record_batch().is_none() {
         // Nothing to process; forward unchanged (context preserved).
         return Ok(Some(OtapPdata::new(context, records.into())));
@@ -61,7 +59,7 @@ mod tests {
     use otel_arrow_dfe_pdata::proto::opentelemetry::logs::v1::LogRecord;
     use otel_arrow_dfe_pdata::testing::round_trip::{otap_to_otlp, to_otap_logs};
 
-    fn logs_pdata_with_severities(severities: &[&str]) -> OtapPdata {
+    fn logs_pdata_with_severities(severities: &[&str]) -> OtapArrowPdata {
         let records = to_otap_logs(
             severities
                 .iter()
@@ -77,14 +75,14 @@ mod tests {
                 })
                 .collect(),
         );
-        OtapPdata::new(Context::default(), records.into())
+        OtapArrowPdata::new(Context::default(), records)
     }
 
     fn severities_of(pdata: OtapPdata) -> Vec<String> {
-        let (_ctx, payload) = pdata.into_parts();
-        let records: OtapArrowRecords = payload
-            .try_into_with_default()
+        let arrow_pdata = pdata
+            .try_into_otap(&mut otel_arrow_dfe_pdata::codec::CodecState::default())
             .expect("convert payload to otap records");
+        let records = arrow_pdata.records();
         let batch = records
             .get(ArrowPayloadType::Logs)
             .expect("logs root record batch");
@@ -106,22 +104,19 @@ mod tests {
     /// Guarantees: The bridge forwards the payload unchanged and does not call the guest closure.
     #[test]
     fn skips_guest_call_when_root_batch_is_missing() {
-        let input = OtapPdata::new(
-            Context::default(),
-            OtapArrowRecords::Logs(Logs::default()).into(),
-        );
+        let input =
+            OtapArrowPdata::new(Context::default(), OtapArrowRecords::Logs(Logs::default()));
         let output = run_on_otap_records(input, |_records| {
             panic!("closure should not be called for empty/rootless payload")
         })
         .expect("run_on_otap_records should pass through empty payloads")
         .expect("empty payload should be forwarded, not dropped");
 
-        let (_ctx, payload) = output.into_parts();
-        let records: OtapArrowRecords = payload
-            .try_into_with_default()
+        let records = output
+            .try_into_otap(&mut otel_arrow_dfe_pdata::codec::CodecState::default())
             .expect("convert payload to otap records");
         assert!(
-            records.get(ArrowPayloadType::Logs).is_none(),
+            records.records().get(ArrowPayloadType::Logs).is_none(),
             "empty logs payload should remain empty"
         );
     }
@@ -186,11 +181,10 @@ mod tests {
             .expect("bridge run succeeds")
             .expect("payload is not dropped");
 
-        let (_ctx, payload) = output.into_parts();
-        let records: OtapArrowRecords = payload
-            .try_into_with_default()
+        let records = output
+            .try_into_otap(&mut otel_arrow_dfe_pdata::codec::CodecState::default())
             .expect("convert payload to otap records");
-        let otlp = otap_to_otlp(&records);
+        let otlp = otap_to_otlp(records.records());
 
         let OtlpProtoMessage::Logs(logs) = otlp else {
             panic!("expected logs payload");

--- a/rust/otap-dataflow/crates/wasm-host/src/processor.rs
+++ b/rust/otap-dataflow/crates/wasm-host/src/processor.rs
@@ -24,14 +24,14 @@ use otel_arrow_dfe_engine::ConsumerEffectHandlerExtension;
 use otel_arrow_dfe_engine::MessageSourceLocalEffectHandlerExtension;
 use otel_arrow_dfe_engine::config::ProcessorConfig;
 use otel_arrow_dfe_engine::context::PipelineContext;
-use otel_arrow_dfe_engine::control::{AckMsg, NodeControlMsg};
+use otel_arrow_dfe_engine::control::{AckMsg, NackMsg, NodeControlMsg};
 use otel_arrow_dfe_engine::error::{Error as EngineError, ProcessorErrorKind};
 use otel_arrow_dfe_engine::local::processor as local;
 use otel_arrow_dfe_engine::message::Message;
 use otel_arrow_dfe_engine::node::NodeId;
 use otel_arrow_dfe_engine::processor::ProcessorWrapper;
 use otel_arrow_dfe_otap::OTAP_PROCESSOR_FACTORIES;
-use otel_arrow_dfe_otap::pdata::OtapPdata;
+use otel_arrow_dfe_otap::pdata::{OtapPdata, PdataEffectHandlerExtension};
 use otel_arrow_dfe_pdata::OtapArrowRecords;
 use otel_arrow_dfe_pdata::OtapPayload;
 use serde::{Deserialize, Serialize};
@@ -168,46 +168,52 @@ impl local::Processor<OtapPdata> for WasmProcessor {
             Message::Control(_) => Ok(()),
             Message::PData(pdata) => {
                 let processor_id = effect_handler.processor_id();
-                let (context, payload) = pdata.into_parts();
-                let signal_type = payload.signal_type();
-                let output = bridge::run_on_otap_records(
-                    OtapPdata::new(context.clone(), payload),
-                    |records| {
-                        self.metrics.pdata.guest_process_calls.add(1);
-                        // Count rows entering the guest before consuming records.
-                        let rows_in = records
-                            .root_record_batch()
-                            .map_or(0, |b| b.num_rows() as u64);
+                let arrow_pdata = match effect_handler.try_into_otap(pdata).await {
+                    Ok(arrow_pdata) => arrow_pdata,
+                    Err(error) => {
+                        let (error, pdata) = error.into_parts();
+                        effect_handler
+                            .notify_nack(NackMsg::new_permanent(error.to_string(), pdata))
+                            .await?;
+                        return Ok(());
+                    }
+                };
+                let context = arrow_pdata.context().clone();
+                let signal_type = arrow_pdata.signal_type();
+                let output = bridge::run_on_otap_records(arrow_pdata, |records| {
+                    self.metrics.pdata.guest_process_calls.add(1);
+                    // Count rows entering the guest before consuming records.
+                    let rows_in = records
+                        .root_record_batch()
+                        .map_or(0, |b| b.num_rows() as u64);
 
-                        let result = self.run_guest(records).map_err(|e| {
-                            self.metrics.pdata.guest_process_errors.add(1);
-                            EngineError::ProcessorError {
-                                processor: processor_id.clone(),
-                                kind: ProcessorErrorKind::Other,
-                                error: format!("wasm plugin process failed: {e}"),
-                                source_detail: String::new(),
-                            }
-                        });
+                    let result = self.run_guest(records).map_err(|e| {
+                        self.metrics.pdata.guest_process_errors.add(1);
+                        EngineError::ProcessorError {
+                            processor: processor_id.clone(),
+                            kind: ProcessorErrorKind::Other,
+                            error: format!("wasm plugin process failed: {e}"),
+                            source_detail: String::new(),
+                        }
+                    });
 
-                        // Record rows-in by signal type.
+                    // Record rows-in by signal type.
+                    self.metrics
+                        .records_for(signal_type)
+                        .records_in
+                        .add(rows_in);
+
+                    // Record rows-out if the guest returned a batch.
+                    if let Ok(Some(ref out)) = result {
+                        let rows_out = out.root_record_batch().map_or(0, |b| b.num_rows() as u64);
                         self.metrics
                             .records_for(signal_type)
-                            .records_in
-                            .add(rows_in);
+                            .records_out
+                            .add(rows_out);
+                    }
 
-                        // Record rows-out if the guest returned a batch.
-                        if let Ok(Some(ref out)) = result {
-                            let rows_out =
-                                out.root_record_batch().map_or(0, |b| b.num_rows() as u64);
-                            self.metrics
-                                .records_for(signal_type)
-                                .records_out
-                                .add(rows_out);
-                        }
-
-                        result
-                    },
-                );
+                    result
+                });
 
                 // Drain per-call kernel counters outside the closure so they
                 // are captured for successful and error-return guest calls.

--- a/rust/otap-dataflow/docs/pdata-codec-benchmarks.md
+++ b/rust/otap-dataflow/docs/pdata-codec-benchmarks.md
@@ -1,0 +1,22 @@
+# PData Codec Benchmark Method
+
+Use the `payload_measurements` and `syslog_cef_receiver` Criterion benchmarks to
+compare representation changes with the legacy implementation.
+
+## Controlled comparison
+
+1. Build release benchmark executables for the baseline and candidate commits.
+2. Select an otherwise idle logical CPU and confirm that its SMT sibling is idle.
+3. Pin every benchmark process to that CPU.
+4. Alternate baseline and candidate runs to reduce temperature and run-order bias.
+5. Use identical warm-up, measurement, sample-count, and input-size settings.
+6. Retain Criterion confidence intervals and record the tested commit IDs.
+
+Matching-representation forwarding must preserve the original `Bytes` buffer and
+must not allocate a representation wrapper. Native OTAP conversion must move the
+records directly. If confidence intervals do not overlap, repeat the interleaved
+runs and use CPU counters or allocation profiling before attributing a regression
+to the codec abstraction.
+
+HTTP compression measurements include encoding directly from the reusable output
+buffer. Keep transport compression separate from codec encoding in reports.


### PR DESCRIPTION
# Change summary

This is PR 4 of the pluggable PData codec series introduced in #3452.

The preceding PRs establish the codec framework, migrate pipeline nodes, and add codec-aware batching. This PR activates the framework for OTLP and removes the transitional OTLP-specific payload path.

### OTLP receiver activation

OTLP-producing receivers now admit protobuf requests through `ResolvedCodec::OTLP.admit`:

- OTLP/HTTP.
- The existing OTLP/gRPC implementation.
- The newer OTLP/gRPC implementation.
- Associated receiver fixtures and compatibility adapters.

Admitted logs, metrics, and traces remain in the generalized encoded representation until a downstream consumer requests native OTAP.

When an OTLP exporter receives matching encoded OTLP, it forwards the original `Bytes` without decoding, re-encoding, or creating a mutable codec instance.

### Transitional cleanup

With all consumers and receivers using representation-independent APIs, this PR removes:

- The specialized `OtlpBytes` payload storage variant.
- `SignalFormat`.
- OTLP-specific dispatch in payload conversion and batching.
- Obsolete default-context and implicit consuming conversions.
- External matching on payload storage variants.

The internal storage enum becomes private as `PayloadStorage`. Public representation identity is exposed through:

- `PdataFormat::OTAP` for native records.
- `PdataFormat::encoded(codec)` for encoded formats.
- `format`, `encoding`, `encoded_bytes`, and `otap_ref` for inspection.
- `try_into_otap`, `view`, `prepare_encoded`, and `BatchPlan` for behavior.

`OtlpProtoBytes` remains available as the OTLP codec’s low-level parsing, compatibility, and batching helper, but wrapping it now produces generalized encoded PData.

### Compatibility

This PR preserves:

- OTLP HTTP and gRPC wire protocols.
- Existing receiver and exporter configuration.
- Configuration aliases.
- Transport compression behavior.
- Durable-storage formats.
- Delivery context and transport headers.
- Ack/Nack ownership and protocol error responses.
- Native OTAP as the mutable processing representation.

### Layout and allocation invariants

The final payload representation preserves:

- A 64-byte `OtapPayload`.
- A 144-byte queued `OtapPdata`.
- Inline encoded metadata without an additional `Arc` envelope.
- Shared `Bytes` cloning across fan-out.
- Allocation-free admission apart from the existing byte buffer.
- Zero-copy movement of native Arrow records.
- No codec creation during matching-format forwarding.

### Scope boundary

This PR does not:

- Add syslog, Parquet, or other codecs.
- Change pipeline configuration or wire semantics.

## Related issue

- Closes #3452

## Validation

- `cargo xtask check`

## User-facing changes

OTLP receivers now preserve protobuf payloads in the generalized encoded representation until native processing is required. Pipeline configuration, OTLP wire behavior, and delivery semantics are unchanged.

A changelog entry is included in `.chloggen/pluggable-pdata-codecs.yaml`.