### PR TITLE
feat(kafka): add Syslog decoding to receiver

### DIFF
--- a/rust/otap-dataflow/.chloggen/kafka-receiver-syslog-decoding.yaml
+++ b/rust/otap-dataflow/.chloggen/kafka-receiver-syslog-decoding.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: pipeline
+note: "Add Syslog decoding for Kafka log topics, including RFC 3164, RFC 5424, and embedded CEF messages."
+issues: [3837]
+subtext: "Set a logs signal encoding to `syslog`, or use a `MessageFormat: syslog` Kafka header. Each Kafka record must contain one complete Syslog message."

--- a/rust/otap-dataflow/crates/contrib-nodes/Cargo.toml
+++ b/rust/otap-dataflow/crates/contrib-nodes/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 otel-arrow-dfe-channel = { workspace = true }
 otel-arrow-dfe-config = { workspace = true }
 otel-arrow-dfe-engine = { workspace = true }
+otel-arrow-dfe-core-nodes = { workspace = true, optional = true }
 otel-arrow-dfe-otap = { workspace = true }
 otel-arrow-dfe-pdata = { workspace = true }
 otel-arrow-dfe-pdata-views = { workspace = true }
@@ -92,6 +93,7 @@ tracepoint_decode = { workspace = true, optional = true }
 [features]
 etw-receiver = ["dep:one_collect", "dep:humantime-serde"]
 kafka-receiver = [
+    "dep:otel-arrow-dfe-core-nodes",
     "dep:rdkafka",
     "dep:smallvec",
     "dep:regex",

--- a/rust/otap-dataflow/crates/contrib-nodes/src/common/kafka/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/common/kafka/mod.rs
@@ -227,6 +227,8 @@ pub enum MessageFormat {
     //OtlpJson,
     /// OTAP (Arrow) protobuf encoding.
     OtapProto,
+    /// Syslog encoding for Kafka log records.
+    Syslog,
     // others eventually
 }
 
@@ -391,6 +393,9 @@ pub const MSG_FORMAT_OTLP: &[u8] = b"otlp";
 
 /// header value for OTAP format in bytes
 pub const MSG_FORMAT_OTAP: &[u8] = b"otap";
+
+/// header value for Syslog format in bytes
+pub const MSG_FORMAT_SYSLOG: &[u8] = b"syslog";
 
 /// Maximum length of a Kafka topic name.
 ///

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/kafka_exporter/config.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/kafka_exporter/config.rs
@@ -653,6 +653,9 @@ pub struct KafkaExporterConfig(KafkaExporterConfigBuilder);
 /// the factory `validate_config` path, which runs this validation without
 /// constructing an exporter.
 fn validate_signal_topics(signal: &SignalConfig) -> Result<(), String> {
+    if signal.encoding == MessageFormat::Syslog {
+        return Err("encoding: syslog is not supported by the Kafka exporter".to_string());
+    }
     validate_kafka_topic(&signal.topic).map_err(|e| format!("topic: {e}"))?;
     for (i, t) in signal.allowed_topics.iter().enumerate() {
         validate_kafka_topic(t).map_err(|e| format!("allowed_topics[{i}]: {e}"))?;
@@ -1188,6 +1191,21 @@ mod tests {
             MessageFormat::OtapProto
         );
         assert_eq!(config.logs().unwrap().encoding(), MessageFormat::OtlpProto);
+    }
+
+    /// Scenario: a Kafka exporter signal is configured with Syslog encoding.
+    /// Guarantees: exporter validation rejects the receiver-only encoding.
+    #[test]
+    fn test_config_syslog_encoding_fails() {
+        let json = r#"{
+            "brokers": "kafka:9092",
+            "client_id": "test",
+            "logs": {"topic": "l", "encoding": "syslog"}
+        }"#;
+
+        let err = serde_json::from_str::<KafkaExporterConfig>(json)
+            .expect_err("Syslog encoding must be rejected");
+        assert!(err.to_string().contains("syslog is not supported"));
     }
 
     // ---- Validation via TryFrom ----

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/kafka_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/kafka_exporter/exporter.rs
@@ -28,7 +28,7 @@ use super::topic_router::TopicRouter;
 use crate::common::kafka::aws::ProducerClientContext;
 #[cfg(feature = "aws")]
 use crate::common::kafka::security::build_aws_msk_context;
-use crate::common::kafka::{MSG_FORMAT_OTAP, MSG_FORMAT_OTLP, MessageFormat};
+use crate::common::kafka::{MSG_FORMAT_OTAP, MSG_FORMAT_OTLP, MSG_FORMAT_SYSLOG, MessageFormat};
 use async_trait::async_trait;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt};
