### PR TITLE
chore(otlp_receiver): adjust rate limit test parameters for deterministic behavior

### DIFF
--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/mod.rs
@@ -3444,8 +3444,10 @@ mod tests {
                 unit: RateLimitUnit::RequestBytes,
                 pressure: RateLimitPressure::Soft,
                 token_bucket: TokenBucketPolicy {
-                    allow: request_weight,
-                    interval: Duration::from_secs(1),
+                    // Keep the bucket saturated for the entire test so the request
+                    // deterministically reaches the pre-decode rejection path.
+                    allow: 1,
+                    interval: Duration::from_secs(60 * 60),
                     burst: Some(burst),
                 },
             },
@@ -3490,10 +3492,13 @@ mod tests {
                 _ = request
                     .metadata_mut()
                     .insert("authorization", "Bearer allowed".parse().unwrap());
-                let status = logs_client
-                    .export(request)
+                let result = logs_client.export(request).await;
+
+                ctx.send_shutdown(Instant::now(), "Test complete")
                     .await
-                    .expect_err("rate limit should reject request");
+                    .expect("Failed to send shutdown");
+
+                let status = result.expect_err("rate limit should reject request");
 
                 assert_eq!(status.code(), tonic::Code::ResourceExhausted);
                 let (expected_message, expected_pushback) = if oversized {
@@ -3533,10 +3538,6 @@ mod tests {
                         0
                     );
                 }
-
-                ctx.send_shutdown(Instant::now(), "Test complete")
-                    .await
-                    .expect("Failed to send shutdown");
             }) as Pin<Box<dyn Future<Output = ()>>>
         };
 


### PR DESCRIPTION
# Change summary

Fix the flakiness in `test_otlp_grpc_transient_rate_limit_rejection` by keeping its rate-limit bucket deterministically saturated for the duration of the test.

The test pre-consumes the bucket and expects the next request to be rejected by the gRPC pre-decode saturation check. The original policy allowed one request-sized burst per second. Because bucket capacity refills continuously, even a small scheduling delay could restore the single unit checked by the saturation probe. The request would then proceed to the weighted admission check, where it was still rejected but returned  grpc-retry-pushback-ms: 1000 . This conflicted with the expected fast-rejection response, which intentionally has no request-specific retry guidance.

The test now configures a one-unit-per-hour refill rate while retaining the request-sized burst. This preserves the behavior under test but prevents wall-clock scheduling from selecting a different rejection path.

The shutdown signal is also sent immediately after the RPC completes, before response assertions. Previously, an assertion failure skipped shutdown and left the receiver running until nextest terminated the test after 120 seconds, obscuring the original assertion failure as a timeout.

## Related issue

Addresses the OTLP receiver flake reported in #2720

## Validation

Ran 50 iterations of `test_otlp_grpc_transient_rate_limit_rejection` successfully

## User-facing changes

None. This is a test-only change.