### PR TITLE
fix(telemetry): apply initial configured log level

### DIFF
--- a/rust/otap-dataflow/.chloggen/apply-initial-log-level.yaml
+++ b/rust/otap-dataflow/.chloggen/apply-initial-log-level.yaml
@@ -1,5 +1,5 @@
 change_type: bug_fix
 component: observability
-note: Apply `engine.telemetry.logs.level` when activating the initial engine configuration instead of waiting for reconciliation.
+note: Honor `RUST_LOG` when `engine.telemetry.logs.level` is omitted, while applying an explicit level before pipelines start.
 issues: [3996]
-subtext:
+subtext: Log level precedence is explicit configuration, then startup `RUST_LOG`, then the built-in default. Removing an explicit level during reconciliation restores the startup fallback.

--- a/rust/otap-dataflow/.chloggen/apply-initial-log-level.yaml
+++ b/rust/otap-dataflow/.chloggen/apply-initial-log-level.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: observability
+note: Apply `engine.telemetry.logs.level` when activating the initial engine configuration instead of waiting for reconciliation.
+issues: [3996]
+subtext:

--- a/rust/otap-dataflow/crates/config/src/settings/telemetry/logs.rs
+++ b/rust/otap-dataflow/crates/config/src/settings/telemetry/logs.rs
@@ -11,27 +11,28 @@ use tracing_subscriber::EnvFilter;
 /// Internal logs configuration.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct LogsConfig {
-    /// The log level for internal engine logs.
+    /// Optional log level for internal engine logs.
     ///
     /// Accepts either a simple level keyword (`off`, `debug`, `info`, `warn`, `error`)
     /// or a full [`RUST_LOG`-style directive string][env-filter] for fine-grained
     /// control (e.g., `"info,typespec_client_core=warn,azure_core=off"`).
     ///
-    /// The value is passed directly to [`tracing_subscriber::EnvFilter`]. When not
-    /// specified, the default is `"info,h2=off,hyper=off"` which silences known
-    /// noisy HTTP dependencies.
+    /// The value is passed directly to [`tracing_subscriber::EnvFilter`]. When
+    /// specified, it takes precedence over `RUST_LOG` from the first tracing
+    /// subscriber onward.
     ///
-    /// A valid `RUST_LOG` environment variable controls early bootstrap logging. When the
-    /// initial engine configuration is activated, this field becomes authoritative. Later
-    /// successful full-engine reconciliations apply the same precedence rule.
+    /// When omitted, a valid `RUST_LOG` value captured at startup remains
+    /// authoritative. If neither is present, the effective default is
+    /// `"info,h2=off,hyper=off"`, which silences known noisy HTTP dependencies.
     ///
     /// Successful full-engine reconciliation applies changes to this field to running
-    /// subscribers without restarting the engine. Reconciled span-scoped directives apply
-    /// to spans created after the update, but not to spans that are already active.
+    /// subscribers without restarting the engine. Removing an explicit value restores the
+    /// startup `RUST_LOG` value or the built-in default. Reconciled span-scoped directives
+    /// apply to spans created after the update, but not to spans that are already active.
     ///
     /// [env-filter]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
-    #[serde(default)]
-    pub level: LogLevel,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub level: Option<LogLevel>,
 
     /// Logging provider configuration.
     #[serde(default = "default_providers")]
