### PR TITLE
feat(query-engine): add now scalar udf

### DIFF
--- a/rust/otap-dataflow/.chloggen/query-engine-now-udf.yaml
+++ b/rust/otap-dataflow/.chloggen/query-engine-now-udf.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: query-engine
+note: Add `now` scalar UDF to OTAP query engine.
+issues: [3967]

--- a/rust/otap-dataflow/crates/query-engine/src/consts.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/consts.rs
@@ -12,6 +12,7 @@ pub(crate) const ENDS_WITH_FUNC_NAME: &str = "ends_with";
 pub(crate) const FORMAT_DATETIME_FUNC_NAME: &str = "format_datetime";
 pub(crate) const LOG_FUNC_NAME: &str = "log10";
 pub(crate) const LTRIM_FUNC_NAME: &str = "ltrim";
+pub(crate) const NOW_FUNC_NAME: &str = "now";
 pub(crate) const REGEXP_SUBSTR_FUNC_NAME: &str = "regexp_substr";
 pub(crate) const RTRIM_FUNC_NAME: &str = "rtrim";
 pub(crate) const SHA256_FUNC_NAME: &str = "sha256";

--- a/rust/otap-dataflow/crates/query-engine/src/parser.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/parser.rs
@@ -14,7 +14,7 @@ use otel_arrow_contrib_data_engine_parser_abstractions::ParserOptions;
 use crate::consts::SHA1_FUNC_NAME;
 use crate::consts::{
     ENCODE_FUNC_NAME, ENDS_WITH_FUNC_NAME, FNV_FUNC_NAME, FORMAT_DATETIME_FUNC_NAME, LOG_FUNC_NAME,
-    LOWER_CASE_FUNC_NAME, LTRIM_FUNC_NAME, MD5_FUNC_NAME, MURMUR3_FUNC_NAME,
+    LOWER_CASE_FUNC_NAME, LTRIM_FUNC_NAME, MD5_FUNC_NAME, MURMUR3_FUNC_NAME, NOW_FUNC_NAME,
     REGEXP_SUBSTR_FUNC_NAME, RTRIM_FUNC_NAME, SHA256_FUNC_NAME, SHA512_FUNC_NAME,
     STARTS_WITH_FUNC_NAME, UPPER_CASE_FUNC_NAME, UUID_FUNC_NAME, UUIDV7_FUNC_NAME, XXH3_FUNC_NAME,
     XXH128_FUNC_NAME,
@@ -42,6 +42,7 @@ pub fn default_parser_options() -> ParserOptions {
         .with_external_function(SHA256_FUNC_NAME, param_placeholders(1), None)
         .with_external_function(MD5_FUNC_NAME, param_placeholders(1), None)
         .with_external_function(FNV_FUNC_NAME, param_placeholders(1), None)
+        .with_external_function(NOW_FUNC_NAME, param_placeholders(0), None)
         .with_external_function(MURMUR3_FUNC_NAME, param_placeholders(1), None)
         .with_external_function(SHA512_FUNC_NAME, param_placeholders(1), None)
         .with_external_function(XXH3_FUNC_NAME, param_placeholders(1), None)

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -2448,6 +2448,8 @@ fn try_upsert_array_in_columns(
 
 #[cfg(test)]
 mod test {
+    use std::time::Duration;
+
     use arrow::{
         array::{Array, StringArray, StructArray, UInt8Array, UInt16Array},
         compute::{
@@ -8340,5 +8342,50 @@ mod test {
     #[tokio::test]
     async fn test_extend_attrs_sparse_multi_scope_kql_parser() {
         test_extend_attrs_sparse_multi_scope::<KqlParser>().await
+    }
+
+    #[tokio::test]
+    async fn test_set_timestamps_to_current_time() {
+        let log_records = vec![LogRecord::build().finish()];
+        assert_eq!(log_records[0].time_unix_nano, 0);
+
+        let pipeline_expr = OplParser::parse_with_options(
+            "logs | set time_unix_nano = now()",
+            default_parser_options(),
+        )
+        .unwrap()
+        .pipeline;
+        let mut pipeline = Pipeline::new(pipeline_expr);
+
+        let result = pipeline
+            .execute(otlp_to_otap(&OtlpProtoMessage::Logs(to_logs_data(
+                log_records.clone(),
+            ))))
+            .await
+            .unwrap();
+
+        let OtlpProtoMessage::Logs(logs_data) = otap_to_otlp(&result) else {
+            panic!("Invalid signal type")
+        };
+
+        let log_record = &logs_data.resource_logs[0].scope_logs[0].log_records[0];
+        assert!(log_record.time_unix_nano > 0);
+
+        // execute again a moment later, and ensure we get a newer timestamp
+        tokio::time::sleep(Duration::from_millis(1)).await;
+        let result = pipeline
+            .execute(otlp_to_otap(&OtlpProtoMessage::Logs(to_logs_data(
+                log_records.clone(),
+            ))))
+            .await
+            .unwrap();
+
+        let OtlpProtoMessage::Logs(logs_data) = otap_to_otlp(&result) else {
+            panic!("Invalid signal type")
+        };
+        let log_record2 = &logs_data.resource_logs[0].scope_logs[0].log_records[0];
+        assert!(log_record2.time_unix_nano > 0);
+
+        assert!(log_record2.time_unix_nano > log_record.time_unix_nano);
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -8344,6 +8344,10 @@ mod test {
         test_extend_attrs_sparse_multi_scope::<KqlParser>().await
     }
 
+    /// Scenario: call the `now()` UDF and assign the value to a timestamp column. Doing this for
+    /// multiple batches with a slight delay.
+    /// Guarantees: the current time is assigned, and we don't inadvertently fold the current time
+    /// to an inlined static during planning.
     #[tokio::test]
     async fn test_set_timestamps_to_current_time() {
         let log_records = vec![LogRecord::build().finish()];

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -39,7 +39,7 @@ use otel_arrow_dfe_pdata::schema::consts;
 use crate::consts::SHA1_FUNC_NAME;
 use crate::consts::{
     ENCODE_FUNC_NAME, ENDS_WITH_FUNC_NAME, FNV_FUNC_NAME, FORMAT_DATETIME_FUNC_NAME, LOG_FUNC_NAME,
-    LOWER_CASE_FUNC_NAME, LTRIM_FUNC_NAME, MD5_FUNC_NAME, MURMUR3_FUNC_NAME,
+    LOWER_CASE_FUNC_NAME, LTRIM_FUNC_NAME, MD5_FUNC_NAME, MURMUR3_FUNC_NAME, NOW_FUNC_NAME,
     REGEXP_SUBSTR_FUNC_NAME, RTRIM_FUNC_NAME, SHA256_FUNC_NAME, SHA512_FUNC_NAME,
     STARTS_WITH_FUNC_NAME, UPPER_CASE_FUNC_NAME, UUID_FUNC_NAME, UUIDV7_FUNC_NAME, XXH3_FUNC_NAME,
     XXH128_FUNC_NAME,
@@ -60,7 +60,8 @@ use crate::pipeline::functions::is_type::IsTypeFunc;
 #[cfg(feature = "sha1-hash")]
 use crate::pipeline::functions::sha1_hash;
 use crate::pipeline::functions::{
-    arity_range, fnv_hash, murmur3_hash, regexp_substr, substring, uuidv7, xxh3_hash, xxh128_hash,
+    arity_range, fnv_hash, murmur3_hash, now, regexp_substr, substring, uuidv7, xxh3_hash,
+    xxh128_hash,
 };
 use crate::pipeline::planner::{AttributesIdentifier, ColumnAccessor};
 use crate::pipeline::project::{Projection, ProjectionOptions};
@@ -1879,6 +1880,7 @@ impl DataFusionFunctionDef {
             ENDS_WITH_FUNC_NAME => Self::new(ends_with(), ExprLogicalType::Boolean, true, None),
             LOG_FUNC_NAME => Self::new(log10(), ExprLogicalType::Float64, true, None),
             LTRIM_FUNC_NAME => Self::new(ltrim(), ExprLogicalType::String, true, None),
+            NOW_FUNC_NAME => Self::new(now(), ExprLogicalType::TimestampNanosecond, false, None),
             REGEXP_SUBSTR_FUNC_NAME => {
                 Self::new(regexp_substr(), ExprLogicalType::String, false, None)
             }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions.rs
@@ -17,6 +17,7 @@ mod contains;
 mod fnv;
 pub(crate) mod is_type;
 mod murmur3;
+mod now;
 mod regexp_substr;
 #[cfg(feature = "sha1-hash")]
 mod sha1;
@@ -27,6 +28,7 @@ mod xxh3;
 
 make_udf_function!(contains::ExtendedContainsFunc, contains);
 make_udf_function!(fnv::FnvHashFunc, fnv_hash);
+make_udf_function!(now::NowFunc, now);
 make_udf_function!(murmur3::Murmur3HashFunc, murmur3_hash);
 #[cfg(feature = "sha1-hash")]
 make_udf_function!(sha1::Sha1Func, sha1_hash);

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/now.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/now.rs
@@ -11,11 +11,11 @@ use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatili
 use datafusion::scalar::ScalarValue;
 
 /// Scalar UDF implementation that evaluates to the current time.
-/// 
+///
 /// Unlike the UDF datafusion `now` scalar built into datafusion, this does not try to inline
 /// the expression to a static result representing when the query was planned. This means an
 /// instance of the physical expr invoking this UDF can be reused for many invocations and will
-/// evaluate to the actual time the the function was invoked.
+/// evaluate to the actual time the function was invoked.
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct NowFunc {
     signature: Signature,
@@ -64,12 +64,12 @@ impl ScalarUDFImpl for NowFunc {
             );
         }
 
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system time before unix epoch");
+        let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) else {
+            return exec_err!("system time before unix epoch");
+        };
 
         Ok(ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(
-            Some(now.as_nanos() as i64),
+            i64::try_from(now.as_nanos()).ok(),
             None,
         )))
     }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/now.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/now.rs
@@ -1,0 +1,76 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::any::Any;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use arrow::datatypes::{DataType, TimeUnit};
+use datafusion::common::exec_err;
+use datafusion::error::Result;
+use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
+use datafusion::scalar::ScalarValue;
+
+/// Scalar UDF implementation that evaluates to the current time.
+/// 
+/// Unlike the UDF datafusion `now` scalar built into datafusion, this does not try to inline
+/// the expression to a static result representing when the query was planned. This means an
+/// instance of the physical expr invoking this UDF can be reused for many invocations and will
+/// evaluate to the actual time the the function was invoked.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct NowFunc {
+    signature: Signature,
+}
+
+impl Default for NowFunc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NowFunc {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::nullary(Volatility::Volatile),
+        }
+    }
+}
+
+impl ScalarUDFImpl for NowFunc {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "now"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Timestamp(TimeUnit::Nanosecond, None))
+    }
+
+    fn invoke_with_args(
+        &self,
+        args: datafusion::logical_expr::ScalarFunctionArgs,
+    ) -> Result<ColumnarValue> {
+        if !args.args.is_empty() {
+            return exec_err!(
+                "{} function does not accept arguments, received {} args",
+                self.name(),
+                args.args.len()
+            );
+        }
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch");
+
+        Ok(ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(
+            Some(now.as_nanos() as i64),
+            None,
+        )))
+    }
+}


### PR DESCRIPTION
# Change summary

<!--Replace with a brief summary of the change in this PR-->

Adds support for a function in the OTAP query engine called `now` which takes 0 arguments and produces a timestamp which is the time the function was invoked.

usage:
```
logs | set observed_time_unix_nano = now()
```

## Related issue

<!--We highly recommend correlation of every PR to an issue-->

* Closes #3967

## Validation

<!--How did you confirm your change has the intended effect?-->

unit tests

## User-facing changes

Yes - this function is available for use in programs in transform processor configuration.

<!--
Describe the impact, or write `None`.
User-facing changes require a `.chloggen/*.yaml` entry. If no entry is needed,
include `chore` in the PR title. Documentation-only changes are exempt.
-->
