### PR TITLE
fix(otap): clarify closed response stream logs

### DIFF
--- a/rust/otap-dataflow/.chloggen/otap-clarify-closed-response-stream.yaml
+++ b/rust/otap-dataflow/.chloggen/otap-clarify-closed-response-stream.yaml
@@ -1,5 +1,5 @@
 change_type: enhancement
 component: otap
 note: "Clarify closed OTAP response stream logs with warning severity, readable channel errors, and batch IDs."
-issues: []
+issues: [3994]
 subtext:

--- a/rust/otap-dataflow/.chloggen/otap-clarify-closed-response-stream.yaml
+++ b/rust/otap-dataflow/.chloggen/otap-clarify-closed-response-stream.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: otap
+note: "Clarify closed OTAP response stream logs with warning severity, readable channel errors, and batch IDs."
+issues: []
+subtext:

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc.rs
@@ -520,10 +520,10 @@ async fn reject_open_stream_for_memory_pressure(
         .send(Err(grpc_memory_pressure_status(admission_state)))
         .await
         .map_err(|e| {
-            otel_error!(
+            otel_warn!(
                 "otap.response.send_failed",
-                error = ?e,
-                message = "Error sending streamed memory pressure response"
+                error = %e,
+                message = "Memory pressure response not sent because the gRPC response stream is closed"
             );
         })
         .ok();
@@ -565,7 +565,12 @@ where
         }))
         .await
         .map_err(|e| {
-            otel_error!("otap.response.send_failed", error = ?e, message = "Error sending BatchStatus response");
+            otel_warn!(
+                "otap.response.send_failed",
+                error = %e,
+                batch_id = batch_id,
+                message = "BatchStatus response not sent because the gRPC response stream is closed"
+            );
         })?;
 
         return Ok(None);
@@ -631,7 +636,12 @@ where
                 }))
                 .await
                 .map_err(|e| {
-                    otel_error!("otap.response.send_failed", error = ?e, message = "Error sending BatchStatus response");
+                    otel_warn!(
+                        "otap.response.send_failed",
+                        error = %e,
+                        batch_id = batch_id,
+                        message = "BatchStatus response not sent because the gRPC response stream is closed"
+                    );
                 })?;
 
                 return Ok(None);
@@ -686,7 +696,12 @@ where
     }))
     .await
     .map_err(|e| {
-        otel_error!("otap.response.send_failed", error = ?e, message = "Error sending BatchStatus response");
+        otel_warn!(
+            "otap.response.send_failed",
+            error = %e,
+            batch_id = batch_id,
+            message = "BatchStatus response not sent because the gRPC response stream is closed"
+        );
     })?;
 
     Ok(None)
@@ -756,8 +771,14 @@ async fn send_pending_response(
         }
     };
 
+    let batch_id = status.batch_id;
     tx.send(Ok(status)).await.map_err(|e| {
-        otel_error!("otap.response.send_failed", error = ?e, message = "Error sending BatchStatus response");
+        otel_warn!(
+            "otap.response.send_failed",
+            error = %e,
+            batch_id = batch_id,
+            message = "BatchStatus response not sent because the gRPC response stream is closed"
+        );
     })
 }
 


### PR DESCRIPTION
## Change summary

Clarify OTAP response-send diagnostics when the gRPC client has already closed its response stream. Render Tokio send errors using Display, include the affected batch ID, and report this recoverable peer-disconnect condition at warning severity.

The nightly occurrence in run 33653473301 happened during orderly teardown: the load generator began draining before the receiving engine, so completed batches briefly attempted to send statuses to response streams the client had already closed. No protocol or control-flow behavior changes.

## Related issue

* Observed in https://github.com/open-telemetry/otel-arrow/actions/runs/33653473301/job/100326067659

## Validation

* `cargo check -p otel-arrow-dfe-otap`
* `cargo test -p otel-arrow-dfe-otap --lib otap_grpc::tests`
* `cargo fmt --all -- --check`
* `python3 tools/sanitycheck.py`
* `cargo xtask check`

## User-facing changes

OTAP closed-response-stream logs now identify the condition and batch, use a readable `channel closed` error, and emit at warning severity. A changelog entry is included.