### PR TITLE
chore(geneva-exporter): update geneva-uploader to 0.7.1

### DIFF
--- a/rust/otap-dataflow/Cargo.lock
+++ b/rust/otap-dataflow/Cargo.lock
@@ -3974,9 +3974,9 @@ dependencies = [
 
 [[package]]
 name = "geneva-uploader"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3a307a6d8a1aadc32faab67e1f8f8f6ab7842f8e3d679cd28cf4d2cec53401"
+checksum = "8b9df81ec31b2f02849b5f5dc9490479680fa76609c9d945033c278b3fd224d7"
 dependencies = [
  "azure_core 0.29.1",
  "azure_identity 0.29.0",

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -292,7 +292,7 @@ tracepoint_decode = "0.5.0"
 tracelogging = "1.2.4"
 tracelogging_dynamic = "1.2.4"
 urlencoding = "2"
-geneva-uploader = { version = "0.7.0", default-features = false, features = ["tls-rustls"] }
+geneva-uploader = { version = "0.7.1", default-features = false, features = ["tls-rustls"] }
 opentelemetry-resource-detectors = "0.12.0"
 
 [patch.crates-io]


### PR DESCRIPTION
## Changes

- update the Geneva exporter dependency from `geneva-uploader` 0.7.0 to 0.7.1
- refresh the lockfile for the published 0.7.1 crate

This consumes the Common Schema compatibility fixes and log resource/instrumentation-scope attribute propagation added in `geneva-uploader` 0.7.1.

## Validation

- `cargo check --locked -p otel-arrow-dfe-contrib-nodes --features geneva-exporter`
- `git diff --check`