### PR TITLE
fix(traffic_generator_receiver): validate traffic generator receiver configuration (#3569)

### DIFF
--- a/rust/otap-dataflow/.chloggen/traffic-generator-receiver-validate-config.yaml
+++ b/rust/otap-dataflow/.chloggen/traffic-generator-receiver-validate-config.yaml
@@ -1,0 +1,21 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: pipeline
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reject invalid traffic generator receiver settings during configuration loading and live reconfiguration.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3569]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries. Breaking entries must include a `Migration:`
+# section with the specific action consumers must take. Keep notes to 200
+# characters and subtext to 300 characters.
+subtext: Invalid settings now produce an invalid-user-configuration error before the receiver starts.

--- a/rust/otap-dataflow/crates/dev-nodes/src/receivers/traffic_generator/mod.rs
+++ b/rust/otap-dataflow/crates/dev-nodes/src/receivers/traffic_generator/mod.rs
@@ -118,8 +118,31 @@ pub static TRAFFIC_GENERATOR_RECEIVER: ReceiverFactory<OtapPdata> = ReceiverFact
             ))
         },
     wiring_contract: otel_arrow_dfe_engine::wiring_contract::WiringContract::UNRESTRICTED,
-    validate_config: otel_arrow_dfe_config::validation::validate_typed_config::<Config>,
+    validate_config: validate_config,
 };
+
+/// Validates the Traffic Generator exporter configuration at config load time.
+///
+/// Runs before any node is started (initial load and live reconfigure), so bad
+/// configuration is rejected fast and attributed to the offending node rather
+/// than surfacing as an opaque client error at startup.
+fn validate_config(config: &Value) -> Result<(), otel_arrow_dfe_config::error::Error> {
+    let _ = validate_config_impl(config)?;
+    Ok(())
+}
+
+fn validate_config_impl(config: &Value) -> Result<Config, otel_arrow_dfe_config::error::Error> {
+    let config: Config = serde_json::from_value(config.clone()).map_err(|err|
+            otel_arrow_dfe_config::error::Error::InvalidUserConfig { error: err.to_string() }
+        )?;
+
+    let _ = config.get_traffic_config().validate().map_err(|e| {
+        otel_arrow_dfe_config::error::Error::InvalidUserConfig {
+            error: e.to_string(),
+        }
+    })?;
+    Ok(config)
+}
 
 impl TrafficGeneratorReceiver {
     /// creates a new TrafficGeneratorReceiver
@@ -138,12 +161,7 @@ impl TrafficGeneratorReceiver {
         pipeline_ctx: PipelineContext,
         config: &Value,
     ) -> Result<Self, otel_arrow_dfe_config::error::Error> {
-        let config: Config = serde_json::from_value(config.clone()).map_err(|e| {
-            otel_arrow_dfe_config::error::Error::InvalidUserConfig {
-                error: e.to_string(),
-            }
-        })?;
-        config.get_traffic_config().validate()?;
+        let config: Config = validate_config_impl(config)?;
         Ok(TrafficGeneratorReceiver::new(pipeline_ctx, config))
     }
 
@@ -785,6 +803,8 @@ mod tests {
     use std::collections::HashSet;
     use weaver_common::vdir::VirtualDirectoryPath;
     use weaver_forge::registry::ResolvedRegistry;
+
+    use serde_json::json;
 
     const RESOURCE_COUNT: usize = 1;
     const SCOPE_COUNT: usize = 1;
@@ -1860,5 +1880,32 @@ mod tests {
             .set_receiver(receiver)
             .run_test(scenario)
             .run_validation(validation);
+    }
+
+    #[test]
+    fn test_config_validation() {
+        let valid_config = json!({
+            "traffic_config": {
+                "max_signal_count": 1,
+                "max_batch_size": 1,
+                "signals_per_second": 1,
+                "log_weight": 1,
+            }
+        });
+
+        let invalid_config = json!({
+            "traffic_config": {
+                "max_signal_count": 1,
+                "max_batch_size": 1,
+                "signals_per_second": 1,
+                // missing log_weight, metric_weight and trace_weight
+            }
+        });
+
+        assert!((TRAFFIC_GENERATOR_RECEIVER.validate_config)(&valid_config).is_ok(),
+                "traffic_generator_receiver factory should call validate_config");
+
+        assert!((TRAFFIC_GENERATOR_RECEIVER.validate_config)(&invalid_config).is_err(),
+                "traffic_generator_receiver factory should call validate_config");
     }
 }


### PR DESCRIPTION

# Change summary

Validate traffic generator settings during configuration loading and live reconfiguration so invalid values are rejected before receiver startup.

Reuse the same validation path when constructing the receiver and add coverage for valid and invalid configurations.

Implement related unit tests.

## Related issue

* Closes #3569

## Validation

- Unit tests pass.
- Invoking df_engine --validate-and-exit with test configurations yields expected results.

## User-facing changes

This fixes a validation bug visible to the users.

A changelog entry is included.