### PR TITLE
chore(ci): reduce ARM test build memory pressure

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -134,9 +134,19 @@ jobs:
       - name: Build reduced-feature ARM test archive
         if: matrix.os == 'ubuntu-24.04-arm'
         shell: bash
+        env:
+          # This job repeatedly died with exit 143 while compiling
+          # `otel-arrow-dfe`. Instrumented runs showed severe memory pressure:
+          # MemAvailable fell from 5.3 to 2.2 GB and swap reached 99% usage,
+          # while disk remained around 30%. Disabling debuginfo reduced swap
+          # use to about 9 MB and disk use by about 11 GB, and the build
+          # completed at the default job concurrency.
+          # `nextest archive` builds under the test profile, so TEST_DEBUG is
+          # the lever; DEV_DEBUG is defensive cover for any dev-profile step.
+          CARGO_PROFILE_TEST_DEBUG: "0"
+          CARGO_PROFILE_DEV_DEBUG: "0"
         run: |
-          # Record live resource usage so this run can be compared with the
-          # reduced-debuginfo ARM builds.
+          # Record live resource usage; remove once stability is established.
           (
             while true; do
               echo "[resources] $(date -u +%T)"

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -143,7 +143,7 @@ jobs:
           # any auxiliary dev-profile Cargo invocation.
           CARGO_PROFILE_TEST_DEBUG: "0"
           CARGO_PROFILE_DEV_DEBUG: "0"
-          CARGO_BUILD_JOBS: "2"
+          CARGO_BUILD_JOBS: "4"
         run: |
           (
             while true; do

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -131,9 +131,31 @@ jobs:
         if: matrix.os != 'ubuntu-24.04-arm'
         run: cargo nextest archive --locked --workspace --archive-file nextest-archive.tar.zst
         working-directory: ./rust/${{ matrix.folder }}
-      - name: Build and archive tests (Incomplete)
+      - name: Build reduced-feature ARM test archive
         if: matrix.os == 'ubuntu-24.04-arm'
+        shell: bash
+        env:
+          # This ARM job has repeatedly died with exit 143 ("runner has received
+          # a shutdown signal") while compiling `otel-arrow-dfe`. Disable test
+          # debuginfo and limit compiler concurrency to reduce resource pressure.
+          # The sampler records live resource usage if the runner fails again.
+          # `nextest archive` uses the test profile; DEV_DEBUG defensively covers
+          # any auxiliary dev-profile Cargo invocation.
+          CARGO_PROFILE_TEST_DEBUG: "0"
+          CARGO_PROFILE_DEV_DEBUG: "0"
+          CARGO_BUILD_JOBS: "2"
         run: |
+          (
+            while true; do
+              echo "[resources] $(date -u +%T)"
+              awk '/^(MemTotal|MemAvailable|SwapTotal|SwapFree):/' /proc/meminfo
+              df -m / "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/rust/${{ matrix.folder }}"
+              sleep 15
+            done
+          ) &
+          sampler_pid=$!
+          trap 'kill "$sampler_pid" 2>/dev/null || true' EXIT
+
           cargo nextest archive \
             --locked \
             --no-default-features \

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -134,17 +134,9 @@ jobs:
       - name: Build reduced-feature ARM test archive
         if: matrix.os == 'ubuntu-24.04-arm'
         shell: bash
-        env:
-          # This ARM job has repeatedly died with exit 143 ("runner has received
-          # a shutdown signal") while compiling `otel-arrow-dfe`. Disable test
-          # debuginfo and limit compiler concurrency to reduce resource pressure.
-          # The sampler records live resource usage if the runner fails again.
-          # `nextest archive` uses the test profile; DEV_DEBUG defensively covers
-          # any auxiliary dev-profile Cargo invocation.
-          CARGO_PROFILE_TEST_DEBUG: "0"
-          CARGO_PROFILE_DEV_DEBUG: "0"
-          CARGO_BUILD_JOBS: "4"
         run: |
+          # Record live resource usage so this run can be compared with the
+          # reduced-debuginfo ARM builds.
           (
             while true; do
               echo "[resources] $(date -u +%T)"


### PR DESCRIPTION
## Summary

  Reduce memory pressure in the non-required ARM test build by disabling Cargo debug information while retaining the default build concurrency and existing test scope.

  ## Root cause

  Instrumented runs showed severe memory pressure while compiling `otel-arrow-dfe` with the default test profile:

  - available memory fell from 5.3 GB to 2.2 GB
  - swap reached 99% usage
  - the runner subsequently exited with code 143
  - disk utilization remained around 30%, ruling out disk exhaustion

  With debug information disabled, swap usage dropped to approximately 9 MB, disk usage fell by approximately 11 GB, and the build completed successfully at the default concurrency.

  ## Why not increase swap?

  Additional swap would accommodate unnecessary debug information by paging compiler and linker data to disk. This would make the build slower while retaining the underlying memory demand.

  These ARM artifacts are built for CI test execution and do not require debugger symbols. Disabling debug information removes that cost without changing the packages, features, test targets, partitions, or test behavior.

  The resource sampler is retained temporarily to confirm stability across additional runs.