### PR TITLE
feat(query-engine/OPL): support cast for primitive types

### DIFF
--- a/rust/otap-dataflow/.chloggen/opl-cast-primitives.yaml
+++ b/rust/otap-dataflow/.chloggen/opl-cast-primitives.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: query-engine
+note: Add capability to cast expression evaluation results to specific primitive type in OPL and OTAP query engine
+issues: [3972]

--- a/rust/otap-dataflow/crates/pdata/src/arrays/sanitize.rs
+++ b/rust/otap-dataflow/crates/pdata/src/arrays/sanitize.rs
@@ -20,7 +20,8 @@ use arrow_schema::DataType;
 
 /// Sanitizes a single array column, returning `Some` with the sanitized array if any changes
 /// were made, or `None` if the array was already clean.
-fn sanitize_column(column: &dyn Array) -> Option<Arc<dyn Array>> {
+#[must_use]
+pub fn sanitize_column(column: &dyn Array) -> Option<Arc<dyn Array>> {
     match column.data_type() {
         DataType::Dictionary(k, _) => match k.as_ref() {
             DataType::UInt8 => {

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/opl.pest
@@ -166,8 +166,14 @@ type_check_expression = {
   | rel_expression ~ (type_check_op ~ ident)?
 }
 
+type_cast_op = @{ "as" }
+
+type_cast_expression = {
+    type_check_expression ~ (type_cast_op ~ ident)?
+}
+
 and_expression = {
-    type_check_expression ~ ("and" ~ and_expression)*
+    type_cast_expression ~ ("and" ~ and_expression)*
 }
 
 or_expression = {

--- a/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/expression.rs
+++ b/rust/otap-dataflow/crates/query-engine-languages/src/opl/parser/expression.rs
@@ -6,16 +6,16 @@ use std::sync::LazyLock;
 use otel_arrow_contrib_data_engine_expressions::{
     AndLogicalExpression, BinaryMathematicalScalarExpression, BooleanScalarExpression,
     CaptureTextScalarExpression, CoalesceScalarExpression, CollectionScalarExpression,
-    CombineScalarExpression, ContainsLogicalExpression, DateTimeScalarExpression,
-    DoubleScalarExpression, DoubleValue, EqualToLogicalExpression, Expression,
-    GetRecordTypeScalarExpression, GetTypeScalarExpression, GreaterThanLogicalExpression,
-    GreaterThanOrEqualToLogicalExpression, IntegerScalarExpression, IntegerValue,
-    InvokeFunctionArgument, InvokeFunctionScalarExpression, JoinTextScalarExpression,
+    CombineScalarExpression, ContainsLogicalExpression, ConversionScalarExpression,
+    ConvertScalarExpression, DateTimeScalarExpression, DoubleScalarExpression, DoubleValue,
+    EqualToLogicalExpression, Expression, GetRecordTypeScalarExpression, GetTypeScalarExpression,
+    GreaterThanLogicalExpression, GreaterThanOrEqualToLogicalExpression, IntegerScalarExpression,
+    IntegerValue, InvokeFunctionArgument, InvokeFunctionScalarExpression, JoinTextScalarExpression,
     ListScalarExpression, LogicalExpression, MatchesLogicalExpression, MathScalarExpression,
     NotLogicalExpression, NullScalarExpression, OrLogicalExpression, QueryLocation,
     RegexScalarExpression, ReplaceTextScalarExpression, ScalarExpression, SliceScalarExpression,
     SourceScalarExpression, StaticScalarExpression, StringScalarExpression, StringValue,
-    TextScalarExpression, ValueAccessor,
+    TextScalarExpression, ValueAccessor, ValueType,
 };
 use otel_arrow_contrib_data_engine_parser_abstractions::{
     ParserError, parse_standard_double_literal, parse_standard_integer_literal,
@@ -138,8 +138,8 @@ pub(crate) fn parse_and_expression(
     let left_expr = parse_next_child_rule(
         pipeline_builder,
         &mut inner_rules,
-        Rule::type_check_expression,
-        parse_type_check_expression,
+        Rule::type_cast_expression,
+        parse_type_cast_expression,
     )
     .transpose()?
     .ok_or_else(|| no_inner_rule_error(query_location.clone()))?;
@@ -197,6 +197,64 @@ impl From<LogicalOrScalarExpr> for ScalarExpression {
             LogicalOrScalarExpr::Scalar(s) => s,
         }
     }
+}
+
+pub(crate) fn parse_type_cast_expression(
+    rule: Pair<'_, Rule>,
+    pipeline_builder: &dyn PipelineBuilder,
+) -> Result<LogicalOrScalarExpr, ParserError> {
+    let query_location = to_query_location(&rule);
+    let mut inner_rules = rule.into_inner();
+
+    let source_rule = inner_rules
+        .next()
+        .ok_or_else(|| no_inner_rule_error(query_location.clone()))?;
+    let source_scalar_expr = parse_type_check_expression(source_rule, pipeline_builder)?;
+
+    let Some(operator_rule) = inner_rules.next() else {
+        // if there's no operator rule (e.g. only one rule), this is a simple type_check_expression
+        return Ok(source_scalar_expr);
+    };
+
+    if !matches!(operator_rule.as_rule(), Rule::type_cast_op) {
+        return Err(invalid_child_rule_error(
+            query_location,
+            Rule::type_cast_expression,
+            operator_rule.as_rule(),
+        ));
+    }
+
+    let type_name_rule = inner_rules
+        .next()
+        .ok_or_else(|| no_inner_rule_error(query_location.clone()))?;
+
+    let convert_scalar_expr_inner =
+        ConversionScalarExpression::new(query_location.clone(), source_scalar_expr.into());
+    let convert_scalar_expr = match ValueType::from_str_opt(type_name_rule.as_str()) {
+        Some(value_type) => match value_type {
+            ValueType::String => ConvertScalarExpression::String(convert_scalar_expr_inner),
+            ValueType::Integer => ConvertScalarExpression::Integer(convert_scalar_expr_inner),
+            ValueType::Boolean => ConvertScalarExpression::Boolean(convert_scalar_expr_inner),
+            ValueType::Double => ConvertScalarExpression::Double(convert_scalar_expr_inner),
+            _ => {
+                return Err(ParserError::SyntaxNotSupported(
+                    query_location,
+                    format!(
+                        "casting to type '{}' not yet supported",
+                        type_name_rule.as_str()
+                    ),
+                ));
+            }
+        },
+        None => {
+            return Err(ParserError::SyntaxNotSupported(
+                query_location,
+                format!("unknown target type for cast '{}'", type_name_rule.as_str()),
+            ));
+        }
+    };
+
+    Ok(ScalarExpression::Convert(convert_scalar_expr).into())
 }
 
 pub(crate) fn parse_type_check_expression(
@@ -1080,8 +1138,9 @@ mod test {
     use otel_arrow_contrib_data_engine_expressions::{
         AndLogicalExpression, BinaryMathematicalScalarExpression, BooleanScalarExpression,
         CaptureTextScalarExpression, CoalesceScalarExpression, CollectionScalarExpression,
-        CombineScalarExpression, ContainsLogicalExpression, DateTimeScalarExpression,
-        DoubleScalarExpression, EqualToLogicalExpression, GreaterThanLogicalExpression,
+        CombineScalarExpression, ContainsLogicalExpression, ConversionScalarExpression,
+        ConvertScalarExpression, DateTimeScalarExpression, DoubleScalarExpression,
+        EqualToLogicalExpression, GreaterThanLogicalExpression,
         GreaterThanOrEqualToLogicalExpression, IntegerScalarExpression, JoinTextScalarExpression,
         ListScalarExpression, LogicalExpression, MatchesLogicalExpression, MathScalarExpression,
         NotLogicalExpression, NullScalarExpression, OrLogicalExpression, PipelineFunction,
@@ -2514,5 +2573,114 @@ mod test {
             ^\n\
             error: unclosed character class"
         );
+    }
+
+    /// Scenario: parsing a type cast expression to some supported primitive type
+    /// Guarantees: parser produces a result containing the expected expression AST
+    #[test]
+    fn test_parse_cast_to_primitive_expr() {
+        struct ConversionConstructor {
+            converter: Box<dyn Fn(ConversionScalarExpression) -> ConvertScalarExpression>,
+        }
+
+        impl ConversionConstructor {
+            fn new(
+                converter: impl Fn(ConversionScalarExpression) -> ConvertScalarExpression + 'static,
+            ) -> Self {
+                Self {
+                    converter: Box::new(converter),
+                }
+            }
+
+            fn convert(&self, val: ConversionScalarExpression) -> ConvertScalarExpression {
+                (self.converter)(val)
+            }
+        }
+
+        let test_inputs = [
+            (
+                "Integer",
+                ConversionConstructor::new(ConvertScalarExpression::Integer),
+            ),
+            (
+                "String",
+                ConversionConstructor::new(ConvertScalarExpression::String),
+            ),
+            (
+                "Double",
+                ConversionConstructor::new(ConvertScalarExpression::Double),
+            ),
+            (
+                "Boolean",
+                ConversionConstructor::new(ConvertScalarExpression::Boolean),
+            ),
+        ];
+
+        for (type_name, convert_expr_constructor) in test_inputs {
+            let input = format!("some_field as {type_name}");
+            let mut rules = OplPestParser::parse(Rule::expression, input.as_ref()).unwrap();
+
+            let result: ScalarExpression =
+                parse_expression(rules.next().unwrap(), default_pipeline_builder().as_ref())
+                    .unwrap()
+                    .into();
+
+            let expected = ScalarExpression::Convert(convert_expr_constructor.convert(
+                ConversionScalarExpression::new(
+                    QueryLocation::new_fake(),
+                    ScalarExpression::Source(SourceScalarExpression::new(
+                        QueryLocation::new_fake(),
+                        ValueAccessor::new_with_selectors(vec![ScalarExpression::Static(
+                            StaticScalarExpression::String(StringScalarExpression::new(
+                                QueryLocation::new_fake(),
+                                "some_field",
+                            )),
+                        )]),
+                    )),
+                ),
+            ));
+
+            assert_eq!(result, expected);
+        }
+    }
+
+    /// Scenario: parsing a type cast expression where the target type is not a known type
+    /// Guarantees: a parser error is produced with the appropriate error message
+    #[test]
+    fn test_parse_cast_to_invalid_type() {
+        let input = "some_field as NotAType"; // not a known type
+        let mut rules = OplPestParser::parse(Rule::expression, input).unwrap();
+        let error = parse_expression(rules.next().unwrap(), default_pipeline_builder().as_ref())
+            .unwrap_err();
+        let error_message = error.to_string();
+        assert!(
+            error_message.contains("unknown target type for cast 'NotAType'"),
+            "unexpected error message {:?}",
+            error_message
+        );
+    }
+
+    /// Scenario: parsing a type cast expression where the target type is not yet supported
+    /// Guarantees: a parser error is produced with the appropriate error message
+    #[test]
+    fn test_parse_cast_to_unsupported_type() {
+        let unsupported_type_names = [
+            "Array", "Bytes", "DateTime", "Map", "Null", "Regex", "TimeSpan",
+        ];
+        for unsupported_type_name in unsupported_type_names {
+            let input = format!("some_field as {unsupported_type_name}");
+            let mut rules = OplPestParser::parse(Rule::expression, &input).unwrap();
+            let error =
+                parse_expression(rules.next().unwrap(), default_pipeline_builder().as_ref())
+                    .unwrap_err();
+            let error_message = error.to_string();
+            assert!(
+                error_message.contains(&format!(
+                    "casting to type '{unsupported_type_name}' not yet supported"
+                )),
+                "unexpected error message {:?}",
+                error_message
+            );
+        }
     }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -8434,6 +8434,21 @@ mod test {
             result,
             AnyValue::new_string("1970-01-01T00:00:00.000000005"),
         );
+
+        // test cast from result of function call
+        let query = r#"logs | set attributes["result"] = now() as Integer"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        let log_record = &result.resource_logs[0].scope_logs[0].log_records[0];
+        let result = log_record
+            .attributes
+            .iter()
+            .find(|kv| kv.key == "result")
+            .map(|kv| kv.value.clone().unwrap().value.unwrap())
+            .unwrap();
+        let any_value::Value::IntValue(value) = result else {
+            panic!("invalid anyvalue {result:?} expected int variant")
+        };
+        assert!(value > 0);
     }
 
     /// Scenario: cast various types of primitives to other primitives

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -8392,4 +8392,259 @@ mod test {
 
         assert!(log_record2.time_unix_nano > log_record.time_unix_nano);
     }
+
+    // Scenario: cast timestamps to int64
+    // Guarantees: timestamp can be casted to int64
+    #[tokio::test]
+    async fn test_assign_attr_from_casted_timestamp_literal() {
+        let logs_data = to_logs_data(vec![LogRecord::build().time_unix_nano(5u64).finish()]);
+
+        fn assert_result(result: LogsData, expected: AnyValue) {
+            assert_eq!(result.resource_logs.len(), 1);
+            assert_eq!(result.resource_logs[0].scope_logs.len(), 1);
+            assert_eq!(result.resource_logs[0].scope_logs[0].log_records.len(), 1);
+
+            let log_record = &result.resource_logs[0].scope_logs[0].log_records[0];
+            let result = log_record
+                .attributes
+                .iter()
+                .find(|kv| kv.key == "result")
+                .unwrap();
+            assert_eq!(result.value.as_ref().unwrap(), &expected);
+        }
+
+        // test from literal as cast source
+        let query =
+            r#"logs | set attributes["result"] = timestamp"1970-01-01T00:00:01.1" as Integer"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_int(1100000000));
+
+        // test from field as cast source
+        let query = r#"logs | set attributes["result"] = time_unix_nano as Integer"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_int(5));
+
+        let query = r#"logs | set attributes["result"] = time_unix_nano as Double"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_double(5.0));
+
+        let query = r#"logs | set attributes["result"] = time_unix_nano as String"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(
+            result,
+            AnyValue::new_string("1970-01-01T00:00:00.000000005"),
+        );
+    }
+
+    /// Scenario: cast various types of primitives to other primitives
+    /// Guarantees: casting behaviour is as expected
+    #[tokio::test]
+    async fn test_cast_success_different_types() {
+        let logs_data = to_logs_data(vec![
+            LogRecord::build()
+                .attributes(vec![
+                    KeyValue::new("bool_attr", AnyValue::new_bool(true)),
+                    KeyValue::new("bool_false", AnyValue::new_bool(false)),
+                    KeyValue::new("int_attr", AnyValue::new_int(5)),
+                    KeyValue::new("int_zero", AnyValue::new_int(0)),
+                    KeyValue::new("double_attr", AnyValue::new_double(6.2)),
+                    KeyValue::new("double_zero", AnyValue::new_double(0.0)),
+                    KeyValue::new("str_attr_numeric", AnyValue::new_string("5")),
+                    KeyValue::new("str_attr_decimal", AnyValue::new_string("6.7")),
+                    KeyValue::new("str_attr_bool", AnyValue::new_string("true")),
+                    KeyValue::new("str_attr_non_numeric", AnyValue::new_string("hello2")),
+                ])
+                .finish(),
+        ]);
+
+        fn assert_result(result: LogsData, expected: AnyValue) {
+            assert_eq!(result.resource_logs.len(), 1);
+            assert_eq!(result.resource_logs[0].scope_logs.len(), 1);
+            assert_eq!(result.resource_logs[0].scope_logs[0].log_records.len(), 1);
+
+            let log_record = &result.resource_logs[0].scope_logs[0].log_records[0];
+            let result = log_record
+                .attributes
+                .iter()
+                .find(|kv| kv.key == "result")
+                .unwrap();
+            assert_eq!(result.value.as_ref().unwrap(), &expected);
+        }
+
+        // from bool
+        let query = r#"logs | set attributes["result"] = attributes["bool_attr"] as Integer"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_int(1));
+
+        let query = r#"logs | set attributes["result"] = attributes["bool_attr"] as String"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_string("true"));
+
+        let query = r#"logs | set attributes["result"] = attributes["bool_attr"] as Double"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_double(1.0));
+
+        // from false bool
+        let query = r#"logs | set attributes["result"] = attributes["bool_false"] as Integer"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_int(0));
+
+        let query = r#"logs | set attributes["result"] = attributes["bool_false"] as String"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_string("false"));
+
+        let query = r#"logs | set attributes["result"] = attributes["bool_false"] as Double"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_double(0.0));
+
+        // from int
+        let query = r#"logs | set attributes["result"] = attributes["int_attr"] as Boolean"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_bool(true));
+
+        let query = r#"logs | set attributes["result"] = attributes["int_zero"] as Boolean"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_bool(false));
+
+        let query = r#"logs | set attributes["result"] = attributes["int_attr"] as String"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_string("5"));
+
+        let query = r#"logs | set attributes["result"] = attributes["int_attr"] as Double"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_double(5.0));
+
+        // from double
+        let query = r#"logs | set attributes["result"] = attributes["double_attr"] as Integer"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_int(6));
+
+        let query = r#"logs | set attributes["result"] = attributes["double_attr"] as String"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_string("6.2"));
+
+        let query = r#"logs | set attributes["result"] = attributes["double_attr"] as Boolean"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_bool(true));
+
+        let query = r#"logs | set attributes["result"] = attributes["double_zero"] as Boolean"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_bool(false));
+
+        // from numberic string
+        let query =
+            r#"logs | set attributes["result"] = attributes["str_attr_numeric"] as Integer"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_int(5));
+
+        let query = r#"logs | set attributes["result"] = attributes["str_attr_numeric"] as Double"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_double(5.0));
+
+        // from decimal string
+        let query = r#"logs | set attributes["result"] = attributes["str_attr_decimal"] as Double"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_double(6.7));
+    }
+
+    /// Scenario: cast a string column to some type requiring parsing but the string is unparsable
+    /// Guarantees: handled by producing execution error
+    #[tokio::test]
+    async fn test_cast_unparsable_strings() {
+        async fn assert_cast_error(query: &str, expected_error: &str) {
+            let logs_data = to_logs_data(vec![
+                LogRecord::build()
+                    .attributes(vec![
+                        KeyValue::new("str_attr_numeric", AnyValue::new_string("5")),
+                        KeyValue::new("str_attr_decimal", AnyValue::new_string("6.7")),
+                        KeyValue::new("str_attr_bool", AnyValue::new_string("true")),
+                        KeyValue::new("str_attr_non_numeric", AnyValue::new_string("hello")),
+                    ])
+                    .finish(),
+            ]);
+
+            let pipeline_expr = OplParser::parse_with_options(query, default_parser_options())
+                .unwrap()
+                .pipeline;
+            let mut pipeline = Pipeline::new(pipeline_expr);
+            let err = pipeline
+                .execute(otlp_to_otap(&OtlpProtoMessage::Logs(logs_data)))
+                .await
+                .unwrap_err();
+            let err_msg = err.to_string();
+            assert!(
+                err_msg.contains(expected_error),
+                "unexpected error: {err_msg} - {err:?}",
+            )
+        }
+
+        assert_cast_error(
+            r#"logs | set attributes["result"] = attributes["str_attr_numeric"] as Boolean"#,
+            "Cannot cast value '5' to value of Boolean type",
+        )
+        .await;
+
+        assert_cast_error(
+            r#"logs | set attributes["result"] = attributes["str_attr_non_numeric"] as Boolean"#,
+            "Cannot cast value 'hello' to value of Boolean type",
+        )
+        .await;
+
+        assert_cast_error(
+            r#"logs | set attributes["result"] = attributes["str_attr_decimal"] as Integer"#,
+            "Cannot cast string '6.7' to value of Int64 type",
+        )
+        .await;
+
+        assert_cast_error(
+            r#"logs | set attributes["result"] = attributes["str_attr_non_numeric"] as Double"#,
+            "Cannot cast string 'hello' to value of Float64 type",
+        )
+        .await;
+
+        assert_cast_error(
+            r#"logs | set attributes["result"] = attributes["str_attr_bool"] as Double"#,
+            "Cannot cast string 'true' to value of Float64 type",
+        )
+        .await;
+
+        assert_cast_error(
+            r#"logs | set attributes["result"] = attributes["str_attr_bool"] as Integer"#,
+            "Cannot cast string 'true' to value of Int64 type",
+        )
+        .await;
+    }
+
+    /// Scenario: cast the boolean array produced by expressions that will be planned as either a
+    /// bitmap and, or something with a predicate applied to the batch
+    /// Guarantees: the cast will be applied to the results of these expression evaluations
+    #[tokio::test]
+    async fn test_cast_boolean_from_non_df_expr_evaluations() {
+        let logs_data = to_logs_data(vec![
+            LogRecord::build()
+                .attributes(vec![
+                    KeyValue::new("foo", AnyValue::new_string("hello")),
+                    KeyValue::new("bar", AnyValue::new_string("world")),
+                ])
+                .finish(),
+        ]);
+
+        fn assert_result(result: LogsData, expected: AnyValue) {
+            assert_eq!(result.resource_logs.len(), 1);
+            assert_eq!(result.resource_logs[0].scope_logs.len(), 1);
+            assert_eq!(result.resource_logs[0].scope_logs[0].log_records.len(), 1);
+
+            let log_record = &result.resource_logs[0].scope_logs[0].log_records[0];
+            let result = log_record
+                .attributes
+                .iter()
+                .find(|kv| kv.key == "result")
+                .unwrap();
+            assert_eq!(result.value.as_ref().unwrap(), &expected);
+        }
+
+        let query = r#"logs | set attributes["result"] = (attributes["foo"] == "hello" and attributes["bar"] == "world") as String"#;
+        let result = exec_logs_pipeline::<OplParser>(query, logs_data.clone()).await;
+        assert_result(result, AnyValue::new_string("true"));
+    }
 }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/join.rs
@@ -357,6 +357,9 @@ pub fn multi_join(
     // are incompatible scopes across 2+ args), but we handle it defensively.
     if results.len() == 1 {
         let result = &results[0];
+        let mut columns = Vec::new();
+        let mut fields = Vec::new();
+
         let values = result.values.to_array(
             result
                 .parent_ids
@@ -365,12 +368,24 @@ pub fn multi_join(
                 .or_else(|| result.ids.as_ref().map(|a| a.len()))
                 .unwrap_or(1),
         )?;
-        let schema = Schema::new(vec![Field::new(
+        fields.push(Field::new(
             arg_column_name(0),
             values.data_type().clone(),
             true,
-        )]);
-        let rb = RecordBatch::try_new(Arc::new(schema), vec![values])?;
+        ));
+        columns.push(values);
+
+        insert_id_columns(
+            result.ids.as_ref(),
+            result.parent_ids.as_ref(),
+            result.scope_ids.as_ref(),
+            result.resource_ids.as_ref(),
+            &mut fields,
+            &mut columns,
+        );
+
+        let schema = Schema::new(fields);
+        let rb = RecordBatch::try_new(Arc::new(schema), columns)?;
         return Ok((rb, result.data_scope.clone()));
     }
 
@@ -485,12 +500,33 @@ pub fn multi_join(
         columns.push(values);
     }
 
-    if let Some(ids) = &accum_ids {
+    insert_id_columns(
+        accum_ids.as_ref(),
+        accum_parent_ids.as_ref(),
+        accum_scope_ids.as_ref(),
+        accum_resource_ids.as_ref(),
+        &mut fields,
+        &mut columns,
+    );
+
+    let record_batch = RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)?;
+    Ok((record_batch, accum_scope))
+}
+
+fn insert_id_columns(
+    ids: Option<&ArrayRef>,
+    parent_ids: Option<&ArrayRef>,
+    scope_ids: Option<&ArrayRef>,
+    resource_ids: Option<&ArrayRef>,
+    fields: &mut Vec<Field>,
+    columns: &mut Vec<ArrayRef>,
+) {
+    if let Some(ids) = ids {
         fields.push(Field::new(consts::ID, ids.data_type().clone(), true));
         columns.push(ids.clone());
     }
 
-    if let Some(parent_ids) = &accum_parent_ids {
+    if let Some(parent_ids) = parent_ids {
         fields.push(Field::new(
             consts::PARENT_ID,
             parent_ids.data_type().clone(),
@@ -499,7 +535,7 @@ pub fn multi_join(
         columns.push(parent_ids.clone());
     }
 
-    if let Some(col) = &accum_resource_ids {
+    if let Some(col) = resource_ids {
         let struct_arr = StructArray::new(
             Fields::from(vec![Field::new(consts::ID, col.data_type().clone(), true)]),
             vec![col.clone()],
@@ -513,7 +549,7 @@ pub fn multi_join(
         columns.push(Arc::new(struct_arr));
     }
 
-    if let Some(col) = &accum_scope_ids {
+    if let Some(col) = scope_ids {
         let struct_arr = StructArray::new(
             Fields::from(vec![Field::new(consts::ID, col.data_type().clone(), true)]),
             vec![col.clone()],
@@ -526,9 +562,6 @@ pub fn multi_join(
         ));
         columns.push(Arc::new(struct_arr));
     }
-
-    let record_batch = RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)?;
-    Ok((record_batch, accum_scope))
 }
 
 // helper functions for producing errors from results. Normally, we wouldn't produce these errors

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -18,18 +18,19 @@ use datafusion::functions::math::log10;
 use datafusion::functions::string::{
     concat, concat_ws, ends_with, lower, ltrim, replace, rtrim, starts_with, upper, uuid,
 };
-use datafusion::logical_expr::ScalarUDFImpl;
 use datafusion::logical_expr::expr::ScalarFunction;
 use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyContext};
 use datafusion::logical_expr::{BinaryExpr, Expr, Operator, ScalarUDF, col, lit, not};
+use datafusion::logical_expr::{ScalarUDFImpl, cast};
 use datafusion::prelude::{binary_expr, lit_timestamp_nano};
 use otel_arrow_contrib_data_engine_expressions::{
     BinaryMathematicalScalarExpression, BooleanValue, CaptureTextScalarExpression,
-    CoalesceScalarExpression, CollectionScalarExpression, CombineScalarExpression, DateTimeValue,
-    DoubleValue, Expression, IntegerValue, InvokeFunctionArgument, InvokeFunctionScalarExpression,
-    JoinTextScalarExpression, LogicalExpression, MathScalarExpression, PipelineFunction,
-    PipelineFunctionImplementation, ReplaceTextScalarExpression, ScalarExpression,
-    StaticScalarExpression, StringScalarExpression, StringValue, TextScalarExpression, ValueType,
+    CoalesceScalarExpression, CollectionScalarExpression, CombineScalarExpression,
+    ConvertScalarExpression, DateTimeValue, DoubleValue, Expression, IntegerValue,
+    InvokeFunctionArgument, InvokeFunctionScalarExpression, JoinTextScalarExpression,
+    LogicalExpression, MathScalarExpression, PipelineFunction, PipelineFunctionImplementation,
+    ReplaceTextScalarExpression, ScalarExpression, StaticScalarExpression, StringScalarExpression,
+    StringValue, TextScalarExpression, ValueType,
 };
 use otel_arrow_dfe_config::SignalType;
 use otel_arrow_dfe_pdata::otlp::metrics::MetricType;
@@ -48,7 +49,7 @@ use crate::error::{Error, Result};
 use crate::pipeline::assign::leaf_requires_dict_downcast;
 use crate::pipeline::expr::join::is_one_to_many;
 use crate::pipeline::expr::types::{
-    ExprLogicalType, coerce_arithmetic, nested_struct_field_type, root_field_type,
+    ExprLogicalType, cast_expr, coerce_arithmetic, nested_struct_field_type, root_field_type,
 };
 use crate::pipeline::expr::{DataScope, VALUE_COLUMN_NAME, arg_column_name};
 use crate::pipeline::expr::{
@@ -254,6 +255,10 @@ impl ExprPlanner {
 
             ScalarExpression::Coalesce(coalesce_expr) => {
                 self.plan_coalesce_expr(coalesce_expr, functions)
+            }
+
+            ScalarExpression::Convert(convert_scalar_expression) => {
+                self.plan_type_cast_expr(convert_scalar_expression, functions)
             }
 
             ScalarExpression::InvokeFunction(invoke_expr) => {
@@ -778,7 +783,7 @@ impl ExprPlanner {
             Expr::ScalarFunction(ScalarFunction::new_udf(df_udf.scalar_udf, arg_exprs));
 
         if let Some(data_type) = df_udf.cast_result_to {
-            logical_expr = datafusion::logical_expr::cast(logical_expr, data_type);
+            logical_expr = cast(logical_expr, data_type);
         }
 
         let dict_downcast = source_dict_downcast || df_udf.requires_dict_downcast;
@@ -1754,6 +1759,104 @@ impl ExprPlanner {
 
             _ => Ok(None),
         }
+    }
+
+    fn plan_type_cast_expr(
+        &self,
+        convert_scalar_expression: &ConvertScalarExpression,
+        functions: &[PipelineFunction],
+    ) -> Result<PlannedOp> {
+        // TODO there are opportunities to optimize this type conversion:
+        //
+        // The convert expression only specifies the logical type that the eval result
+        // should be converted to. For now we're naively casting to the arrow data type
+        // type which will may eventually be converted to yet another type for example:
+        // - if the result is being used in assignment to a dictionary field, we may need
+        //   to convert the cast result to a DictionaryArray
+        // - in the cast of an integer type, the type may be converted to a different int
+        //   according to arithmetic conversion rules or for assignment to a field of a
+        //   different type of integer.
+        //
+        // We may do better here by:
+        // a) implementing a UDF that can do a "logical cast", and apply the cast operation
+        // to only dictionary values if that is what it receives as an argument
+        // b) have an expression optimizer that can check for double casts, for example to
+        // different integer types or from dict to non-dict arrays multiple times, and
+        // collapsing into a single cast to the final target type.
+
+        let (expr_logical_type, arrow_type, inner) = match convert_scalar_expression {
+            ConvertScalarExpression::Integer(inner) => {
+                (ExprLogicalType::AnyInt, DataType::Int64, inner)
+            }
+            ConvertScalarExpression::String(inner) => {
+                (ExprLogicalType::String, DataType::Utf8, inner)
+            }
+            ConvertScalarExpression::Double(inner) => {
+                (ExprLogicalType::Float64, DataType::Float64, inner)
+            }
+            ConvertScalarExpression::Boolean(inner) => {
+                (ExprLogicalType::Boolean, DataType::Boolean, inner)
+            }
+            other => {
+                return Err(Error::NotYetSupportedError {
+                    message: format!("conversion expression not yet supported {other:?}"),
+                });
+            }
+        };
+
+        fn cast_leaf_eval(eval: &mut LeafEval, arrow_type: DataType) -> Result<()> {
+            match eval {
+                LeafEval::DatafusionExpr {
+                    logical_expr,
+                    eval_anyval_as_struct,
+                    projection_opts,
+                    ..
+                } => {
+                    cast_expr(logical_expr, arrow_type);
+                    *eval_anyval_as_struct = false;
+
+                    // arrow-rs's "cast" implementation has a particular quirk where it will apply
+                    // the cast to all the dictionary values before possibly expanding them into a
+                    // non-dict encoded array. This includes dict values that are orphaned, which
+                    // means if we have an expr like `attributes["stringified_int"] as Integer`,
+                    // we will filter the attr record batch by this key and then must ensure there
+                    // are no orphaned values in a post-filter, dict encoded values column, as
+                    // these could cause the cast to unexpectedly fail
+                    projection_opts.sanitize_dicts = true;
+
+                    Ok(())
+                }
+                LeafEval::BatchPredicate(_) => {
+                    // TODO add support for expressions such as `is Log as String` which would
+                    // produce "true" for log batches, and false otherwise
+                    Err(Error::NotYetSupportedError {
+                        message: "casting result of batch predicate not yet supported".into(),
+                    })
+                }
+            }
+        }
+
+        let mut source = self.plan_scalar(inner.get_inner_expression(), functions)?;
+        source.expr_type = expr_logical_type.clone();
+
+        match &mut source.expr {
+            ScopedExpr::BitmapAnd(_, _) | ScopedExpr::BitmapOr(_, _) | ScopedExpr::BitmapNot(_) => {
+                let mut eval = LeafEval::new_df_expr(col(arg_column_name(0)), false)?;
+                cast_leaf_eval(&mut eval, arrow_type)?;
+                source.expr = ScopedExpr::JoinAndEval {
+                    children: vec![source.expr],
+                    eval,
+                    default_null_children: false,
+                    align_children_to_root: false,
+                    short_circuit: None,
+                };
+            }
+            ScopedExpr::Eval { eval, .. } | ScopedExpr::JoinAndEval { eval, .. } => {
+                cast_leaf_eval(eval, arrow_type)?;
+            }
+        }
+
+        Ok(source)
     }
 
     /// Build a binary operation as either a single `Eval` (same-scope) or `JoinAndEval`

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/types.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/types.rs
@@ -223,7 +223,7 @@ fn coerce_integer_types(left: &ExprLogicalType, right: &ExprLogicalType) -> Expr
 /// Adds a cast logical expression to cast the value of the expression to the passed data type.
 ///
 /// This is used when coercing the input types for expression operations.
-fn cast_expr(expr: &mut Expr, data_type: DataType) {
+pub fn cast_expr(expr: &mut Expr, data_type: DataType) {
     *expr = cast(std::mem::take(expr), data_type)
 }
 

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/project.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/project.rs
@@ -14,6 +14,7 @@ use datafusion::error::DataFusionError;
 use datafusion::functions::core::getfield::GetFieldFunc;
 use datafusion::logical_expr::Expr;
 use datafusion::scalar::ScalarValue;
+use otel_arrow_dfe_pdata::arrays::sanitize::sanitize_column;
 
 use crate::error::Result;
 
@@ -24,6 +25,14 @@ pub struct ProjectionOptions {
     /// Whether or not to downcast dictionary arrays to the native type. Some types of expressions,
     /// arithmetic operations for example, do not work on dictionary encoded columns.
     pub downcast_dicts: bool,
+
+    /// Whether or not to sanitize dictionaries. Often we may filter a record batch containing
+    /// dictionary columns and then evaluate an expression on the result. The filtering operation
+    /// may leave orphaned keys in dictionary column's values array. If there's some kind of
+    /// operation that operates directly on dictionary values indiscriminantly of whether they are
+    /// orphaned and it may fail for the orphaned keys in particular, set this option to remove
+    /// sanitize the columns before evaluation
+    pub sanitize_dicts: bool,
 
     /// Whether to create null placeholders when some column does not exist. A column not being
     /// present means it is optional in the OTAP model, or it represents the value of an attribute
@@ -75,6 +84,10 @@ impl Projection {
 
         if options.downcast_dicts {
             Self::try_downcast_dicts(&mut fields, &mut columns)?;
+        }
+
+        if options.sanitize_dicts {
+            Self::try_sanitize_columns(&mut columns)?;
         }
 
         // safety: `try_new` should not return an error here unless the columns do not match the
@@ -203,6 +216,16 @@ impl Projection {
                 let new_column = cast(&columns[i], v.as_ref())?;
                 fields[i] = new_field;
                 columns[i] = new_column;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn try_sanitize_columns(columns: &mut [ArrayRef]) -> Result<()> {
+        for column in columns.iter_mut() {
+            if let Some(new_column) = sanitize_column(column.as_ref()) {
+                *column = new_column;
             }
         }
 


### PR DESCRIPTION
# Change summary

<!--Replace with a brief summary of the change in this PR-->

Adds a syntax to OPL that can be used to cast the result of some expression to a different primitive type.

The syntax has the form: `<expr> as <type>` where supported types for now are `String`, `Double`, `Integer` and `Boolean`.

```kql
// cast time unix nano to integer, so can assign to an AnyValue
log | set attributes["exec.time.nanos"] = now() as Integer 
```

This PR also adds initial/best-effort support to to the OTAP query engine to evaluate such expressions.

Cast rules:
- `<Int/Double/Bool> as String` results in stringified number. e.g. `"1", "2.3" or "true"`
- `<Int> as <Double>` as expected
- `<String> as <Int/Double/Bool>` - String is parsed as int, decimal, or from `"true"`, `"false"`. fails to execute if unparsable
- `<timestamp> as Int` - to nanoseconds since unix epoch
- `<timestamp> as Double` - to nanoseconds since unix epoch, but as a f64
- `<timestamp> as String` - iso 8601 with nanosecond precision
- `<timestamp> as Boolean>` - fails to execute

There is clearly some future optimization and refinement we could add to such a feature. For example:
- Perhaps we _don't_ want string parsing to fail
- The cast target type is logical, so we could apply the cast only to dictionary values, but we do not
- We could be more intelligent about the target type for integers -- currently we always cast to an int64 and let arithmetic or assignment rules worry about choosing the correct type afterward
- Improve type checking to detect incompatible casts at planning time when possible.

All this can happen in followups.

One note to explain part of the implementation.. when we plan an expression like `attributes["x"] == "Y" and attributes["z"] == "y2"`, this will get planned as a variant of our expr called `ScopedExpr::BitmapAnd`, which is supposed to produce a boolean array. Presumably, someone may wish to cast this to some other type. To support this, we make this expr child of a `JoinAndEval` variant of `ScopedExpr`, where the "join" basically just materializes a record batch with a single boolean column, and then applies the cast to this. However, our "single column join" would omit the ID columns, which meant we couldn't figure out which rows these casted booleans were associated with from the original batch. So this PR also makes some changes to correct that in `join.rs`.

## Related issue

<!--We highly recommend correlation of every PR to an issue-->

* Closes #3972

## Validation

unit tests

<!--How did you confirm your change has the intended effect?-->

## User-facing changes

yes this new syntax is available for users to configure in their transform processor programs.

<!--
Describe the impact, or write `None`.
User-facing changes require a `.chloggen/*.yaml` entry. If no entry is needed,
include `chore` in the PR title. Documentation-only changes are exempt.
-->