@@ -66,15 +67,9 @@ pub struct InternalLogTapConfig {
 ///
 /// See the [`EnvFilter` directives documentation][env-filter] for the full syntax.
 ///
-/// Defaults to `"info,h2=off,hyper=off"`.
+/// The built-in fallback is `"info,h2=off,hyper=off"`.
 ///
-/// A valid `RUST_LOG` environment variable controls early bootstrap logging. When the initial
-/// engine configuration is activated, this value becomes authoritative. Later successful
-/// full-engine reconciliations apply the same precedence rule.
-///
-/// Successful full-engine reconciliation applies changes to this value to running
-/// subscribers without restarting the engine. Reconciled span-scoped directives apply
-/// to spans created after the update, but not to spans that are already active.
+/// See [`LogsConfig::level`] for precedence and runtime reconciliation behavior.
 ///
 /// [env-filter]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
@@ -250,7 +245,7 @@ impl Default for InternalLogTapConfig {
 impl Default for LogsConfig {
     fn default() -> Self {
         Self {
-            level: LogLevel::default(),
+            level: None,
             providers: default_providers(),
             tap: InternalLogTapConfig::default(),
         }
@@ -354,11 +349,13 @@ mod tests {
         );
     }
 
+    /// Scenario: log settings are constructed through Rust and serde defaults.
+    /// Guarantees: both paths omit an explicit level and select identical provider and tap settings.
     #[test]
     fn test_defaults() {
         // Manual Default impl matches serde defaults
         let config = LogsConfig::default();
-        assert_eq!(config.level.as_str(), "info,h2=off,hyper=off");
+        assert!(config.level.is_none());
         assert_eq!(config.providers.global, ProviderMode::ConsoleAsync);
         assert_eq!(config.providers.engine, ProviderMode::ConsoleAsync);
         assert_eq!(config.providers.internal, ProviderMode::Noop);
@@ -377,23 +374,52 @@ mod tests {
         assert_eq!(parsed.tap.enabled, config.tap.enabled);
         assert_eq!(parsed.tap.max_entries, config.tap.max_entries);
         assert_eq!(parsed.tap.max_bytes, config.tap.max_bytes);
+
+        let serialized = serde_json::to_value(&config).expect("default config should serialize");
+        assert!(serialized.get("level").is_none());
+        assert!(parse("level: null").level.is_none());
     }
 
+    /// Scenario: each supported simple directive is supplied as an explicit logs.level.
+    /// Guarantees: deserialization preserves every explicit level as a configured override.
     #[test]
     fn test_log_level_parsing_simple() {
         for name in ["off", "debug", "info", "warn", "error"] {
             let config = parse(&format!("level: {name}"));
-            assert_eq!(config.level.as_str(), name);
+            assert_eq!(
+                config
+                    .level
+                    .as_ref()
+                    .expect("level should be explicit")
+                    .as_str(),
+                name
+            );
         }
     }
 
+    /// Scenario: target-specific EnvFilter directives are supplied as explicit logs.level values.
+    /// Guarantees: deserialization preserves each complete directive string without normalization.
     #[test]
     fn test_log_level_parsing_directive_string() {
         let config = parse("level: \"info,typespec_client_core=warn\"");
-        assert_eq!(config.level.as_str(), "info,typespec_client_core=warn");
+        assert_eq!(
+            config
+                .level
+                .as_ref()
+                .expect("level should be explicit")
+                .as_str(),
+            "info,typespec_client_core=warn"
+        );
 
         let config = parse("level: \"warn,azure_core=off,h2=off\"");
-        assert_eq!(config.level.as_str(), "warn,azure_core=off,h2=off");
+        assert_eq!(
+            config
+                .level
+                .as_ref()
+                .expect("level should be explicit")
+                .as_str(),
+            "warn,azure_core=off,h2=off"
+        );
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/config/src/settings/telemetry/logs.rs
+++ b/rust/otap-dataflow/crates/config/src/settings/telemetry/logs.rs
@@ -21,8 +21,9 @@ pub struct LogsConfig {
     /// specified, the default is `"info,h2=off,hyper=off"` which silences known
     /// noisy HTTP dependencies.
     ///
-    /// At startup, a valid `RUST_LOG` environment variable takes precedence over this field.
-    /// A subsequent successful full-engine reconciliation makes this field authoritative.
+    /// A valid `RUST_LOG` environment variable controls early bootstrap logging. When the
+    /// initial engine configuration is activated, this field becomes authoritative. Later
+    /// successful full-engine reconciliations apply the same precedence rule.
     ///
     /// Successful full-engine reconciliation applies changes to this field to running
     /// subscribers without restarting the engine. Reconciled span-scoped directives apply
@@ -67,8 +68,9 @@ pub struct InternalLogTapConfig {
 ///
 /// Defaults to `"info,h2=off,hyper=off"`.
 ///
-/// At startup, a valid `RUST_LOG` environment variable takes precedence over this value.
-/// A subsequent successful full-engine reconciliation makes this value authoritative.
+/// A valid `RUST_LOG` environment variable controls early bootstrap logging. When the initial
+/// engine configuration is activated, this value becomes authoritative. Later successful
+/// full-engine reconciliations apply the same precedence rule.
 ///
 /// Successful full-engine reconciliation applies changes to this value to running
 /// subscribers without restarting the engine. Reconciled span-scoped directives apply

--- a/rust/otap-dataflow/crates/controller/src/live_control/mod.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/mod.rs
@@ -83,7 +83,7 @@ pub(super) struct ControllerRuntime<PData: 'static + Clone + Send + Sync + std::
     topology: NumaTopology,
     /// Tracing setup cloned into launched runtime threads.
     engine_tracing_setup: TracingSetup,
-    /// Applies reconciled log-level directives to every tracing setup.
+    /// Applies initial and reconciled log-level directives to every tracing setup.
     log_filter_handle: RuntimeLogFilterHandle,
     /// Runtime telemetry reporting cadence.
     telemetry_reporting_interval: Duration,
@@ -136,6 +136,7 @@ impl<
         memory_pressure_tx: tokio::sync::watch::Sender<MemoryPressureChanged>,
         live_config: OtelDataflowSpec,
     ) -> Self {
+        log_filter_handle.apply(&live_config.engine.telemetry.logs.level);
         Self {
             pipeline_factory,
             controller_context,

--- a/rust/otap-dataflow/crates/controller/src/live_control/mod.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/mod.rs
@@ -136,7 +136,7 @@ impl<
         memory_pressure_tx: tokio::sync::watch::Sender<MemoryPressureChanged>,
         live_config: OtelDataflowSpec,
     ) -> Self {
-        log_filter_handle.apply(&live_config.engine.telemetry.logs.level);
+        log_filter_handle.apply(live_config.engine.telemetry.logs.level.as_ref());
         Self {
             pipeline_factory,
             controller_context,

--- a/rust/otap-dataflow/crates/controller/src/live_control/planning.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/planning.rs
@@ -1520,7 +1520,7 @@ impl<
 
     fn apply_reconcile_success(&self, desired_config: &OtelDataflowSpec, delete_missing: bool) {
         self.log_filter_handle
-            .apply(&desired_config.engine.telemetry.logs.level);
+            .apply(desired_config.engine.telemetry.logs.level.as_ref());
         let mut state = self
             .state
             .lock()

--- a/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
@@ -320,6 +320,28 @@ fn test_runtime_with_log_filter_and_topology(
     RuntimeLogFilterHandle,
     RuntimeLogFilter,
 ) {
+    let (log_filter, log_filter_handle) =
+        RuntimeLogFilter::new(&config.engine.telemetry.logs.level);
+    test_runtime_with_supplied_log_filter_and_topology(
+        config,
+        pipeline_factory,
+        topology,
+        log_filter,
+        log_filter_handle,
+    )
+}
+
+fn test_runtime_with_supplied_log_filter_and_topology(
+    config: &OtelDataflowSpec,
+    pipeline_factory: &'static PipelineFactory<()>,
+    topology: NumaTopology,
+    log_filter: RuntimeLogFilter,
+    log_filter_handle: RuntimeLogFilterHandle,
+) -> (
+    Arc<ControllerRuntime<()>>,
+    RuntimeLogFilterHandle,
+    RuntimeLogFilter,
+) {
     let registry = TelemetryRegistryHandle::new();
     let observed_state_store =
         ObservedStateStore::new(&ObservedStateSettings::default(), registry.clone());
@@ -330,9 +352,6 @@ fn test_runtime_with_log_filter_and_topology(
         Controller::<()>::declare_topics(config).expect("declared topics should be valid");
     let (memory_pressure_tx, _memory_pressure_rx) =
         tokio::sync::watch::channel(MemoryPressureChanged::initial());
-    let (log_filter, log_filter_handle) =
-        RuntimeLogFilter::new(&config.engine.telemetry.logs.level);
-
     (
         Arc::new(ControllerRuntime::new(
             pipeline_factory,
@@ -3982,6 +4001,56 @@ fn reconcile_engine_config_applies_runtime_log_level() {
     assert_eq!(log_filter_handle.configured_level().as_str(), "warn");
     tracing::dispatcher::with_default(&dispatch, emit_info);
     assert_eq!(event_count.load(Ordering::SeqCst), 0);
+}
+
+/// Scenario: a bootstrap filter is stricter than the initial engine log level,
+/// as can occur when `RUST_LOG` is set during startup.
+/// Guarantees: initial activation applies the engine level before pipelines run,
+/// and reconciling the unchanged configuration preserves that effective level.
+#[test]
+fn initial_config_activation_applies_log_level_before_noop_reconciliation() {
+    let mut config = empty_engine_config();
+    config.engine.telemetry.logs.level =
+        serde_json::from_value(serde_json::json!("info")).expect("info level should parse");
+    let bootstrap_level =
+        serde_json::from_value(serde_json::json!("error")).expect("error level should parse");
+    let (log_filter, log_filter_handle) = RuntimeLogFilter::new_configured(&bootstrap_level);
+    let event_count = Arc::new(AtomicUsize::new(0));
+    let dispatch = tracing::Dispatch::new(
+        Registry::default()
+            .with(log_filter.layer())
+            .with(CountingLayer(Arc::clone(&event_count))),
+    );
+    tracing::dispatcher::with_default(&dispatch, || {
+        otel_info!("test.controller.bootstrap_runtime_filter");
+    });
+    assert_eq!(event_count.swap(0, Ordering::SeqCst), 0);
+
+    let (runtime, log_filter_handle, _log_filter) =
+        test_runtime_with_supplied_log_filter_and_topology(
+            &config,
+            &TEST_PIPELINE_FACTORY,
+            NumaTopology::unknown(),
+            log_filter,
+            log_filter_handle,
+        );
+
+    assert_eq!(log_filter_handle.configured_level().as_str(), "info");
+    tracing::dispatcher::with_default(&dispatch, || {
+        otel_info!("test.controller.activated_runtime_filter");
+    });
+    assert_eq!(event_count.swap(0, Ordering::SeqCst), 1);
+
+    let status = runtime
+        .reconcile_engine_config(reconcile_request(config, true))
+        .expect("unchanged config should reconcile");
+
+    assert_eq!(status.state, EngineConfigReconcileState::Succeeded);
+    assert_eq!(log_filter_handle.configured_level().as_str(), "info");
+    tracing::dispatcher::with_default(&dispatch, || {
+        otel_info!("test.controller.reconciled_runtime_filter");
+    });
+    assert_eq!(event_count.load(Ordering::SeqCst), 1);
 }
 
 /// Scenario: a full-config reconciliation request omits live stopped

--- a/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
@@ -321,7 +321,7 @@ fn test_runtime_with_log_filter_and_topology(
     RuntimeLogFilter,
 ) {
     let (log_filter, log_filter_handle) =
-        RuntimeLogFilter::new(&config.engine.telemetry.logs.level);
+        RuntimeLogFilter::new(config.engine.telemetry.logs.level.as_ref());
     test_runtime_with_supplied_log_filter_and_topology(
         config,
         pipeline_factory,
@@ -3967,7 +3967,7 @@ fn reconcile_engine_config_reports_noop_for_matching_live_config() {
 fn reconcile_engine_config_applies_runtime_log_level() {
     let mut config = empty_engine_config();
     config.engine.telemetry.logs.level =
-        serde_json::from_value(serde_json::json!("warn")).expect("warn level should parse");
+        Some(serde_json::from_value(serde_json::json!("warn")).expect("warn level should parse"));
     let (runtime, log_filter_handle, log_filter) =
         test_runtime_with_log_filter(&config, &TEST_PIPELINE_FACTORY);
     let event_count = Arc::new(AtomicUsize::new(0));
@@ -3983,13 +3983,13 @@ fn reconcile_engine_config_applies_runtime_log_level() {
 
     let mut desired = config.clone();
     desired.engine.telemetry.logs.level =
-        serde_json::from_value(serde_json::json!("info")).expect("info level should parse");
+        Some(serde_json::from_value(serde_json::json!("info")).expect("info level should parse"));
     let status = runtime
         .reconcile_engine_config(reconcile_request(desired, true))
         .expect("info level should reconcile");
 
     assert_eq!(status.state, EngineConfigReconcileState::Succeeded);
-    assert_eq!(log_filter_handle.configured_level().as_str(), "info");
+    assert_eq!(log_filter_handle.effective_level().as_str(), "info");
     tracing::dispatcher::with_default(&dispatch, emit_info);
     assert_eq!(event_count.swap(0, Ordering::SeqCst), 1);
 
@@ -3998,20 +3998,19 @@ fn reconcile_engine_config_applies_runtime_log_level() {
         .expect("warn level should reconcile");
 
     assert_eq!(status.state, EngineConfigReconcileState::Succeeded);
-    assert_eq!(log_filter_handle.configured_level().as_str(), "warn");
+    assert_eq!(log_filter_handle.effective_level().as_str(), "warn");
     tracing::dispatcher::with_default(&dispatch, emit_info);
     assert_eq!(event_count.load(Ordering::SeqCst), 0);
 }
 
-/// Scenario: a bootstrap filter is stricter than the initial engine log level,
-/// as can occur when `RUST_LOG` is set during startup.
-/// Guarantees: initial activation applies the engine level before pipelines run,
-/// and reconciling the unchanged configuration preserves that effective level.
+/// Scenario: an existing shared filter is stricter than an explicit initial engine log level.
+/// Guarantees: activation applies the explicit level before pipelines run, and an unchanged
+/// reconciliation preserves that effective level.
 #[test]
 fn initial_config_activation_applies_log_level_before_noop_reconciliation() {
     let mut config = empty_engine_config();
     config.engine.telemetry.logs.level =
-        serde_json::from_value(serde_json::json!("info")).expect("info level should parse");
+        Some(serde_json::from_value(serde_json::json!("info")).expect("info level should parse"));
     let bootstrap_level =
         serde_json::from_value(serde_json::json!("error")).expect("error level should parse");
     let (log_filter, log_filter_handle) = RuntimeLogFilter::new_configured(&bootstrap_level);
@@ -4035,7 +4034,7 @@ fn initial_config_activation_applies_log_level_before_noop_reconciliation() {
             log_filter_handle,
         );
 
-    assert_eq!(log_filter_handle.configured_level().as_str(), "info");
+    assert_eq!(log_filter_handle.effective_level().as_str(), "info");
     tracing::dispatcher::with_default(&dispatch, || {
         otel_info!("test.controller.activated_runtime_filter");
     });
@@ -4046,7 +4045,7 @@ fn initial_config_activation_applies_log_level_before_noop_reconciliation() {
         .expect("unchanged config should reconcile");
 
     assert_eq!(status.state, EngineConfigReconcileState::Succeeded);
-    assert_eq!(log_filter_handle.configured_level().as_str(), "info");
+    assert_eq!(log_filter_handle.effective_level().as_str(), "info");
     tracing::dispatcher::with_default(&dispatch, || {
         otel_info!("test.controller.reconciled_runtime_filter");
     });
@@ -4127,7 +4126,7 @@ fn reconcile_engine_config_preserves_missing_resources_when_requested() {
 fn reconcile_engine_config_does_not_publish_scaffold_on_conflict() {
     let mut config = engine_config_with_pipeline(simple_pipeline_yaml());
     config.engine.telemetry.logs.level =
-        serde_json::from_value(serde_json::json!("warn")).expect("warn level should parse");
+        Some(serde_json::from_value(serde_json::json!("warn")).expect("warn level should parse"));
     let (runtime, log_filter_handle, _log_filter) =
         test_runtime_with_log_filter(&config, &TEST_PIPELINE_FACTORY);
     let pipeline_key = PipelineKey::new("g1".into(), "p1".into());
@@ -4143,7 +4142,7 @@ fn reconcile_engine_config_does_not_publish_scaffold_on_conflict() {
 
     let mut desired = config.clone();
     desired.engine.telemetry.logs.level =
-        serde_json::from_value(serde_json::json!("info")).expect("info level should parse");
+        Some(serde_json::from_value(serde_json::json!("info")).expect("info level should parse"));
     _ = desired
         .engine
         .custom
@@ -4155,7 +4154,7 @@ fn reconcile_engine_config_does_not_publish_scaffold_on_conflict() {
 
     assert_eq!(err, ControlPlaneError::RolloutConflict);
     assert!(runtime.engine_config_snapshot().engine.custom.is_empty());
-    assert_eq!(log_filter_handle.configured_level().as_str(), "warn");
+    assert_eq!(log_filter_handle.effective_level().as_str(), "warn");
 }
 
 /// Scenario: full-config reconciliation would change an existing topic

--- a/rust/otap-dataflow/crates/telemetry/README.md
+++ b/rust/otap-dataflow/crates/telemetry/README.md
@@ -118,11 +118,13 @@ metrics. Log provider modes determine how logging is configured in different
 parts of the code.
 
 All modes use a [`tracing_subscriber::EnvFilter`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html).
-The `engine.telemetry.logs.level` field accepts either a severity such as
-`warn` or a complete target directive string. Successful full-engine
-reconciliation applies changes to this field to existing tracing subscribers,
-so an OpAMP or admin control plane can temporarily increase verbosity without
-restarting the engine. Failed reconciliation preserves the active filter.
+The optional `engine.telemetry.logs.level` field accepts either a severity such
+as `warn` or a complete target directive string. When specified, it takes
+precedence over `RUST_LOG` from the first tracing subscriber onward. Successful
+full-engine reconciliation applies changes to this field to existing tracing
+subscribers, so an OpAMP or admin control plane can temporarily increase
+verbosity without restarting the engine. Failed reconciliation preserves the
+active filter.
 
 `EnvFilter` target directives use prefix matching. A directive for
 `<namespace>.<kind>.<name>` also matches another component whose target begins
@@ -137,21 +139,21 @@ by `otel-arrow-dfe-otap`:
 warn,otel.receiver.otlp=debug,otel-arrow-dfe-otap=debug
 ```
 
-A valid `RUST_LOG` environment variable initializes logging during early
-bootstrap, before the engine configuration is active. When the initial engine
-configuration is activated, `logs.level` becomes authoritative and replaces
-the environment-derived filter before the initial pipelines start. Later,
-successful full-engine reconciliations apply the same precedence rule. This
-lets an OpAMP or admin control plane reliably change verbosity even when the
-process was launched with `RUST_LOG`.
+When `logs.level` is omitted, a valid `RUST_LOG` value captured at startup
+remains authoritative. If both are absent, the effective default is
+`info,h2=off,hyper=off`. A later reconciliation can install an explicit
+`logs.level`; removing it restores the captured `RUST_LOG` value or the
+built-in default. This preserves `RUST_LOG` as a restart-time operator override
+without allowing it to supersede explicit engine configuration.
 
 ### Limitation: active span state is not reconstructed
 
 `EnvFilter` supports span-scoped directives such as
 `warn,[pipeline_thread]=debug`, which raise verbosity only while a matching
-span is entered. Those directives work when supplied at startup through
-`logs.level` or `RUST_LOG`, but reconciliation cannot apply them to spans that
-are already entered.
+span is entered. Those directives work when supplied before the span is
+created, through an explicit initial `logs.level` or through `RUST_LOG` when
+the field is omitted. Reconciliation cannot apply them to spans that are
+already entered.
 
 Reconciliation installs a newly built `EnvFilter` into each live dispatcher.
 `EnvFilter` tracks span scopes through `on_new_span` and `on_enter`, so a

--- a/rust/otap-dataflow/crates/telemetry/README.md
+++ b/rust/otap-dataflow/crates/telemetry/README.md
@@ -137,11 +137,13 @@ by `otel-arrow-dfe-otap`:
 warn,otel.receiver.otlp=debug,otel-arrow-dfe-otap=debug
 ```
 
-At startup, a valid `RUST_LOG` environment variable takes precedence over
-`logs.level`. After startup, a successful full-engine reconciliation makes the
-reconciled `logs.level` authoritative and replaces the environment-derived
-filter. This lets an OpAMP or admin control plane reliably change verbosity
-even when the process was launched with `RUST_LOG`.
+A valid `RUST_LOG` environment variable initializes logging during early
+bootstrap, before the engine configuration is active. When the initial engine
+configuration is activated, `logs.level` becomes authoritative and replaces
+the environment-derived filter before the initial pipelines start. Later,
+successful full-engine reconciliations apply the same precedence rule. This
+lets an OpAMP or admin control plane reliably change verbosity even when the
+process was launched with `RUST_LOG`.
 
 ### Limitation: active span state is not reconstructed
 

--- a/rust/otap-dataflow/crates/telemetry/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/lib.rs
@@ -285,7 +285,7 @@ impl InternalTelemetrySystem {
             )
         };
 
-        let (log_filter, log_filter_handle) = RuntimeLogFilter::new(&config.logs.level);
+        let (log_filter, log_filter_handle) = RuntimeLogFilter::new(config.logs.level.as_ref());
 
         Ok(Self {
             registry: telemetry_registry,
@@ -381,13 +381,10 @@ impl InternalTelemetrySystem {
         &self.its_reporter
     }
 
-    /// Returns the desired configured log level.
-    ///
-    /// Before initial configuration activation this may differ from the
-    /// effective bootstrap filter when `RUST_LOG` supplied that filter.
+    /// Returns the effective log level installed in tracing filters.
     #[must_use]
     pub fn log_level(&self) -> LogLevel {
-        self.log_filter.configured_level()
+        self.log_filter.effective_level()
     }
 
     /// Returns the handle for applying runtime log-level configuration.
@@ -476,16 +473,41 @@ mod tests {
     }
 
     /// Scenario: runtime reconciliation changes the shared internal log filter.
-    /// Guarantees: InternalTelemetrySystem reports the current configured level.
+    /// Guarantees: InternalTelemetrySystem reports the current effective level.
     #[test]
     fn log_level_follows_runtime_filter_updates() {
         with_cleared_rust_log(|| {
             let its = test_system(&TelemetryConfig::default());
             let level: LogLevel = serde_yaml::from_str("debug").expect("valid log level");
 
-            its.log_filter_handle().apply(&level);
+            its.log_filter_handle().apply(Some(&level));
 
             assert_eq!(its.log_level(), level);
+        });
+    }
+
+    /// Scenario: RUST_LOG is set and the telemetry configuration omits logs.level.
+    /// Guarantees: InternalTelemetrySystem installs the captured environment directive.
+    #[test]
+    fn omitted_log_level_uses_rust_log() {
+        with_rust_log(Some("debug"), || {
+            let its = test_system(&TelemetryConfig::default());
+
+            assert_eq!(its.log_level().as_str(), "debug");
+        });
+    }
+
+    /// Scenario: telemetry configuration explicitly sets logs.level while RUST_LOG is present.
+    /// Guarantees: InternalTelemetrySystem installs the explicit configuration immediately.
+    #[test]
+    fn explicit_log_level_overrides_rust_log() {
+        with_rust_log(Some("debug"), || {
+            let mut config = TelemetryConfig::default();
+            config.logs.level =
+                Some(serde_yaml::from_str("info").expect("explicit level should parse"));
+            let its = test_system(&config);
+
+            assert_eq!(its.log_level().as_str(), "info");
         });
     }
 

--- a/rust/otap-dataflow/crates/telemetry/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/lib.rs
@@ -383,8 +383,8 @@ impl InternalTelemetrySystem {
 
     /// Returns the desired configured log level.
     ///
-    /// Before the first reconciliation this may differ from the effective startup
-    /// filter when `RUST_LOG` supplied that filter.
+    /// Before initial configuration activation this may differ from the
+    /// effective bootstrap filter when `RUST_LOG` supplied that filter.
     #[must_use]
     pub fn log_level(&self) -> LogLevel {
         self.log_filter.configured_level()

--- a/rust/otap-dataflow/crates/telemetry/src/log_filter.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/log_filter.rs
@@ -3,7 +3,7 @@
 
 //! Runtime-reloadable filtering for internal telemetry logs.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::env;
 use std::sync::{Arc, Mutex, Weak};
 
 use arc_swap::ArcSwap;
@@ -16,11 +16,10 @@ use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::layer::{Context, Layer};
 
 struct SharedState {
-    // Desired config value; startup RUST_LOG may temporarily select a different filter.
-    configured_level: ArcSwap<LogLevel>,
-    // Initial configuration activation must replace RUST_LOG even when
-    // logs.level is unchanged.
-    startup_override_active: AtomicBool,
+    // Captured once so removing an explicit setting has deterministic behavior.
+    fallback_level: LogLevel,
+    // The directive currently installed in all dispatcher-local filters.
+    effective_level: ArcSwap<LogLevel>,
     template: ArcSwap<EnvFilter>,
     layers: Mutex<Vec<Weak<ArcSwap<EnvFilter>>>>,
 }
@@ -30,21 +29,22 @@ pub struct RuntimeLogFilterLayer {
     filter: Arc<ArcSwap<EnvFilter>>,
 }
 
-/// Creates the startup `EnvFilter` from `RUST_LOG`, falling back to `level`.
+/// Creates an `EnvFilter` from a validated log level.
 #[cfg(test)]
 #[must_use]
 pub(crate) fn create_env_filter(level: &LogLevel) -> EnvFilter {
-    create_startup_env_filter(level).0
+    env_filter(level)
 }
 
-fn create_startup_env_filter(level: &LogLevel) -> (EnvFilter, bool) {
-    match EnvFilter::try_from_default_env() {
-        Ok(filter) => (filter, true),
-        Err(_) => (
-            EnvFilter::try_new(level.as_str()).expect("logs.level must be validated before use"),
-            false,
-        ),
-    }
+fn env_filter(level: &LogLevel) -> EnvFilter {
+    EnvFilter::try_new(level.as_str()).expect("log level must be validated before use")
+}
+
+fn capture_fallback_level() -> LogLevel {
+    env::var("RUST_LOG")
+        .ok()
+        .and_then(|value| LogLevel::try_from(value).ok())
+        .unwrap_or_default()
 }
 
 /// A shared factory for runtime-reloadable `EnvFilter` layers.
@@ -64,11 +64,18 @@ pub struct RuntimeLogFilterHandle {
 }
 
 impl RuntimeLogFilter {
-    /// Creates a filter and its update handle from the configured log level.
+    /// Creates a filter and its update handle from optional configuration.
+    ///
+    /// An explicit configured level takes precedence. When configuration omits
+    /// the level, a valid `RUST_LOG` value captured here is used, followed by
+    /// the built-in [`LogLevel::default`].
     #[must_use]
-    pub fn new(level: &LogLevel) -> (Self, RuntimeLogFilterHandle) {
-        let (filter, startup_override_active) = create_startup_env_filter(level);
-        Self::from_configured_filter(level, filter, startup_override_active)
+    pub fn new(configured_level: Option<&LogLevel>) -> (Self, RuntimeLogFilterHandle) {
+        let fallback_level = capture_fallback_level();
+        let effective_level = configured_level
+            .cloned()
+            .unwrap_or_else(|| fallback_level.clone());
+        Self::from_levels(effective_level, fallback_level)
     }
 
     /// Creates a filter from the configured level without consulting `RUST_LOG`.
@@ -77,19 +84,17 @@ impl RuntimeLogFilter {
     /// configured-filter behavior independent of the process environment.
     #[must_use]
     pub fn new_configured(level: &LogLevel) -> (Self, RuntimeLogFilterHandle) {
-        let filter =
-            EnvFilter::try_new(level.as_str()).expect("logs.level must be validated before use");
-        Self::from_configured_filter(level, filter, false)
+        Self::from_levels(level.clone(), LogLevel::default())
     }
 
-    fn from_configured_filter(
-        level: &LogLevel,
-        filter: EnvFilter,
-        startup_override_active: bool,
+    fn from_levels(
+        effective_level: LogLevel,
+        fallback_level: LogLevel,
     ) -> (Self, RuntimeLogFilterHandle) {
+        let filter = env_filter(&effective_level);
         let shared = Arc::new(SharedState {
-            configured_level: ArcSwap::from_pointee(level.clone()),
-            startup_override_active: AtomicBool::new(startup_override_active),
+            fallback_level,
+            effective_level: ArcSwap::from_pointee(effective_level),
             template: ArcSwap::from_pointee(filter),
             layers: Mutex::new(Vec::new()),
         });
@@ -105,8 +110,8 @@ impl RuntimeLogFilter {
     pub(crate) fn from_filter(level: LogLevel, filter: EnvFilter) -> Self {
         Self {
             shared: Arc::new(SharedState {
-                configured_level: ArcSwap::from_pointee(level),
-                startup_override_active: AtomicBool::new(false),
+                fallback_level: level.clone(),
+                effective_level: ArcSwap::from_pointee(level),
                 template: ArcSwap::from_pointee(filter),
                 layers: Mutex::new(Vec::new()),
             }),
@@ -129,13 +134,10 @@ impl RuntimeLogFilter {
         RuntimeLogFilterLayer { filter }
     }
 
-    /// Returns the desired configuration value.
-    ///
-    /// Before initial configuration activation this may differ from the
-    /// effective bootstrap filter when `RUST_LOG` supplied that filter.
+    /// Returns the effective level currently installed in tracing filters.
     #[must_use]
-    pub fn configured_level(&self) -> LogLevel {
-        self.shared.configured_level.load().as_ref().clone()
+    pub fn effective_level(&self) -> LogLevel {
+        self.shared.effective_level.load().as_ref().clone()
     }
 }
 
@@ -148,23 +150,20 @@ impl RuntimeLogFilterHandle {
     /// observed their `on_new_span`/`on_enter` callbacks, so its scope stack
     /// stays empty for them. Such directives still work when supplied at
     /// startup. See the crate README for operator-facing details.
-    pub fn apply(&self, level: &LogLevel) {
-        if self.shared.configured_level.load().as_ref() == level
-            && !self.shared.startup_override_active.load(Ordering::Acquire)
-        {
+    pub fn apply(&self, configured_level: Option<&LogLevel>) {
+        let level = configured_level
+            .cloned()
+            .unwrap_or_else(|| self.shared.fallback_level.clone());
+        if self.shared.effective_level.load().as_ref() == &level {
             return;
         }
-        let filter =
-            EnvFilter::try_new(level.as_str()).expect("logs.level must be validated before use");
+        let filter = env_filter(&level);
         let mut layers = self
             .shared
             .layers
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        self.shared.configured_level.store(Arc::new(level.clone()));
-        self.shared
-            .startup_override_active
-            .store(false, Ordering::Release);
+        self.shared.effective_level.store(Arc::new(level));
         self.shared.template.store(Arc::new(filter.clone()));
         layers.retain(|layer| {
             if let Some(layer) = layer.upgrade() {
@@ -178,13 +177,10 @@ impl RuntimeLogFilterHandle {
         tracing::callsite::rebuild_interest_cache();
     }
 
-    /// Returns the desired configuration value.
-    ///
-    /// Before initial configuration activation this may differ from the
-    /// effective bootstrap filter when `RUST_LOG` supplied that filter.
+    /// Returns the effective level currently installed in tracing filters.
     #[must_use]
-    pub fn configured_level(&self) -> LogLevel {
-        self.shared.configured_level.load().as_ref().clone()
+    pub fn effective_level(&self) -> LogLevel {
+        self.shared.effective_level.load().as_ref().clone()
     }
 }
 
@@ -259,7 +255,7 @@ mod tests {
     fn same_callsite_tracks_runtime_level_updates() {
         crate::with_cleared_rust_log(|| {
             let count = Arc::new(AtomicUsize::new(0));
-            let (filter, handle) = RuntimeLogFilter::new(&level("warn"));
+            let (filter, handle) = RuntimeLogFilter::new(Some(&level("warn")));
             let subscriber = Registry::default()
                 .with(filter.layer())
                 .with(CountingLayer(Arc::clone(&count)));
@@ -270,11 +266,11 @@ mod tests {
                 emit_info();
                 assert_eq!(count.swap(0, Ordering::SeqCst), 0);
 
-                handle.apply(&level("info"));
+                handle.apply(Some(&level("info")));
                 emit_info();
                 assert_eq!(count.swap(0, Ordering::SeqCst), 1);
 
-                handle.apply(&level("error"));
+                handle.apply(Some(&level("error")));
                 emit_info();
                 assert_eq!(count.swap(0, Ordering::SeqCst), 0);
             });
@@ -287,7 +283,7 @@ mod tests {
     fn runtime_update_preserves_target_directives() {
         crate::with_cleared_rust_log(|| {
             let count = Arc::new(AtomicUsize::new(0));
-            let (filter, handle) = RuntimeLogFilter::new(&level("off"));
+            let (filter, handle) = RuntimeLogFilter::new(Some(&level("off")));
             let subscriber = Registry::default()
                 .with(filter.layer())
                 .with(CountingLayer(Arc::clone(&count)));
@@ -296,7 +292,7 @@ mod tests {
                 tracing::info!(target: "runtime_allowed", "allowed target");
                 assert_eq!(count.swap(0, Ordering::SeqCst), 0);
 
-                handle.apply(&level("off,runtime_allowed=info"));
+                handle.apply(Some(&level("off,runtime_allowed=info")));
                 tracing::info!(target: "runtime_allowed", "allowed target");
                 tracing::info!(target: "runtime_blocked", "blocked target");
                 assert_eq!(count.swap(0, Ordering::SeqCst), 1);
@@ -310,7 +306,7 @@ mod tests {
     fn runtime_update_applies_span_directive_only_to_new_spans() {
         crate::with_cleared_rust_log(|| {
             let count = Arc::new(AtomicUsize::new(0));
-            let (filter, handle) = RuntimeLogFilter::new(&level("warn,[reload_span]=debug"));
+            let (filter, handle) = RuntimeLogFilter::new(Some(&level("warn,[reload_span]=debug")));
             let subscriber = Registry::default()
                 .with(filter.layer())
                 .with(CountingLayer(Arc::clone(&count)));
@@ -321,7 +317,7 @@ mod tests {
                 tracing::debug!("old span directive permits this event");
                 assert_eq!(count.swap(0, Ordering::SeqCst), 1);
 
-                handle.apply(&level("warn,[reload_span]=trace"));
+                handle.apply(Some(&level("warn,[reload_span]=trace")));
                 tracing::debug!("existing span falls back to warn");
                 assert_eq!(count.swap(0, Ordering::SeqCst), 0);
                 drop(entered);
@@ -342,7 +338,7 @@ mod tests {
         crate::with_cleared_rust_log(|| {
             let first_count = Arc::new(AtomicUsize::new(0));
             let second_count = Arc::new(AtomicUsize::new(0));
-            let (filter, handle) = RuntimeLogFilter::new(&level("warn"));
+            let (filter, handle) = RuntimeLogFilter::new(Some(&level("warn")));
             let first = tracing::Dispatch::new(
                 Registry::default()
                     .with(filter.layer())
@@ -360,7 +356,7 @@ mod tests {
             assert_eq!(first_count.load(Ordering::SeqCst), 0);
             assert_eq!(second_count.load(Ordering::SeqCst), 0);
 
-            handle.apply(&level("info"));
+            handle.apply(Some(&level("info")));
             tracing::dispatcher::with_default(&first, emit_info);
             tracing::dispatcher::with_default(&second, emit_info);
             assert_eq!(first_count.load(Ordering::SeqCst), 1);
@@ -374,9 +370,9 @@ mod tests {
     fn dispatcher_created_after_update_uses_latest_filter() {
         crate::with_cleared_rust_log(|| {
             let count = Arc::new(AtomicUsize::new(0));
-            let (filter, handle) = RuntimeLogFilter::new(&level("warn"));
+            let (filter, handle) = RuntimeLogFilter::new(Some(&level("warn")));
 
-            handle.apply(&level("info"));
+            handle.apply(Some(&level("info")));
             let dispatch = tracing::Dispatch::new(
                 Registry::default()
                     .with(filter.layer())
@@ -390,27 +386,71 @@ mod tests {
         });
     }
 
-    /// Scenario: RUST_LOG sets the startup filter before runtime configuration changes.
-    /// Guarantees: a reconciled logs.level replaces the startup environment filter.
+    /// Scenario: RUST_LOG is set while logs.level is explicitly configured.
+    /// Guarantees: the explicit configuration controls the initial filter without an activation update.
     #[test]
-    fn runtime_update_overrides_rust_log_startup_filter() {
+    fn explicit_config_overrides_rust_log_from_initial_filter() {
         crate::with_rust_log(Some("error"), || {
             let count = Arc::new(AtomicUsize::new(0));
-            let (filter, handle) = RuntimeLogFilter::new(&level("warn"));
+            let (filter, handle) = RuntimeLogFilter::new(Some(&level("info")));
             let subscriber = Registry::default()
                 .with(filter.layer())
                 .with(CountingLayer(Arc::clone(&count)));
 
             tracing::subscriber::with_default(subscriber, || {
-                tracing::info!("RUST_LOG blocks this startup event");
-                assert_eq!(count.swap(0, Ordering::SeqCst), 0);
-
-                handle.apply(&level("info"));
-                tracing::info!("reconciled logs.level permits this event");
+                tracing::info!("explicit logs.level permits this initial event");
                 assert_eq!(count.swap(0, Ordering::SeqCst), 1);
             });
 
-            assert_eq!(handle.configured_level().as_str(), "info");
+            assert_eq!(handle.effective_level().as_str(), "info");
+        });
+    }
+
+    /// Scenario: logs.level is omitted while RUST_LOG supplies the startup fallback.
+    /// Guarantees: an explicit runtime override can be applied and later removed to restore RUST_LOG.
+    #[test]
+    fn omitted_config_uses_and_restores_captured_rust_log() {
+        crate::with_rust_log(Some("error"), || {
+            let count = Arc::new(AtomicUsize::new(0));
+            let (filter, handle) = RuntimeLogFilter::new(None);
+            let subscriber = Registry::default()
+                .with(filter.layer())
+                .with(CountingLayer(Arc::clone(&count)));
+
+            tracing::subscriber::with_default(subscriber, || {
+                tracing::info!("RUST_LOG blocks the initial event");
+                assert_eq!(count.swap(0, Ordering::SeqCst), 0);
+
+                handle.apply(Some(&level("info")));
+                tracing::info!("explicit logs.level permits the event");
+                assert_eq!(count.swap(0, Ordering::SeqCst), 1);
+
+                handle.apply(None);
+                tracing::info!("restored RUST_LOG blocks the event again");
+                assert_eq!(count.swap(0, Ordering::SeqCst), 0);
+            });
+
+            assert_eq!(handle.effective_level().as_str(), "error");
+        });
+    }
+
+    /// Scenario: logs.level is omitted and RUST_LOG contains an invalid directive.
+    /// Guarantees: the initial filter safely uses the built-in default directive.
+    #[test]
+    fn invalid_rust_log_uses_builtin_fallback() {
+        crate::with_rust_log(Some("info,["), || {
+            let (filter, handle) = RuntimeLogFilter::new(None);
+            let count = Arc::new(AtomicUsize::new(0));
+            let subscriber = Registry::default()
+                .with(filter.layer())
+                .with(CountingLayer(Arc::clone(&count)));
+
+            tracing::subscriber::with_default(subscriber, || {
+                tracing::info!("built-in info fallback permits this event");
+            });
+
+            assert_eq!(count.load(Ordering::SeqCst), 1);
+            assert_eq!(handle.effective_level(), LogLevel::default());
         });
     }
 
@@ -433,34 +473,12 @@ mod tests {
         });
     }
 
-    /// Scenario: RUST_LOG overrides bootstrap with the same logs.level activated by the engine.
-    /// Guarantees: initial configuration activation replaces the environment-derived filter.
-    #[test]
-    fn initial_activation_overrides_matching_rust_log_startup_filter() {
-        crate::with_rust_log(Some("error"), || {
-            let count = Arc::new(AtomicUsize::new(0));
-            let (filter, handle) = RuntimeLogFilter::new(&level("info"));
-            let subscriber = Registry::default()
-                .with(filter.layer())
-                .with(CountingLayer(Arc::clone(&count)));
-
-            tracing::subscriber::with_default(subscriber, || {
-                tracing::info!("RUST_LOG blocks this startup event");
-                assert_eq!(count.swap(0, Ordering::SeqCst), 0);
-
-                handle.apply(&level("info"));
-                tracing::info!("activated logs.level permits this event");
-                assert_eq!(count.swap(0, Ordering::SeqCst), 1);
-            });
-        });
-    }
-
     /// Scenario: a dispatcher-local layer is dropped before another is created.
     /// Guarantees: dead registrations are pruned without waiting for an update.
     #[test]
     fn layer_creation_prunes_dropped_dispatchers() {
         crate::with_cleared_rust_log(|| {
-            let (filter, _handle) = RuntimeLogFilter::new(&level("warn"));
+            let (filter, _handle) = RuntimeLogFilter::new(Some(&level("warn")));
             let first = filter.layer();
             assert_eq!(filter.shared.layers.lock().unwrap().len(), 1);
             drop(first);
@@ -475,11 +493,11 @@ mod tests {
     #[test]
     fn unchanged_level_does_not_replace_filters() {
         crate::with_cleared_rust_log(|| {
-            let (filter, handle) = RuntimeLogFilter::new(&level("warn"));
+            let (filter, handle) = RuntimeLogFilter::new(Some(&level("warn")));
             let layer = filter.layer();
             let before = layer.filter.load_full();
 
-            handle.apply(&level("warn"));
+            handle.apply(Some(&level("warn")));
 
             let after = layer.filter.load_full();
             assert!(Arc::ptr_eq(&before, &after));

--- a/rust/otap-dataflow/crates/telemetry/src/log_filter.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/log_filter.rs
@@ -18,7 +18,8 @@ use tracing_subscriber::layer::{Context, Layer};
 struct SharedState {
     // Desired config value; startup RUST_LOG may temporarily select a different filter.
     configured_level: ArcSwap<LogLevel>,
-    // The first reconciliation must replace RUST_LOG even when logs.level is unchanged.
+    // Initial configuration activation must replace RUST_LOG even when
+    // logs.level is unchanged.
     startup_override_active: AtomicBool,
     template: ArcSwap<EnvFilter>,
     layers: Mutex<Vec<Weak<ArcSwap<EnvFilter>>>>,
@@ -56,7 +57,7 @@ pub struct RuntimeLogFilter {
     shared: Arc<SharedState>,
 }
 
-/// A cloneable handle for applying reconciled log-level directives.
+/// A cloneable handle for applying configured log-level directives.
 #[derive(Clone)]
 pub struct RuntimeLogFilterHandle {
     shared: Arc<SharedState>,
@@ -130,8 +131,8 @@ impl RuntimeLogFilter {
 
     /// Returns the desired configuration value.
     ///
-    /// Before the first reconciliation this may differ from the effective startup
-    /// filter when `RUST_LOG` supplied that filter.
+    /// Before initial configuration activation this may differ from the
+    /// effective bootstrap filter when `RUST_LOG` supplied that filter.
     #[must_use]
     pub fn configured_level(&self) -> LogLevel {
         self.shared.configured_level.load().as_ref().clone()
@@ -179,8 +180,8 @@ impl RuntimeLogFilterHandle {
 
     /// Returns the desired configuration value.
     ///
-    /// Before the first reconciliation this may differ from the effective startup
-    /// filter when `RUST_LOG` supplied that filter.
+    /// Before initial configuration activation this may differ from the
+    /// effective bootstrap filter when `RUST_LOG` supplied that filter.
     #[must_use]
     pub fn configured_level(&self) -> LogLevel {
         self.shared.configured_level.load().as_ref().clone()
@@ -432,10 +433,10 @@ mod tests {
         });
     }
 
-    /// Scenario: RUST_LOG overrides startup with the same logs.level later reconciled.
-    /// Guarantees: the first reconciliation replaces the environment-derived filter.
+    /// Scenario: RUST_LOG overrides bootstrap with the same logs.level activated by the engine.
+    /// Guarantees: initial configuration activation replaces the environment-derived filter.
     #[test]
-    fn unchanged_runtime_level_overrides_rust_log_startup_filter() {
+    fn initial_activation_overrides_matching_rust_log_startup_filter() {
         crate::with_rust_log(Some("error"), || {
             let count = Arc::new(AtomicUsize::new(0));
             let (filter, handle) = RuntimeLogFilter::new(&level("info"));
@@ -448,7 +449,7 @@ mod tests {
                 assert_eq!(count.swap(0, Ordering::SeqCst), 0);
 
                 handle.apply(&level("info"));
-                tracing::info!("reconciled logs.level permits this event");
+                tracing::info!("activated logs.level permits this event");
                 assert_eq!(count.swap(0, Ordering::SeqCst), 1);
             });
         });

--- a/rust/otap-dataflow/crates/telemetry/src/tracing_init.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/tracing_init.rs
@@ -41,7 +41,7 @@ impl TracingSetup {
     /// the internal telemetry system.
     #[must_use]
     pub fn new(provider: ProviderSetup, log_level: LogLevel, context_fn: LogContextFn) -> Self {
-        let (log_filter, _handle) = RuntimeLogFilter::new(&log_level);
+        let (log_filter, _handle) = RuntimeLogFilter::new_configured(&log_level);
         Self::from_log_filter(provider, log_filter, context_fn)
     }
 
@@ -84,7 +84,7 @@ impl TracingSetup {
     where
         F: FnOnce() -> R,
     {
-        let log_level = self.log_filter.configured_level();
+        let log_level = self.log_filter.effective_level();
         self.provider
             .with_subscriber_ignoring_env(&log_level, self.context_fn, f)
     }
@@ -280,7 +280,7 @@ mod tests {
     fn internal_async_provider_applies_runtime_level_updates() {
         crate::with_cleared_rust_log(|| {
             let (reporter, receiver) = test_reporter();
-            let (filter, handle) = RuntimeLogFilter::new(&level("warn"));
+            let (filter, handle) = RuntimeLogFilter::new(Some(&level("warn")));
             let setup = test_setup(internal_async_provider(reporter), level("warn"))
                 .with_log_filter(filter);
 
@@ -290,11 +290,11 @@ mod tests {
                 emit_info();
                 assert!(receiver.try_recv().is_err());
 
-                handle.apply(&level("info"));
+                handle.apply(Some(&level("info")));
                 emit_info();
                 assert!(matches!(receiver.try_recv(), Ok(ObservedEvent::Log(_))));
 
-                handle.apply(&level("warn"));
+                handle.apply(Some(&level("warn")));
                 emit_info();
                 assert!(receiver.try_recv().is_err());
             });


### PR DESCRIPTION
# Change summary

Apply `engine.telemetry.logs.level` when the initial engine configuration is activated, before observability and user pipelines start.

When defined `engine.telemetry.logs.level` takes precedence on `RUST_LOG`. Initial activation and subsequent successful reconciliations now use the same precedence rule, so reconciling an unchanged configuration does not alter the effective log level.

This PR also updates the logging lifecycle documentation and adds regression coverage for conflicting bootstrap and configured log levels.

## Related issue

* Closes #3996

## Validation

* Ran `cargo xtask check`
* Ran targeted telemetry and controller tests.


## User-facing changes

When defined `engine.telemetry.logs.level` takes precedence on `RUST_LOG`.

A `bug_fix` changelog entry is included under the `observability` component.