### PR TITLE
fix: inserting new attributes when no previous attributes did exist

### DIFF
--- a/rust/otap-dataflow/.chloggen/insert-new-attrs-none-existing-bugs.yaml
+++ b/rust/otap-dataflow/.chloggen/insert-new-attrs-none-existing-bugs.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: query-engine
+note: fix invalid ID column encoding when inserting new attributes when no prior attributes existed
+issues: [3985]

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/mod.rs
@@ -1339,7 +1339,7 @@ mod tests {
             resource_logs: vec![ResourceLogs {
                 scope_logs: vec![ScopeLogs {
                     log_records: vec![
-                        LogRecord::build().finish(), 
+                        LogRecord::build().finish(),
                         LogRecord::build().finish(),
                         LogRecord::build().finish(),
                     ],
@@ -1384,10 +1384,6 @@ mod tests {
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
 
-                let otap: OtapArrowRecords = first.clone().try_into_with_default().unwrap();
-                let rb = otap.get(ArrowPayloadType::LogAttrs).unwrap();
-                println!("{:?}{:?}", rb.schema(), rb);
-
                 let otlp_bytes: OtlpProtoBytes =
                     first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
@@ -1416,6 +1412,8 @@ mod tests {
             })
             .validate(|_| async move {});
     }
+
+ 
 
     #[test]
     fn test_insert_attrs_with_u32_parent_ids() {

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/mod.rs
@@ -1413,8 +1413,6 @@ mod tests {
             .validate(|_| async move {});
     }
 
- 
-
     #[test]
     fn test_insert_attrs_with_u32_parent_ids() {
         let input = MetricsData {

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/attributes_processor/mod.rs
@@ -1338,7 +1338,11 @@ mod tests {
         let input = ExportLogsServiceRequest {
             resource_logs: vec![ResourceLogs {
                 scope_logs: vec![ScopeLogs {
-                    log_records: vec![LogRecord::build().finish(), LogRecord::build().finish()],
+                    log_records: vec![
+                        LogRecord::build().finish(), 
+                        LogRecord::build().finish(),
+                        LogRecord::build().finish(),
+                    ],
                     ..Default::default()
                 }],
                 ..Default::default()
@@ -1380,6 +1384,10 @@ mod tests {
                 let out = ctx.drain_pdata().await;
                 let first = out.into_iter().next().expect("one output").payload();
 
+                let otap: OtapArrowRecords = first.clone().try_into_with_default().unwrap();
+                let rb = otap.get(ArrowPayloadType::LogAttrs).unwrap();
+                println!("{:?}{:?}", rb.schema(), rb);
+
                 let otlp_bytes: OtlpProtoBytes =
                     first.try_into_with_default().expect("convert to otlp");
                 let bytes = match otlp_bytes {
@@ -1397,6 +1405,12 @@ mod tests {
                 let log_1 = &decoded.resource_logs[0].scope_logs[0].log_records[1];
                 assert_eq!(
                     log_1.attributes,
+                    vec![KeyValue::new("b", AnyValue::new_string("val"))]
+                );
+
+                let log_2 = &decoded.resource_logs[0].scope_logs[0].log_records[2];
+                assert_eq!(
+                    log_2.attributes,
                     vec![KeyValue::new("b", AnyValue::new_string("val"))]
                 );
             })

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform.rs
@@ -1325,7 +1325,7 @@ fn replace_id_column(
     }
 
     let schema = update_field_metadata(
-        &Schema::new(fields),
+        &Schema::new(fields).with_metadata(schema.metadata().clone()),
         consts::ID,
         metadata::COLUMN_ENCODING,
         encoding,

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform.rs
@@ -179,11 +179,6 @@ where
     <T as ParentId>::ArrayType: ArrowPrimitiveType,
     <<T as ParentId>::ArrayType as ArrowPrimitiveType>::Native: AddAssign,
 {
-    // if the batch is empty, just skip all this logic and return a batch
-    if record_batch.num_rows() == 0 {
-        return Ok(record_batch.clone());
-    }
-
     // check if the column is already decoded
     let column_encoding = get_field_metadata(
         record_batch.schema_ref(),
@@ -193,6 +188,18 @@ where
     if let Some(metadata::encodings::PLAIN) = column_encoding {
         // column already decoded, nothing to do
         return Ok(record_batch.clone());
+    }
+
+    // if the batch is empty, just skip all this logic and return a batch, but still update the
+    // field metadata incase the caller is relying on it.
+    if record_batch.num_rows() == 0 {
+        let schema = record_batch.schema();
+        return Ok(RecordBatch::new_empty(Arc::new(update_field_metadata(
+            schema.as_ref(),
+            consts::PARENT_ID,
+            metadata::COLUMN_ENCODING,
+            metadata::encodings::PLAIN,
+        ))));
     }
 
     // in the implementation below, to compare the items from the type, key, and value columns to
@@ -1130,7 +1137,11 @@ pub fn apply_attribute_transform(
                 if existing_id_col.null_count() > 0 {
                     // fill nulls in the existing ID column
                     let new_ids = try_fill_null_ids(existing_id_col)?;
-                    let new_parent_batch = replace_id_column(parent_batch, new_ids.clone());
+                    let new_parent_batch = replace_id_column(
+                        parent_batch,
+                        new_ids.clone(),
+                        metadata::encodings::PLAIN,
+                    );
                     otap_batch.set(parent_payload_type, new_parent_batch)?;
                     new_ids
                 } else {
@@ -1151,7 +1162,8 @@ pub fn apply_attribute_transform(
                         0..parent_batch.num_rows() as u32,
                     )),
                 };
-                let new_parent_batch = replace_id_column(parent_batch, new_ids.clone());
+                let new_parent_batch =
+                    replace_id_column(parent_batch, new_ids.clone(), metadata::encodings::PLAIN);
                 otap_batch.set(parent_payload_type, new_parent_batch)?;
                 new_ids
             }
@@ -1290,7 +1302,11 @@ fn try_fill_null_ids_primitive<T: ArrowPrimitiveType>(
     Ok(PrimitiveArray::new(ScalarBuffer::from(new_ids), None))
 }
 
-fn replace_id_column(record_batch: &RecordBatch, id_column: ArrayRef) -> RecordBatch {
+fn replace_id_column(
+    record_batch: &RecordBatch,
+    id_column: ArrayRef,
+    encoding: &str,
+) -> RecordBatch {
     let schema = record_batch.schema();
     let fields = schema.fields();
     let index = fields.find(consts::ID).map(|(i, _)| i);
@@ -1308,10 +1324,17 @@ fn replace_id_column(record_batch: &RecordBatch, id_column: ArrayRef) -> RecordB
         columns.push(id_column);
     }
 
+    let schema = update_field_metadata(
+        &Schema::new(fields),
+        consts::ID,
+        metadata::COLUMN_ENCODING,
+        encoding,
+    );
+
     // safety: the ID column we're inserting should have the same length as the existing batch
     // because it has been constructed from the original batch just with nulls filled in, so
     // this construction should not fail
-    RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).expect("can build record batch")
+    RecordBatch::try_new(Arc::new(schema), columns).expect("can build record batch")
 }
 
 /// Apply an [`AttributesTransform`] to an attributes [`RecordBatch`] and return both the

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/upsert_attributes.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/upsert_attributes.rs
@@ -13,7 +13,7 @@ use arrow::util::bit_iterator::BitSliceIterator;
 use smallvec::{SmallVec, smallvec};
 
 use crate::otlp::attributes::AttributeValueType;
-use crate::schema::consts;
+use crate::schema::{consts, is_parent_id_plain_encoded};
 use arrow::array::{
     Array, ArrayData, ArrayRef, ArrowPrimitiveType, BooleanArray, BooleanBufferBuilder,
     DictionaryArray, MutableArrayData, PrimitiveArray, RecordBatch, StringArray, UInt8Array,
@@ -129,6 +129,12 @@ pub fn upsert_attributes<T: ArrowPrimitiveType>(
     existing_attrs: &RecordBatch,
     upserts: &[AttributeUpsert<'_, T>],
 ) -> Result<RecordBatch> {
+    if !is_parent_id_plain_encoded(existing_attrs) {
+        return Err(Error::UnexpectedRecordBatchState {
+            reason: "upsert_attributes expected parent_id column to be plain encoded".into(),
+        });
+    }
+
     let num_existing = existing_attrs.num_rows();
 
     // Resolve each upsert: determine type, target column, extract values, compute counts, and
@@ -2053,6 +2059,8 @@ fn create_new_value_column_batched<T: ArrowPrimitiveType>(
 
 #[cfg(test)]
 mod tests {
+    use crate::schema::FieldExt;
+
     use super::*;
     use arrow::datatypes::UInt32Type;
 
@@ -2784,7 +2792,7 @@ mod tests {
         let strs = dict_utf8_u16(&rows.iter().map(|(_, _, _, s)| *s).collect::<Vec<_>>());
 
         let schema = Schema::new(vec![
-            Field::new(consts::PARENT_ID, DataType::UInt16, false),
+            Field::new(consts::PARENT_ID, DataType::UInt16, false).with_plain_encoding(),
             Field::new(consts::ATTRIBUTE_KEY, keys.data_type().clone(), true),
             Field::new(consts::ATTRIBUTE_TYPE, DataType::UInt8, false),
             Field::new(consts::ATTRIBUTE_STR, strs.data_type().clone(), true),

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -643,8 +643,20 @@ impl AssignPipelineStage {
         };
 
         let attrs_record_batch = match otap_batch.get(attrs_payload_type) {
-            Some(attrs_batch) => attrs_batch,
-            None => EMPTY_U16_ATTRS_RECORD_BATCH.deref(),
+            Some(attrs_batch) => Cow::Borrowed(attrs_batch),
+            None => {
+                // add an indicator to the parent id column that it is not transport/delta encoded.
+                // the upsert_attrs function assumes that transport/delta encoding has already been
+                // removed from the parent ID.
+                let batch = EMPTY_U16_ATTRS_RECORD_BATCH.deref();
+                let schema = batch.schema_ref();
+                Cow::Owned(RecordBatch::new_empty(Arc::new(update_field_metadata(
+                    schema,
+                    consts::PARENT_ID,
+                    metadata::COLUMN_ENCODING,
+                    metadata::encodings::PLAIN,
+                ))))
+            }
         };
 
         let mut parent_id_set = self.id_bitmap_pool.acquire();
@@ -821,7 +833,7 @@ impl AssignPipelineStage {
         self.id_bitmap_pool.release(parent_id_set);
 
         // replace attributes batch
-        let new_attrs = upsert_attributes(attrs_record_batch, &attrs_upserts)?;
+        let new_attrs = upsert_attributes(&attrs_record_batch, &attrs_upserts)?;
         otap_batch.set(attrs_payload_type, new_attrs)?;
 
         Ok(otap_batch)
@@ -2474,7 +2486,7 @@ mod test {
                 trace::v1::Span,
             },
         },
-        schema::consts,
+        schema::{consts, is_parent_id_plain_encoded},
         testing::round_trip::{
             otap_to_otlp, otlp_to_otap, to_logs_data, to_metrics_data, to_traces_data,
         },
@@ -4794,6 +4806,7 @@ mod test {
         let logs_data = to_logs_data(vec![
             LogRecord::build().event_name("event1").finish(),
             LogRecord::build().event_name("event2").finish(),
+            LogRecord::build().event_name("event2").finish(),
         ]);
 
         // there is no attribute z
@@ -5567,9 +5580,66 @@ mod test {
         );
     }
 
+    /// Scenario: inserting an attribute to the root record when there are no existing attributes
+    /// Guarantees: a new attribute record batch is created containing the new attributes and with
+    /// the correct ID column encoding to ensure attrs can be decoded to OTLP.
+    #[tokio::test]
+    async fn test_insert_root_attribute_no_existing_batch() {
+        // use three logs - these should get assigned ids [0, 1, 2], so if for some reason the
+        // new attrs parent_id column wasn't plain encoded, we'd have trouble associating the IDs
+        // because the decoder may consider them delta encoded.
+        let log_records = vec![
+            LogRecord::build().finish(),
+            LogRecord::build().finish(),
+            LogRecord::build().finish(),
+        ];
+        let query = "logs 
+            | extend attributes[\"x\"] = \"a\"
+            | extend attributes[\"y\"] = \"b\"
+            | extend attributes[\"z\"] = \"c\"
+            ";
+        let pipeline_expr = OplParser::parse(query).unwrap().pipeline;
+        let mut pipeline = Pipeline::new(pipeline_expr);
+        let input = otlp_to_otap(&OtlpProtoMessage::Logs(to_logs_data(log_records)));
+        assert!(input.get(ArrowPayloadType::LogAttrs).is_none());
+
+        let result = pipeline.execute(input).await.unwrap();
+        let log_attrs = result.get(ArrowPayloadType::LogAttrs).unwrap();
+        assert!(is_parent_id_plain_encoded(log_attrs));
+
+        let OtlpProtoMessage::Logs(result_logs_data) = otap_to_otlp(&result) else {
+            panic!("invalid signal type");
+        };
+        let result_log_records = &result_logs_data.resource_logs[0].scope_logs[0].log_records;
+        assert_eq!(result_log_records.len(), 3);
+        for log_record in result_log_records {
+            assert_eq!(
+                log_record.attributes,
+                vec![
+                    KeyValue::new("x", AnyValue::new_string("a")),
+                    KeyValue::new("y", AnyValue::new_string("b")),
+                    KeyValue::new("z", AnyValue::new_string("c")),
+                ]
+            )
+        }
+    }
+
+    /// Scenario: inserting an attribute to the root record when there are no existing attributes
+    /// Guarantees: a new attribute record batch is created containing the new attributes and with
+    /// the correct ID column encoding to ensure attrs can be decoded to OTLP.
     #[tokio::test]
     async fn test_insert_non_root_attribute_no_existing_batch() {
+        // use three resources - these should get assigned ids [0, 1, 2], so if for some reason the
+        // new attrs parent_id column wasn't plain encoded, we'd have trouble associating the IDs
+        // because the decoder may consider them delta encoded.
         let logs_data = LogsData::new(vec![
+            ResourceLogs::new(
+                Resource::build().finish(),
+                vec![ScopeLogs::new(
+                    InstrumentationScope::default(),
+                    vec![LogRecord::build().finish()],
+                )],
+            ),
             ResourceLogs::new(
                 Resource::build().finish(),
                 vec![ScopeLogs::new(
@@ -5593,6 +5663,9 @@ mod test {
         let input = otlp_to_otap(&OtlpProtoMessage::Logs(logs_data));
         assert!(input.get(ArrowPayloadType::ResourceAttrs).is_none());
         let result = pipeline.execute(input).await.unwrap();
+
+        let resource_attrs = result.get(ArrowPayloadType::ResourceAttrs).unwrap();
+        assert!(is_parent_id_plain_encoded(resource_attrs));
         let OtlpProtoMessage::Logs(result_logs_data) = otap_to_otlp(&result) else {
             panic!("invalid signal type");
         };
@@ -5602,6 +5675,11 @@ mod test {
             vec![KeyValue::new("y", AnyValue::new_string("b")),]
         );
         let resource = &result_logs_data.resource_logs[1].resource.as_ref().unwrap();
+        assert_eq!(
+            resource.attributes,
+            vec![KeyValue::new("y", AnyValue::new_string("b")),]
+        );
+        let resource = &result_logs_data.resource_logs[2].resource.as_ref().unwrap();
         assert_eq!(
             resource.attributes,
             vec![KeyValue::new("y", AnyValue::new_string("b")),]


### PR DESCRIPTION
# Change summary

Fixes two related issues related to inserting new attributes when none did previously exist.

The first issue was that, when using the transform processor, if writing a program like:
```
logs | set attributes["x"] = "y"
```
If some input batch had no existing attribute record batch, a new one would be created but we wouldn't set the schema metadata to indicate that parent_id the column was not delta encoded. So when we decoded that to OTLP, we'd treat it as a delta encoded column and the net effect would be that some attributes would end up missing from the result.

The second issue is somewhat similar - when inserting attributes using the attribute processor we'd create a new attribute record batch, this time with the correct parent_id encoding, but we'd also create a new ID column for the root batch and this did not have indicator that said it was not delta encoded.

This PR 
- corrects the behaviour to add the proper encoding metadata to the id/parent_id columns
- updates tests so that our tests cover regressions agains these kind of errors
- adds a check in the upsert attributes helper function to ensure it is passed an attribute record batch with plain encoded parent_ids.

<!--Replace with a brief summary of the change in this PR-->

## Related issue

<!--We highly recommend correlation of every PR to an issue-->

* Closes #3985

## Validation

Unit tests

<!--How did you confirm your change has the intended effect?-->

## User-facing changes

no

<!--
Describe the impact, or write `None`.
User-facing changes require a `.chloggen/*.yaml` entry. If no entry is needed,
include `chore` in the PR title. Documentation-only changes are exempt.
-->
