### PR TITLE
chore(release): Remove redundant release environment check from prepare-release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,8 +23,13 @@ jobs:
       contents: read
       pull-requests: read
     runs-on: ubuntu-latest
-    environment: ${{ !inputs.dry_run && 'release' || '' }}
     steps:
+      - name: Validate dispatch ref
+        if: "!inputs.dry_run && github.ref != 'refs/heads/main'"
+        run: |
+          echo "Non-dry-run release preparation must run from main"
+          exit 1
+
       - name: Checkout (dry run)
         if: inputs.dry_run
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
# Chore summary

Prepare Release currently requires approval through the protected `release` environment before it can create a release pull request. That approval is redundant because the generated pull request still requires normal review and CI before it can merge.

This change removes the environment from Prepare Release while preserving the relevant boundaries:

- non-dry-run preparation must be dispatched from `main`
- the GitHub App token is used only to push the release branch and create or update its pull request
- the generated pull request remains the review gate for release changes
- Push Release retains protected-environment approval for crates.io publishing, release tags, and the GitHub release

Dry runs remain available from other refs because they do not access the GitHub App secret or modify the repository.