### PR TITLE
fix(release): Remove engine crate self-dev-dependency preventing crate publish

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -312,6 +312,28 @@ Do not yank a version merely because a later tag or GitHub release step failed.
 Yanking prevents normal dependency resolution and does not permit republishing
 the same version.
 
+#### Complete a Partial Release Manually
+
+If a newly allowlisted crate cannot be published at the prepared version and
+the successfully published crates are valid, preserve their source provenance
+with a partial release:
+
+1. Stop the Push Release workflow. Do not bypass package verification or
+   publish a missing crate from modified sources.
+2. Confirm every published crate was built from the exact merged Prepare
+   Release commit. Leave valid versions published and unyanked.
+3. From a clean checkout of that commit, create and push the three release tags
+   using step 6 of the emergency release process below.
+4. Create a draft GitHub release using `vX.Y.Z`. List only the Rust crates that
+   were actually published, identify the omitted crates, and link the planned
+   patch release that will complete the set.
+5. Review and publish the draft release.
+6. Fix the blocker on `main`, then use Prepare Release normally for a new patch
+   version. Do not bump only the missing crates or reuse the partial version.
+
+This procedure records the Go module, Rust workspace source, and valid crate
+artifacts without claiming that the complete crates.io plan succeeded.
+
 ### Emergency Release Process
 
 In case the automated workflow cannot be used, you can create a manual

--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -7648,7 +7648,6 @@ dependencies = [
  "otel-arrow-dfe-channel",
  "otel-arrow-dfe-component-inventory-syntax",
  "otel-arrow-dfe-config",
- "otel-arrow-dfe-engine",
  "otel-arrow-dfe-engine-macros",
  "otel-arrow-dfe-pdata",
  "otel-arrow-dfe-state",

--- a/rust/otap-dataflow/crates/engine/Cargo.toml
+++ b/rust/otap-dataflow/crates/engine/Cargo.toml
@@ -57,7 +57,6 @@ tikv-jemalloc-ctl = { workspace = true, optional = true }
 tikv-jemalloc-sys = { workspace = true, optional = true }
 
 [dev-dependencies]
-otel-arrow-dfe-engine = { workspace = true, features = ["test-utils"] }
 async-trait = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/rust/otap-dataflow/crates/engine/src/context.rs
+++ b/rust/otap-dataflow/crates/engine/src/context.rs
@@ -524,12 +524,12 @@ impl PipelineContext {
         } else if let Some(entity_key) = node_entity_key() {
             for_entity(handle, entity_key)
         } else {
-            #[cfg(feature = "test-utils")]
+            #[cfg(any(test, feature = "test-utils"))]
             {
                 with_scope(self, handle)
             }
 
-            #[cfg(not(feature = "test-utils"))]
+            #[cfg(not(any(test, feature = "test-utils")))]
             {
                 let _ = with_scope;
                 panic!(

--- a/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/flow_metrics.rs
@@ -756,7 +756,7 @@ impl PipelineFlowMetricState {
     }
 }
 
-#[cfg(all(test, feature = "test-utils"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::testing::test_pipeline_ctx;

--- a/rust/otap-dataflow/crates/engine/src/process_duration.rs
+++ b/rust/otap-dataflow/crates/engine/src/process_duration.rs
@@ -118,7 +118,7 @@ impl ComputeDuration {
     }
 }
 
-#[cfg(all(test, feature = "test-utils"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::testing::test_pipeline_ctx;

--- a/rust/otap-dataflow/xtask/src/crates_publish.rs
+++ b/rust/otap-dataflow/xtask/src/crates_publish.rs
@@ -191,6 +191,20 @@ fn build_plan(
         bail!("publish set must be exactly {expected_names:?}, found {names:?}");
     }
 
+    for package in &publishable {
+        if package
+            .dependencies
+            .iter()
+            .any(|dependency| dependency.name == package.name)
+        {
+            bail!(
+                "publishable package {} depends on itself; first publication cannot resolve a \
+                 registry self-dependency",
+                package.name
+            );
+        }
+    }
+
     let package_versions = publishable
         .iter()
         .map(|package| (package.name.as_str(), package.version.as_str()))
@@ -628,6 +642,28 @@ mod tests {
             .push(dependency("otel-arrow-dfe-engine"));
 
         assert!(build_plan(packages, PathBuf::from("/target")).is_err());
+    }
+
+    /// Scenario: a publishable crate uses a self dev-dependency to enable test features.
+    /// Guarantees: release preparation rejects the first-publication cycle before packaging.
+    #[test]
+    fn plan_rejects_self_dev_dependency() {
+        let mut packages = publishable_packages();
+        packages
+            .iter_mut()
+            .find(|package| package.name == "otel-arrow-dfe-engine")
+            .expect("engine package should exist")
+            .dependencies
+            .push(CargoDependency {
+                name: "otel-arrow-dfe-engine".to_owned(),
+                kind: Some("dev".to_owned()),
+                path: Some("/crates/otel-arrow-dfe-engine".into()),
+                req: "^0.51.0".to_owned(),
+            });
+
+        let error = build_plan(packages, PathBuf::from("/target"))
+            .expect_err("self dependencies must be rejected");
+        assert!(error.to_string().contains("depends on itself"));
     }
 
     /// Scenario: dependency requirements use abbreviated, ranged, exact, and excluding syntax.


### PR DESCRIPTION
# Chore Summary

Hit a problem in the Wave3 Crate bootstrapping. The `engine` crate had a dev dependency on itself, preventing crate publishing. This PR:
- Removes the self-dependency
- Adds some guidance on manual recovery from partial release

I plan to release a `0.54.1` with this commit added to test out patch release on our workflows as well.

## Related issue

<!-- Link the related issue if one exists. -->