@@ -491,6 +491,7 @@ impl KafkaExporter {
         let format_value = match encoding {
             MessageFormat::OtlpProto => MSG_FORMAT_OTLP,
             MessageFormat::OtapProto => MSG_FORMAT_OTAP,
+            MessageFormat::Syslog => MSG_FORMAT_SYSLOG,
         };
         headers = headers.insert(Header {
             key: format_header_key,
@@ -645,6 +646,9 @@ impl KafkaExporter {
                 payload.clone(),
                 &mut self.pdata_producer,
             ),
+            MessageFormat::Syslog => Err(KafkaExporterError::Configuration(
+                "syslog encoding is not supported by the Kafka exporter".to_string(),
+            )),
         };
 
         // nack on failed encoding bytes

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/README.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/README.md
@@ -11,7 +11,8 @@
 ## Overview
 
 The Kafka receiver consumes OpenTelemetry traces, metrics, and logs from
-Apache Kafka topics. It supports OTLP and OTAP protobuf encodings,
+Apache Kafka topics. It supports OTLP and OTAP protobuf encodings for all
+signals and Syslog encoding for logs,
 per-signal topic routing, SASL authentication (PLAIN, SCRAM, AWS MSK IAM),
 TLS, manual and automatic offset commit modes, and Kafka message header
 extraction into resource attributes or pipeline transport headers.
@@ -61,7 +62,7 @@ config:
 | `resource_attrs_from_headers` | map | `{}` | Rules for extracting Kafka message headers into resource attributes. |
 | `enable_idempotency` | bool | `false` | Skip duplicate messages by offset (manual commit mode only). |
 | `rebalance_strategy` | string | *none* | Partition assignment strategy: `range`, `round_robin`, or `cooperative_sticky`. When omitted, librdkafka uses its default (`range,roundrobin`). |
-| `message_format_header` | string | `"MessageFormat"` | Kafka header key for per-message format detection. The receiver checks each message for a header with this key and value `otlp` or `otap` to override the per-signal encoding. |
+| `message_format_header` | string | `"MessageFormat"` | Kafka header key for per-message format detection. The receiver checks each message for a header with this key and value `otlp`, `otap`, or `syslog` to override the per-signal encoding. Syslog is valid only for logs. |
 | `debug` | list | *none* | List of librdkafka debug contexts: `generic`, `broker`, `topic`, `metadata`, `feature`, `queue`, `msg`, `protocol`, `cgrp`, `security`, `fetch`, `interceptor`, `plugin`, `consumer`, `admin`, `eos`, `mock`, `assignor`, `conf`, `telemetry`, `all`. |
 | `log_level` | string | *none* | Librdkafka log level: `emerg`, `alert`, `critical`, `error`, `warning`, `notice`, `info`, `debug`. When omitted, inferred from the application's log configuration. |
 | `consumer_config` | map | `{}` | Additional librdkafka consumer settings as key-value string pairs. |
@@ -74,7 +75,7 @@ Each signal type (`traces`, `metrics`, `logs`) accepts a nested configuration:
 | --- | --- | --- | --- |
 | `topics` | list | `[]` | Topics to subscribe to. Entries starting with `^` are regex patterns. |
 | `exclude_topics` | list | `[]` | Regex patterns for topics to exclude (requires at least one regex in `topics`). |
-| `encoding` | string | `otlp_proto` | Default encoding format: `otlp_proto` or `otap_proto`. |
+| `encoding` | string | `otlp_proto` | Default encoding format: `otlp_proto`, `otap_proto`, or `syslog`. Syslog is valid only for logs. |
 
 At least one signal must have non-empty `topics` for the receiver to consume any data. Topic names must be **disjoint across signal types** -- the receiver rejects configurations where the same topic appears in more than one signal type.
 
@@ -129,6 +130,7 @@ Each signal can specify its own encoding format via the `encoding` field:
 | --- | --- |
 | `otlp_proto` | OTLP protobuf encoding (default). |
 | `otap_proto` | OTAP Arrow protobuf encoding. |
+| `syslog` | One RFC 3164 or RFC 5424 message per Kafka record (logs only). CEF in the message body is decoded using the Syslog/CEF receiver mapping. |
 
 Encoding can differ per signal:
 
@@ -142,7 +144,7 @@ config:
     encoding: otap_proto
 ```
 
-Individual Kafka messages can override the per-signal encoding via the `message_format_header` header (defaults to `"MessageFormat"`). The receiver checks each incoming message for a header matching the configured key. If the header is present and its value is `otlp` or `otap`, that encoding is used instead of the per-signal default. If the header is absent or unrecognized, the per-signal encoding is used as a fallback.
+Individual Kafka messages can override the per-signal encoding via the `message_format_header` header (defaults to `"MessageFormat"`). The receiver checks each incoming message for a header matching the configured key. If the header is present and its value is `otlp`, `otap`, or `syslog`, that encoding is used instead of the per-signal default. Syslog overrides are valid only for log topics. If the header is absent or unrecognized, the per-signal encoding is used as a fallback.
 
 ### Commit Configuration
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/config.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/config.rs
@@ -570,6 +570,19 @@ impl TryFrom<KafkaReceiverConfigBuilder> for KafkaReceiverConfig {
             return Err(KafkaReceiverError::ConfigNoSignalTopics);
         }
 
+        if builder.traces.encoding() == MessageFormat::Syslog {
+            return Err(KafkaReceiverError::ConfigUnsupportedEncoding {
+                signal: "traces".to_string(),
+                encoding: "syslog".to_string(),
+            });
+        }
+        if builder.metrics.encoding() == MessageFormat::Syslog {
+            return Err(KafkaReceiverError::ConfigUnsupportedEncoding {
+                signal: "metrics".to_string(),
+                encoding: "syslog".to_string(),
+            });
+        }
+
         // Topics must be disjoint across signals
         {
             let traces: HashSet<&str> =
@@ -2578,6 +2591,41 @@ mod tests {
                 ..Default::default()
             });
         assert!(KafkaReceiverConfig::try_from(cfg).is_ok());
+    }
+
+    /// Scenario (routing and payload correctness): a logs signal selects Syslog encoding.
+    /// Guarantees: validation accepts Syslog for logs so Kafka records can use the shared
+    /// Syslog decoder.
+    #[test]
+    fn validate_syslog_encoding_for_logs_is_valid() {
+        let cfg = KafkaReceiverConfigBuilder::new("b", "g", "c").with_logs(
+            SignalConfig::new(vec!["logs-topic".to_string()]).with_encoding(MessageFormat::Syslog),
+        );
+        assert!(KafkaReceiverConfig::try_from(cfg).is_ok());
+    }
+
+    /// Scenario (routing and payload correctness): a traces signal selects Syslog encoding.
+    /// Guarantees: validation rejects the logs-only encoding before the receiver starts.
+    #[test]
+    fn validate_syslog_encoding_for_traces_is_invalid() {
+        let cfg = KafkaReceiverConfigBuilder::new("b", "g", "c").with_traces(
+            SignalConfig::new(vec!["traces-topic".to_string()])
+                .with_encoding(MessageFormat::Syslog),
+        );
+        let err = KafkaReceiverConfig::try_from(cfg).unwrap_err().to_string();
+        assert!(err.contains("syslog encoding is not supported for traces"));
+    }
+
+    /// Scenario (routing and payload correctness): a metrics signal selects Syslog encoding.
+    /// Guarantees: validation rejects the logs-only encoding before the receiver starts.
+    #[test]
+    fn validate_syslog_encoding_for_metrics_is_invalid() {
+        let cfg = KafkaReceiverConfigBuilder::new("b", "g", "c").with_metrics(
+            SignalConfig::new(vec!["metrics-topic".to_string()])
+                .with_encoding(MessageFormat::Syslog),
+        );
+        let err = KafkaReceiverConfig::try_from(cfg).unwrap_err().to_string();
+        assert!(err.contains("syslog encoding is not supported for metrics"));
     }
 
     /// Scenario (routing and payload correctness): no signal has any topic configured.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/error.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/error.rs
@@ -73,6 +73,17 @@ pub enum KafkaReceiverError {
     #[error("invalid kafka receiver configuration: kafka topics overlap across signals")]
     ConfigOverlappingTopics,
 
+    /// A signal was configured with an encoding that it does not support.
+    #[error(
+        "invalid kafka receiver configuration: {encoding} encoding is not supported for {signal}"
+    )]
+    ConfigUnsupportedEncoding {
+        /// The signal with the unsupported encoding.
+        signal: String,
+        /// The configured encoding.
+        encoding: String,
+    },
+
     /// A literal topic name failed Kafka topic-name validation.
     #[error("invalid kafka receiver configuration: {signal}.topics: {message}")]
     ConfigInvalidTopicName {

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/headers.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/headers.rs
@@ -9,6 +9,10 @@
 
 use super::config::{AttributeValueType, HeaderExtraction};
 use bytes::Bytes;
+use otel_arrow_dfe_core_nodes::receivers::syslog_cef_receiver::{
+    arrow_records_encoder::ArrowRecordsBuilder as SyslogArrowRecordsBuilder,
+    parser::parse as parse_syslog,
+};
 use otel_arrow_dfe_engine::error::Error as EngineError;
 use otel_arrow_dfe_otap::pdata::{Context, OtapPdata};
 use otel_arrow_dfe_pdata::Consumer as PdataConsumer;
@@ -272,6 +276,15 @@ impl HeaderExtractions {
         self.apply_otap_resource_attrs(arrow_records)
     }
 
+    /// Apply header extractions to a Syslog logs payload.
+    ///
+    /// Parses one complete Syslog message, converts it to OTAP Arrow logs, and
+    /// injects attributes into `ResourceAttrs`.
+    pub(crate) fn apply_syslog_logs(&self, data: &[u8]) -> Result<OtapPdata, EngineError> {
+        let arrow_records = decode_syslog_logs(data)?;
+        self.apply_otap_resource_attrs(arrow_records)
+    }
+
     /// Shared OTAP logic: apply attribute transform to `ResourceAttrs`.
     fn apply_otap_resource_attrs(
         &self,
@@ -350,6 +363,20 @@ fn decode_otap_logs(data: &[u8]) -> Result<OtapArrowRecords, EngineError> {
             error: e.to_string(),
         })?,
     ))
+}
+
+/// Parse one complete Syslog message and encode it as OTAP Arrow logs.
+pub(crate) fn decode_syslog_logs(data: &[u8]) -> Result<OtapArrowRecords, EngineError> {
+    let parsed = parse_syslog(data).map_err(|e| EngineError::PdataConversionError {
+        error: format!("Failed to parse Syslog payload: {e:?}"),
+    })?;
+    let mut builder = SyslogArrowRecordsBuilder::new();
+    builder.append_syslog(parsed);
+    builder
+        .build()
+        .map_err(|e| EngineError::PdataConversionError {
+            error: format!("Failed to encode Syslog payload as Arrow records: {e}"),
+        })
 }
 
 /// Parse raw header bytes into an [`any_value::Value`] for the OTLP protobuf path.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/headers.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/headers.rs
@@ -10,6 +10,7 @@
 use super::config::{AttributeValueType, HeaderExtraction};
 use bytes::Bytes;
 use otel_arrow_dfe_core_nodes::receivers::syslog_cef_receiver::{
+    MAX_MESSAGE_SIZE as MAX_SYSLOG_MESSAGE_SIZE,
     arrow_records_encoder::ArrowRecordsBuilder as SyslogArrowRecordsBuilder,
     parser::parse as parse_syslog,
 };
@@ -367,6 +368,16 @@ fn decode_otap_logs(data: &[u8]) -> Result<OtapArrowRecords, EngineError> {
 
 /// Parse one complete Syslog message and encode it as OTAP Arrow logs.
 pub(crate) fn decode_syslog_logs(data: &[u8]) -> Result<OtapArrowRecords, EngineError> {
+    if data.len() > MAX_SYSLOG_MESSAGE_SIZE {
+        return Err(EngineError::PdataConversionError {
+            error: format!(
+                "Syslog/CEF payload size {} exceeds the maximum of {} bytes",
+                data.len(),
+                MAX_SYSLOG_MESSAGE_SIZE,
+            ),
+        });
+    }
+
     let parsed = parse_syslog(data).map_err(|e| EngineError::PdataConversionError {
         error: format!("Failed to parse Syslog payload: {e:?}"),
     })?;
@@ -616,6 +627,15 @@ mod tests {
         }
     }
 
+    fn syslog_payload_with_size(size: usize) -> Vec<u8> {
+        let header = b"<34>1 2024-01-15T10:30:45.123Z host app - ID47 - ";
+        assert!(size >= header.len());
+        let mut payload = Vec::with_capacity(size);
+        payload.extend_from_slice(header);
+        payload.resize(size, b'X');
+        payload
+    }
+
     /// Create OTAP Arrow wire bytes from the `create_traces_with_spans()` helper.
     fn create_traces_otap_bytes() -> Vec<u8> {
         let request = create_traces_with_spans();
@@ -649,6 +669,33 @@ mod tests {
             .try_into_with_default()
             .expect("OTAP -> OTLP conversion");
         ExportTraceServiceRequest::decode(otlp.as_bytes()).expect("decode OTLP traces")
+    }
+
+    // ---- Routing and payload correctness: Syslog bounds ----
+
+    /// Scenario: a Kafka record contains a valid Syslog message exactly at the shared
+    /// Syslog receiver size limit.
+    /// Guarantees: the boundary-sized payload is accepted and encoded as Arrow logs.
+    #[test]
+    fn decode_syslog_logs_accepts_payload_at_size_limit() {
+        let payload = syslog_payload_with_size(MAX_SYSLOG_MESSAGE_SIZE);
+        let _ = decode_syslog_logs(&payload).expect("payload at the size limit should decode");
+    }
+
+    /// Scenario: a Kafka record contains a Syslog message one byte larger than the
+    /// shared Syslog receiver size limit.
+    /// Guarantees: the payload is rejected before parsing to bound parser and Arrow
+    /// encoder resource use.
+    #[test]
+    fn decode_syslog_logs_rejects_payload_over_size_limit() {
+        let payload = syslog_payload_with_size(MAX_SYSLOG_MESSAGE_SIZE + 1);
+        let error = decode_syslog_logs(&payload).expect_err("oversized payload should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("exceeds the maximum of 16384 bytes")
+        );
     }
 
     // ---- Routing and payload correctness: header extraction ----

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/receiver.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/receiver.rs
@@ -8,7 +8,7 @@
 
 use super::config::{HeaderExtraction, KafkaReceiverConfig};
 use super::error::KafkaReceiverError;
-use super::headers::HeaderExtractions;
+use super::headers::{HeaderExtractions, decode_syslog_logs};
 use super::identity::{DeliveryGeneration, OwnershipGeneration};
 use super::metrics::{KafkaReceiverMetrics, KafkaReceiverRejectionReason};
 use super::offset_tracker::OffsetTracker;
@@ -16,7 +16,7 @@ use super::rebalance::{RebalanceState, RebalancingConsumerContext};
 use super::retry::RetryManager;
 #[cfg(feature = "aws")]
 use crate::common::kafka::security::build_aws_msk_context;
-use crate::common::kafka::{MSG_FORMAT_OTAP, MSG_FORMAT_OTLP, MessageFormat};
+use crate::common::kafka::{MSG_FORMAT_OTAP, MSG_FORMAT_OTLP, MSG_FORMAT_SYSLOG, MessageFormat};
 use async_trait::async_trait;
 use bytes::Bytes;
 use linkme::distributed_slice;
@@ -169,6 +169,7 @@ fn detect_message_format(
     {
         value if value == Some(MSG_FORMAT_OTLP) => MessageFormat::OtlpProto,
         value if value == Some(MSG_FORMAT_OTAP) => MessageFormat::OtapProto,
+        value if value == Some(MSG_FORMAT_SYSLOG) => MessageFormat::Syslog,
         _ => default,
     }
 }
@@ -421,6 +422,7 @@ impl KafkaReceiver {
                     message_format,
                     HeaderExtractions::apply_otlp_traces,
                     HeaderExtractions::apply_otap_traces,
+                    reject_syslog_extractions,
                     decode_traces_payload,
                 )
                 .map_err(KafkaReceiverError::TracesDecode)
@@ -438,6 +440,7 @@ impl KafkaReceiver {
                     message_format,
                     HeaderExtractions::apply_otlp_metrics,
                     HeaderExtractions::apply_otap_metrics,
+                    reject_syslog_extractions,
                     decode_metrics_payload,
                 )
                 .map_err(KafkaReceiverError::MetricsDecode)
@@ -455,6 +458,7 @@ impl KafkaReceiver {
                     message_format,
                     HeaderExtractions::apply_otlp_logs,
                     HeaderExtractions::apply_otap_logs,
+                    HeaderExtractions::apply_syslog_logs,
                     decode_logs_payload,
                 )
                 .map_err(KafkaReceiverError::LogsDecode)
@@ -1646,6 +1650,9 @@ fn decode_traces_payload(
                 .into(),
             ))
         }
+        MessageFormat::Syslog => Err(EngineError::PdataConversionError {
+            error: "syslog encoding is only supported for logs".to_string(),
+        }),
     }
 }
 
@@ -1676,6 +1683,9 @@ fn decode_metrics_payload(
                 .into(),
             ))
         }
+        MessageFormat::Syslog => Err(EngineError::PdataConversionError {
+            error: "syslog encoding is only supported for logs".to_string(),
+        }),
     }
 }
 
@@ -1706,7 +1716,21 @@ fn decode_logs_payload(
                 .into(),
             ))
         }
+        MessageFormat::Syslog => Ok(OtapPdata::new(
+            Context::default(),
+            decode_syslog_logs(data)?.into(),
+        )),
     }
+}
+
+/// Reject Syslog extraction for traces and metrics.
+fn reject_syslog_extractions(
+    _extractions: &HeaderExtractions,
+    _data: &[u8],
+) -> Result<OtapPdata, EngineError> {
+    Err(EngineError::PdataConversionError {
+        error: "syslog encoding is only supported for logs".to_string(),
+    })
 }
 
 /// Decode a Kafka payload with optional header extraction applied to resource
@@ -1724,17 +1748,20 @@ fn decode_with_extractions(
     message_format: MessageFormat,
     apply_otlp: fn(&HeaderExtractions, &[u8]) -> Result<OtapPdata, EngineError>,
     apply_otap: fn(&HeaderExtractions, &[u8]) -> Result<OtapPdata, EngineError>,
+    apply_syslog: fn(&HeaderExtractions, &[u8]) -> Result<OtapPdata, EngineError>,
     decode: fn(&[u8], MessageFormat) -> Result<OtapPdata, EngineError>,
 ) -> Result<OtapPdata, EngineError> {
     if !extractors.is_empty() {
         let extractions = match message_format {
             MessageFormat::OtlpProto => HeaderExtractions::otlp(kafka_message, extractors),
             MessageFormat::OtapProto => HeaderExtractions::otap(kafka_message, extractors),
+            MessageFormat::Syslog => HeaderExtractions::otap(kafka_message, extractors),
         };
         if extractions.has_any() {
             return match message_format {
                 MessageFormat::OtlpProto => apply_otlp(&extractions, data),
                 MessageFormat::OtapProto => apply_otap(&extractions, data),
+                MessageFormat::Syslog => apply_syslog(&extractions, data),
             };
         }
     }
@@ -6184,6 +6211,70 @@ mod tests {
         );
     }
 
+    /// Scenario (routing and payload correctness): one RFC 5424 message is received in a
+    /// Kafka record configured for Syslog.
+    /// Guarantees: the shared Syslog parser produces exactly one OpenTelemetry log record.
+    #[test]
+    fn decode_logs_payload_syslog_rfc5424() {
+        let input = b"<34>1 2003-10-11T22:14:15.003Z host app - ID47 - Test message";
+        let mut pdata = decode_logs_payload(input, MessageFormat::Syslog).expect("decode Syslog");
+        let proto: OtlpProtoBytes = pdata
+            .take_payload()
+            .try_into_with_default()
+            .expect("convert Syslog Arrow logs to OTLP");
+        let request = ExportLogsServiceRequest::decode(proto.as_bytes()).expect("decode OTLP logs");
+
+        assert_eq!(request.resource_logs.len(), 1);
+        assert_eq!(request.resource_logs[0].scope_logs.len(), 1);
+        assert_eq!(request.resource_logs[0].scope_logs[0].log_records.len(), 1);
+    }
+
+    /// Scenario (routing and payload correctness): an RFC 3164 message contains a CEF body.
+    /// Guarantees: Kafka Syslog decoding reuses the existing CEF mapping and emits CEF
+    /// attributes on the OpenTelemetry log record.
+    #[test]
+    fn decode_logs_payload_syslog_with_embedded_cef() {
+        let input = b"<34>Oct 11 22:14:15 firewall CEF:0|Vendor|Product|2.0|signature-123|Intrusion detected|7|act=blocked";
+        let mut pdata =
+            decode_logs_payload(input, MessageFormat::Syslog).expect("decode Syslog CEF");
+        let proto: OtlpProtoBytes = pdata
+            .take_payload()
+            .try_into_with_default()
+            .expect("convert Syslog Arrow logs to OTLP");
+        let request = ExportLogsServiceRequest::decode(proto.as_bytes()).expect("decode OTLP logs");
+        let attributes = &request.resource_logs[0].scope_logs[0].log_records[0].attributes;
+
+        assert!(attributes.iter().any(|attribute| {
+            attribute.key == "cef.device_vendor"
+                && attribute
+                    .value
+                    .as_ref()
+                    .and_then(|value| value.value.as_ref())
+                    .is_some_and(|value| {
+                        matches!(value, any_value::Value::StringValue(value) if value == "Vendor")
+                    })
+        }));
+    }
+
+    /// Scenario (routing and payload correctness): an empty Kafka record is decoded as
+    /// Syslog.
+    /// Guarantees: malformed Syslog returns a recoverable per-message error instead of
+    /// panicking or stalling the consumer loop.
+    #[test]
+    fn decode_logs_payload_empty_syslog_returns_error() {
+        let result = decode_logs_payload(b"", MessageFormat::Syslog);
+        assert!(result.is_err());
+    }
+
+    /// Scenario (routing and payload correctness): a traces or metrics message-format
+    /// header requests Syslog.
+    /// Guarantees: runtime header overrides cannot route Syslog bytes into non-log signals.
+    #[test]
+    fn decode_non_logs_payload_syslog_returns_error() {
+        assert!(decode_traces_payload(b"message", MessageFormat::Syslog).is_err());
+        assert!(decode_metrics_payload(b"message", MessageFormat::Syslog).is_err());
+    }
+
     /// Scenario (routing and payload correctness): undecodable bytes are passed to the OTAP
     /// traces decoder.
     /// Guarantees: decode returns an error rather than panicking, so a malformed OTAP
@@ -6788,6 +6879,91 @@ mod tests {
                         }
                     }
                 }
+
+                receiver.shutdown(Duration::from_secs(5));
+                receiver.await_stopped().await;
+            },
+        )
+        .await;
+    }
+
+    /// Scenario (routing and payload correctness): a raw Syslog Kafka record carries an
+    /// `x-tenant-id` header configured for resource-attribute extraction.
+    /// Guarantees: Syslog uses the shared extraction orchestration and emits the header
+    /// value as the `tenant.id` resource attribute on the decoded log.
+    #[tokio::test]
+    async fn test_kafka_receiver_logs_header_extraction_syslog() {
+        const TOPIC: &str = "test-logs-headers-syslog";
+        with_cluster(
+            KafkaTestCluster::builder().topic(TOPIC),
+            |cluster| async move {
+                let producer = cluster.producer().build();
+                let tenant_value = "acme-corp";
+                let syslog = b"<34>1 2003-10-11T22:14:15.003Z host app - ID47 - Test message";
+
+                producer
+                    .send_full(
+                        SendRecord::new(TOPIC, syslog)
+                            .header("x-tenant-id", tenant_value.as_bytes())
+                            .header("MessageFormat", MSG_FORMAT_SYSLOG),
+                    )
+                    .await
+                    .expect("send Syslog message");
+
+                let mut resource_attrs_from_headers = HashMap::new();
+                let _ = resource_attrs_from_headers.insert(
+                    "x-tenant-id".to_string(),
+                    HeaderExtraction {
+                        key: "tenant.id".to_string(),
+                        value_type: AttributeValueType::String,
+                    },
+                );
+
+                let cfg = KafkaReceiverConfig::try_from(
+                    KafkaReceiverConfigBuilder::new(
+                        cluster.bootstrap_servers(),
+                        "test-group",
+                        "test-client",
+                    )
+                    .with_logs(
+                        SignalConfig::new(vec![TOPIC.to_string()])
+                            .with_encoding(MessageFormat::Syslog),
+                    )
+                    .with_commit(CommitConfig {
+                        mode: ConfigCommitMode::Auto,
+                        interval_ms: Some(1000),
+                    })
+                    .with_auto_offset_reset(AutoOffsetReset::Earliest)
+                    .with_isolation_level(IsolationLevel::ReadUncommitted)
+                    .with_resource_attrs_from_headers(resource_attrs_from_headers),
+                )
+                .expect("test config valid");
+                let mut receiver = KafkaReceiverHarness::start(&cluster, cfg);
+
+                let mut pdata = receiver.recv_pdata().await;
+                let otlp: OtlpProtoBytes = pdata
+                    .take_payload()
+                    .try_into_with_default()
+                    .expect("convert Syslog Arrow logs to OTLP");
+                let result =
+                    ExportLogsServiceRequest::decode(otlp.as_bytes()).expect("decode OTLP logs");
+                let resource = result.resource_logs[0]
+                    .resource
+                    .as_ref()
+                    .expect("log should have a resource");
+                let tenant_attr = resource
+                    .attributes
+                    .iter()
+                    .find(|attribute| attribute.key == "tenant.id")
+                    .expect("resource should contain tenant.id");
+
+                assert!(matches!(
+                    tenant_attr
+                        .value
+                        .as_ref()
+                        .and_then(|value| value.value.as_ref()),
+                    Some(any_value::Value::StringValue(value)) if value == tenant_value
+                ));
 
                 receiver.shutdown(Duration::from_secs(5));
                 receiver.await_stopped().await;

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/receiver.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/receiver.rs
@@ -422,7 +422,7 @@ impl KafkaReceiver {
                     message_format,
                     HeaderExtractions::apply_otlp_traces,
                     HeaderExtractions::apply_otap_traces,
-                    reject_syslog_extractions,
+                    reject_syslog_for_non_log_signal,
                     decode_traces_payload,
                 )
                 .map_err(KafkaReceiverError::TracesDecode)
@@ -440,7 +440,7 @@ impl KafkaReceiver {
                     message_format,
                     HeaderExtractions::apply_otlp_metrics,
                     HeaderExtractions::apply_otap_metrics,
-                    reject_syslog_extractions,
+                    reject_syslog_for_non_log_signal,
                     decode_metrics_payload,
                 )
                 .map_err(KafkaReceiverError::MetricsDecode)
@@ -1723,8 +1723,8 @@ fn decode_logs_payload(
     }
 }
 
-/// Reject Syslog extraction for traces and metrics.
-fn reject_syslog_extractions(
+/// Reject Syslog decoding for signal types other than logs.
+fn reject_syslog_for_non_log_signal(
     _extractions: &HeaderExtractions,
     _data: &[u8],
 ) -> Result<OtapPdata, EngineError> {

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/mod.rs
@@ -65,7 +65,7 @@ const DEFAULT_MAX_BATCH_SIZE: u16 = 100;
 /// metric is incremented. 16 KiB covers virtually all real-world syslog and
 /// CEF messages (RFC 5424 Section 6.1 recommends supporting messages of at least
 /// 2048 bytes).
-const MAX_MESSAGE_SIZE: usize = 16 * 1024;
+pub const MAX_MESSAGE_SIZE: usize = 16 * 1024;
 
 /// Initial capacity for the per-connection TCP message buffer.
 ///

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/parser/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/parser/mod.rs
@@ -43,7 +43,7 @@ pub enum ParseError {
 }
 
 /// Parse a syslog message from bytes, automatically detecting the format
-pub(crate) fn parse(input: &[u8]) -> Result<ParsedSyslogMessage<'_>, ParseError> {
+pub fn parse(input: &[u8]) -> Result<ParsedSyslogMessage<'_>, ParseError> {
     if input.is_empty() {
         return Err(ParseError::EmptyInput);
     }


### PR DESCRIPTION
# Change summary

Add `syslog` decoding support to the Kafka receiver's logs path.

The receiver reuses the existing Syslog/CEF parser to decode one complete Syslog message from each Kafka record and convert it into OTAP Arrow logs. It supports RFC 3164, RFC 5424, CEF, and CEF embedded in Syslog messages.

The format can be selected through the receiver configuration or the Kafka message-format header. Existing Kafka-header-to-resource-attribute extraction is also applied to decoded Syslog logs.

Syslog remains logs-only: configuration and runtime format overrides reject it for traces and metrics. The Kafka exporter also rejects `syslog`, because it does not encode telemetry back into raw Syslog messages.

## Related issue

* Closes #3837

## Validation

- Compiled the Kafka receiver and the combined Kafka receiver/exporter feature set in Linux Docker.
- Passed focused tests covering RFC 5424, embedded CEF, malformed input, logs-only validation, format-header selection, and resource attributes extracted from Kafka headers.
- Passed the Kafka exporter test confirming that `syslog` output encoding is rejected.
- Validated the end-to-end flow against a Kafka broker:
  - Published RFC 5424 message to Kafka.
  - The Kafka receiver consumed it using `encoding: syslog`.
  - The console output contained the expected `syslog.*` attributes and `input.format=rfc5424`.
- Passed Markdown lint for the updated Kafka receiver documentation.

## User-facing changes

Kafka log receivers can now configure:

```yaml
logs:
  topics: ["syslog"]
  encoding: syslog
```

Each Kafka record is interpreted as one complete Syslog or CEF message and emitted as an OpenTelemetry log record. The `syslog` encoding is not supported for traces, metrics, or the Kafka exporter.

Added `.chloggen/kafka-receiver-syslog-decoding.yaml`.

```