### PR TITLE
chore(deps): Raise the `otap-dataflow` Rust MSV to `1.88`

### DIFF
--- a/rust/otap-dataflow/.chloggen/raise-rust-msrv-1-88.yaml
+++ b/rust/otap-dataflow/.chloggen/raise-rust-msrv-1-88.yaml
@@ -1,0 +1,6 @@
+change_type: breaking
+component: all
+note: Raise the minimum supported Rust version for OTAP Dataflow from 1.87 to 1.88.
+issues: [1340]
+subtext: |
+  Migration: Upgrade the Rust toolchain used to build OTAP Dataflow to Rust 1.88 or newer.

--- a/rust/otap-dataflow/.clippy.toml
+++ b/rust/otap-dataflow/.clippy.toml
@@ -1,4 +1,4 @@
-msrv = "1.87.0"
+msrv = "1.88.0"
 warn-on-all-wildcard-imports = true
 allow-expect-in-tests = true
 allow-unwrap-in-tests = true

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 repository = "https://github.com/open-telemetry/otel-arrow"
 license = "Apache-2.0"
 publish = false
-rust-version = "1.87.0"
+rust-version = "1.88.0"
 
 [package]
 name = "otel-arrow-dfe"

--- a/rust/otap-dataflow/crates/admin-api/src/endpoint.rs
+++ b/rust/otap-dataflow/crates/admin-api/src/endpoint.rs
@@ -171,13 +171,14 @@ impl AdminEndpoint {
         if self.host.trim().is_empty() {
             return Err(EndpointError::EmptyHost);
         }
-        if let Some(base_path) = &self.base_path {
-            if !base_path.is_empty() && !base_path.starts_with('/') {
-                return Err(EndpointError::InvalidBasePath {
-                    base_path: base_path.clone(),
-                    reason: "base path must start with '/'".to_string(),
-                });
-            }
+        if let Some(base_path) = &self.base_path
+            && !base_path.is_empty()
+            && !base_path.starts_with('/')
+        {
+            return Err(EndpointError::InvalidBasePath {
+                base_path: base_path.clone(),
+                reason: "base path must start with '/'".to_string(),
+            });
         }
         Ok(())
     }

--- a/rust/otap-dataflow/crates/admin/src/telemetry.rs
+++ b/rust/otap-dataflow/crates/admin/src/telemetry.rs
@@ -2113,17 +2113,17 @@ struct LogFilter {
 impl LogFilter {
     /// Returns `true` when the rendered log entry passes all active criteria.
     fn matches(&self, entry: &LogEntry) -> bool {
-        if let Some(min_ts) = &self.minimum_timestamp {
-            if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(&entry.timestamp) {
-                if ts.with_timezone(&chrono::Utc) < *min_ts {
-                    return false;
-                }
-            }
+        if let Some(min_ts) = &self.minimum_timestamp
+            && let Ok(ts) = chrono::DateTime::parse_from_rfc3339(&entry.timestamp)
+            && ts.with_timezone(&chrono::Utc) < *min_ts
+        {
+            return false;
         }
-        if let Some(min_level) = self.minimum_level {
-            if level_severity(&entry.level) < min_level {
-                return false;
-            }
+
+        if let Some(min_level) = self.minimum_level
+            && level_severity(&entry.level) < min_level
+        {
+            return false;
         }
         if let Some(q) = &self.search_query {
             // `q` is already lowercased at construction time; only the entry

--- a/rust/otap-dataflow/crates/channel/src/mpmc.rs
+++ b/rust/otap-dataflow/crates/channel/src/mpmc.rs
@@ -94,19 +94,19 @@ impl SenderWaiters {
     }
 
     fn register_or_refresh(&mut self, waiter_key: &mut Option<SenderWaiterKey>, waker: &Waker) {
-        if let Some(existing_key) = *waiter_key {
-            if let Some(slot) = self.slots.get_mut(existing_key.index) {
-                if slot.in_use && slot.generation == existing_key.generation {
-                    if slot.waker.as_ref().is_none_or(|w| !w.will_wake(waker)) {
-                        slot.waker = Some(waker.clone());
-                    }
-                    if !slot.queued {
-                        slot.queued = true;
-                        self.queue.push_back(existing_key);
-                    }
-                    return;
-                }
+        if let Some(existing_key) = *waiter_key
+            && let Some(slot) = self.slots.get_mut(existing_key.index)
+            && slot.in_use
+            && slot.generation == existing_key.generation
+        {
+            if slot.waker.as_ref().is_none_or(|w| !w.will_wake(waker)) {
+                slot.waker = Some(waker.clone());
             }
+            if !slot.queued {
+                slot.queued = true;
+                self.queue.push_back(existing_key);
+            }
+            return;
         }
 
         let index = if let Some(index) = self.free_slots.pop() {

--- a/rust/otap-dataflow/crates/channel/src/mpsc.rs
+++ b/rust/otap-dataflow/crates/channel/src/mpsc.rs
@@ -92,19 +92,19 @@ impl SenderWaiters {
     }
 
     fn register_or_refresh(&mut self, waiter_key: &mut Option<SenderWaiterKey>, waker: &Waker) {
-        if let Some(existing_key) = *waiter_key {
-            if let Some(slot) = self.slots.get_mut(existing_key.index) {
-                if slot.in_use && slot.generation == existing_key.generation {
-                    if slot.waker.as_ref().is_none_or(|w| !w.will_wake(waker)) {
-                        slot.waker = Some(waker.clone());
-                    }
-                    if !slot.queued {
-                        slot.queued = true;
-                        self.queue.push_back(existing_key);
-                    }
-                    return;
-                }
+        if let Some(existing_key) = *waiter_key
+            && let Some(slot) = self.slots.get_mut(existing_key.index)
+            && slot.in_use
+            && slot.generation == existing_key.generation
+        {
+            if slot.waker.as_ref().is_none_or(|w| !w.will_wake(waker)) {
+                slot.waker = Some(waker.clone());
             }
+            if !slot.queued {
+                slot.queued = true;
+                self.queue.push_back(existing_key);
+            }
+            return;
         }
 
         let index = if let Some(index) = self.free_slots.pop() {

--- a/rust/otap-dataflow/crates/component-inventory-syntax/src/lib.rs
+++ b/rust/otap-dataflow/crates/component-inventory-syntax/src/lib.rs
@@ -517,17 +517,17 @@ impl ComponentInventoryArgs {
         let Some(urn) = literal_urn else {
             return Ok(());
         };
-        if let Some(mid) = urn.split(':').nth(2) {
-            if mid != seg {
-                return Err(syn::Error::new_spanned(
-                    &self.category,
-                    format!(
-                        "category `{}` (URN segment `{seg}`) does not match the \
-                         component URN `{urn}` (segment `{mid}`)",
-                        self.category
-                    ),
-                ));
-            }
+        if let Some(mid) = urn.split(':').nth(2)
+            && mid != seg
+        {
+            return Err(syn::Error::new_spanned(
+                &self.category,
+                format!(
+                    "category `{}` (URN segment `{seg}`) does not match the \
+                     component URN `{urn}` (segment `{mid}`)",
+                    self.category
+                ),
+            ));
         }
         Ok(())
     }

--- a/rust/otap-dataflow/crates/config/src/env_substitution.rs
+++ b/rust/otap-dataflow/crates/config/src/env_substitution.rs
@@ -55,49 +55,47 @@ pub fn substitute_env_vars(input: &str) -> Result<String, Error> {
         }
 
         // Possible `${...}` placeholder.
-        if rest.starts_with("${") {
-            if let Some(close) = rest[2..].find('}') {
-                let inner = &rest[2..2 + close]; // content between `${` and `}`
+        if rest.starts_with("${")
+            && let Some(close) = rest[2..].find('}')
+        {
+            let inner = &rest[2..2 + close]; // content between `${` and `}`
 
-                if let Some(spec) = inner.strip_prefix("env:") {
-                    // Split on the first `:-` to allow an optional default.
-                    let (var_name, default) = match spec.find(":-") {
-                        Some(p) => (&spec[..p], Some(&spec[p + 2..])),
-                        None => (spec, None),
-                    };
+            if let Some(spec) = inner.strip_prefix("env:") {
+                // Split on the first `:-` to allow an optional default.
+                let (var_name, default) = match spec.find(":-") {
+                    Some(p) => (&spec[..p], Some(&spec[p + 2..])),
+                    None => (spec, None),
+                };
 
-                    let value = match std::env::var(var_name) {
-                        Ok(v) => v,
-                        Err(env_var_error) => match default {
-                            Some(d) => d.to_string(),
-                            None => {
-                                match env_var_error {
-                                    std::env::VarError::NotPresent => {
-                                        // Variable is simply not set.
-                                        return Err(Error::EnvVarNotFound {
-                                            var: var_name.to_string(),
-                                        });
-                                    }
-                                    std::env::VarError::NotUnicode(_) => {
-                                        // Variable is set but contains invalid Unicode.
-                                        return Err(Error::EnvVarCannotBeParsed {
-                                            var: var_name.to_string(),
-                                        });
-                                    }
-                                }
+                let value = match std::env::var(var_name) {
+                    Ok(v) => v,
+                    Err(env_var_error) => match default {
+                        Some(d) => d.to_string(),
+                        None => match env_var_error {
+                            std::env::VarError::NotPresent => {
+                                // Variable is simply not set.
+                                return Err(Error::EnvVarNotFound {
+                                    var: var_name.to_string(),
+                                });
+                            }
+                            std::env::VarError::NotUnicode(_) => {
+                                // Variable is set but contains invalid Unicode.
+                                return Err(Error::EnvVarCannotBeParsed {
+                                    var: var_name.to_string(),
+                                });
                             }
                         },
-                    };
+                    },
+                };
 
-                    output.push_str(&value);
-                    rest = &rest[2 + close + 1..]; // skip past `}`
-                } else {
-                    // Not an `env:` provider -- pass through verbatim.
-                    output.push_str(&rest[..2 + close + 1]);
-                    rest = &rest[2 + close + 1..];
-                }
-                continue;
+                output.push_str(&value);
+                rest = &rest[2 + close + 1..]; // skip past `}`
+            } else {
+                // Not an `env:` provider -- pass through verbatim.
+                output.push_str(&rest[..2 + close + 1]);
+                rest = &rest[2 + close + 1..];
             }
+            continue;
         }
 
         // Bare `$` with no recognised pattern -- emit and advance.

--- a/rust/otap-dataflow/crates/config/src/node.rs
+++ b/rust/otap-dataflow/crates/config/src/node.rs
@@ -362,12 +362,12 @@ impl NodeUserConfig {
 
         // Validate the selector shape inside node-level header_propagation so
         // that invalid selectors are rejected uniformly.
-        if let Some(propagation) = &self.header_propagation {
-            if let Err(e) = propagation.validate() {
-                errors.push(Error::InvalidUserConfig {
-                    error: format!("node `{node_name}`: header_propagation.default.selector: {e}"),
-                });
-            }
+        if let Some(propagation) = &self.header_propagation
+            && let Err(e) = propagation.validate()
+        {
+            errors.push(Error::InvalidUserConfig {
+                error: format!("node `{node_name}`: header_propagation.default.selector: {e}"),
+            });
         }
     }
 
@@ -446,11 +446,10 @@ pub(crate) fn redact_secret_headers(value: &mut Value) {
                         }
                         Value::Array(entries) => {
                             for entry in entries.iter_mut() {
-                                if let Value::Object(fields) = entry {
-                                    if let Some(static_value) = fields.get_mut("value") {
-                                        *static_value =
-                                            Value::String(REDACTED_HEADER_VALUE.to_owned());
-                                    }
+                                if let Value::Object(fields) = entry
+                                    && let Some(static_value) = fields.get_mut("value")
+                                {
+                                    *static_value = Value::String(REDACTED_HEADER_VALUE.to_owned());
                                 }
                             }
                             continue;

--- a/rust/otap-dataflow/crates/config/src/policy.rs
+++ b/rust/otap-dataflow/crates/config/src/policy.rs
@@ -214,10 +214,9 @@ impl Policies {
             .resources
             .as_ref()
             .and_then(|resources| resources.core_allocation.as_ref())
+            && let Err(e) = core_allocation.validate()
         {
-            if let Err(e) = core_allocation.validate() {
-                errors.push(format!("{path_prefix}.resources.core_allocation: {e}"));
-            }
+            errors.push(format!("{path_prefix}.resources.core_allocation: {e}"));
         }
         if let Some(runtime_recovery) = &self.runtime_recovery {
             errors.extend(
@@ -227,12 +226,12 @@ impl Policies {
         if let Some(telemetry) = &self.telemetry {
             errors.extend(telemetry.validation_errors(&format!("{path_prefix}.telemetry")));
         }
-        if let Some(transport_headers) = &self.transport_headers {
-            if let Err(e) = transport_headers.header_propagation.validate() {
-                errors.push(format!(
-                    "{path_prefix}.transport_headers.header_propagation.default.selector: {e}"
-                ));
-            }
+        if let Some(transport_headers) = &self.transport_headers
+            && let Err(e) = transport_headers.header_propagation.validate()
+        {
+            errors.push(format!(
+                "{path_prefix}.transport_headers.header_propagation.default.selector: {e}"
+            ));
         }
         if let Some(rate_limiters) = self
             .resources

--- a/rust/otap-dataflow/crates/contrib-extensions/src/common/token_refresh/provider.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/common/token_refresh/provider.rs
@@ -419,11 +419,11 @@ impl<S: TokenSource, M: TokenProviderMetrics> SharedExtension for TokenProviderE
                         // expiry, but a token stays usable until ~30 s before
                         // expiry, so reusing it here would defer the planned
                         // early refresh far too long.
-                        if rx.has_changed().unwrap_or(false) {
-                            if let Some(token) = inner.current_fresh_token() {
+                        if rx.has_changed().unwrap_or(false)
+                            && let Some(token) = inner.current_fresh_token()
+                        {
                                 return Ok(token);
                             }
-                        }
                         inner.refresh_once().await
                     };
                     tokio::pin!(refresh);

--- a/rust/otap-dataflow/crates/contrib-extensions/src/k8s_service_account_token_auth/cache.rs
+++ b/rust/otap-dataflow/crates/contrib-extensions/src/k8s_service_account_token_auth/cache.rs
@@ -125,20 +125,20 @@ impl SharedDecisionCache {
         cleanup.armed = false;
         match result {
             Ok(decision) => {
-                if lease.complete_on_success {
-                    if let Ok(mut entries) = self.entries.lock() {
-                        entries.complete(&key, lease.handle(), Instant::now());
-                    }
+                if lease.complete_on_success
+                    && let Ok(mut entries) = self.entries.lock()
+                {
+                    entries.complete(&key, lease.handle(), Instant::now());
                 }
                 // Cloned after the guard is released; a deep clone under it
                 // would stall requests for unrelated tokens.
                 Ok(decision.clone())
             }
             Err(error) => {
-                if lease.tracked {
-                    if let Ok(mut entries) = self.entries.lock() {
-                        entries.remove(&key, lease.handle());
-                    }
+                if lease.tracked
+                    && let Ok(mut entries) = self.entries.lock()
+                {
+                    entries.remove(&key, lease.handle());
                 }
                 Err(error.clone())
             }

--- a/rust/otap-dataflow/crates/contrib-nodes/examples/mock_la_server.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/examples/mock_la_server.rs
@@ -144,27 +144,27 @@ async fn ingest_handler(
     }
 
     // Check payload size limit.
-    if let Some(max_size) = state.cli.payload_too_large {
-        if body.len() > max_size {
-            println!(
-                "[mock-la] POST dcr={dcr} stream={stream} \
-                 \u{2014} 413 Payload Too Large ({} > {max_size})",
-                body.len()
-            );
-            return (StatusCode::PAYLOAD_TOO_LARGE, "Payload Too Large").into_response();
-        }
+    if let Some(max_size) = state.cli.payload_too_large
+        && body.len() > max_size
+    {
+        println!(
+            "[mock-la] POST dcr={dcr} stream={stream} \
+             \u{2014} 413 Payload Too Large ({} > {max_size})",
+            body.len()
+        );
+        return (StatusCode::PAYLOAD_TOO_LARGE, "Payload Too Large").into_response();
     }
 
     // Check fail-after threshold.
     let success_so_far = state.stats.success_count.load(Ordering::Relaxed);
-    if let Some(fail_after) = state.cli.fail_after {
-        if success_so_far >= fail_after {
-            println!(
-                "[mock-la] POST dcr={dcr} stream={stream} \
-                 \u{2014} 503 (fail-after {fail_after} reached)"
-            );
-            return (StatusCode::SERVICE_UNAVAILABLE, "Service Unavailable").into_response();
-        }
+    if let Some(fail_after) = state.cli.fail_after
+        && success_so_far >= fail_after
+    {
+        println!(
+            "[mock-la] POST dcr={dcr} stream={stream} \
+             \u{2014} 503 (fail-after {fail_after} reached)"
+        );
+        return (StatusCode::SERVICE_UNAVAILABLE, "Service Unavailable").into_response();
     }
 
     // Random failure simulation.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/common/kafka/security.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/common/kafka/security.rs
@@ -95,13 +95,12 @@ pub fn apply_sasl_config(auth: Option<&Auth>, config: &mut ClientConfig) {
 #[cfg(feature = "aws")]
 #[must_use]
 pub fn build_aws_msk_context(auth: Option<&Auth>) -> Option<AwsMskAuthClientContext> {
-    if let Some(Auth::Sasl(sasl_auth)) = auth {
-        if sasl_auth.mechanism() == SaslMechanism::AwsMskIamOauthbearer {
-            if let Some(aws_msk) = sasl_auth.aws_msk() {
-                let region = Region::new(Cow::Owned(aws_msk.region().to_owned()));
-                return Some(AwsMskAuthClientContext::new(region));
-            }
-        }
+    if let Some(Auth::Sasl(sasl_auth)) = auth
+        && sasl_auth.mechanism() == SaslMechanism::AwsMskIamOauthbearer
+        && let Some(aws_msk) = sasl_auth.aws_msk()
+    {
+        let region = Region::new(Cow::Owned(aws_msk.region().to_owned()));
+        return Some(AwsMskAuthClientContext::new(region));
     }
     None
 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/config.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/config.rs
@@ -248,10 +248,10 @@ impl Config {
                     // `attributes: { key: Column, ... }` maps specific attributes.
                     Value::Object(map) => {
                         for v in map.values() {
-                            if let Value::String(s) = v {
-                                if !seen.insert(s.clone()) {
-                                    _ = duplicates.insert(s.clone());
-                                }
+                            if let Value::String(s) = v
+                                && !seen.insert(s.clone())
+                            {
+                                _ = duplicates.insert(s.clone());
                             }
                         }
                     }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/state.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/state.rs
@@ -104,12 +104,11 @@ impl AzureMonitorExporterState {
                 // Remove this message from ALL batches it belongs to
                 if let Some(other_batches) = self.msg_to_batch.remove(&msg_id) {
                     for other_batch_id in other_batches {
-                        if other_batch_id != batch_id {
-                            if let Some(other_batch_msgs) =
+                        if other_batch_id != batch_id
+                            && let Some(other_batch_msgs) =
                                 self.batch_to_msg.get_mut(&other_batch_id)
-                            {
-                                _ = other_batch_msgs.remove(&msg_id);
-                            }
+                        {
+                            _ = other_batch_msgs.remove(&msg_id);
                         }
                     }
                 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/transformer.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/transformer.rs
@@ -483,15 +483,15 @@ impl Transformer {
         if !schema.attribute_mapping.is_empty() {
             for attr in log_record.attributes() {
                 let attr_key: Cow<'_, str> = String::from_utf8_lossy(attr.key());
-                if let Some(dest) = schema.attribute_mapping.get(attr_key.as_ref()) {
-                    if let Some(val) = attr.value() {
-                        if has_field {
-                            out.push(b',');
-                        }
-                        has_field = true;
-                        out.extend_from_slice(dest);
-                        Self::write_any_value_json(&val, out);
+                if let Some(dest) = schema.attribute_mapping.get(attr_key.as_ref())
+                    && let Some(val) = attr.value()
+                {
+                    if has_field {
+                        out.push(b',');
                     }
+                    has_field = true;
+                    out.extend_from_slice(dest);
+                    Self::write_any_value_json(&val, out);
                 }
             }
         }
@@ -804,10 +804,10 @@ impl Transformer {
     ) {
         for attr in resource.attributes() {
             let key: Cow<'_, str> = String::from_utf8_lossy(attr.key());
-            if let Some(mapped_name) = schema.resource_mapping.get(key.as_ref()) {
-                if let Some(value) = attr.value() {
-                    _ = map.insert(mapped_name.clone(), Self::convert_any_value(&value));
-                }
+            if let Some(mapped_name) = schema.resource_mapping.get(key.as_ref())
+                && let Some(value) = attr.value()
+            {
+                _ = map.insert(mapped_name.clone(), Self::convert_any_value(&value));
             }
         }
     }
@@ -820,10 +820,10 @@ impl Transformer {
     ) {
         for attr in scope.attributes() {
             let key: Cow<'_, str> = String::from_utf8_lossy(attr.key());
-            if let Some(mapped_name) = schema.scope_mapping.get(key.as_ref()) {
-                if let Some(value) = attr.value() {
-                    _ = map.insert(mapped_name.clone(), Self::convert_any_value(&value));
-                }
+            if let Some(mapped_name) = schema.scope_mapping.get(key.as_ref())
+                && let Some(value) = attr.value()
+            {
+                _ = map.insert(mapped_name.clone(), Self::convert_any_value(&value));
             }
         }
     }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/transform_attributes.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/transform_attributes.rs
@@ -403,76 +403,76 @@ pub(crate) fn group_attributes_to_map_str(
                 }
 
                 t if t == AttributeValueType::Str as u8 => {
-                    if let Some(str_accessor) = &str_accessor {
-                        if let Some(v) = str_accessor.str_at(row) {
-                            map_builder.values().append_value(v);
-                            continue;
-                        }
+                    if let Some(str_accessor) = &str_accessor
+                        && let Some(v) = str_accessor.str_at(row)
+                    {
+                        map_builder.values().append_value(v);
+                        continue;
                     }
                     map_builder.values().append_value("");
                 }
 
                 t if t == AttributeValueType::Int as u8 => {
-                    if let Some(int_accessor) = &int_accessor {
-                        if let Some(v) = int_accessor.value_at(row) {
-                            let mut itoa_buf = itoa::Buffer::new();
-                            map_builder.values().append_value(itoa_buf.format(v));
-                            continue;
-                        }
+                    if let Some(int_accessor) = &int_accessor
+                        && let Some(v) = int_accessor.value_at(row)
+                    {
+                        let mut itoa_buf = itoa::Buffer::new();
+                        map_builder.values().append_value(itoa_buf.format(v));
+                        continue;
                     }
                     map_builder.values().append_value("");
                 }
 
                 t if t == AttributeValueType::Double as u8 => {
-                    if let Some(col) = double_col {
-                        if !col.is_null(row) {
-                            let mut r_buf = ryu::Buffer::new();
-                            map_builder
-                                .values()
-                                .append_value(r_buf.format(col.value(row)));
-                            continue;
-                        }
+                    if let Some(col) = double_col
+                        && !col.is_null(row)
+                    {
+                        let mut r_buf = ryu::Buffer::new();
+                        map_builder
+                            .values()
+                            .append_value(r_buf.format(col.value(row)));
+                        continue;
                     }
                     map_builder.values().append_value("");
                 }
 
                 t if t == AttributeValueType::Bool as u8 => {
-                    if let Some(col) = bool_col {
-                        if !col.is_null(row) {
-                            if col.value(row) {
-                                map_builder.values().append_value("true");
-                                continue;
-                            } else {
-                                map_builder.values().append_value("false");
-                                continue;
-                            }
+                    if let Some(col) = bool_col
+                        && !col.is_null(row)
+                    {
+                        if col.value(row) {
+                            map_builder.values().append_value("true");
+                            continue;
+                        } else {
+                            map_builder.values().append_value("false");
+                            continue;
                         }
                     }
                     map_builder.values().append_value("");
                 }
 
                 t if t == AttributeValueType::Bytes as u8 => {
-                    if let Some(col) = bytes_col {
-                        if !col.is_null(row) {
-                            let bytes = col.value(row);
-                            let v = base64::engine::general_purpose::STANDARD.encode(bytes);
-                            map_builder.values().append_value(v);
-                            continue;
-                        }
+                    if let Some(col) = bytes_col
+                        && !col.is_null(row)
+                    {
+                        let bytes = col.value(row);
+                        let v = base64::engine::general_purpose::STANDARD.encode(bytes);
+                        map_builder.values().append_value(v);
+                        continue;
                     }
                     map_builder.values().append_value("");
                 }
 
                 t if t == AttributeValueType::Map as u8 || t == AttributeValueType::Slice as u8 => {
-                    if let Some(byte_accessor) = &ser_accessor {
-                        if let Some(v) = byte_accessor.slice_at(row) {
-                            let mut buf = Vec::with_capacity(v.len() * 2);
-                            if append_cbor_as_json(&mut buf, v).is_ok() {
-                                if let Ok(json) = String::from_utf8(buf) {
-                                    map_builder.values().append_value(json);
-                                    continue;
-                                }
-                            }
+                    if let Some(byte_accessor) = &ser_accessor
+                        && let Some(v) = byte_accessor.slice_at(row)
+                    {
+                        let mut buf = Vec::with_capacity(v.len() * 2);
+                        if append_cbor_as_json(&mut buf, v).is_ok()
+                            && let Ok(json) = String::from_utf8(buf)
+                        {
+                            map_builder.values().append_value(json);
+                            continue;
                         }
                     }
                     map_builder.values().append_value("");

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/transform_column.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/transform/transform_column.rs
@@ -542,22 +542,21 @@ fn build_child_attr_list(
         })?;
 
         for j in 0..ids.len() {
-            if !ids.is_null(j) {
-                if let (Some((map, keys, vals)), Some(remap)) = (compact, remap) {
-                    if let Some(&src) = remap.get(&ids.value(j)) {
-                        let src = src as usize;
-                        if src < map.len() && !map.is_null(src) {
-                            let offsets = map.offsets();
-                            let start = offsets[src] as usize;
-                            let end = offsets[src + 1] as usize;
-                            for k in start..end {
-                                out.values().keys().append_value(keys.value(k));
-                                if vals.is_null(k) {
-                                    out.values().values().append_null();
-                                } else {
-                                    out.values().values().append_value(vals.value(k));
-                                }
-                            }
+            if !ids.is_null(j)
+                && let (Some((map, keys, vals)), Some(remap)) = (compact, remap)
+                && let Some(&src) = remap.get(&ids.value(j))
+            {
+                let src = src as usize;
+                if src < map.len() && !map.is_null(src) {
+                    let offsets = map.offsets();
+                    let start = offsets[src] as usize;
+                    let end = offsets[src + 1] as usize;
+                    for k in start..end {
+                        out.values().keys().append_value(keys.value(k));
+                        if vals.is_null(k) {
+                            out.values().values().append_null();
+                        } else {
+                            out.values().values().append_value(vals.value(k));
                         }
                     }
                 }
@@ -900,11 +899,11 @@ pub fn struct_column_to_string(
             }
 
             t if t == AttributeValueType::Str as u8 => {
-                if let Some(string_accessor) = &string_accessor {
-                    if let Some(v) = string_accessor.str_at(i) {
-                        builder.append_value(v);
-                        continue;
-                    }
+                if let Some(string_accessor) = &string_accessor
+                    && let Some(v) = string_accessor.str_at(i)
+                {
+                    builder.append_value(v);
+                    continue;
                 };
                 builder.append_null();
             }
@@ -930,15 +929,15 @@ pub fn struct_column_to_string(
             }
 
             t if t == AttributeValueType::Bool as u8 => {
-                if let Some(bool_accessor) = bool_accessor {
-                    if let Some(v) = bool_accessor.value_at(i) {
-                        if v {
-                            builder.append_value("true");
-                        } else {
-                            builder.append_value("false");
-                        }
-                        continue;
+                if let Some(bool_accessor) = bool_accessor
+                    && let Some(v) = bool_accessor.value_at(i)
+                {
+                    if v {
+                        builder.append_value("true");
+                    } else {
+                        builder.append_value("false");
                     }
+                    continue;
                 };
                 builder.append_null();
             }
@@ -957,15 +956,15 @@ pub fn struct_column_to_string(
             }
 
             t if t == AttributeValueType::Map as u8 || t == AttributeValueType::Slice as u8 => {
-                if let Some(ser_accessor) = &ser_accessor {
-                    if let Some(v) = ser_accessor.slice_at(i) {
-                        let mut buf = Vec::with_capacity(v.len() * 2);
-                        if append_cbor_as_json(&mut buf, v).is_err() {
-                            builder.append_null();
-                        } else {
-                            builder.append_value(buf);
-                            continue;
-                        }
+                if let Some(ser_accessor) = &ser_accessor
+                    && let Some(v) = ser_accessor.slice_at(i)
+                {
+                    let mut buf = Vec::with_capacity(v.len() * 2);
+                    if append_cbor_as_json(&mut buf, v).is_err() {
+                        builder.append_null();
+                    } else {
+                        builder.append_value(buf);
+                        continue;
                     }
                 }
                 builder.append_null();

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
@@ -264,12 +264,12 @@ where
     D: Deserializer<'de>,
 {
     let value: Option<String> = Option::deserialize(deserializer)?;
-    if let Some(ref name) = value {
-        if name.trim().is_empty() {
-            return Err(serde::de::Error::custom(
-                "'default_event_name' must be a non-empty table name",
-            ));
-        }
+    if let Some(ref name) = value
+        && name.trim().is_empty()
+    {
+        return Err(serde::de::Error::custom(
+            "'default_event_name' must be a non-empty table name",
+        ));
     }
     Ok(value)
 }
@@ -296,14 +296,14 @@ fn validate_events_map(
                 "{signal}.event_name_mapping.events source keys must not be blank"
             ));
         }
-        if let Some(dest) = destination {
-            if dest.trim().is_empty() {
-                return Err(format!(
-                    "{signal}.event_name_mapping.events destination for source '{source}' must \
+        if let Some(dest) = destination
+            && dest.trim().is_empty()
+        {
+            return Err(format!(
+                "{signal}.event_name_mapping.events destination for source '{source}' must \
                      not be empty or whitespace; omit the value (use null) to route to the \
                      source value unchanged"
-                ));
-            }
+            ));
         }
     }
     Ok(())
@@ -596,13 +596,13 @@ impl TryFrom<OboConfigRaw> for OboConfig {
                     "obo.events entry for '{event_name}' must have a non-empty identity"
                 ));
             }
-            if let Some(annotations) = &entry.annotations {
-                if annotations.trim().is_empty() {
-                    return Err(format!(
-                        "obo.events entry for '{event_name}' has an empty annotations value; \
+            if let Some(annotations) = &entry.annotations
+                && annotations.trim().is_empty()
+            {
+                return Err(format!(
+                    "obo.events entry for '{event_name}' has an empty annotations value; \
                          omit the field (or use null) instead of an empty string"
-                    ));
-                }
+                ));
             }
         }
         Ok(Self { events: raw.events })

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/kafka_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/kafka_exporter/exporter.rs
@@ -499,18 +499,18 @@ impl KafkaExporter {
 
         // Propagate transport headers onto the Kafka record if a propagation
         // policy is configured and the pdata context carries transport headers.
-        if let Some(policy) = effect_handler.and_then(|eh| eh.propagation_policy()) {
-            if let Some(transport_headers) = context.transport_headers() {
-                for propagated in policy.propagate(transport_headers) {
-                    // Skip propagated headers that collide with the format header.
-                    if propagated.header_name == format_header_key {
-                        continue;
-                    }
-                    headers = headers.insert(Header {
-                        key: propagated.header_name,
-                        value: Some(propagated.value),
-                    });
+        if let Some(policy) = effect_handler.and_then(|eh| eh.propagation_policy())
+            && let Some(transport_headers) = context.transport_headers()
+        {
+            for propagated in policy.propagate(transport_headers) {
+                // Skip propagated headers that collide with the format header.
+                if propagated.header_name == format_header_key {
+                    continue;
                 }
+                headers = headers.insert(Header {
+                    key: propagated.header_name,
+                    value: Some(propagated.value),
+                });
             }
         }
 
@@ -740,14 +740,14 @@ impl KafkaExporter {
                 } else {
                     reporter.nack(reason, refused).await
                 };
-                if let Err(e) = nack_result {
-                    if let Some(eh) = effect_handler {
-                        eh.info(&format!(
-                            "Failed to report nack for Kafka export enqueue failure: {}",
-                            e
-                        ))
-                        .await;
-                    }
+                if let Err(e) = nack_result
+                    && let Some(eh) = effect_handler
+                {
+                    eh.info(&format!(
+                        "Failed to report nack for Kafka export enqueue failure: {}",
+                        e
+                    ))
+                    .await;
                 }
                 // Enqueue failure was reported synchronously; there is no
                 // in-flight delivery to track.
@@ -796,14 +796,14 @@ impl KafkaExporter {
                 );
                 self.metrics
                     .record_success(signal_type, export_start.elapsed(), payload_bytes);
-                if let Err(e) = reporter.ack(pdata).await {
-                    if let Some(eh) = effect_handler {
-                        eh.info(&format!(
-                            "Failed to report ack for Kafka export (export succeeded): {}",
-                            e
-                        ))
-                        .await;
-                    }
+                if let Err(e) = reporter.ack(pdata).await
+                    && let Some(eh) = effect_handler
+                {
+                    eh.info(&format!(
+                        "Failed to report ack for Kafka export (export succeeded): {}",
+                        e
+                    ))
+                    .await;
                 }
                 return;
             }
@@ -839,14 +839,14 @@ impl KafkaExporter {
         } else {
             reporter.nack(reason, pdata).await
         };
-        if let Err(e) = nack_result {
-            if let Some(eh) = effect_handler {
-                eh.info(&format!(
-                    "Failed to report nack for Kafka export failure: {}",
-                    e
-                ))
-                .await;
-            }
+        if let Err(e) = nack_result
+            && let Some(eh) = effect_handler
+        {
+            eh.info(&format!(
+                "Failed to report nack for Kafka export failure: {}",
+                e
+            ))
+            .await;
         }
     }
 
@@ -1150,17 +1150,15 @@ impl Exporter<OtapPdata> for KafkaExporter {
                     if let Ok(Some((delivery, meta))) = self
                         .enqueue_pdata(pdata, &ack_nack_reporter, Some(&effect_handler))
                         .await
+                        && let Some((done_meta, done_result)) = in_flight.push(delivery, meta).await
                     {
-                        if let Some((done_meta, done_result)) = in_flight.push(delivery, meta).await
-                        {
-                            self.finalize_send_completion(
-                                done_meta,
-                                done_result,
-                                &ack_nack_reporter,
-                                Some(&effect_handler),
-                            )
-                            .await;
-                        }
+                        self.finalize_send_completion(
+                            done_meta,
+                            done_result,
+                            &ack_nack_reporter,
+                            Some(&effect_handler),
+                        )
+                        .await;
                     }
                 }
                 Message::Control(NodeControlMsg::CollectTelemetry {

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/kafka_exporter/partitioner.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/kafka_exporter/partitioner.rs
@@ -81,10 +81,10 @@ pub fn partition_key_for_signal(
     signal_config: &super::config::SignalConfig,
     context: &otel_arrow_dfe_otap::pdata::Context,
 ) -> Option<String> {
-    if signal_config.partition_by_transport_headers() {
-        if let Some(headers) = context.transport_headers() {
-            return partition_key_from_transport_headers(headers);
-        }
+    if signal_config.partition_by_transport_headers()
+        && let Some(headers) = context.transport_headers()
+    {
+        return partition_key_from_transport_headers(headers);
     }
 
     None

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/condense_attributes_processor/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/condense_attributes_processor/mod.rs
@@ -128,27 +128,27 @@ impl Config {
         }
 
         // Validate that destination_key is not in source_keys
-        if let Some(ref keys) = source_keys {
-            if keys.contains(&destination_key) {
-                return Err(ConfigError::InvalidUserConfig {
-                    error: format!(
-                        "destination_key '{}' cannot be included in source_keys",
-                        destination_key
-                    ),
-                });
-            }
+        if let Some(ref keys) = source_keys
+            && keys.contains(&destination_key)
+        {
+            return Err(ConfigError::InvalidUserConfig {
+                error: format!(
+                    "destination_key '{}' cannot be included in source_keys",
+                    destination_key
+                ),
+            });
         }
 
         // Validate that destination_key is not in exclude_keys
-        if let Some(ref keys) = exclude_keys {
-            if keys.contains(&destination_key) {
-                return Err(ConfigError::InvalidUserConfig {
-                    error: format!(
-                        "destination_key '{}' cannot be included in exclude_keys",
-                        destination_key
-                    ),
-                });
-            }
+        if let Some(ref keys) = exclude_keys
+            && keys.contains(&destination_key)
+        {
+            return Err(ConfigError::InvalidUserConfig {
+                error: format!(
+                    "destination_key '{}' cannot be included in exclude_keys",
+                    destination_key
+                ),
+            });
         }
 
         Ok(Self {

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/attached_records.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/attached_records.rs
@@ -99,15 +99,15 @@ impl MapValue for InstrumentationScope {
     }
 
     fn get_items<'a>(&'a self, item_callback: &mut MapValueIteratorCallback<'a, '_>) -> bool {
-        if let Some(v) = &self.name {
-            if !(item_callback)("Name", Value::String(v)) {
-                return false;
-            }
+        if let Some(v) = &self.name
+            && !(item_callback)("Name", Value::String(v))
+        {
+            return false;
         }
-        if let Some(v) = &self.version {
-            if !(item_callback)("Version", Value::String(v)) {
-                return false;
-            }
+        if let Some(v) = &self.version
+            && !(item_callback)("Version", Value::String(v))
+        {
+            return false;
         }
         (item_callback)("Attributes", Value::Map(&self.attributes))
     }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/logs.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/recordset_kql_processor/otlp_bridge/logs.rs
@@ -108,53 +108,53 @@ impl MapValue for LogRecord {
     }
 
     fn get_items<'a>(&'a self, item_callback: &mut MapValueIteratorCallback<'a, '_>) -> bool {
-        if let Some(v) = &self.timestamp {
-            if !(item_callback)("time_unix_nano", Value::DateTime(v)) {
-                return false;
-            }
+        if let Some(v) = &self.timestamp
+            && !(item_callback)("time_unix_nano", Value::DateTime(v))
+        {
+            return false;
         }
-        if let Some(v) = &self.observed_timestamp {
-            if !(item_callback)("observed_time_unix_nano", Value::DateTime(v)) {
-                return false;
-            }
+        if let Some(v) = &self.observed_timestamp
+            && !(item_callback)("observed_time_unix_nano", Value::DateTime(v))
+        {
+            return false;
         }
-        if let Some(v) = &self.severity_number {
-            if !(item_callback)("severity_number", Value::Integer(v)) {
-                return false;
-            }
+        if let Some(v) = &self.severity_number
+            && !(item_callback)("severity_number", Value::Integer(v))
+        {
+            return false;
         }
-        if let Some(v) = &self.severity_text {
-            if !(item_callback)("severity_text", Value::String(v)) {
-                return false;
-            }
+        if let Some(v) = &self.severity_text
+            && !(item_callback)("severity_text", Value::String(v))
+        {
+            return false;
         }
-        if let Some(v) = &self.body {
-            if !(item_callback)("body", v.to_value()) {
-                return false;
-            }
+        if let Some(v) = &self.body
+            && !(item_callback)("body", v.to_value())
+        {
+            return false;
         }
         if !(item_callback)("attributes", Value::Map(&self.attributes)) {
             return false;
         }
-        if let Some(v) = &self.flags {
-            if !(item_callback)("flags", Value::Integer(v)) {
-                return false;
-            }
+        if let Some(v) = &self.flags
+            && !(item_callback)("flags", Value::Integer(v))
+        {
+            return false;
         }
-        if let Some(v) = &self.trace_id {
-            if !(item_callback)("trace_id", Value::Array(v)) {
-                return false;
-            }
+        if let Some(v) = &self.trace_id
+            && !(item_callback)("trace_id", Value::Array(v))
+        {
+            return false;
         }
-        if let Some(v) = &self.span_id {
-            if !(item_callback)("span_id", Value::Array(v)) {
-                return false;
-            }
+        if let Some(v) = &self.span_id
+            && !(item_callback)("span_id", Value::Array(v))
+        {
+            return false;
         }
-        if let Some(v) = &self.event_name {
-            if !(item_callback)("event_name", Value::String(v)) {
-                return false;
-            }
+        if let Some(v) = &self.event_name
+            && !(item_callback)("event_name", Value::String(v))
+        {
+            return false;
         }
 
         true
@@ -403,53 +403,53 @@ impl MapValueMut for LogRecord {
     }
 
     fn retain(&mut self, item_callback: &mut MapValueMutIteratorCallback<'_>) {
-        if let Some(v) = &mut self.timestamp {
-            if !(item_callback)("time_unix_nano", v) {
-                self.timestamp = None;
-            }
+        if let Some(v) = &mut self.timestamp
+            && !(item_callback)("time_unix_nano", v)
+        {
+            self.timestamp = None;
         }
-        if let Some(v) = &mut self.observed_timestamp {
-            if !(item_callback)("observed_time_unix_nano", v) {
-                self.observed_timestamp = None;
-            }
+        if let Some(v) = &mut self.observed_timestamp
+            && !(item_callback)("observed_time_unix_nano", v)
+        {
+            self.observed_timestamp = None;
         }
-        if let Some(v) = &mut self.severity_number {
-            if !(item_callback)("severity_number", v) {
-                self.severity_number = None;
-            }
+        if let Some(v) = &mut self.severity_number
+            && !(item_callback)("severity_number", v)
+        {
+            self.severity_number = None;
         }
-        if let Some(v) = &mut self.severity_text {
-            if !(item_callback)("severity_text", v) {
-                self.severity_text = None;
-            }
+        if let Some(v) = &mut self.severity_text
+            && !(item_callback)("severity_text", v)
+        {
+            self.severity_text = None;
         }
-        if let Some(v) = &mut self.body {
-            if !(item_callback)("body", v) {
-                self.body = None;
-            }
+        if let Some(v) = &mut self.body
+            && !(item_callback)("body", v)
+        {
+            self.body = None;
         }
         if !(item_callback)("attributes", &mut self.attributes) {
             self.attributes = MapValueStorage::new(HashMap::new());
         }
-        if let Some(v) = &mut self.flags {
-            if !(item_callback)("flags", v) {
-                self.flags = None;
-            }
+        if let Some(v) = &mut self.flags
+            && !(item_callback)("flags", v)
+        {
+            self.flags = None;
         }
-        if let Some(v) = &mut self.trace_id {
-            if !(item_callback)("trace_id", v) {
-                self.trace_id = None;
-            }
+        if let Some(v) = &mut self.trace_id
+            && !(item_callback)("trace_id", v)
+        {
+            self.trace_id = None;
         }
-        if let Some(v) = &mut self.span_id {
-            if !(item_callback)("span_id", v) {
-                self.span_id = None;
-            }
+        if let Some(v) = &mut self.span_id
+            && !(item_callback)("span_id", v)
+        {
+            self.span_id = None;
         }
-        if let Some(v) = &mut self.event_name {
-            if !(item_callback)("event_name", v) {
-                self.event_name = None;
-            }
+        if let Some(v) = &mut self.event_name
+            && !(item_callback)("event_name", v)
+        {
+            self.event_name = None;
         }
     }
 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/mod.rs
@@ -271,23 +271,19 @@ impl Config {
             // here rather than letting it fail later (a blank GUID errors at
             // parse time; a blank name would hash to a bogus GUID on the
             // automatic path).
-            if let Some(name) = &provider.name {
-                if name.trim().is_empty() {
-                    return Err(otel_arrow_dfe_config::error::Error::InvalidUserConfig {
-                        error: format!(
-                            "provider[{i}]: 'name' must not be empty or whitespace-only"
-                        ),
-                    });
-                }
+            if let Some(name) = &provider.name
+                && name.trim().is_empty()
+            {
+                return Err(otel_arrow_dfe_config::error::Error::InvalidUserConfig {
+                    error: format!("provider[{i}]: 'name' must not be empty or whitespace-only"),
+                });
             }
-            if let Some(guid) = &provider.guid {
-                if guid.trim().is_empty() {
-                    return Err(otel_arrow_dfe_config::error::Error::InvalidUserConfig {
-                        error: format!(
-                            "provider[{i}]: 'guid' must not be empty or whitespace-only"
-                        ),
-                    });
-                }
+            if let Some(guid) = &provider.guid
+                && guid.trim().is_empty()
+            {
+                return Err(otel_arrow_dfe_config::error::Error::InvalidUserConfig {
+                    error: format!("provider[{i}]: 'guid' must not be empty or whitespace-only"),
+                });
             }
 
             // `kind` selects a name-resolution strategy and is meaningless for a
@@ -302,13 +298,12 @@ impl Config {
             }
         }
 
-        if let Some(ref batching) = self.batching {
-            if batching.max_duration.is_zero() {
-                return Err(otel_arrow_dfe_config::error::Error::InvalidUserConfig {
-                    error: "ETW receiver `batching.max_duration` must be greater than zero"
-                        .to_string(),
-                });
-            }
+        if let Some(ref batching) = self.batching
+            && batching.max_duration.is_zero()
+        {
+            return Err(otel_arrow_dfe_config::error::Error::InvalidUserConfig {
+                error: "ETW receiver `batching.max_duration` must be greater than zero".to_string(),
+            });
         }
 
         Ok(())

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/session.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/session.rs
@@ -783,7 +783,9 @@ fn decode_utf16le(data: &[u8]) -> String {
 
     // ASCII fast path: find the first NUL or first non-ASCII code unit.
     let ascii_end = bytes
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .position(|c| c[0] == 0 || c[1] != 0)
         .map(|i| i * 2)
         .unwrap_or(len);
@@ -792,7 +794,7 @@ fn decode_utf16le(data: &[u8]) -> String {
         // Entirely ASCII up to the end (or a terminating NUL): copy the low
         // bytes directly, no surrogate logic needed.
         let mut out = String::with_capacity(ascii_end / 2);
-        for chunk in bytes[..ascii_end].chunks_exact(2) {
+        for chunk in bytes[..ascii_end].as_chunks::<2>().0 {
             out.push(chunk[0] as char);
         }
         return out;
@@ -802,7 +804,9 @@ fn decode_utf16le(data: &[u8]) -> String {
     // substituting U+FFFD for invalid surrogate pairs.
     let mut out = String::with_capacity(len / 2);
     let u16_iter = bytes
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|c| u16::from_le_bytes([c[0], c[1]]))
         .take_while(|&c| c != 0);
     out.extend(char::decode_utf16(u16_iter).map(|r| r.unwrap_or('\u{FFFD}')));

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/session.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/session.rs
@@ -1570,10 +1570,10 @@ mod tests {
 
     impl Drop for TestSession {
         fn drop(&mut self) {
-            if let Ok(mut guard) = SESSIONS.lock() {
-                if let Some(sessions) = guard.as_mut() {
-                    let _ = sessions.remove(&self.name);
-                }
+            if let Ok(mut guard) = SESSIONS.lock()
+                && let Some(sessions) = guard.as_mut()
+            {
+                let _ = sessions.remove(&self.name);
             }
         }
     }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/config.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/config.rs
@@ -537,12 +537,12 @@ impl TryFrom<KafkaReceiverConfigBuilder> for KafkaReceiverConfig {
         }
 
         // Reject empty optional string fields when explicitly set
-        if let Some(ref id) = builder.group_instance_id {
-            if id.is_empty() {
-                return Err(KafkaReceiverError::ConfigEmptyField {
-                    field: "group_instance_id".to_string(),
-                });
-            }
+        if let Some(ref id) = builder.group_instance_id
+            && id.is_empty()
+        {
+            return Err(KafkaReceiverError::ConfigEmptyField {
+                field: "group_instance_id".to_string(),
+            });
         }
         if builder.message_format_header.is_empty() {
             return Err(KafkaReceiverError::ConfigEmptyField {
@@ -1043,10 +1043,8 @@ impl KafkaReceiverConfigBuilder {
 
         // Commit settings derived from CommitConfig
         let auto_commit = matches!(self.commit.mode, CommitMode::Auto);
-        if auto_commit {
-            if let Some(interval) = self.commit.interval_ms {
-                _ = config.set("auto.commit.interval.ms", interval.to_string());
-            }
+        if auto_commit && let Some(interval) = self.commit.interval_ms {
+            _ = config.set("auto.commit.interval.ms", interval.to_string());
         }
         _ = config.set(
             "enable.auto.commit",

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/rebalance.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/rebalance.rs
@@ -686,14 +686,14 @@ impl RebalanceState {
             build_commit_tpl(&committable, &revoked)
         };
 
-        if commit_tpl.count() > 0 {
-            if let Err(e) = consumer.commit(&commit_tpl, CommitMode::Sync) {
-                let _ = self.rebalance_commit_errors.fetch_add(1, Ordering::Relaxed);
-                otel_error!(
-                    "kafka.rebalance.commit_failed",
-                    error = %e,
-                );
-            }
+        if commit_tpl.count() > 0
+            && let Err(e) = consumer.commit(&commit_tpl, CommitMode::Sync)
+        {
+            let _ = self.rebalance_commit_errors.fetch_add(1, Ordering::Relaxed);
+            otel_error!(
+                "kafka.rebalance.commit_failed",
+                error = %e,
+            );
         }
 
         // Pause state is client-local and survives revocation/reassignment in

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/receiver.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/receiver.rs
@@ -290,11 +290,11 @@ impl KafkaReceiver {
         // unique group.instance.id. On a multi-core pipeline every core would
         // otherwise share the configured ID and fence one another, so suffix it
         // with the pipeline core ID.
-        if pipeline_ctx.num_cores() > 1 {
-            if let Some(base_id) = config.group_instance_id() {
-                let resolved = format!("{base_id}-{}", pipeline_ctx.core_id());
-                config.set_group_instance_id(resolved);
-            }
+        if pipeline_ctx.num_cores() > 1
+            && let Some(base_id) = config.group_instance_id()
+        {
+            let resolved = format!("{base_id}-{}", pipeline_ctx.core_id());
+            config.set_group_instance_id(resolved);
         }
 
         // Warn about consumer_config keys that may be overwritten by first-class fields.
@@ -828,12 +828,10 @@ impl KafkaReceiver {
         // A transient NACK configured for replay never advances the offset.
         // The timer delivers `NodeControlMsg::TimerTick` on the control
         // channel, which is handled in the main loop below.
-        if manual_commit {
-            if let Some(ms) = self.config.commit_interval_ms() {
-                let _commit_timer_handle = effect_handler
-                    .start_periodic_timer(Duration::from_millis(ms))
-                    .await?;
-            }
+        if manual_commit && let Some(ms) = self.config.commit_interval_ms() {
+            let _commit_timer_handle = effect_handler
+                .start_periodic_timer(Duration::from_millis(ms))
+                .await?;
         }
 
         // Opt-in consumer-lag refresh timer, derived from the configured
@@ -1751,20 +1749,20 @@ fn capture_transport_headers(
     capture_policy: Option<&HeaderCapturePolicy>,
     pdata: &mut OtapPdata,
 ) {
-    if let Some(policy) = capture_policy {
-        if let Some(headers) = kafka_message.headers() {
-            let pairs = headers.iter().filter_map(|h| h.value.map(|v| (h.key, v)));
-            let mut transport_headers = TransportHeaders::new();
-            let stats = policy.capture_from_pairs(pairs, &mut transport_headers);
-            if let Some(stats) = stats {
-                otel_error!(
-                    "kafka.capture_policy.limits_exceeded",
-                    stats = %stats,
-                );
-            }
-            if !transport_headers.is_empty() {
-                pdata.set_transport_headers(transport_headers);
-            }
+    if let Some(policy) = capture_policy
+        && let Some(headers) = kafka_message.headers()
+    {
+        let pairs = headers.iter().filter_map(|h| h.value.map(|v| (h.key, v)));
+        let mut transport_headers = TransportHeaders::new();
+        let stats = policy.capture_from_pairs(pairs, &mut transport_headers);
+        if let Some(stats) = stats {
+            otel_error!(
+                "kafka.capture_policy.limits_exceeded",
+                stats = %stats,
+            );
+        }
+        if !transport_headers.is_empty() {
+            pdata.set_transport_headers(transport_headers);
         }
     }
 }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/receiver.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/receiver.rs
@@ -3940,11 +3940,11 @@ mod tests {
                 // Poll B until it is assigned a partition (drives the rebalance).
                 let mut b_partition = None;
                 for _ in 0..40 {
-                    if let Ok(a) = consumer_b.assignment() {
-                        if let Some(elem) = a.elements().first() {
-                            b_partition = Some(elem.partition());
-                            break;
-                        }
+                    if let Ok(a) = consumer_b.assignment()
+                        && let Some(elem) = a.elements().first()
+                    {
+                        b_partition = Some(elem.partition());
+                        break;
                     }
                     let _ =
                         tokio::time::timeout(Duration::from_millis(500), consumer_b.recv()).await;
@@ -7724,16 +7724,15 @@ mod tests {
                 let mut found_tenant = false;
                 for rs in &result.resource_spans {
                     let resource = rs.resource.as_ref().expect("resource present");
-                    if let Some(kv) = resource.attributes.iter().find(|kv| kv.key == "tenant.id") {
-                        if let Some(any_value::Value::StringValue(s)) =
+                    if let Some(kv) = resource.attributes.iter().find(|kv| kv.key == "tenant.id")
+                        && let Some(any_value::Value::StringValue(s)) =
                             kv.value.as_ref().and_then(|v| v.value.as_ref())
-                        {
-                            assert_eq!(
-                                s, &adversarial_value,
-                                "adversarial header value is extracted verbatim",
-                            );
-                            found_tenant = true;
-                        }
+                    {
+                        assert_eq!(
+                            s, &adversarial_value,
+                            "adversarial header value is extracted verbatim",
+                        );
+                        found_tenant = true;
                     }
                 }
                 assert!(found_tenant, "the tenant.id attribute should be extracted");

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/retry.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/retry.rs
@@ -218,10 +218,10 @@ impl RetryManager {
         partition: i32,
         ownership_generation: OwnershipGeneration,
     ) -> DeliveryGeneration {
-        if let Some(state) = self.state(topic, partition) {
-            if state.ownership_generation == ownership_generation {
-                return state.delivery_generation;
-            }
+        if let Some(state) = self.state(topic, partition)
+            && state.ownership_generation == ownership_generation
+        {
+            return state.delivery_generation;
         }
 
         if let Some(previous) = self.take_state(topic, partition) {

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/user_events_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/user_events_receiver/mod.rs
@@ -539,12 +539,12 @@ async fn process_drained_records(
             &subscription.format,
         );
         builder.append(decoded);
-        if builder.len() >= batch_cfg.max_size {
-            if let Err(error) = flush_batch(effect_handler, metrics, builder).await {
-                let remaining = u64::try_from(drained.count()).unwrap_or(u64::MAX);
-                add_dropped_send_error(metrics, remaining);
-                return Err(error);
-            }
+        if builder.len() >= batch_cfg.max_size
+            && let Err(error) = flush_batch(effect_handler, metrics, builder).await
+        {
+            let remaining = u64::try_from(drained.count()).unwrap_or(u64::MAX);
+            add_dropped_send_error(metrics, remaining);
+            return Err(error);
         }
     }
 
@@ -649,8 +649,9 @@ impl local::Receiver<OtapPdata> for UserEventsReceiver {
                         }
                         Ok(NodeControlMsg::DrainIngress { deadline, .. }) => {
                             let _ = telemetry_timer_handle.cancel().await;
-                            if let Some(session) = session.as_mut() {
-                                if Instant::now() < deadline {
+                            if let Some(session) = session.as_mut()
+                                && Instant::now() < deadline
+                            {
                                     let drain_stats = session
                                         .drain_once(&drain_cfg, &mut drained_records)
                                         .map_err(|error| Error::ReceiverError {
@@ -672,7 +673,6 @@ impl local::Receiver<OtapPdata> for UserEventsReceiver {
                                     )
                                     .await?;
                                 }
-                            }
                             if self.admission_state.should_shed_ingress() {
                                 drop_batch(&self.metrics, &mut builder);
                             } else {

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/user_events_receiver/one_collect_adapter.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/user_events_receiver/one_collect_adapter.rs
@@ -453,19 +453,20 @@ impl PendingQueues {
                     return false;
                 };
 
-                if let Some(max_pending_events) = subscription.limits.max_pending_events {
-                    if subscription.events.len() >= max_pending_events {
-                        subscription.dropped_subscription_cap =
-                            subscription.dropped_subscription_cap.saturating_add(1);
-                        return false;
-                    }
+                if let Some(max_pending_events) = subscription.limits.max_pending_events
+                    && subscription.events.len() >= max_pending_events
+                {
+                    subscription.dropped_subscription_cap =
+                        subscription.dropped_subscription_cap.saturating_add(1);
+                    return false;
                 }
-                if let Some(max_pending_bytes) = subscription.limits.max_pending_bytes {
-                    if subscription.pending_bytes.saturating_add(payload_len) > max_pending_bytes {
-                        subscription.dropped_subscription_cap =
-                            subscription.dropped_subscription_cap.saturating_add(1);
-                        return false;
-                    }
+
+                if let Some(max_pending_bytes) = subscription.limits.max_pending_bytes
+                    && subscription.pending_bytes.saturating_add(payload_len) > max_pending_bytes
+                {
+                    subscription.dropped_subscription_cap =
+                        subscription.dropped_subscription_cap.saturating_add(1);
+                    return false;
                 }
 
                 if !pending_accepts_event(
@@ -591,14 +592,16 @@ fn drain_shared_pending(
     // Forward-progress guarantee: ensure at least one event drains per turn
     // when the queue is non-empty, even if the parse phase consumed the
     // deadline before the pop loop could run.
-    if events.is_empty() && !pending_events.is_empty() && max_records > 0 {
-        if let Some(front) = pending_events.front() {
-            let front_len = front.event_data.len();
-            if front_len <= max_bytes {
-                if let Some(event) = pop_pending_event(&mut pending_events, &pending.bytes) {
-                    events.push(event);
-                }
-            }
+    if events.is_empty()
+        && !pending_events.is_empty()
+        && max_records > 0
+        && let Some(front) = pending_events.front()
+    {
+        let front_len = front.event_data.len();
+        if front_len <= max_bytes
+            && let Some(event) = pop_pending_event(&mut pending_events, &pending.bytes)
+        {
+            events.push(event);
         }
     }
 }

--- a/rust/otap-dataflow/crates/control-channel/src/channel.rs
+++ b/rust/otap-dataflow/crates/control-channel/src/channel.rs
@@ -186,24 +186,24 @@ impl SenderWaiters {
     }
 
     fn register_or_refresh(&mut self, waiter_key: &mut Option<SenderWaiterKey>, waker: &Waker) {
-        if let Some(existing_key) = *waiter_key {
-            if let Some(slot) = self.slots.get_mut(existing_key.index) {
-                if slot.in_use && slot.generation == existing_key.generation {
-                    if slot
-                        .waker
-                        .as_ref()
-                        .is_none_or(|existing| !existing.will_wake(waker))
-                    {
-                        slot.waker = Some(waker.clone());
-                    }
-                    if !slot.queued {
-                        slot.queued = true;
-                        self.queue.push_back(existing_key);
-                        self.queued_live += 1;
-                    }
-                    return;
-                }
+        if let Some(existing_key) = *waiter_key
+            && let Some(slot) = self.slots.get_mut(existing_key.index)
+            && slot.in_use
+            && slot.generation == existing_key.generation
+        {
+            if slot
+                .waker
+                .as_ref()
+                .is_none_or(|existing| !existing.will_wake(waker))
+            {
+                slot.waker = Some(waker.clone());
             }
+            if !slot.queued {
+                slot.queued = true;
+                self.queue.push_back(existing_key);
+                self.queued_live += 1;
+            }
+            return;
         }
 
         let index = if let Some(index) = self.free_slots.pop() {
@@ -573,14 +573,14 @@ impl<PData, Meta> Future for SendFuture<'_, PData, Meta> {
                 if needs_reset {
                     this.deadline_sleep = Some(Box::pin(sleep_until(deadline)));
                 }
-                if let Some(sleep) = this.deadline_sleep.as_mut() {
-                    if sleep.as_mut().poll(cx).is_ready() {
-                        this.deadline_sleep = None;
-                        if let Some(waiter_key) = this.waiter_key.take() {
-                            this.sender.state.unregister_sender_waiter(waiter_key);
-                        }
-                        continue;
+                if let Some(sleep) = this.deadline_sleep.as_mut()
+                    && sleep.as_mut().poll(cx).is_ready()
+                {
+                    this.deadline_sleep = None;
+                    if let Some(waiter_key) = this.waiter_key.take() {
+                        this.sender.state.unregister_sender_waiter(waiter_key);
                     }
+                    continue;
                 }
             } else {
                 this.deadline_sleep = None;

--- a/rust/otap-dataflow/crates/control-channel/src/core.rs
+++ b/rust/otap-dataflow/crates/control-channel/src/core.rs
@@ -378,10 +378,10 @@ impl<PData, Meta> Inner<PData, Meta> {
 
         // Once the completion burst budget is exhausted, force one pending
         // normal event before emitting more completion traffic.
-        if self.completion_burst_len >= self.config.completion_burst_limit {
-            if let Some(event) = self.take_next_normal_event() {
-                return Some(event);
-            }
+        if self.completion_burst_len >= self.config.completion_burst_limit
+            && let Some(event) = self.take_next_normal_event()
+        {
+            return Some(event);
         }
 
         // Otherwise, prefer completion traffic until the burst limit says one
@@ -411,11 +411,11 @@ impl<PData, Meta> Inner<PData, Meta> {
             return;
         }
 
-        if let Some(deadline) = self.shutdown_deadline {
-            if now >= deadline {
-                self.shutdown_forced = true;
-                self.bump_version();
-            }
+        if let Some(deadline) = self.shutdown_deadline
+            && now >= deadline
+        {
+            self.shutdown_forced = true;
+            self.bump_version();
         }
     }
 

--- a/rust/otap-dataflow/crates/controller/src/live_control/mod.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/mod.rs
@@ -286,11 +286,12 @@ impl<
         now: Instant,
     ) {
         let mut enqueue = false;
-        if let Some(rollout) = state.rollouts.get_mut(rollout_id) {
-            if rollout.state.is_terminal() && rollout.completed_at.is_none() {
-                rollout.completed_at = Some(now);
-                enqueue = true;
-            }
+        if let Some(rollout) = state.rollouts.get_mut(rollout_id)
+            && rollout.state.is_terminal()
+            && rollout.completed_at.is_none()
+        {
+            rollout.completed_at = Some(now);
+            enqueue = true;
         }
         if enqueue {
             state
@@ -351,11 +352,12 @@ impl<
         now: Instant,
     ) {
         let mut enqueue = false;
-        if let Some(shutdown) = state.shutdowns.get_mut(shutdown_id) {
-            if shutdown.state.is_terminal() && shutdown.completed_at.is_none() {
-                shutdown.completed_at = Some(now);
-                enqueue = true;
-            }
+        if let Some(shutdown) = state.shutdowns.get_mut(shutdown_id)
+            && shutdown.state.is_terminal()
+            && shutdown.completed_at.is_none()
+        {
+            shutdown.completed_at = Some(now);
+            enqueue = true;
         }
         if enqueue {
             state

--- a/rust/otap-dataflow/crates/controller/src/live_control/runtime.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/runtime.rs
@@ -1201,27 +1201,26 @@ impl<
             deployed_key.pipeline_id.clone(),
         );
         loop {
-            if let Some(status) = self.observed_state_handle.pipeline_status(&pipeline_key) {
-                if let Some(instance) =
+            if let Some(status) = self.observed_state_handle.pipeline_status(&pipeline_key)
+                && let Some(instance) =
                     status.instance_status(deployed_key.core_id, deployed_key.deployment_generation)
-                {
-                    let accepted = instance.accepted_condition().status == ConditionStatus::True;
-                    let ready = instance.ready_condition().status == ConditionStatus::True;
-                    if accepted && ready {
-                        return Ok(());
+            {
+                let accepted = instance.accepted_condition().status == ConditionStatus::True;
+                let ready = instance.ready_condition().status == ConditionStatus::True;
+                if accepted && ready {
+                    return Ok(());
+                }
+                match instance.phase() {
+                    PipelinePhase::Failed(_)
+                    | PipelinePhase::Rejected(_)
+                    | PipelinePhase::Deleted
+                    | PipelinePhase::Stopped => {
+                        return Err(format!(
+                            "pipeline failed to become ready on core {} (generation {})",
+                            deployed_key.core_id, deployed_key.deployment_generation
+                        ));
                     }
-                    match instance.phase() {
-                        PipelinePhase::Failed(_)
-                        | PipelinePhase::Rejected(_)
-                        | PipelinePhase::Deleted
-                        | PipelinePhase::Stopped => {
-                            return Err(format!(
-                                "pipeline failed to become ready on core {} (generation {})",
-                                deployed_key.core_id, deployed_key.deployment_generation
-                            ));
-                        }
-                        _ => {}
-                    }
+                    _ => {}
                 }
             }
 

--- a/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
@@ -459,10 +459,10 @@ where
 {
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
-        if let Some(status) = runtime.observed_state_handle.pipeline_status(pipeline_key) {
-            if predicate(&status) {
-                return status;
-            }
+        if let Some(status) = runtime.observed_state_handle.pipeline_status(pipeline_key)
+            && predicate(&status)
+        {
+            return status;
         }
         assert!(
             Instant::now() < deadline,

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/pretty_metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/pretty_metrics.rs
@@ -454,10 +454,10 @@ fn write_optional_f64(w: &mut MetricsWriter<'_>, name: &str, value: Option<f64>)
 }
 
 fn write_average(writer: &mut MetricsWriter<'_>, sum: Option<f64>, count: u64) -> io::Result<()> {
-    if count > 0 {
-        if let Some(sum) = sum {
-            write!(writer, " avg={}", sum / count as f64)?;
-        }
+    if count > 0
+        && let Some(sum) = sum
+    {
+        write!(writer, " avg={}", sum / count as f64)?;
     }
     Ok(())
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
@@ -1742,10 +1742,10 @@ mod tests {
 
             let interceptor =
                 move |req: tonic::Request<()>| -> Result<tonic::Request<()>, tonic::Status> {
-                    if let Some(value) = req.metadata().get("authorization") {
-                        if let Ok(value) = value.to_str() {
-                            *captured_auth_srv.lock().unwrap() = Some(value.to_string());
-                        }
+                    if let Some(value) = req.metadata().get("authorization")
+                        && let Ok(value) = value.to_str()
+                    {
+                        *captured_auth_srv.lock().unwrap() = Some(value.to_string());
                     }
                     Ok(req)
                 };

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
@@ -486,19 +486,19 @@ impl Exporter<OtapPdata> for OTLPExporter {
                     // force-drains buffered pdata even while auth is pending: with no
                     // usable token we cannot send, so NACK it as retryable -- a token
                     // may yet arrive, so nothing is dropped.
-                    if let Some(a) = auth.as_ref() {
-                        if !a.is_ready() {
-                            let reason = a.not_ready_reason();
-                            nack_without_usable_token(
-                                pdata,
-                                reason,
-                                export_started_at,
-                                &effect_handler,
-                                &mut self.metrics,
-                            )
-                            .await;
-                            continue;
-                        }
+                    if let Some(a) = auth.as_ref()
+                        && !a.is_ready()
+                    {
+                        let reason = a.not_ready_reason();
+                        nack_without_usable_token(
+                            pdata,
+                            reason,
+                            export_started_at,
+                            &effect_handler,
+                            &mut self.metrics,
+                        )
+                        .await;
+                        continue;
                     }
 
                     let signal_type = pdata.signal_type();

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
@@ -459,22 +459,20 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                     // force-drains buffered pdata even while auth was pending: with no
                     // usable token we cannot send, so NACK it as retryable -- a token
                     // may yet arrive, so nothing is dropped.
-                    if let Some(a) = auth.as_ref() {
-                        if !a.is_ready() {
-                            let export_duration = export_started_at.elapsed();
-                            // `NackMsg::new` is retryable by construction.
-                            let nack = NackMsg::new(
-                                a.not_ready_reason(),
-                                OtapPdata::new(context, payload),
-                            );
-                            _ = effect_handler.notify_nack(nack).await;
-                            self.metrics.record_failure(
-                                signal_type,
-                                OtlpHttpExporterErrorType::Authentication,
-                                export_duration,
-                            );
-                            continue;
-                        }
+                    if let Some(a) = auth.as_ref()
+                        && !a.is_ready()
+                    {
+                        let export_duration = export_started_at.elapsed();
+                        // `NackMsg::new` is retryable by construction.
+                        let nack =
+                            NackMsg::new(a.not_ready_reason(), OtapPdata::new(context, payload));
+                        _ = effect_handler.notify_nack(nack).await;
+                        self.metrics.record_failure(
+                            signal_type,
+                            OtlpHttpExporterErrorType::Authentication,
+                            export_duration,
+                        );
+                        continue;
                     }
 
                     // The cached bearer header, together with the generation of the

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
@@ -163,10 +163,10 @@ impl ParquetExporter {
             snapshots.extend(metrics.terminal_snapshots());
         }
 
-        if let Some(metrics) = &io_metrics {
-            if metrics.needs_flush() {
-                snapshots.push(metrics.snapshot());
-            }
+        if let Some(metrics) = &io_metrics
+            && metrics.needs_flush()
+        {
+            snapshots.push(metrics.snapshot());
         }
 
         TerminalState::new(deadline, snapshots)

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/topic_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/topic_exporter/mod.rs
@@ -417,8 +417,9 @@ impl Exporter<OtapPdata> for TopicExporter {
                         biased;
 
                         maybe_outcome = pending_outcomes.next(), if !pending_outcomes.is_empty() => {
-                            if let Some((message_id, outcome)) = maybe_outcome {
-                                if let Some(data) = pending_messages.remove(&message_id) {
+                            if let Some((message_id, outcome)) = maybe_outcome
+                                && let Some(data) = pending_messages.remove(&message_id)
+                            {
                                     match outcome {
                                         TrackedPublishOutcome::Ack => {
                                             metrics.end_to_end_acks.add(1);
@@ -447,7 +448,6 @@ impl Exporter<OtapPdata> for TopicExporter {
                                                 .await?;
                                         }
                                     }
-                                }
                             }
                         }
 
@@ -510,8 +510,9 @@ impl Exporter<OtapPdata> for TopicExporter {
                         biased;
 
                         maybe_outcome = pending_outcomes.next(), if !pending_outcomes.is_empty() => {
-                            if let Some((message_id, outcome)) = maybe_outcome {
-                                if let Some(data) = pending_messages.remove(&message_id) {
+                            if let Some((message_id, outcome)) = maybe_outcome
+                                && let Some(data) = pending_messages.remove(&message_id)
+                            {
                                     match outcome {
                                         TrackedPublishOutcome::Ack => {
                                             metrics.end_to_end_acks.add(1);
@@ -540,7 +541,6 @@ impl Exporter<OtapPdata> for TopicExporter {
                                                 .await?;
                                         }
                                     }
-                                }
                             }
                         }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -427,15 +427,15 @@ impl FormatConfig {
         }
 
         // If both sizes are set, check max_size is >= the min_size.
-        if let (Some(max_size), Some(min_size)) = (self.max_size, self.min_size) {
-            if max_size < min_size {
-                return Err(ConfigError::InvalidUserConfig {
-                    error: format!(
-                        "max_size ({}) must be >= min_size ({}) or unset",
-                        max_size, min_size,
-                    ),
-                });
-            }
+        if let (Some(max_size), Some(min_size)) = (self.max_size, self.min_size)
+            && max_size < min_size
+        {
+            return Err(ConfigError::InvalidUserConfig {
+                error: format!(
+                    "max_size ({}) must be >= min_size ({}) or unset",
+                    max_size, min_size,
+                ),
+            });
         }
 
         // immediate_flush indicates there is not a time-based flush criteria, which

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/content_router/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/content_router/mod.rs
@@ -287,12 +287,12 @@ impl ContentRouterConfig {
                 });
             }
         }
-        if let Some(ref default) = self.default_output {
-            if default.trim().is_empty() {
-                return Err(ConfigError::InvalidUserConfig {
-                    error: "default_output must not be empty when specified".to_string(),
-                });
-            }
+        if let Some(ref default) = self.default_output
+            && default.trim().is_empty()
+        {
+            return Err(ConfigError::InvalidUserConfig {
+                error: "default_output must not be empty when specified".to_string(),
+            });
         }
         // Detect case-insensitive key collisions
         if !self.case_sensitive {
@@ -318,18 +318,17 @@ impl ContentRouterConfig {
                     });
                 }
             }
-            if let Some(ref default) = self.default_output {
-                if !declared_outputs
+            if let Some(ref default) = self.default_output
+                && !declared_outputs
                     .iter()
                     .any(|o| o.as_ref() == default.as_str())
-                {
-                    return Err(ConfigError::InvalidUserConfig {
-                        error: format!(
-                            "default_output '{}' references undeclared output port",
-                            default
-                        ),
-                    });
-                }
+            {
+                return Err(ConfigError::InvalidUserConfig {
+                    error: format!(
+                        "default_output '{}' references undeclared output port",
+                        default
+                    ),
+                });
             }
         }
         Ok(())

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/debug_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/debug_processor/mod.rs
@@ -898,12 +898,11 @@ mod tests {
                         .any(|(k, v)| *k == "signal" && v.eq_ignore_ascii_case("logs"));
                     if has_logs_signal {
                         for (field, value) in iter {
-                            if field.name == "consumed.events" {
-                                if let otel_arrow_dfe_telemetry::metrics::MetricValue::U64(c) =
+                            if field.name == "consumed.events"
+                                && let otel_arrow_dfe_telemetry::metrics::MetricValue::U64(c) =
                                     value
-                                {
-                                    expected_log_events = *c;
-                                }
+                            {
+                                expected_log_events = *c;
                             }
                         }
                     }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/bundle_adapter.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/durable_buffer_processor/bundle_adapter.rs
@@ -352,10 +352,10 @@ impl RecordBundle for OtapRecordBundleAdapter {
         let payload_type = slot_to_payload_type(slot)?;
 
         // For signal-specific slots, verify the signal type matches
-        if let Some((signal_type, _)) = from_slot_id(slot) {
-            if signal_type != self.signal_type {
-                return None;
-            }
+        if let Some((signal_type, _)) = from_slot_id(slot)
+            && signal_type != self.signal_type
+        {
+            return None;
         }
         // Shared slots (RESOURCE_ATTRS, SCOPE_ATTRS) are allowed for any signal type
 
@@ -702,12 +702,12 @@ where
                 .map_err(|e| BundleConversionError::RecordBatchCreationError(e.to_string()))?;
         }
         // Also include shared slots (RESOURCE_ATTRS, SCOPE_ATTRS)
-        else if let Some(payload_type) = slot_to_payload_type(*slot_id) {
-            if is_shared_slot(*slot_id) {
-                store
-                    .set(payload_type, batch.clone())
-                    .map_err(|e| BundleConversionError::RecordBatchCreationError(e.to_string()))?;
-            }
+        else if let Some(payload_type) = slot_to_payload_type(*slot_id)
+            && is_shared_slot(*slot_id)
+        {
+            store
+                .set(payload_type, batch.clone())
+                .map_err(|e| BundleConversionError::RecordBatchCreationError(e.to_string()))?;
         }
     }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/fanout_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/fanout_processor/mod.rs
@@ -149,10 +149,10 @@ impl FanoutConfig {
         }
 
         // Default primary to the first destination if none set.
-        if !self.destinations.iter().any(|d| d.primary) {
-            if let Some(first) = self.destinations.first_mut() {
-                first.primary = true;
-            }
+        if !self.destinations.iter().any(|d| d.primary)
+            && let Some(first) = self.destinations.first_mut()
+        {
+            first.primary = true;
         }
 
         let mut primary_seen = false;
@@ -244,18 +244,18 @@ impl FanoutConfig {
         // Reject ambiguous configs where multiple destinations declare fallback_for the same port.
         let mut fallback_for_dest = vec![None; self.destinations.len()];
         for (fb_idx, fb_dest) in self.destinations.iter().enumerate() {
-            if let Some(fb_for_port) = &fb_dest.fallback_for {
-                if let Some(&origin_idx) = port_index.get(fb_for_port) {
-                    if fallback_for_dest[origin_idx].is_some() {
-                        return Err(ConfigError::InvalidUserConfig {
-                            error: format!(
-                                "fanout: multiple fallbacks declared for port `{}`",
-                                fb_for_port
-                            ),
-                        });
-                    }
-                    fallback_for_dest[origin_idx] = Some(fb_idx);
+            if let Some(fb_for_port) = &fb_dest.fallback_for
+                && let Some(&origin_idx) = port_index.get(fb_for_port)
+            {
+                if fallback_for_dest[origin_idx].is_some() {
+                    return Err(ConfigError::InvalidUserConfig {
+                        error: format!(
+                            "fanout: multiple fallbacks declared for port `{}`",
+                            fb_for_port
+                        ),
+                    });
                 }
+                fallback_for_dest[origin_idx] = Some(fb_idx);
             }
         }
 
@@ -633,25 +633,25 @@ impl FanoutProcessor {
         };
 
         // Trigger fallback if configured (O(1) lookup via precomputed map).
-        if let Some(fb_idx) = self.config.fallback_for_dest[dest_index] {
-            if inflight.destinations[fb_idx].status == DestinationStatus::PendingSend {
-                inflight.destinations[fb_idx].status = DestinationStatus::InFlight;
-                let timeout_at = self.config.destinations[fb_idx].timeout.map(|d| now() + d);
-                inflight.destinations[fb_idx].timeout_at = timeout_at;
-                // Push fallback deadline to the heap if timeout is configured.
-                if let Some(at) = timeout_at {
-                    self.deadline_heap.push(Reverse(Deadline {
-                        at,
-                        request_id,
-                        dest_index: fb_idx,
-                    }));
-                }
-                if matches!(inflight.mode, DeliveryMode::Sequential) {
-                    inflight.next_send_queue.clear();
-                    inflight.next_send_queue.push(fb_idx);
-                }
-                return None;
+        if let Some(fb_idx) = self.config.fallback_for_dest[dest_index]
+            && inflight.destinations[fb_idx].status == DestinationStatus::PendingSend
+        {
+            inflight.destinations[fb_idx].status = DestinationStatus::InFlight;
+            let timeout_at = self.config.destinations[fb_idx].timeout.map(|d| now() + d);
+            inflight.destinations[fb_idx].timeout_at = timeout_at;
+            // Push fallback deadline to the heap if timeout is configured.
+            if let Some(at) = timeout_at {
+                self.deadline_heap.push(Reverse(Deadline {
+                    at,
+                    request_id,
+                    dest_index: fb_idx,
+                }));
             }
+            if matches!(inflight.mode, DeliveryMode::Sequential) {
+                inflight.next_send_queue.clear();
+                inflight.next_send_queue.push(fb_idx);
+            }
+            return None;
         }
 
         // No fallback, produce a nack using original pdata for correct upstream routing.
@@ -791,8 +791,8 @@ impl FanoutProcessor {
             if matches!(inflight.mode, DeliveryMode::Sequential) {
                 inflight.next_send_queue.retain(|idx| *idx != dest_index);
                 // Advance to the next pending send for this request (skip Skipped destinations).
-                if inflight.next_send_queue.is_empty() {
-                    if let Some(next_idx) = inflight
+                if inflight.next_send_queue.is_empty()
+                    && let Some(next_idx) = inflight
                         .destinations
                         .iter()
                         .enumerate()
@@ -800,10 +800,9 @@ impl FanoutProcessor {
                             dest.status == DestinationStatus::PendingSend && dest.payload.is_some()
                         })
                         .map(|(idx, _)| idx)
-                    {
-                        inflight.destinations[next_idx].status = DestinationStatus::InFlight;
-                        inflight.next_send_queue.push(next_idx);
-                    }
+                {
+                    inflight.destinations[next_idx].status = DestinationStatus::InFlight;
+                    inflight.next_send_queue.push(next_idx);
                 }
             }
             (origin, inflight.await_ack, inflight.primary, inflight.mode)
@@ -827,19 +826,19 @@ impl FanoutProcessor {
             return Ok(());
         }
 
-        if matches!(mode, DeliveryMode::Sequential) {
-            if let Some(inflight) = self.inflight.get_mut(&request_id) {
-                let deadlines = Self::dispatch_ready(
-                    request_id,
-                    inflight,
-                    &self.config.destinations,
-                    effect_handler,
-                )
-                .await
-                .map_err(|error| *error)?;
-                for d in deadlines {
-                    self.deadline_heap.push(Reverse(d));
-                }
+        if matches!(mode, DeliveryMode::Sequential)
+            && let Some(inflight) = self.inflight.get_mut(&request_id)
+        {
+            let deadlines = Self::dispatch_ready(
+                request_id,
+                inflight,
+                &self.config.destinations,
+                effect_handler,
+            )
+            .await
+            .map_err(|error| *error)?;
+            for d in deadlines {
+                self.deadline_heap.push(Reverse(d));
             }
         }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/signal_type_router/mod.rs
@@ -274,10 +274,8 @@ impl SignalTypeRouter {
             }
         }
 
-        if default_reachable {
-            if let Some(default_port) = effect_handler.default_port() {
-                let _ = candidates.insert(default_port.clone());
-            }
+        if default_reachable && let Some(default_port) = effect_handler.default_port() {
+            let _ = candidates.insert(default_port.clone());
         }
 
         self.admission.observe_pause_candidate_ports(candidates);

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
@@ -1485,10 +1485,10 @@ fn has_aggregatable_metrics<V: MetricsView>(view: &V) -> bool {
     for resource_metrics in view.resources() {
         for scope_metrics in resource_metrics.scopes() {
             for metric in scope_metrics.metrics() {
-                if let Some(data) = metric.data() {
-                    if is_data_aggregatable(&data) {
-                        return true;
-                    }
+                if let Some(data) = metric.data()
+                    && is_data_aggregatable(&data)
+                {
+                    return true;
                 }
             }
         }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/temporal_reaggregation_processor/mod.rs
@@ -3941,20 +3941,20 @@ mod tests {
                 let mut match_reason = true;
                 let mut match_error = true;
 
-                if let Some(o) = outcome {
-                    if s.measurement_attribute_value("outcome") != Some(o) {
-                        match_outcome = false;
-                    }
+                if let Some(o) = outcome
+                    && s.measurement_attribute_value("outcome") != Some(o)
+                {
+                    match_outcome = false;
                 }
-                if let Some(r) = reason {
-                    if s.measurement_attribute_value("reason") != Some(r) {
-                        match_reason = false;
-                    }
+                if let Some(r) = reason
+                    && s.measurement_attribute_value("reason") != Some(r)
+                {
+                    match_reason = false;
                 }
-                if let Some(e) = error_type {
-                    if s.measurement_attribute_value("error.type") != Some(e) {
-                        match_error = false;
-                    }
+                if let Some(e) = error_type
+                    && s.measurement_attribute_value("error.type") != Some(e)
+                {
+                    match_error = false;
                 }
 
                 if match_outcome && match_reason && match_error {

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
@@ -635,16 +635,16 @@ fn worker_loop_inner(
                     .filter(|remaining| !remaining.is_zero())
                     .map(|remaining| remaining.min(config.wait_timeout))
             };
-            if let Some(timeout) = read_timeout {
-                if let Some(entry) = reader.next_entry_with_wait_timeout(timeout)? {
-                    if builder.len() == 0 {
-                        first_cursor = entry.cursor.clone();
-                        first_record_at = StdInstant::now();
-                    }
-                    dropped_fields = dropped_fields.saturating_add(entry.dropped_fields);
-                    builder.append(&entry);
-                    last_cursor = entry.cursor;
+            if let Some(timeout) = read_timeout
+                && let Some(entry) = reader.next_entry_with_wait_timeout(timeout)?
+            {
+                if builder.len() == 0 {
+                    first_cursor = entry.cursor.clone();
+                    first_record_at = StdInstant::now();
                 }
+                dropped_fields = dropped_fields.saturating_add(entry.dropped_fields);
+                builder.append(&entry);
+                last_cursor = entry.cursor;
             }
         }
 
@@ -799,11 +799,11 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                                 continue;
                             };
                             if let Some(effect) = apply_pending_ack(&mut pending, batch_id) {
-                                if let Some(metrics) = metrics.as_mut() {
-                                    if effect.record_ack {
+                                if let Some(metrics) = metrics.as_mut()
+                                    && effect.record_ack
+                                {
                                         metrics.acks.add(1);
                                     }
-                                }
                                 if let Some(command) = effect.command {
                                     send_worker_command(&worker.cmd_tx, command, &effect_handler).await?;
                                 }
@@ -1105,12 +1105,12 @@ impl local::Receiver<OtapPdata> for JournaldReceiver {
                         Some(WorkerEvent::Stopped) | None => {
                             drop(event_rx);
                             join_worker(worker, &effect_handler).await?;
-                            if let Some(deadline) = drain_deadline {
-                                if pending.is_empty() {
+                            if let Some(deadline) = drain_deadline
+                                && pending.is_empty()
+                            {
                                     effect_handler.notify_receiver_drained().await?;
                                     return Ok(terminal_state(deadline, &metrics));
                                 }
-                            }
                             return Err(terminal_error(&effect_handler, "journald worker stopped unexpectedly"));
                         }
                     }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/mod.rs
@@ -272,18 +272,18 @@ impl OTLPReceiver {
         // - Same port with either IP being unspecified (0.0.0.0 or ::), since unspecified binds all interfaces
         // - Same port with identical specific IPs
         // Different specific IPs on the same port are allowed (different network interfaces).
-        if let (Some(grpc), Some(http)) = (&config.protocols.grpc, &config.protocols.http) {
-            if grpc.listening_addr.port() == http.listening_addr.port() {
-                let g_ip = grpc.listening_addr.ip();
-                let h_ip = http.listening_addr.ip();
-                if g_ip.is_unspecified() || h_ip.is_unspecified() || g_ip == h_ip {
-                    return Err(otel_arrow_dfe_config::error::Error::InvalidUserConfig {
-                        error: format!(
-                            "gRPC and HTTP protocols have conflicting listening addresses ({} and {})",
-                            grpc.listening_addr, http.listening_addr
-                        ),
-                    });
-                }
+        if let (Some(grpc), Some(http)) = (&config.protocols.grpc, &config.protocols.http)
+            && grpc.listening_addr.port() == http.listening_addr.port()
+        {
+            let g_ip = grpc.listening_addr.ip();
+            let h_ip = http.listening_addr.ip();
+            if g_ip.is_unspecified() || h_ip.is_unspecified() || g_ip == h_ip {
+                return Err(otel_arrow_dfe_config::error::Error::InvalidUserConfig {
+                    error: format!(
+                        "gRPC and HTTP protocols have conflicting listening addresses ({} and {})",
+                        grpc.listening_addr, http.listening_addr
+                    ),
+                });
             }
         }
 
@@ -857,22 +857,24 @@ impl OTLPReceiver {
         // Ensure HTTP shutdown is triggered and wait for it to complete.
         http_shutdown.cancel();
 
-        if grpc_enabled && !grpc_task_done {
-            if let Err(error) = grpc_fut.await {
-                self.metrics
-                    .lock()
-                    .record_transport_error(OtlpProtocol::Grpc);
-                return Err(self.map_transport_error(effect_handler, error));
-            }
+        if grpc_enabled
+            && !grpc_task_done
+            && let Err(error) = grpc_fut.await
+        {
+            self.metrics
+                .lock()
+                .record_transport_error(OtlpProtocol::Grpc);
+            return Err(self.map_transport_error(effect_handler, error));
         }
 
-        if http_enabled && !http_task_done {
-            if let Err(error) = http_fut.await {
-                self.metrics
-                    .lock()
-                    .record_transport_error(OtlpProtocol::Http);
-                return Err(self.map_transport_error(effect_handler, error));
-            }
+        if http_enabled
+            && !http_task_done
+            && let Err(error) = http_fut.await
+        {
+            self.metrics
+                .lock()
+                .record_transport_error(OtlpProtocol::Http);
+            return Err(self.map_transport_error(effect_handler, error));
         }
 
         Ok(TerminalState::new(

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/parser/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/parser/mod.rs
@@ -49,10 +49,10 @@ pub(crate) fn parse(input: &[u8]) -> Result<ParsedSyslogMessage<'_>, ParseError>
     }
 
     // Try pure CEF first - it's the simplest check
-    if input.starts_with(b"CEF:") {
-        if let Ok(cef_msg) = parse_cef(input) {
-            return Ok(ParsedSyslogMessage::Cef(cef_msg));
-        }
+    if input.starts_with(b"CEF:")
+        && let Ok(cef_msg) = parse_cef(input)
+    {
+        return Ok(ParsedSyslogMessage::Cef(cef_msg));
     }
 
     // Parse priority once -- both RFC 5424 and RFC 3164 start with <priority>.
@@ -62,12 +62,11 @@ pub(crate) fn parse(input: &[u8]) -> Result<ParsedSyslogMessage<'_>, ParseError>
             // Try RFC 5424 first (has version number after priority)
             if let Ok(rfc5424_msg) = parse_rfc5424(priority.clone(), remaining, input) {
                 // Check if the message contains CEF
-                if let Some(msg) = rfc5424_msg.message {
-                    if msg.starts_with(b"CEF:") {
-                        if let Ok(cef_msg) = parse_cef(msg) {
-                            return Ok(ParsedSyslogMessage::CefWithRfc5424(rfc5424_msg, cef_msg));
-                        }
-                    }
+                if let Some(msg) = rfc5424_msg.message
+                    && msg.starts_with(b"CEF:")
+                    && let Ok(cef_msg) = parse_cef(msg)
+                {
+                    return Ok(ParsedSyslogMessage::CefWithRfc5424(rfc5424_msg, cef_msg));
                 }
                 return Ok(ParsedSyslogMessage::Rfc5424(rfc5424_msg));
             }
@@ -99,12 +98,11 @@ fn try_rfc3164_cef<'a>(
     input: &'a [u8],
 ) -> Result<ParsedSyslogMessage<'a>, ParseError> {
     // Check if the content contains CEF
-    if let Some(content) = rfc3164_msg.content {
-        if content.starts_with(b"CEF:") {
-            if let Ok(cef_msg) = parse_cef(content) {
-                return Ok(ParsedSyslogMessage::CefWithRfc3164(rfc3164_msg, cef_msg));
-            }
-        }
+    if let Some(content) = rfc3164_msg.content
+        && content.starts_with(b"CEF:")
+        && let Ok(cef_msg) = parse_cef(content)
+    {
+        return Ok(ParsedSyslogMessage::CefWithRfc3164(rfc3164_msg, cef_msg));
     }
 
     // Special case: If tag is "CEF", the full CEF message spans from "CEF:" in the input

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/parser/parsed_message.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/syslog_cef_receiver/parser/parsed_message.rs
@@ -466,14 +466,14 @@ mod tests {
         // For RFC 3164, we expect the current year to be used since it's not specified
         let current_year = Local::now().year();
         let full_timestamp = format!("{current_year} Oct 11 22:14:15");
-        if let Ok(naive_dt) = NaiveDateTime::parse_from_str(&full_timestamp, "%Y %b %d %H:%M:%S") {
-            if let Some(local_dt) = Local.from_local_datetime(&naive_dt).single() {
-                let expected_nanos = local_dt
-                    .with_timezone(&Utc)
-                    .timestamp_nanos_opt()
-                    .unwrap_or(0) as u64;
-                assert_eq!(timestamp_nanos, expected_nanos);
-            }
+        if let Ok(naive_dt) = NaiveDateTime::parse_from_str(&full_timestamp, "%Y %b %d %H:%M:%S")
+            && let Some(local_dt) = Local.from_local_datetime(&naive_dt).single()
+        {
+            let expected_nanos = local_dt
+                .with_timezone(&Utc)
+                .timestamp_nanos_opt()
+                .unwrap_or(0) as u64;
+            assert_eq!(timestamp_nanos, expected_nanos);
         }
     }
 

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/topic_receiver/mod.rs
@@ -271,8 +271,9 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
         let run_result: Result<TerminalState, Error> = async {
             loop {
                 if let Some(deadline) = draining_deadline {
-                    if let Some(pending) = pending_forward.take() {
-                        if let Some(reason) = draining_reason.as_deref() {
+                    if let Some(pending) = pending_forward.take()
+                        && let Some(reason) = draining_reason.as_deref()
+                    {
                             if let Some(message_id) = pending.tracked_message_id {
                                 match subscription.nack(message_id, reason) {
                                     Ok(()) => metrics.bridged_downstream_nacks.add(1),
@@ -300,7 +301,6 @@ impl local::Receiver<OtapPdata> for TopicReceiver {
                                 message = "Topic receiver dropped an unsent topic message while entering ingress drain"
                             );
                         }
-                    }
 
                     if pending_tracked_message_ids.is_empty() {
                         effect_handler.notify_receiver_drained().await?;

--- a/rust/otap-dataflow/crates/ctl/src/ui/app/helpers.rs
+++ b/rust/otap-dataflow/crates/ctl/src/ui/app/helpers.rs
@@ -159,10 +159,10 @@ where
     if items.is_empty() {
         return None;
     }
-    if let Some(selected) = selected {
-        if items.iter().any(|item| map(item) == selected) {
-            return Some(selected);
-        }
+    if let Some(selected) = selected
+        && items.iter().any(|item| map(item) == selected)
+    {
+        return Some(selected);
     }
     Some(map(&items[0]))
 }

--- a/rust/otap-dataflow/crates/ctl/src/ui/input.rs
+++ b/rust/otap-dataflow/crates/ctl/src/ui/input.rs
@@ -275,14 +275,15 @@ pub(super) fn handle_key_event(key: KeyEvent, app: &mut AppState) -> EventOutcom
             EventOutcome::Refresh
         }
         KeyCode::Enter => {
-            if app.view == View::Engine && app.focus == FocusArea::List {
-                if let Some((group_id, pipeline_id)) = app.selected_engine_pipeline_target() {
-                    app.view = View::Pipelines;
-                    app.pipeline_selected = Some(format!("{group_id}:{pipeline_id}"));
-                    app.focus = FocusArea::Detail;
-                    app.reset_scroll();
-                    return EventOutcome::Refresh;
-                }
+            if app.view == View::Engine
+                && app.focus == FocusArea::List
+                && let Some((group_id, pipeline_id)) = app.selected_engine_pipeline_target()
+            {
+                app.view = View::Pipelines;
+                app.pipeline_selected = Some(format!("{group_id}:{pipeline_id}"));
+                app.focus = FocusArea::Detail;
+                app.reset_scroll();
+                return EventOutcome::Refresh;
             }
             app.focus = FocusArea::Detail;
             app.reset_scroll();

--- a/rust/otap-dataflow/crates/ctl/src/ui/refresh.rs
+++ b/rust/otap-dataflow/crates/ctl/src/ui/refresh.rs
@@ -38,27 +38,27 @@ pub(crate) fn build_command_context(
         prefix_args.push("--connect-timeout".to_string());
         prefix_args.push(format_duration(settings.connect_timeout).to_string());
     }
-    if settings.timeout != defaults.timeout {
-        if let Some(timeout) = settings.timeout {
-            prefix_args.push("--request-timeout".to_string());
-            prefix_args.push(format_duration(timeout).to_string());
-        }
+    if settings.timeout != defaults.timeout
+        && let Some(timeout) = settings.timeout
+    {
+        prefix_args.push("--request-timeout".to_string());
+        prefix_args.push(format_duration(timeout).to_string());
     }
     if settings.tcp_nodelay != defaults.tcp_nodelay {
         prefix_args.push("--tcp-nodelay".to_string());
         prefix_args.push(settings.tcp_nodelay.to_string());
     }
-    if settings.tcp_keepalive != defaults.tcp_keepalive {
-        if let Some(keepalive) = settings.tcp_keepalive {
-            prefix_args.push("--tcp-keepalive".to_string());
-            prefix_args.push(format_duration(keepalive).to_string());
-        }
+    if settings.tcp_keepalive != defaults.tcp_keepalive
+        && let Some(keepalive) = settings.tcp_keepalive
+    {
+        prefix_args.push("--tcp-keepalive".to_string());
+        prefix_args.push(format_duration(keepalive).to_string());
     }
-    if settings.tcp_keepalive_interval != defaults.tcp_keepalive_interval {
-        if let Some(interval) = settings.tcp_keepalive_interval {
-            prefix_args.push("--tcp-keepalive-interval".to_string());
-            prefix_args.push(format_duration(interval).to_string());
-        }
+    if settings.tcp_keepalive_interval != defaults.tcp_keepalive_interval
+        && let Some(interval) = settings.tcp_keepalive_interval
+    {
+        prefix_args.push("--tcp-keepalive-interval".to_string());
+        prefix_args.push(format_duration(interval).to_string());
     }
     if let Some(tls) = &settings.tls {
         if let Some(path) = &tls.ca_file {

--- a/rust/otap-dataflow/crates/ctl/src/ui/view/theme.rs
+++ b/rust/otap-dataflow/crates/ctl/src/ui/view/theme.rs
@@ -397,17 +397,17 @@ pub(super) fn build_detail_header_line(app: &AppState, header: &DetailHeader) ->
         ));
     }
 
-    if let Some(subtitle) = header.subtitle.as_deref() {
-        if !subtitle.is_empty() {
-            spans.push(Span::styled(
-                TAB_SEPARATOR,
-                separator_style(app.color_enabled),
-            ));
-            spans.push(Span::styled(
-                subtitle.to_string(),
-                muted_style(app.color_enabled),
-            ));
-        }
+    if let Some(subtitle) = header.subtitle.as_deref()
+        && !subtitle.is_empty()
+    {
+        spans.push(Span::styled(
+            TAB_SEPARATOR,
+            separator_style(app.color_enabled),
+        ));
+        spans.push(Span::styled(
+            subtitle.to_string(),
+            muted_style(app.color_enabled),
+        ));
     }
 
     Line::from(spans)

--- a/rust/otap-dataflow/crates/dev-nodes/src/receivers/traffic_generator/synthetic_signal.rs
+++ b/rust/otap-dataflow/crates/dev-nodes/src/receivers/traffic_generator/synthetic_signal.rs
@@ -1270,14 +1270,14 @@ mod tests {
         let logs = static_otlp_logs_with_config(5, Some(1024), None, false, None);
         let records = &logs.resource_logs[0].scope_logs[0].log_records;
         assert_eq!(records.len(), 5);
-        if let Some(body) = &records[0].body {
-            if let Some(ref value) = body.value {
-                match value {
-                    otel_arrow_dfe_pdata::proto::opentelemetry::common::v1::any_value::Value::StringValue(s) => {
-                        assert_eq!(s.len(), 1024);
-                    }
-                    _ => panic!("Expected string body"),
+        if let Some(body) = &records[0].body
+            && let Some(ref value) = body.value
+        {
+            match value {
+                otel_arrow_dfe_pdata::proto::opentelemetry::common::v1::any_value::Value::StringValue(s) => {
+                    assert_eq!(s.len(), 1024);
                 }
+                _ => panic!("Expected string body"),
             }
         }
         // Default attributes (2) should be used

--- a/rust/otap-dataflow/crates/engine-macros/src/component_inventory.rs
+++ b/rust/otap-dataflow/crates/engine-macros/src/component_inventory.rs
@@ -174,10 +174,10 @@ fn inspect_item(item: &Item) -> syn::Result<(Ident, Option<Expr>, Vec<Attribute>
 fn struct_field_expr(expr: &Expr, field: &str) -> Option<Expr> {
     if let Expr::Struct(s) = expr {
         for fv in &s.fields {
-            if let syn::Member::Named(ident) = &fv.member {
-                if ident == field {
-                    return Some(fv.expr.clone());
-                }
+            if let syn::Member::Named(ident) = &fv.member
+                && ident == field
+            {
+                return Some(fv.expr.clone());
             }
         }
     }

--- a/rust/otap-dataflow/crates/engine/src/control.rs
+++ b/rust/otap-dataflow/crates/engine/src/control.rs
@@ -714,10 +714,10 @@ impl<PData> ControlSenders<PData> {
 
         for typed_sender in self.senders.values() {
             // Apply filter if specified
-            if let Some(filter_type) = node_type_filter {
-                if typed_sender.node_type != filter_type {
-                    continue;
-                }
+            if let Some(filter_type) = node_type_filter
+                && typed_sender.node_type != filter_type
+            {
+                continue;
             }
 
             let shutdown_msg = NodeControlMsg::Shutdown {

--- a/rust/otap-dataflow/crates/engine/src/extension/builder.rs
+++ b/rust/otap-dataflow/crates/engine/src/extension/builder.rs
@@ -871,14 +871,14 @@ impl ExtensionBundleBuilder {
     /// (dual registration requires distinct local and shared
     /// implementations).
     pub(super) fn build(self) -> Result<ExtensionBundle, Error> {
-        if let (Some(local), Some(shared)) = (&self.local, &self.shared) {
-            if local.type_id == shared.type_id {
-                return Err(Error::InternalError {
-                    message: "local and shared variants must use different concrete types; \
+        if let (Some(local), Some(shared)) = (&self.local, &self.shared)
+            && local.type_id == shared.type_id
+        {
+            return Err(Error::InternalError {
+                message: "local and shared variants must use different concrete types; \
                               register only one execution model for single-variant extensions"
-                        .into(),
-                });
-            }
+                    .into(),
+            });
         }
 
         let cap = self.runtime_config.control_channel.capacity;
@@ -895,12 +895,12 @@ impl ExtensionBundleBuilder {
             local_signaller,
         } = self;
 
-        if let Some(probe) = local_probe.as_ref().or(shared_probe.as_ref()) {
-            if probe.timeout().is_zero() {
-                return Err(Error::ExtensionReadinessZeroTimeout {
-                    extension: name.as_ref().to_owned(),
-                });
-            }
+        if let Some(probe) = local_probe.as_ref().or(shared_probe.as_ref())
+            && probe.timeout().is_zero()
+        {
+            return Err(Error::ExtensionReadinessZeroTimeout {
+                extension: name.as_ref().to_owned(),
+            });
         }
 
         debug_assert!(

--- a/rust/otap-dataflow/crates/engine/src/lib.rs
+++ b/rust/otap-dataflow/crates/engine/src/lib.rs
@@ -992,10 +992,10 @@ impl<PData: 'static + Clone + Debug> PipelineFactory<PData> {
                 otel_arrow_dfe_config::node::NodeKind::Receiver => {
                     // Inject internal telemetry settings into context if this is the ITR node.
                     // The ITR factory will extract these settings during construction.
-                    if node_config.r#type.as_ref() == INTERNAL_TELEMETRY_RECEIVER_URN {
-                        if let Some(ref settings) = internal_telemetry {
-                            base_ctx.set_internal_telemetry(settings.clone());
-                        }
+                    if node_config.r#type.as_ref() == INTERNAL_TELEMETRY_RECEIVER_URN
+                        && let Some(ref settings) = internal_telemetry
+                    {
+                        base_ctx.set_internal_telemetry(settings.clone());
                     }
 
                     let wrapper = self.build_node_wrapper(

--- a/rust/otap-dataflow/crates/engine/src/local/message.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/message.rs
@@ -130,16 +130,16 @@ impl<T> LocalSender<T> {
         {
             queue_depth.record_send();
         }
-        if let Some(metrics) = &self.metrics {
-            if let Ok(mut metrics) = metrics.try_borrow_mut() {
-                match &result {
-                    Ok(()) => metrics.record_send_ok(signal),
-                    Err(SendError::Full(_)) => {
-                        metrics.record_send_error(signal, ChannelSendErrorType::Full);
-                    }
-                    Err(SendError::Closed(_)) => {
-                        metrics.record_send_error(signal, ChannelSendErrorType::Closed);
-                    }
+        if let Some(metrics) = &self.metrics
+            && let Ok(mut metrics) = metrics.try_borrow_mut()
+        {
+            match &result {
+                Ok(()) => metrics.record_send_ok(signal),
+                Err(SendError::Full(_)) => {
+                    metrics.record_send_error(signal, ChannelSendErrorType::Full);
+                }
+                Err(SendError::Closed(_)) => {
+                    metrics.record_send_error(signal, ChannelSendErrorType::Closed);
                 }
             }
         }
@@ -160,16 +160,16 @@ impl<T> LocalSender<T> {
         {
             queue_depth.record_send();
         }
-        if let Some(metrics) = &self.metrics {
-            if let Ok(mut metrics) = metrics.try_borrow_mut() {
-                match &result {
-                    Ok(()) => metrics.record_send_ok(signal),
-                    Err(SendError::Full(_)) => {
-                        metrics.record_send_error(signal, ChannelSendErrorType::Full);
-                    }
-                    Err(SendError::Closed(_)) => {
-                        metrics.record_send_error(signal, ChannelSendErrorType::Closed);
-                    }
+        if let Some(metrics) = &self.metrics
+            && let Ok(mut metrics) = metrics.try_borrow_mut()
+        {
+            match &result {
+                Ok(()) => metrics.record_send_ok(signal),
+                Err(SendError::Full(_)) => {
+                    metrics.record_send_error(signal, ChannelSendErrorType::Full);
+                }
+                Err(SendError::Closed(_)) => {
+                    metrics.record_send_error(signal, ChannelSendErrorType::Closed);
                 }
             }
         }
@@ -283,17 +283,17 @@ impl<T> LocalReceiver<T> {
             LocalReceiverInner::Mpmc(receiver) => receiver.recv().await,
         };
 
-        if result.is_ok() {
-            if let Some(queue_depth) = &self.queue_depth {
-                queue_depth.record_receive();
-            }
+        if result.is_ok()
+            && let Some(queue_depth) = &self.queue_depth
+        {
+            queue_depth.record_receive();
         }
-        if let Some(metrics) = &self.metrics {
-            if let Ok(mut metrics) = metrics.try_borrow_mut() {
-                if let Ok(message) = &result {
-                    metrics.record_recv_ok(self.signal.and_then(|extract| extract(message)));
-                }
-            }
+
+        if let Some(metrics) = &self.metrics
+            && let Ok(mut metrics) = metrics.try_borrow_mut()
+            && let Ok(message) = &result
+        {
+            metrics.record_recv_ok(self.signal.and_then(|extract| extract(message)));
         }
 
         result
@@ -306,17 +306,17 @@ impl<T> LocalReceiver<T> {
             LocalReceiverInner::Mpmc(receiver) => receiver.try_recv(),
         };
 
-        if result.is_ok() {
-            if let Some(queue_depth) = &self.queue_depth {
-                queue_depth.record_receive();
-            }
+        if result.is_ok()
+            && let Some(queue_depth) = &self.queue_depth
+        {
+            queue_depth.record_receive();
         }
-        if let Some(metrics) = &self.metrics {
-            if let Ok(mut metrics) = metrics.try_borrow_mut() {
-                if let Ok(message) = &result {
-                    metrics.record_recv_ok(self.signal.and_then(|extract| extract(message)));
-                }
-            }
+
+        if let Some(metrics) = &self.metrics
+            && let Ok(mut metrics) = metrics.try_borrow_mut()
+            && let Ok(message) = &result
+        {
+            metrics.record_recv_ok(self.signal.and_then(|extract| extract(message)));
         }
 
         result

--- a/rust/otap-dataflow/crates/engine/src/message.rs
+++ b/rust/otap-dataflow/crates/engine/src/message.rs
@@ -416,15 +416,13 @@ where
                     .as_ref()
                     .expect("pdata_rx must exist")
                     .is_empty()
-            {
-                if let Err(RecvError::Closed) = self
+                && let Err(RecvError::Closed) = self
                     .pdata_rx
                     .as_mut()
                     .expect("pdata_rx must exist")
                     .try_recv()
-                {
-                    return Ok(self.closed_pdata_shutdown());
-                }
+            {
+                return Ok(self.closed_pdata_shutdown());
             }
 
             // Draining mode: Shutdown pending

--- a/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
+++ b/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
@@ -434,41 +434,41 @@ impl<PData> RuntimeCtrlMsgManager<PData> {
 
             let now = clock::now();
 
-            if let Some(deadline) = shutdown_deadline {
-                if now >= deadline {
-                    shutdown_deadline_forced = true;
-                    self.runtime_control_metrics
-                        .record_shutdown_deadline_forced(now);
-                    self.event_reporter
-                        .report(EngineEvent::drain_deadline_reached(
-                            self.pipeline_key.clone(),
-                            shutdown_reason.clone(),
-                        ));
-                    if let Some(reason) = shutdown_reason.as_ref() {
-                        for node_id in self.control_senders.non_receiver_ids() {
-                            self.send(
-                                node_id,
-                                NodeControlMsg::Shutdown {
-                                    deadline,
-                                    reason: reason.clone(),
-                                },
-                            );
-                        }
-                        for node_id in pending_receivers.iter().copied() {
-                            self.send(
-                                node_id,
-                                NodeControlMsg::Shutdown {
-                                    deadline,
-                                    reason: reason.clone(),
-                                },
-                            );
-                        }
+            if let Some(deadline) = shutdown_deadline
+                && now >= deadline
+            {
+                shutdown_deadline_forced = true;
+                self.runtime_control_metrics
+                    .record_shutdown_deadline_forced(now);
+                self.event_reporter
+                    .report(EngineEvent::drain_deadline_reached(
+                        self.pipeline_key.clone(),
+                        shutdown_reason.clone(),
+                    ));
+                if let Some(reason) = shutdown_reason.as_ref() {
+                    for node_id in self.control_senders.non_receiver_ids() {
+                        self.send(
+                            node_id,
+                            NodeControlMsg::Shutdown {
+                                deadline,
+                                reason: reason.clone(),
+                            },
+                        );
                     }
-                    // Deadline-forced drain is a major lifecycle boundary; do
-                    // not wait for the periodic flush interval to surface it.
-                    self.report_runtime_control_metrics();
-                    break;
+                    for node_id in pending_receivers.iter().copied() {
+                        self.send(
+                            node_id,
+                            NodeControlMsg::Shutdown {
+                                deadline,
+                                reason: reason.clone(),
+                            },
+                        );
+                    }
                 }
+                // Deadline-forced drain is a major lifecycle boundary; do
+                // not wait for the periodic flush interval to surface it.
+                self.report_runtime_control_metrics();
+                break;
             }
 
             let next_earliest = if is_draining_ingress {
@@ -678,11 +678,11 @@ impl<PData> RuntimeCtrlMsgManager<PData> {
                     }
                 }
                 _ = async {
-                    if let Some(when) = next_earliest {
-                        if when > now {
+                    if let Some(when) = next_earliest
+                        && when > now
+                    {
                             clock::sleep_until(when).await;
                         }
-                    }
                 }, if next_earliest.is_some() => {
                     consecutive_runtime_ctrl = 0;
                     if !is_draining_ingress {
@@ -860,10 +860,10 @@ impl<PData> RuntimeCtrlMsgManager<PData> {
                 }
             }
         }
-        if self.telemetry.runtime_metrics >= MetricLevel::Normal {
-            if let Err(err) = self.report_node_metrics() {
-                otel_warn!("node.metrics.reporting.fail", error = err.to_string());
-            }
+        if self.telemetry.runtime_metrics >= MetricLevel::Normal
+            && let Err(err) = self.report_node_metrics()
+        {
+            otel_warn!("node.metrics.reporting.fail", error = err.to_string());
         }
 
         for (node_id, msg) in to_send {
@@ -1056,77 +1056,77 @@ impl<PData> PipelineCompletionMsgDispatcher<PData> {
     ) {
         let mut handles_guard = self.node_metric_handles.borrow_mut();
         if let Some(Some(handles)) = handles_guard.get_mut(node_id) {
-            if interests.contains(Interests::CONSUMER_METRICS) {
-                if let Some(input) = &mut handles.input {
-                    if let Some(signal) = signal {
-                        let outcome = match outcome {
-                            RequestOutcome::Success => Outcome::Success,
-                            RequestOutcome::Failure => Outcome::Failure,
-                            RequestOutcome::Refused => Outcome::Refused,
-                        };
-                        let input = input.with(SignalOutcomeAttributes { signal, outcome });
-                        input.messages.inc();
-                        if consumed_items > 0
-                            && let Some(input_items) = &mut handles.input_items
-                        {
-                            input_items
-                                .with(SignalOutcomeAttributes { signal, outcome })
-                                .items
-                                .add(consumed_items as u64);
-                        }
-                        if consumed_size > 0
-                            && let Some(input_size) = &mut handles.input_size
-                        {
-                            input_size
-                                .with(SignalOutcomeAttributes { signal, outcome })
-                                .size
-                                .add(consumed_size);
-                        }
-                        if route.entry_time_ns > 0 && now_ns > 0 {
-                            let duration_ns = now_ns.saturating_sub(route.entry_time_ns);
-                            input
-                                .duration
-                                .record(Duration::from_nanos(duration_ns).as_secs_f64());
-                        }
-                    }
+            if interests.contains(Interests::CONSUMER_METRICS)
+                && let Some(input) = &mut handles.input
+                && let Some(signal) = signal
+            {
+                let outcome = match outcome {
+                    RequestOutcome::Success => Outcome::Success,
+                    RequestOutcome::Failure => Outcome::Failure,
+                    RequestOutcome::Refused => Outcome::Refused,
+                };
+                let input = input.with(SignalOutcomeAttributes { signal, outcome });
+                input.messages.inc();
+                if consumed_items > 0
+                    && let Some(input_items) = &mut handles.input_items
+                {
+                    input_items
+                        .with(SignalOutcomeAttributes { signal, outcome })
+                        .items
+                        .add(consumed_items as u64);
+                }
+                if consumed_size > 0
+                    && let Some(input_size) = &mut handles.input_size
+                {
+                    input_size
+                        .with(SignalOutcomeAttributes { signal, outcome })
+                        .size
+                        .add(consumed_size);
+                }
+                if route.entry_time_ns > 0 && now_ns > 0 {
+                    let duration_ns = now_ns.saturating_sub(route.entry_time_ns);
+                    input
+                        .duration
+                        .record(Duration::from_nanos(duration_ns).as_secs_f64());
                 }
             }
+
             if interests.contains(Interests::PRODUCER_METRICS) {
                 let port = route.output_port_index as usize;
-                if let Some(output) = handles.outputs.get_mut(port) {
-                    if let Some(signal) = signal {
-                        let outcome = match outcome {
-                            RequestOutcome::Success => Outcome::Success,
-                            RequestOutcome::Failure => Outcome::Failure,
-                            RequestOutcome::Refused => Outcome::Refused,
-                        };
-                        let output = output.with(SignalOutcomeAttributes { signal, outcome });
-                        output.messages.inc();
-                        if produced_items > 0
-                            && let Some(output_items) = handles.output_items.get_mut(port)
-                        {
-                            output_items
-                                .with(SignalOutcomeAttributes { signal, outcome })
-                                .items
-                                .add(produced_items as u64);
-                        }
-                        if produced_size > 0
-                            && let Some(output_size) = handles.output_size.get_mut(port)
-                        {
-                            output_size
-                                .with(SignalOutcomeAttributes { signal, outcome })
-                                .size
-                                .add(produced_size);
-                        }
-                        if !interests.contains(Interests::CONSUMER_METRICS)
-                            && route.entry_time_ns > 0
-                            && now_ns > 0
-                        {
-                            let duration_ns = now_ns.saturating_sub(route.entry_time_ns);
-                            output
-                                .duration
-                                .record(Duration::from_nanos(duration_ns).as_secs_f64());
-                        }
+                if let Some(output) = handles.outputs.get_mut(port)
+                    && let Some(signal) = signal
+                {
+                    let outcome = match outcome {
+                        RequestOutcome::Success => Outcome::Success,
+                        RequestOutcome::Failure => Outcome::Failure,
+                        RequestOutcome::Refused => Outcome::Refused,
+                    };
+                    let output = output.with(SignalOutcomeAttributes { signal, outcome });
+                    output.messages.inc();
+                    if produced_items > 0
+                        && let Some(output_items) = handles.output_items.get_mut(port)
+                    {
+                        output_items
+                            .with(SignalOutcomeAttributes { signal, outcome })
+                            .items
+                            .add(produced_items as u64);
+                    }
+                    if produced_size > 0
+                        && let Some(output_size) = handles.output_size.get_mut(port)
+                    {
+                        output_size
+                            .with(SignalOutcomeAttributes { signal, outcome })
+                            .size
+                            .add(produced_size);
+                    }
+                    if !interests.contains(Interests::CONSUMER_METRICS)
+                        && route.entry_time_ns > 0
+                        && now_ns > 0
+                    {
+                        let duration_ns = now_ns.saturating_sub(route.entry_time_ns);
+                        output
+                            .duration
+                            .record(Duration::from_nanos(duration_ns).as_secs_f64());
                     }
                 }
             }

--- a/rust/otap-dataflow/crates/engine/src/pipeline_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/pipeline_metrics.rs
@@ -510,31 +510,30 @@ impl PipelineMetricsMonitor {
     pub fn update_pipeline_metrics(&mut self) {
         // === Update thread memory allocation metrics (jemalloc only) ===
         #[cfg(all(not(windows), feature = "jemalloc"))]
-        if self.jemalloc_supported {
-            if let (Some(allocated), Some(deallocated)) =
+        if self.jemalloc_supported
+            && let (Some(allocated), Some(deallocated)) =
                 (self.allocated.as_ref(), self.deallocated.as_ref())
-            {
-                // Fast path: `get()` is just `*ptr` and is #[inline].
-                let cur_alloc = allocated.get();
-                let cur_dealloc = deallocated.get();
+        {
+            // Fast path: `get()` is just `*ptr` and is #[inline].
+            let cur_alloc = allocated.get();
+            let cur_dealloc = deallocated.get();
 
-                // Deltas since last time.
-                // Use wrapping_sub to be robust if jemalloc ever wraps the counters.
-                let delta_alloc = cur_alloc.wrapping_sub(self.last_allocated);
-                let delta_dealloc = cur_dealloc.wrapping_sub(self.last_deallocated);
+            // Deltas since last time.
+            // Use wrapping_sub to be robust if jemalloc ever wraps the counters.
+            let delta_alloc = cur_alloc.wrapping_sub(self.last_allocated);
+            let delta_dealloc = cur_dealloc.wrapping_sub(self.last_deallocated);
 
-                // Update baselines.
-                self.last_allocated = cur_alloc;
-                self.last_deallocated = cur_dealloc;
+            // Update baselines.
+            self.last_allocated = cur_alloc;
+            self.last_deallocated = cur_dealloc;
 
-                self.metrics.memory_allocated.observe(cur_alloc);
-                self.metrics.memory_freed.observe(cur_dealloc);
-                self.metrics.memory_allocated_delta.add(delta_alloc);
-                self.metrics.memory_freed_delta.add(delta_dealloc);
-                self.metrics
-                    .memory_usage
-                    .observe(cur_alloc.saturating_sub(cur_dealloc));
-            }
+            self.metrics.memory_allocated.observe(cur_alloc);
+            self.metrics.memory_freed.observe(cur_dealloc);
+            self.metrics.memory_allocated_delta.add(delta_alloc);
+            self.metrics.memory_freed_delta.add(delta_dealloc);
+            self.metrics
+                .memory_usage
+                .observe(cur_alloc.saturating_sub(cur_dealloc));
         }
 
         // === Update thread scheduling / page-fault metrics (when available) ===

--- a/rust/otap-dataflow/crates/engine/src/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/processor.rs
@@ -703,19 +703,17 @@ impl<PData> ProcessorWrapper<PData> {
                 }
                 // Collect final metrics before exiting
                 let terminal_metrics_deadline = terminal_metrics_deadline.get();
-                if effect_handler.is_flow_start()
+                if (effect_handler.is_flow_start()
                     || effect_handler.is_flow_end()
-                    || effect_handler.is_flow_decision()
-                {
-                    if let Err(error) = effect_handler
+                    || effect_handler.is_flow_decision())
+                    && let Err(error) = effect_handler
                         .report_flow_metrics_reliably(terminal_metrics_deadline)
                         .await
-                    {
-                        otel_arrow_dfe_telemetry::otel_warn!(
-                            "processor.flow_metrics.final_reporting.fail",
-                            error = error.to_string()
-                        );
-                    }
+                {
+                    otel_arrow_dfe_telemetry::otel_warn!(
+                        "processor.flow_metrics.final_reporting.fail",
+                        error = error.to_string()
+                    );
                 }
                 let (terminal_metrics_tx, terminal_metrics_rx) = flume::unbounded();
                 let terminal_metrics_reporter = MetricsReporter::new(terminal_metrics_tx);
@@ -802,19 +800,17 @@ impl<PData> ProcessorWrapper<PData> {
                 }
                 // Collect final metrics before exiting
                 let terminal_metrics_deadline = terminal_metrics_deadline.get();
-                if effect_handler.is_flow_start()
+                if (effect_handler.is_flow_start()
                     || effect_handler.is_flow_end()
-                    || effect_handler.is_flow_decision()
-                {
-                    if let Err(error) = effect_handler
+                    || effect_handler.is_flow_decision())
+                    && let Err(error) = effect_handler
                         .report_flow_metrics_reliably(terminal_metrics_deadline)
                         .await
-                    {
-                        otel_arrow_dfe_telemetry::otel_warn!(
-                            "processor.flow_metrics.final_reporting.fail",
-                            error = error.to_string()
-                        );
-                    }
+                {
+                    otel_arrow_dfe_telemetry::otel_warn!(
+                        "processor.flow_metrics.final_reporting.fail",
+                        error = error.to_string()
+                    );
                 }
                 let (terminal_metrics_tx, terminal_metrics_rx) = flume::unbounded();
                 let terminal_metrics_reporter = MetricsReporter::new(terminal_metrics_tx);

--- a/rust/otap-dataflow/crates/engine/src/shared/message.rs
+++ b/rust/otap-dataflow/crates/engine/src/shared/message.rs
@@ -133,16 +133,16 @@ impl<T> SharedSender<T> {
         {
             queue_depth.record_send();
         }
-        if let Some(metrics) = &self.metrics {
-            if let Ok(mut metrics) = metrics.lock() {
-                match &result {
-                    Ok(()) => metrics.record_send_ok(signal),
-                    Err(SendError::Full(_)) => {
-                        metrics.record_send_error(signal, ChannelSendErrorType::Full);
-                    }
-                    Err(SendError::Closed(_)) => {
-                        metrics.record_send_error(signal, ChannelSendErrorType::Closed);
-                    }
+        if let Some(metrics) = &self.metrics
+            && let Ok(mut metrics) = metrics.lock()
+        {
+            match &result {
+                Ok(()) => metrics.record_send_ok(signal),
+                Err(SendError::Full(_)) => {
+                    metrics.record_send_error(signal, ChannelSendErrorType::Full);
+                }
+                Err(SendError::Closed(_)) => {
+                    metrics.record_send_error(signal, ChannelSendErrorType::Closed);
                 }
             }
         }
@@ -169,16 +169,16 @@ impl<T> SharedSender<T> {
         {
             queue_depth.record_send();
         }
-        if let Some(metrics) = &self.metrics {
-            if let Ok(mut metrics) = metrics.lock() {
-                match &result {
-                    Ok(()) => metrics.record_send_ok(signal),
-                    Err(SendError::Full(_)) => {
-                        metrics.record_send_error(signal, ChannelSendErrorType::Full);
-                    }
-                    Err(SendError::Closed(_)) => {
-                        metrics.record_send_error(signal, ChannelSendErrorType::Closed);
-                    }
+        if let Some(metrics) = &self.metrics
+            && let Ok(mut metrics) = metrics.lock()
+        {
+            match &result {
+                Ok(()) => metrics.record_send_ok(signal),
+                Err(SendError::Full(_)) => {
+                    metrics.record_send_error(signal, ChannelSendErrorType::Full);
+                }
+                Err(SendError::Closed(_)) => {
+                    metrics.record_send_error(signal, ChannelSendErrorType::Closed);
                 }
             }
         }
@@ -299,12 +299,11 @@ impl<T> SharedReceiver<T> {
         {
             queue_depth.record_receive();
         }
-        if let Some(metrics) = &self.metrics {
-            if let Ok(mut metrics) = metrics.lock() {
-                if let Ok(message) = &result {
-                    metrics.record_recv_ok(self.signal.and_then(|extract| extract(message)));
-                }
-            }
+        if let Some(metrics) = &self.metrics
+            && let Ok(mut metrics) = metrics.lock()
+            && let Ok(message) = &result
+        {
+            metrics.record_recv_ok(self.signal.and_then(|extract| extract(message)));
         }
 
         result
@@ -328,12 +327,11 @@ impl<T> SharedReceiver<T> {
         {
             queue_depth.record_receive();
         }
-        if let Some(metrics) = &self.metrics {
-            if let Ok(mut metrics) = metrics.lock() {
-                if let Ok(message) = &result {
-                    metrics.record_recv_ok(self.signal.and_then(|extract| extract(message)));
-                }
-            }
+        if let Some(metrics) = &self.metrics
+            && let Ok(mut metrics) = metrics.lock()
+            && let Ok(message) = &result
+        {
+            metrics.record_recv_ok(self.signal.and_then(|extract| extract(message)));
         }
 
         result

--- a/rust/otap-dataflow/crates/engine/src/testing/dst/heavy_ingress.rs
+++ b/rust/otap-dataflow/crates/engine/src/testing/dst/heavy_ingress.rs
@@ -293,10 +293,10 @@ async fn run_backpressure_interblock_seed(seed: u64) {
                     biased;
 
                     _ = async {
-                        if let Some(when) = next_due {
-                            if when > clock::now() {
-                                clock::sleep_until(when).await;
-                            }
+                        if let Some(when) = next_due
+                            && when > clock::now()
+                        {
+                            clock::sleep_until(when).await;
                         }
                     }, if next_due.is_some() => {
                         let now = clock::now();

--- a/rust/otap-dataflow/crates/engine/tests/extension_e2e.rs
+++ b/rust/otap-dataflow/crates/engine/tests/extension_e2e.rs
@@ -1685,13 +1685,11 @@ impl local_proc::Processor<()> for ProbeProcessor {
                 *slot = Some(Instant::now());
             }
         }
-        if let Message::Control(otel_arrow_dfe_engine::control::NodeControlMsg::Shutdown {
-            ..
-        }) = msg
+        if let Message::Control(otel_arrow_dfe_engine::control::NodeControlMsg::Shutdown { .. }) =
+            msg
+            && let Some(lc) = &self.lifecycle
         {
-            if let Some(lc) = &self.lifecycle {
-                *lc.processor_end_at.lock() = Some(Instant::now());
-            }
+            *lc.processor_end_at.lock() = Some(Instant::now());
         }
         Ok(())
     }

--- a/rust/otap-dataflow/crates/expohisto/src/histogram/mod.rs
+++ b/rust/otap-dataflow/crates/expohisto/src/histogram/mod.rs
@@ -766,10 +766,10 @@ impl<const N: usize> HistogramNN<N> {
         // The common case is a word already inside the active window, which
         // moves nothing. Testing that first keeps the emptiness check, and the
         // load it makes, off the recording path.
-        if word_index < self.word_start || word_index > self.word_end {
-            if let Some(blocked) = self.open_word(word_index) {
-                return blocked;
-            }
+        if (word_index < self.word_start || word_index > self.word_end)
+            && let Some(blocked) = self.open_word(word_index)
+        {
+            return blocked;
         }
 
         if let Err(oflow) = self.bucket_try_increment(&addr, incr) {

--- a/rust/otap-dataflow/crates/otap/src/accessory/context/split_contexts.rs
+++ b/rust/otap-dataflow/crates/otap/src/accessory/context/split_contexts.rs
@@ -187,10 +187,10 @@ impl Contexts {
     /// this outbound key. This should be set to `false` when any outbound succeeds (is ACk'd) or
     /// is Nack'd with a permanent error.
     pub fn set_outbound_all_transient_errors(&mut self, outbound_key: Key, value: bool) {
-        if let Some(inbound_key) = self.outbound.get(outbound_key).map(|o| o.inbound_key) {
-            if let Some(inbound) = self.inbound.get_mut(inbound_key) {
-                inbound.outbound_all_transient_errors = value
-            }
+        if let Some(inbound_key) = self.outbound.get(outbound_key).map(|o| o.inbound_key)
+            && let Some(inbound) = self.inbound.get_mut(inbound_key)
+        {
+            inbound.outbound_all_transient_errors = value
         }
     }
 }

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc.rs
@@ -429,10 +429,10 @@ async fn handle_stream<T, F>(
         }
 
         while pending.len() >= max_pending {
-            if let Some(response) = pending.next().await {
-                if send_pending_response(response, &tx).await.is_err() {
-                    return;
-                }
+            if let Some(response) = pending.next().await
+                && send_pending_response(response, &tx).await.is_err()
+            {
+                return;
             }
         }
 

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/client_settings.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/client_settings.rs
@@ -235,13 +235,14 @@ fn validate_grpc_endpoint(endpoint: &str) -> Result<(), String> {
         .map_err(|e| format!("invalid grpc_endpoint \"{trimmed}\": {e}"))?;
 
     // Reject unsupported schemes.
-    if let Some(scheme) = uri.scheme_str() {
-        if scheme != "http" && scheme != "https" {
-            return Err(format!(
-                "unsupported scheme \"{scheme}\" in grpc_endpoint \"{trimmed}\"; \
+    if let Some(scheme) = uri.scheme_str()
+        && scheme != "http"
+        && scheme != "https"
+    {
+        return Err(format!(
+            "unsupported scheme \"{scheme}\" in grpc_endpoint \"{trimmed}\"; \
                  expected \"http\" or \"https\""
-            ));
-        }
+        ));
     }
 
     Ok(())

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/proxy.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/proxy.rs
@@ -73,12 +73,12 @@ impl SensitiveUrl {
 
         // Redact credentials in the authority if present.
         // This intentionally mirrors the existing behavior of `ProxyConfig`'s logging.
-        if let Ok(uri) = url.parse::<Uri>() {
-            if let Some(authority) = uri.authority() {
-                let auth_str = authority.as_str();
-                if let Some((_, host)) = auth_str.rsplit_once('@') {
-                    return Cow::Owned(url.replace(auth_str, &format!("[REDACTED]@{host}")));
-                }
+        if let Ok(uri) = url.parse::<Uri>()
+            && let Some(authority) = uri.authority()
+        {
+            let auth_str = authority.as_str();
+            if let Some((_, host)) = auth_str.rsplit_once('@') {
+                return Cow::Owned(url.replace(auth_str, &format!("[REDACTED]@{host}")));
             }
         }
 
@@ -314,19 +314,19 @@ impl ProxyConfig {
 
         fn split_host_and_port(pattern: &str) -> (Cow<'_, str>, Option<u16>) {
             // Bracketed IPv6: [::1]:4317
-            if let Some(rest) = pattern.strip_prefix('[') {
-                if let Some(end) = rest.find(']') {
-                    let host = &rest[..end];
-                    let after = &rest[end + 1..];
-                    if let Some(port_str) = after.strip_prefix(':') {
-                        if !port_str.is_empty() && port_str.chars().all(|c| c.is_ascii_digit()) {
-                            if let Ok(p) = port_str.parse::<u16>() {
-                                return (Cow::Borrowed(host), Some(p));
-                            }
-                        }
-                    }
-                    return (Cow::Borrowed(host), None);
+            if let Some(rest) = pattern.strip_prefix('[')
+                && let Some(end) = rest.find(']')
+            {
+                let host = &rest[..end];
+                let after = &rest[end + 1..];
+                if let Some(port_str) = after.strip_prefix(':')
+                    && !port_str.is_empty()
+                    && port_str.chars().all(|c| c.is_ascii_digit())
+                    && let Ok(p) = port_str.parse::<u16>()
+                {
+                    return (Cow::Borrowed(host), Some(p));
                 }
+                return (Cow::Borrowed(host), None);
             }
 
             // CIDRs never have ports.
@@ -335,16 +335,14 @@ impl ProxyConfig {
             }
 
             // Hostname/IPv4 with port: example.com:443, 127.0.0.1:4317
-            if let Some((lhs, rhs)) = pattern.rsplit_once(':') {
-                if !lhs.contains(':')
-                    && !rhs.is_empty()
-                    && rhs.chars().all(|c| c.is_ascii_digit())
-                    && rhs.len() <= 5
-                {
-                    if let Ok(p) = rhs.parse::<u16>() {
-                        return (Cow::Borrowed(lhs), Some(p));
-                    }
-                }
+            if let Some((lhs, rhs)) = pattern.rsplit_once(':')
+                && !lhs.contains(':')
+                && !rhs.is_empty()
+                && rhs.chars().all(|c| c.is_ascii_digit())
+                && rhs.len() <= 5
+                && let Ok(p) = rhs.parse::<u16>()
+            {
+                return (Cow::Borrowed(lhs), Some(p));
             }
 
             (Cow::Borrowed(pattern), None)
@@ -370,10 +368,10 @@ impl ProxyConfig {
             }
 
             let (pattern_host, pattern_port) = split_host_and_port(&pattern);
-            if let Some(pattern_port) = pattern_port {
-                if pattern_port != port {
-                    continue;
-                }
+            if let Some(pattern_port) = pattern_port
+                && pattern_port != port
+            {
+                continue;
             }
 
             let pattern_host = pattern_host.as_ref().trim_end_matches('.');
@@ -386,10 +384,10 @@ impl ProxyConfig {
             // Handle CIDR notation (e.g., "192.168.0.0/16", "10.0.0.0/8")
             if pattern_host.contains('/') {
                 if let Ok(net) = pattern_host.parse::<IpNet>() {
-                    if let Some(ip) = host_ip {
-                        if net.contains(&ip) {
-                            return true;
-                        }
+                    if let Some(ip) = host_ip
+                        && net.contains(&ip)
+                    {
+                        return true;
                     }
                 } else {
                     otel_arrow_dfe_telemetry::otel_warn!(

--- a/rust/otap-dataflow/crates/otap/src/otlp_http.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_http.rs
@@ -758,18 +758,18 @@ impl HttpHandler {
 
             // Collect request body.
             let size_hint = body.size_hint();
-            if let Some(upper) = size_hint.upper() {
-                if (upper as usize) > max_len {
-                    otel_arrow_dfe_telemetry::otel_debug!(
-                        "otlp_http_receiver.request_rejected",
-                        reason = "body_too_large_hint",
-                        max_len = max_len,
-                        size_hint = upper,
-                        path = parts.uri.path().to_string()
-                    );
-                    self.record_rejection(ReceiverRejectionErrorType::PayloadTooLarge);
-                    return Err(limited_body_too_large());
-                }
+            if let Some(upper) = size_hint.upper()
+                && (upper as usize) > max_len
+            {
+                otel_arrow_dfe_telemetry::otel_debug!(
+                    "otlp_http_receiver.request_rejected",
+                    reason = "body_too_large_hint",
+                    max_len = max_len,
+                    size_hint = upper,
+                    path = parts.uri.path().to_string()
+                );
+                self.record_rejection(ReceiverRejectionErrorType::PayloadTooLarge);
+                return Err(limited_body_too_large());
             }
 
             let collected = Limited::new(body, max_len).collect().await.map_err(|e| {

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -257,20 +257,20 @@ impl Context {
     /// When `ENTRY_TIMESTAMP` is present in `interests`, the frame's
     /// entry timestamp is captured automatically.
     fn update_send_context(&mut self, node_id: usize, interests: Interests) {
-        if let Some(top) = self.stack.last_mut() {
-            if top.node_id == node_id {
-                top.interests |= interests;
-                if interests.contains(Interests::ENTRY_TIMESTAMP | Interests::PRODUCER_METRICS)
-                    && top.route.entry_time_ns == 0
-                {
-                    // Note: This update is only for receivers which need
-                    // to capture timestamp here in case they did not use
-                    // subscribe_to. If they called called subscribe_to,
-                    // this will be skipped by a non-zero timestamp.
-                    top.route.entry_time_ns = nanos_since_birth();
-                }
-                return;
+        if let Some(top) = self.stack.last_mut()
+            && top.node_id == node_id
+        {
+            top.interests |= interests;
+            if interests.contains(Interests::ENTRY_TIMESTAMP | Interests::PRODUCER_METRICS)
+                && top.route.entry_time_ns == 0
+            {
+                // Note: This update is only for receivers which need
+                // to capture timestamp here in case they did not use
+                // subscribe_to. If they called called subscribe_to,
+                // this will be skipped by a non-zero timestamp.
+                top.route.entry_time_ns = nanos_since_birth();
             }
+            return;
         }
         // Different node (or empty stack) -> push new frame.
         let mut frame_interests = interests;
@@ -961,10 +961,10 @@ fn flow_accumulate<H: FlowMetricEffectHandler>(
     }
     data.add_flow_compute(delta_ns);
     if is_end {
-        if let Some(total) = data.take_flow_compute() {
-            if interests.contains(FlowMetricInterests::COMPUTE_DURATION) {
-                handler.record_flow_duration(data.signal_type(), total);
-            }
+        if let Some(total) = data.take_flow_compute()
+            && interests.contains(FlowMetricInterests::COMPUTE_DURATION)
+        {
+            handler.record_flow_duration(data.signal_type(), total);
         }
         if emitted_output && interests.contains(FlowMetricInterests::OUTPUT_MESSAGES) {
             handler.record_flow_output_message(data.signal_type());

--- a/rust/otap-dataflow/crates/otap/tests/common/flaky_exporter.rs
+++ b/rust/otap-dataflow/crates/otap/tests/common/flaky_exporter.rs
@@ -293,10 +293,10 @@ impl Exporter<OtapPdata> for FlakyExporter {
                                     .as_ref()
                                     .map(|n| n.load(Ordering::Acquire))
                                     .unwrap_or(0);
-                                if transient.saturating_add(permanent) >= threshold {
-                                    if let Some(ref should_ack) = self.should_ack {
-                                        should_ack.store(true, Ordering::SeqCst);
-                                    }
+                                if transient.saturating_add(permanent) >= threshold
+                                    && let Some(ref should_ack) = self.should_ack
+                                {
+                                    should_ack.store(true, Ordering::SeqCst);
                                 }
                             }
                         }

--- a/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
+++ b/rust/otap-dataflow/crates/otap/tests/durable_buffer_processor_tests.rs
@@ -229,18 +229,18 @@ impl TestConfigBuilder {
             "max_segment_open_duration": "50ms"
         });
 
-        if let Some(retry) = self.retry_config {
-            if let (Some(base), Some(extra)) = (buffer_config.as_object_mut(), retry.as_object()) {
-                for (k, v) in extra {
-                    let _ = base.insert(k.clone(), v.clone());
-                }
+        if let Some(retry) = self.retry_config
+            && let (Some(base), Some(extra)) = (buffer_config.as_object_mut(), retry.as_object())
+        {
+            for (k, v) in extra {
+                let _ = base.insert(k.clone(), v.clone());
             }
         }
 
-        if let Some(handling) = self.otlp_handling {
-            if let Some(obj) = buffer_config.as_object_mut() {
-                let _ = obj.insert("otlp_handling".to_owned(), json!(handling));
-            }
+        if let Some(handling) = self.otlp_handling
+            && let Some(obj) = buffer_config.as_object_mut()
+        {
+            let _ = obj.insert("otlp_handling".to_owned(), json!(handling));
         }
 
         let (exporter_name, exporter_urn, exporter_config) = match self.exporter_type {
@@ -505,11 +505,11 @@ where
             if start.elapsed() >= max_duration {
                 break;
             }
-            if let Some(ref condition) = shutdown_condition {
-                if condition() {
-                    condition_triggered = true;
-                    break;
-                }
+            if let Some(ref condition) = shutdown_condition
+                && condition()
+            {
+                condition_triggered = true;
+                break;
             }
             std::thread::sleep(poll_interval);
         }
@@ -1693,19 +1693,19 @@ fn test_durable_buffer_otlp_item_count_metrics() {
     for entry in std::fs::read_dir(&segments_dir).expect("read segments dir") {
         let entry = entry.expect("dir entry");
         let path = entry.path();
-        if path.extension().is_some_and(|ext| ext == "qseg") {
-            if let Ok(reader) = SegmentReader::open(&path) {
-                for manifest_entry in reader.manifest() {
-                    total_bundles += 1;
-                    let ic = manifest_entry.item_count();
-                    // Classify by OTLP slot ID present in the bundle.
-                    for slot in manifest_entry.slot_ids() {
-                        match slot.raw() {
-                            OTLP_LOGS_SLOT => log_items += ic,
-                            OTLP_TRACES_SLOT => trace_items += ic,
-                            OTLP_METRICS_SLOT => metric_items += ic,
-                            _ => {} // shared or unknown slots
-                        }
+        if path.extension().is_some_and(|ext| ext == "qseg")
+            && let Ok(reader) = SegmentReader::open(&path)
+        {
+            for manifest_entry in reader.manifest() {
+                total_bundles += 1;
+                let ic = manifest_entry.item_count();
+                // Classify by OTLP slot ID present in the bundle.
+                for slot in manifest_entry.slot_ids() {
+                    match slot.raw() {
+                        OTLP_LOGS_SLOT => log_items += ic,
+                        OTLP_TRACES_SLOT => trace_items += ic,
+                        OTLP_METRICS_SLOT => metric_items += ic,
+                        _ => {} // shared or unknown slots
                     }
                 }
             }

--- a/rust/otap-dataflow/crates/pdata/src/encode/record/array.rs
+++ b/rust/otap-dataflow/crates/pdata/src/encode/record/array.rs
@@ -267,10 +267,10 @@ where
     where
         T: PartialEq<T2>,
     {
-        if let Some(default_val) = default_value {
-            if default_val == value {
-                return true;
-            }
+        if let Some(default_val) = default_value
+            && default_val == value
+        {
+            return true;
         }
 
         false

--- a/rust/otap-dataflow/crates/pdata/src/encode/record/logs.rs
+++ b/rust/otap-dataflow/crates/pdata/src/encode/record/logs.rs
@@ -453,10 +453,10 @@ impl LogsBodyBuilder {
         let nulls = self.nulls.finish();
 
         // if it's all null, don't bother creating the struct array
-        if let Some(nulls) = &nulls {
-            if nulls.null_count() == len {
-                return None;
-            }
+        if let Some(nulls) = &nulls
+            && nulls.null_count() == len
+        {
+            return None;
         }
 
         let mut fields = vec![];

--- a/rust/otap-dataflow/crates/pdata/src/otap/filter.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/filter.rs
@@ -227,12 +227,12 @@ impl IdBitmap {
     /// In-place difference: `self &= !other`.
     pub fn difference_with(&mut self, other: &Self) {
         for (i, self_page) in self.pages.iter_mut().enumerate() {
-            if let Some(sp) = self_page {
-                if let Some(Some(op)) = other.pages.get(i) {
-                    sp.last_used_generation = self.generation;
-                    for (sw, ow) in sp.words.iter_mut().zip(op.words.iter()) {
-                        *sw &= !ow;
-                    }
+            if let Some(sp) = self_page
+                && let Some(Some(op)) = other.pages.get(i)
+            {
+                sp.last_used_generation = self.generation;
+                for (sw, ow) in sp.words.iter_mut().zip(op.words.iter()) {
+                    *sw &= !ow;
                 }
             }
         }
@@ -342,16 +342,16 @@ impl Iterator for IdBitmapIter<'_> {
             // Find the next non-zero word, advancing through words and pages as needed.
             loop {
                 // Try the next word in the current page
-                if let Some(Some(page)) = self.bitmap.pages.get(self.page_idx) {
-                    if self.word_idx < ID_BITMAP_PAGE_WORDS {
-                        let word = page.words[self.word_idx];
-                        self.word_idx += 1;
-                        if word != 0 {
-                            self.current_word = word;
-                            break; // Break inner loop, outer loop will extract bits
-                        }
-                        continue; // Try next word in this page
+                if let Some(Some(page)) = self.bitmap.pages.get(self.page_idx)
+                    && self.word_idx < ID_BITMAP_PAGE_WORDS
+                {
+                    let word = page.words[self.word_idx];
+                    self.word_idx += 1;
+                    if word != 0 {
+                        self.current_word = word;
+                        break; // Break inner loop, outer loop will extract bits
                     }
+                    continue; // Try next word in this page
                 }
 
                 // No more words in this page (or page was None) -- advance to the next page

--- a/rust/otap-dataflow/crates/pdata/src/otap/filter/traces.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/filter/traces.rs
@@ -469,27 +469,26 @@ impl TraceFilter {
             );
         }
 
-        if let Some(span_link_attrs_record_batch) = span_link_attrs {
-            if let Some(link_filter) = &span_link_filter {
-                let span_link_ids_column = if let Some(span_links_record_batch) = span_links {
-                    get_required_array(span_links_record_batch, consts::ID)?
-                } else {
-                    return Err(Error::UnexpectedRecordBatchState {
-                        reason:
-                            "Span Link Attribute Record Batch found without Span Link Record Batch"
-                                .to_string(),
-                    });
-                };
-                _ = child_record_batch_filters.insert(
-                    ArrowPayloadType::SpanLinkAttrs,
-                    update_child_record_batch_filter(
-                        span_link_attrs_record_batch,
-                        span_link_ids_column,
-                        &span_link_attr_filter,
-                        link_filter,
-                    )?,
-                );
-            }
+        if let Some(span_link_attrs_record_batch) = span_link_attrs
+            && let Some(link_filter) = &span_link_filter
+        {
+            let span_link_ids_column = if let Some(span_links_record_batch) = span_links {
+                get_required_array(span_links_record_batch, consts::ID)?
+            } else {
+                return Err(Error::UnexpectedRecordBatchState {
+                    reason: "Span Link Attribute Record Batch found without Span Link Record Batch"
+                        .to_string(),
+                });
+            };
+            _ = child_record_batch_filters.insert(
+                ArrowPayloadType::SpanLinkAttrs,
+                update_child_record_batch_filter(
+                    span_link_attrs_record_batch,
+                    span_link_ids_column,
+                    &span_link_attr_filter,
+                    link_filter,
+                )?,
+            );
         }
 
         Ok((span_filter, child_record_batch_filters))

--- a/rust/otap-dataflow/crates/pdata/src/otap/schema.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/schema.rs
@@ -97,15 +97,15 @@ impl SchemaIdBuilder {
 
             Map(field, _) => {
                 self.out.push_str("Map<");
-                if let Struct(fields) = field.data_type() {
-                    if fields.len() == 2 {
-                        // Assume the first field is key type and the second field is value type for simplicity
-                        // arrow-go has similar logic
-                        // See https://github.com/apache/arrow-go/blob/3ae84281674622d33b4617c878e099d13d4a1113/arrow/datatype_nested.go#L593-L596
-                        self.write_data_type(fields[0].data_type());
-                        self.out.push(',');
-                        self.write_data_type(fields[1].data_type());
-                    }
+                if let Struct(fields) = field.data_type()
+                    && fields.len() == 2
+                {
+                    // Assume the first field is key type and the second field is value type for simplicity
+                    // arrow-go has similar logic
+                    // See https://github.com/apache/arrow-go/blob/3ae84281674622d33b4617c878e099d13d4a1113/arrow/datatype_nested.go#L593-L596
+                    self.write_data_type(fields[0].data_type());
+                    self.out.push(',');
+                    self.write_data_type(fields[1].data_type());
                 }
                 self.out.push('>');
             }

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform.rs
@@ -3316,18 +3316,18 @@ fn should_remove_transport_optimized_encoding(
                 }
             }
             KeyTransformRangeType::Delete => {
-                if let Some(prev) = prev_neighbour.as_ref() {
-                    if let Some(next) = next_neighbour.as_ref() {
-                        let delete_joins = are_neighbours_with_delta_encoded_parent_ids(
-                            &key_column,
-                            &val_columns,
-                            replacement_bytes,
-                            prev,
-                            next,
-                        )?;
-                        if delete_joins {
-                            return Ok(true);
-                        }
+                if let Some(prev) = prev_neighbour.as_ref()
+                    && let Some(next) = next_neighbour.as_ref()
+                {
+                    let delete_joins = are_neighbours_with_delta_encoded_parent_ids(
+                        &key_column,
+                        &val_columns,
+                        replacement_bytes,
+                        prev,
+                        next,
+                    )?;
+                    if delete_joins {
+                        return Ok(true);
                     }
                 }
             }

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/concatenate.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/concatenate.rs
@@ -745,9 +745,18 @@ fn estimate_cardinality_from_bytes<'a, const ELEMENT_WIDTH: usize>(
         match nulls {
             Some(nulls) => Either::Left(nulls.valid_slices().flat_map(move |(start, end)| {
                 let range = start * ELEMENT_WIDTH..end * ELEMENT_WIDTH;
-                buf[range].chunks_exact(ELEMENT_WIDTH)
+                buf[range]
+                    .as_chunks::<ELEMENT_WIDTH>()
+                    .0
+                    .iter()
+                    .map(|chunk| chunk.as_slice())
             })),
-            None => Either::Right(buf.chunks_exact(ELEMENT_WIDTH)),
+            None => Either::Right(
+                buf.as_chunks::<ELEMENT_WIDTH>()
+                    .0
+                    .iter()
+                    .map(|chunk| chunk.as_slice()),
+            ),
         }
     });
 

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/transport_optimize/attributes.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/transport_optimize/attributes.rs
@@ -379,14 +379,13 @@ where
         // and we only want to append segment to the column builder once per value column per type
         if type_range_attr_type != AttributeValueType::Map
             && type_range_attr_type != AttributeValueType::Slice
+            && let Some(sorted_val_col_builder) = sorted_ser_column.as_mut()
         {
-            if let Some(sorted_val_col_builder) = sorted_ser_column.as_mut() {
-                let len = type_range.len();
-                // append the nulls to the null buffer
-                sorted_val_col_builder.append_n_nulls(len);
-                // fill in the data buffers with default values
-                sorted_val_col_builder.append_n_default_values(len);
-            }
+            let len = type_range.len();
+            // append the nulls to the null buffer
+            sorted_val_col_builder.append_n_nulls(len);
+            // fill in the data buffers with default values
+            sorted_val_col_builder.append_n_default_values(len);
         }
     }
 

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/upsert_attributes.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/upsert_attributes.rs
@@ -697,33 +697,33 @@ fn merge_type_column<T: ArrowPrimitiveType>(
                 let count = run.end - run.start;
                 let attr_type = resolved_upsert.attr_value_type as u8;
 
-                if let Some(arr) = &resolved_upsert.new_values_array {
-                    if let Some(nulls) = arr.nulls() {
-                        // Array with nulls: write Empty for null values, attr_type for
-                        // non-null.
-                        let counter = &mut update_counters[idx];
-                        let validity_iter =
-                            BitSliceIterator::new(nulls.buffer().as_slice(), *counter, count);
-                        let mut last_valid_range_end = 0;
-                        for (start, end) in validity_iter {
-                            if start != last_valid_range_end {
-                                output.extend(std::iter::repeat_n(
-                                    AttributeValueType::Empty as u8,
-                                    start - last_valid_range_end,
-                                ));
-                            }
-                            output.extend(std::iter::repeat_n(attr_type, end - start));
-                            last_valid_range_end = end;
-                        }
-                        if last_valid_range_end != count {
+                if let Some(arr) = &resolved_upsert.new_values_array
+                    && let Some(nulls) = arr.nulls()
+                {
+                    // Array with nulls: write Empty for null values, attr_type for
+                    // non-null.
+                    let counter = &mut update_counters[idx];
+                    let validity_iter =
+                        BitSliceIterator::new(nulls.buffer().as_slice(), *counter, count);
+                    let mut last_valid_range_end = 0;
+                    for (start, end) in validity_iter {
+                        if start != last_valid_range_end {
                             output.extend(std::iter::repeat_n(
                                 AttributeValueType::Empty as u8,
-                                count - last_valid_range_end,
+                                start - last_valid_range_end,
                             ));
                         }
-                        *counter += count;
-                        continue;
+                        output.extend(std::iter::repeat_n(attr_type, end - start));
+                        last_valid_range_end = end;
                     }
+                    if last_valid_range_end != count {
+                        output.extend(std::iter::repeat_n(
+                            AttributeValueType::Empty as u8,
+                            count - last_valid_range_end,
+                        ));
+                    }
+                    *counter += count;
+                    continue;
                 }
 
                 // No nulls (or scalar): fill with this upsert's type discriminant.
@@ -735,37 +735,36 @@ fn merge_type_column<T: ArrowPrimitiveType>(
     // Insert rows: each upsert's type discriminant
     for resolved_upsert in resolved {
         let attr_type = resolved_upsert.attr_value_type as u8;
-        if let Some(arr) = &resolved_upsert.new_values_array {
-            if let Some(nulls) = arr.nulls() {
-                let validity_slice_iter = BitSliceIterator::new(
-                    nulls.buffer().as_slice(),
-                    resolved_upsert.num_updates,
-                    resolved_upsert.num_inserts,
-                );
-                let mut last_valid_range_end = 0;
-                for (start, end) in validity_slice_iter {
-                    // put the null range that came before the last valid range
-                    if start != last_valid_range_end {
-                        output.extend(std::iter::repeat_n(
-                            AttributeValueType::Empty as u8,
-                            start - last_valid_range_end,
-                        ));
-                    }
-                    output.extend(std::iter::repeat_n(attr_type, end - start));
-
-                    last_valid_range_end = end;
-                }
-
-                // put the remaining nulls
-                if last_valid_range_end != resolved_upsert.num_inserts {
+        if let Some(arr) = &resolved_upsert.new_values_array
+            && let Some(nulls) = arr.nulls()
+        {
+            let validity_slice_iter = BitSliceIterator::new(
+                nulls.buffer().as_slice(),
+                resolved_upsert.num_updates,
+                resolved_upsert.num_inserts,
+            );
+            let mut last_valid_range_end = 0;
+            for (start, end) in validity_slice_iter {
+                // put the null range that came before the last valid range
+                if start != last_valid_range_end {
                     output.extend(std::iter::repeat_n(
                         AttributeValueType::Empty as u8,
-                        resolved_upsert.num_inserts - last_valid_range_end,
+                        start - last_valid_range_end,
                     ));
                 }
+                output.extend(std::iter::repeat_n(attr_type, end - start));
 
-                continue;
+                last_valid_range_end = end;
             }
+
+            // put the remaining nulls
+            if last_valid_range_end != resolved_upsert.num_inserts {
+                output.extend(std::iter::repeat_n(
+                    AttributeValueType::Empty as u8,
+                    resolved_upsert.num_inserts - last_valid_range_end,
+                ));
+            }
+            continue;
         }
 
         output.extend(std::iter::repeat_n(attr_type, resolved_upsert.num_inserts));
@@ -1945,24 +1944,24 @@ fn create_new_value_column_batched<T: ArrowPrimitiveType>(
     let supports_dict_encoding = values_column_supports_dictionary_encoding(target_col_name);
 
     // Try dict encoding path first if supported.
-    if supports_dict_encoding {
-        if let Some(unified) = try_build_unified_dict_multi(None, resolved, target_col_name)? {
-            let field = Field::new(
-                target_col_name,
-                DataType::Dictionary(
-                    Box::new(DataType::UInt16),
-                    Box::new(unified.values.data_type().clone()),
-                ),
-                true,
-            );
-            return merge_values_with_unified_dict(
-                &field,
-                row_owners,
-                &unified,
-                resolved,
-                total_output_rows,
-            );
-        }
+    if supports_dict_encoding
+        && let Some(unified) = try_build_unified_dict_multi(None, resolved, target_col_name)?
+    {
+        let field = Field::new(
+            target_col_name,
+            DataType::Dictionary(
+                Box::new(DataType::UInt16),
+                Box::new(unified.values.data_type().clone()),
+            ),
+            true,
+        );
+        return merge_values_with_unified_dict(
+            &field,
+            row_owners,
+            &unified,
+            resolved,
+            total_output_rows,
+        );
     }
 
     // Fallback: primitive merge with decoded-to-plain sources.

--- a/rust/otap-dataflow/crates/pdata/src/otap/transform/util.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/transform/util.rs
@@ -376,24 +376,24 @@ pub(crate) fn replace_column(
         let field_index = schema.index_of(struct_col_name).ok();
         if let Some(field_index) = field_index {
             let struct_column = columns[field_index].as_any().downcast_ref::<StructArray>();
-            if let Some(struct_column) = struct_column {
-                if let Some((struct_idx, _)) = struct_column.fields().find(ID) {
-                    // replace the encoding metadata on the struct field
-                    let mut new_struct_fields = struct_column.fields().to_vec();
-                    update_field_encoding_metadata(ID, encoding, &mut new_struct_fields);
+            if let Some(struct_column) = struct_column
+                && let Some((struct_idx, _)) = struct_column.fields().find(ID)
+            {
+                // replace the encoding metadata on the struct field
+                let mut new_struct_fields = struct_column.fields().to_vec();
+                update_field_encoding_metadata(ID, encoding, &mut new_struct_fields);
 
-                    // build new struct array
-                    let mut new_struct_columns = struct_column.columns().to_vec();
-                    new_struct_columns[struct_idx] = new_column;
-                    let new_struct_array = Arc::new(StructArray::new(
-                        new_struct_fields.into(),
-                        new_struct_columns,
-                        struct_column.nulls().cloned(),
-                    ));
+                // build new struct array
+                let mut new_struct_columns = struct_column.columns().to_vec();
+                new_struct_columns[struct_idx] = new_column;
+                let new_struct_array = Arc::new(StructArray::new(
+                    new_struct_fields.into(),
+                    new_struct_columns,
+                    struct_column.nulls().cloned(),
+                ));
 
-                    // replace the original struct column with the new one
-                    columns[field_index] = new_struct_array;
-                }
+                // replace the original struct column with the new one
+                columns[field_index] = new_struct_array;
             }
         }
         return;
@@ -422,17 +422,17 @@ pub(crate) fn update_field_encoding_metadata(
             .enumerate()
             .find(|(_, f)| f.name().as_str() == struct_col_name);
 
-        if let Some((idx, field)) = found_field {
-            if let DataType::Struct(struct_fields) = field.data_type() {
-                let mut new_struct_fields = struct_fields.to_vec();
-                update_field_encoding_metadata(ID, encoding, &mut new_struct_fields);
+        if let Some((idx, field)) = found_field
+            && let DataType::Struct(struct_fields) = field.data_type()
+        {
+            let mut new_struct_fields = struct_fields.to_vec();
+            update_field_encoding_metadata(ID, encoding, &mut new_struct_fields);
 
-                let new_field = field
-                    .as_ref()
-                    .clone()
-                    .with_data_type(DataType::Struct(new_struct_fields.into()));
-                fields[idx] = Arc::new(new_field)
-            }
+            let new_field = field
+                .as_ref()
+                .clone()
+                .with_data_type(DataType::Struct(new_struct_fields.into()));
+            fields[idx] = Arc::new(new_field)
         }
     }
 

--- a/rust/otap-dataflow/crates/pdata/src/otlp/attributes.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/attributes.rs
@@ -222,15 +222,15 @@ mod test {
         let mut protobuf = ProtoBuffer::default();
 
         for i in 0..rb.num_rows() {
-            if let Some(value_type) = any_val_arrays.attr_type.value_at(i) {
-                if let Ok(value_type) = AttributeValueType::try_from(value_type) {
-                    protobuf
-                        .encode_len_delimited(
-                            1, // the values field in ArrayValue message
-                            |protobuf| encode_any_value(&any_val_arrays, i, value_type, protobuf),
-                        )
-                        .unwrap();
-                }
+            if let Some(value_type) = any_val_arrays.attr_type.value_at(i)
+                && let Ok(value_type) = AttributeValueType::try_from(value_type)
+            {
+                protobuf
+                    .encode_len_delimited(
+                        1, // the values field in ArrayValue message
+                        |protobuf| encode_any_value(&any_val_arrays, i, value_type, protobuf),
+                    )
+                    .unwrap();
             }
         }
 

--- a/rust/otap-dataflow/crates/pdata/src/otlp/attributes.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/attributes.rs
@@ -88,15 +88,15 @@ pub(crate) fn encode_key_value<T: ArrowPrimitiveType>(
         result_buf.encode_string(KEY_VALUE_KEY, key)?;
     }
 
-    if let Some(value_type) = attr_arrays.anyval_arrays.attr_type.value_at(index) {
-        if let Ok(value_type) = AttributeValueType::try_from(value_type) {
-            // TODO try to compute the length of the value here. This would probably be
-            // straight forward for most types for all cases except map/slice, and even then
-            // we could maybe guess order of magnitude by looking at the CBOR representation
-            result_buf.encode_len_delimited(KEY_VALUE_VALUE, |result_buf| {
-                encode_any_value(&attr_arrays.anyval_arrays, index, value_type, result_buf)
-            })?;
-        }
+    if let Some(value_type) = attr_arrays.anyval_arrays.attr_type.value_at(index)
+        && let Ok(value_type) = AttributeValueType::try_from(value_type)
+    {
+        // TODO try to compute the length of the value here. This would probably be
+        // straight forward for most types for all cases except map/slice, and even then
+        // we could maybe guess order of magnitude by looking at the CBOR representation
+        result_buf.encode_len_delimited(KEY_VALUE_VALUE, |result_buf| {
+            encode_any_value(&attr_arrays.anyval_arrays, index, value_type, result_buf)
+        })?;
     }
 
     Ok(())
@@ -120,11 +120,11 @@ pub(crate) fn encode_any_value(
         AttributeValueType::Bool => {
             // TODO handle case when bool column is missing we correct the default value handling
             // https://github.com/open-telemetry/otel-arrow/issues/1449
-            if let Some(attr_bool) = &attr_arrays.attr_bool {
-                if let Some(val) = attr_bool.value_at(index) {
-                    result_buf.encode_field_tag(ANY_VALUE_BOOL_VALUE, wire_types::VARINT)?;
-                    result_buf.encode_varint(val as u64)?;
-                }
+            if let Some(attr_bool) = &attr_arrays.attr_bool
+                && let Some(val) = attr_bool.value_at(index)
+            {
+                result_buf.encode_field_tag(ANY_VALUE_BOOL_VALUE, wire_types::VARINT)?;
+                result_buf.encode_varint(val as u64)?;
             }
         }
         AttributeValueType::Int => {
@@ -154,10 +154,10 @@ pub(crate) fn encode_any_value(
             result_buf.encode_bytes(ANY_VALUE_BYTES_VALUE, val)?;
         }
         AttributeValueType::Map | AttributeValueType::Slice => {
-            if let Some(ser_bytes) = &attr_arrays.attr_ser {
-                if let Some(val) = ser_bytes.slice_at(index) {
-                    proto_encode_cbor_bytes(val, result_buf)?;
-                }
+            if let Some(ser_bytes) = &attr_arrays.attr_ser
+                && let Some(val) = ser_bytes.slice_at(index)
+            {
+                proto_encode_cbor_bytes(val, result_buf)?;
             }
         }
         AttributeValueType::Empty => {

--- a/rust/otap-dataflow/crates/pdata/src/otlp/common.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/common.rs
@@ -62,23 +62,23 @@ pub(crate) fn proto_encode_resource(
     result_buf: &mut ProtoBuffer,
 ) -> Result<()> {
     // add attributes
-    if let Some(attrs_arrays) = resource_attrs_arrays {
-        if let Some(res_id) = resource_arrays.id.value_at(index) {
-            for attr_index in
-                ChildIndexIter::new(res_id, &attrs_arrays.parent_id, resource_attrs_cursor)
-            {
-                result_buf.encode_len_delimited(RESOURCE_ATTRIBUTES, |result_buf| {
-                    encode_key_value(attrs_arrays, attr_index, result_buf)
-                })?;
-            }
+    if let Some(attrs_arrays) = resource_attrs_arrays
+        && let Some(res_id) = resource_arrays.id.value_at(index)
+    {
+        for attr_index in
+            ChildIndexIter::new(res_id, &attrs_arrays.parent_id, resource_attrs_cursor)
+        {
+            result_buf.encode_len_delimited(RESOURCE_ATTRIBUTES, |result_buf| {
+                encode_key_value(attrs_arrays, attr_index, result_buf)
+            })?;
         }
     }
 
-    if let Some(col) = resource_arrays.dropped_attributes_count {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(RESOURCE_DROPPED_ATTRIBUTES_COUNT, wire_types::VARINT)?;
-            result_buf.encode_varint(val as u64)?;
-        }
+    if let Some(col) = resource_arrays.dropped_attributes_count
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(RESOURCE_DROPPED_ATTRIBUTES_COUNT, wire_types::VARINT)?;
+        result_buf.encode_varint(val as u64)?;
     }
 
     Ok(())
@@ -192,37 +192,35 @@ pub(crate) fn proto_encode_instrumentation_scope(
     scope_attrs_cursor: &mut SortedBatchCursor,
     result_buf: &mut ProtoBuffer,
 ) -> Result<()> {
-    if let Some(col) = &scope_arrays.name {
-        if let Some(val) = col.str_at(index) {
-            result_buf.encode_string(INSTRUMENTATION_SCOPE_NAME, val)?;
+    if let Some(col) = &scope_arrays.name
+        && let Some(val) = col.str_at(index)
+    {
+        result_buf.encode_string(INSTRUMENTATION_SCOPE_NAME, val)?;
+    }
+
+    if let Some(col) = &scope_arrays.version
+        && let Some(val) = col.str_at(index)
+    {
+        result_buf.encode_string(INSTRUMENTATION_SCOPE_VERSION, val)?;
+    }
+
+    if let Some(attr_arrays) = scope_attrs_arrays
+        && let Some(scope_id) = scope_arrays.id.value_at(index)
+    {
+        for attr_index in ChildIndexIter::new(scope_id, &attr_arrays.parent_id, scope_attrs_cursor)
+        {
+            result_buf.encode_len_delimited(INSTRUMENTATION_SCOPE_ATTRIBUTES, |result_buf| {
+                encode_key_value(attr_arrays, attr_index, result_buf)
+            })?;
         }
     }
 
-    if let Some(col) = &scope_arrays.version {
-        if let Some(val) = col.str_at(index) {
-            result_buf.encode_string(INSTRUMENTATION_SCOPE_VERSION, val)?;
-        }
-    }
-
-    if let Some(attr_arrays) = scope_attrs_arrays {
-        if let Some(scope_id) = scope_arrays.id.value_at(index) {
-            for attr_index in
-                ChildIndexIter::new(scope_id, &attr_arrays.parent_id, scope_attrs_cursor)
-            {
-                result_buf
-                    .encode_len_delimited(INSTRUMENTATION_SCOPE_ATTRIBUTES, |result_buf| {
-                        encode_key_value(attr_arrays, attr_index, result_buf)
-                    })?;
-            }
-        }
-    }
-
-    if let Some(col) = scope_arrays.dropped_attributes_count {
-        if let Some(val) = col.value_at(index) {
-            result_buf
-                .encode_field_tag(INSTRUMENTATION_DROPPED_ATTRIBUTES_COUNT, wire_types::VARINT)?;
-            result_buf.encode_varint(val as u64)?;
-        }
+    if let Some(col) = scope_arrays.dropped_attributes_count
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf
+            .encode_field_tag(INSTRUMENTATION_DROPPED_ATTRIBUTES_COUNT, wire_types::VARINT)?;
+        result_buf.encode_varint(val as u64)?;
     }
 
     Ok(())
@@ -1088,16 +1086,16 @@ impl SortedBatchCursor {
         // If the most recently consumed row's parent id is `<= target`, then `target`'s rows (if
         // any) are at or after `curr_index`, so a forward scan suffices -- no search needed. Nulls
         // (value_at == None) fall through to the search, as does the very first seek of a batch.
-        if self.curr_index > 0 {
-            if let Some(prev) = parent_id_col.value_at(self.sorted_indices[self.curr_index - 1]) {
-                // `target >= prev`: forward scan suffices. Incomparable values (partial_cmp ==
-                // None) fall through to the search as a safe default.
-                if matches!(
-                    target.partial_cmp(&prev),
-                    Some(Ordering::Greater | Ordering::Equal)
-                ) {
-                    return;
-                }
+        if self.curr_index > 0
+            && let Some(prev) = parent_id_col.value_at(self.sorted_indices[self.curr_index - 1])
+        {
+            // `target >= prev`: forward scan suffices. Incomparable values (partial_cmp ==
+            // None) fall through to the search as a safe default.
+            if matches!(
+                target.partial_cmp(&prev),
+                Some(Ordering::Greater | Ordering::Equal)
+            ) {
+                return;
             }
         }
 

--- a/rust/otap-dataflow/crates/pdata/src/otlp/logs.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/logs.rs
@@ -324,10 +324,10 @@ impl LogsProtoBytesEncoder {
         }
 
         // encode schema url
-        if let Some(col) = &logs_data_arrays.resource_arrays.schema_url {
-            if let Some(val) = col.str_at(index) {
-                result_buf.encode_string(RESOURCE_LOGS_SCHEMA_URL, val)?;
-            }
+        if let Some(col) = &logs_data_arrays.resource_arrays.schema_url
+            && let Some(val) = col.str_at(index)
+        {
+            result_buf.encode_string(RESOURCE_LOGS_SCHEMA_URL, val)?;
         }
 
         Ok(())
@@ -382,10 +382,10 @@ impl LogsProtoBytesEncoder {
         }
 
         // encode schema url
-        if let Some(col) = &logs_data_arrays.log_arrays.schema_url {
-            if let Some(val) = col.str_at(index) {
-                result_buf.encode_string(SCOPE_LOGS_SCHEMA_URL, val)?;
-            }
+        if let Some(col) = &logs_data_arrays.log_arrays.schema_url
+            && let Some(val) = col.str_at(index)
+        {
+            result_buf.encode_string(SCOPE_LOGS_SCHEMA_URL, val)?;
         }
 
         Ok(())
@@ -403,92 +403,89 @@ impl LogsProtoBytesEncoder {
 
         let log_arrays = &logs_data_arrays.log_arrays;
 
-        if let Some(col) = log_arrays.time_unix_nano {
-            if let Some(val) = col.value_at(index) {
-                result_buf.encode_field_tag(LOG_RECORD_TIME_UNIX_NANO, wire_types::FIXED64)?;
-                result_buf.extend_from_slice(&val.to_le_bytes())?;
+        if let Some(col) = log_arrays.time_unix_nano
+            && let Some(val) = col.value_at(index)
+        {
+            result_buf.encode_field_tag(LOG_RECORD_TIME_UNIX_NANO, wire_types::FIXED64)?;
+            result_buf.extend_from_slice(&val.to_le_bytes())?;
+        }
+
+        if let Some(col) = &log_arrays.severity_number
+            && let Some(val) = col.value_at(index)
+        {
+            result_buf.encode_field_tag(LOG_RECORD_SEVERITY_NUMBER, wire_types::VARINT)?;
+            result_buf.encode_varint(val as u64)?;
+        }
+
+        if let Some(col) = &log_arrays.severity_text
+            && let Some(val) = col.str_at(index)
+        {
+            result_buf.encode_string(LOG_RECORD_SEVERITY_TEXT, val)?;
+        }
+
+        if let Some(log_body_arrays) = &logs_data_arrays.log_arrays.body
+            && log_body_arrays.is_valid(index)
+        {
+            let anyval_arrays = &log_body_arrays.anyval_arrays;
+            if let Some(value_type) = anyval_arrays.attr_type.value_at(index)
+                && let Ok(value_type) = AttributeValueType::try_from(value_type)
+            {
+                result_buf.encode_len_delimited(LOG_RECORD_BODY, |result_buf| {
+                    encode_any_value(anyval_arrays, index, value_type, result_buf)
+                })?;
             }
         }
 
-        if let Some(col) = &log_arrays.severity_number {
-            if let Some(val) = col.value_at(index) {
-                result_buf.encode_field_tag(LOG_RECORD_SEVERITY_NUMBER, wire_types::VARINT)?;
-                result_buf.encode_varint(val as u64)?;
+        if let Some(log_attrs) = logs_data_arrays.log_attrs.as_ref()
+            && let Some(id_array) = log_arrays.id
+            && let Some(id) = id_array.value_at(index)
+        {
+            let attrs_index_iter =
+                ChildIndexIter::new(id, &log_attrs.parent_id, &mut self.log_attrs_cursor);
+            for attr_index in attrs_index_iter {
+                result_buf.encode_len_delimited(LOG_RECORD_ATTRIBUTES, |result_buf| {
+                    encode_key_value(log_attrs, attr_index, result_buf)
+                })?;
             }
         }
 
-        if let Some(col) = &log_arrays.severity_text {
-            if let Some(val) = col.str_at(index) {
-                result_buf.encode_string(LOG_RECORD_SEVERITY_TEXT, val)?;
-            }
+        if let Some(col) = log_arrays.dropped_attributes_count
+            && let Some(val) = col.value_at(index)
+        {
+            result_buf.encode_field_tag(LOG_RECORD_DROPPED_ATTRIBUTES_COUNT, wire_types::VARINT)?;
+            result_buf.encode_varint(val as u64)?;
         }
 
-        if let Some(log_body_arrays) = &logs_data_arrays.log_arrays.body {
-            if log_body_arrays.is_valid(index) {
-                let anyval_arrays = &log_body_arrays.anyval_arrays;
-                if let Some(value_type) = anyval_arrays.attr_type.value_at(index) {
-                    if let Ok(value_type) = AttributeValueType::try_from(value_type) {
-                        result_buf.encode_len_delimited(LOG_RECORD_BODY, |result_buf| {
-                            encode_any_value(anyval_arrays, index, value_type, result_buf)
-                        })?;
-                    }
-                }
-            }
+        if let Some(col) = &log_arrays.flags
+            && let Some(val) = col.value_at(index)
+        {
+            result_buf.encode_field_tag(LOG_RECORD_FLAGS, wire_types::FIXED32)?;
+            result_buf.extend_from_slice(&val.to_le_bytes())?;
         }
 
-        if let Some(log_attrs) = logs_data_arrays.log_attrs.as_ref() {
-            if let Some(id_array) = log_arrays.id {
-                if let Some(id) = id_array.value_at(index) {
-                    let attrs_index_iter =
-                        ChildIndexIter::new(id, &log_attrs.parent_id, &mut self.log_attrs_cursor);
-                    for attr_index in attrs_index_iter {
-                        result_buf.encode_len_delimited(LOG_RECORD_ATTRIBUTES, |result_buf| {
-                            encode_key_value(log_attrs, attr_index, result_buf)
-                        })?;
-                    }
-                }
-            }
+        if let Some(col) = &log_arrays.trace_id
+            && let Some(val) = col.slice_at(index)
+        {
+            result_buf.encode_bytes(LOG_RECORD_TRACE_ID, val)?;
         }
 
-        if let Some(col) = log_arrays.dropped_attributes_count {
-            if let Some(val) = col.value_at(index) {
-                result_buf
-                    .encode_field_tag(LOG_RECORD_DROPPED_ATTRIBUTES_COUNT, wire_types::VARINT)?;
-                result_buf.encode_varint(val as u64)?;
-            }
+        if let Some(col) = &log_arrays.span_id
+            && let Some(val) = col.slice_at(index)
+        {
+            result_buf.encode_bytes(LOG_RECORD_SPAN_ID, val)?;
         }
 
-        if let Some(col) = &log_arrays.flags {
-            if let Some(val) = col.value_at(index) {
-                result_buf.encode_field_tag(LOG_RECORD_FLAGS, wire_types::FIXED32)?;
-                result_buf.extend_from_slice(&val.to_le_bytes())?;
-            }
+        if let Some(col) = log_arrays.observed_time_unix_nano
+            && let Some(val) = col.value_at(index)
+        {
+            result_buf.encode_field_tag(LOG_RECORD_OBSERVED_TIME_UNIX_NANO, wire_types::FIXED64)?;
+            result_buf.extend_from_slice(&val.to_le_bytes())?;
         }
 
-        if let Some(col) = &log_arrays.trace_id {
-            if let Some(val) = col.slice_at(index) {
-                result_buf.encode_bytes(LOG_RECORD_TRACE_ID, val)?;
-            }
-        }
-
-        if let Some(col) = &log_arrays.span_id {
-            if let Some(val) = col.slice_at(index) {
-                result_buf.encode_bytes(LOG_RECORD_SPAN_ID, val)?;
-            }
-        }
-
-        if let Some(col) = log_arrays.observed_time_unix_nano {
-            if let Some(val) = col.value_at(index) {
-                result_buf
-                    .encode_field_tag(LOG_RECORD_OBSERVED_TIME_UNIX_NANO, wire_types::FIXED64)?;
-                result_buf.extend_from_slice(&val.to_le_bytes())?;
-            }
-        }
-
-        if let Some(col) = &log_arrays.event_name {
-            if let Some(val) = col.str_at(index) {
-                result_buf.encode_string(LOG_RECORD_EVENT_NAME, val)?;
-            }
+        if let Some(col) = &log_arrays.event_name
+            && let Some(val) = col.str_at(index)
+        {
+            result_buf.encode_string(LOG_RECORD_EVENT_NAME, val)?;
         }
 
         self.root_cursor.advance();

--- a/rust/otap-dataflow/crates/pdata/src/otlp/macros/src/field_info.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/macros/src/field_info.rs
@@ -110,25 +110,25 @@ fn parse_prost_tag_and_type(field: &syn::Field) -> (u32, String) {
         .iter()
         .find(|attr| attr.path().is_ident("prost"));
 
-    if let Some(attr) = prost_attr {
-        if let syn::Meta::List(meta_list) = &attr.meta {
-            let tokens = &meta_list.tokens;
-            let attr_str = tokens.to_string();
+    if let Some(attr) = prost_attr
+        && let syn::Meta::List(meta_list) = &attr.meta
+    {
+        let tokens = &meta_list.tokens;
+        let attr_str = tokens.to_string();
 
-            // Parse tag number using helper function
-            let tag = parse_tag_value(&attr_str).unwrap_or(0);
+        // Parse tag number using helper function
+        let tag = parse_tag_value(&attr_str).unwrap_or(0);
 
-            // Extract first identifier as protobuf type (string, int64, message, etc.)
-            let proto_type = attr_str
-                .split(',')
-                .next()
-                .map(|first_part| first_part.trim())
-                .filter(|type_part| !type_part.starts_with("tag"))
-                .map(|type_part| type_part.to_string())
-                .unwrap_or_else(|| "unknown".to_string());
+        // Extract first identifier as protobuf type (string, int64, message, etc.)
+        let proto_type = attr_str
+            .split(',')
+            .next()
+            .map(|first_part| first_part.trim())
+            .filter(|type_part| !type_part.starts_with("tag"))
+            .map(|type_part| type_part.to_string())
+            .unwrap_or_else(|| "unknown".to_string());
 
-            return (tag, proto_type);
-        }
+        return (tag, proto_type);
     }
 
     // Return default values instead of panicking, which helps us see more of what's happening

--- a/rust/otap-dataflow/crates/pdata/src/otlp/metrics.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/metrics.rs
@@ -563,10 +563,10 @@ impl MetricsProtoBytesEncoder {
         }
 
         // encode schema url
-        if let Some(col) = &metrics_data_arrays.resource_arrays.schema_url {
-            if let Some(val) = col.str_at(index) {
-                result_buf.encode_string(RESOURCE_METRICS_SCHEMA_URL, val)?;
-            }
+        if let Some(col) = &metrics_data_arrays.resource_arrays.schema_url
+            && let Some(val) = col.str_at(index)
+        {
+            result_buf.encode_string(RESOURCE_METRICS_SCHEMA_URL, val)?;
         }
 
         Ok(())
@@ -623,10 +623,10 @@ impl MetricsProtoBytesEncoder {
         }
 
         // encode the schema url
-        if let Some(col) = &metrics_data_arrays.metrics_arrays.schema_url {
-            if let Some(val) = col.str_at(index) {
-                result_buf.encode_string(SCOPE_METRICS_SCHEMA_URL, val)?;
-            }
+        if let Some(col) = &metrics_data_arrays.metrics_arrays.schema_url
+            && let Some(val) = col.str_at(index)
+        {
+            result_buf.encode_string(SCOPE_METRICS_SCHEMA_URL, val)?;
         }
 
         Ok(())
@@ -648,16 +648,16 @@ impl MetricsProtoBytesEncoder {
             result_buf.encode_string(METRIC_NAME, val)?;
         }
 
-        if let Some(col) = &metrics_arrays.description {
-            if let Some(val) = col.str_at(index) {
-                result_buf.encode_string(METRIC_DESCRIPTION, val)?;
-            }
+        if let Some(col) = &metrics_arrays.description
+            && let Some(val) = col.str_at(index)
+        {
+            result_buf.encode_string(METRIC_DESCRIPTION, val)?;
         }
 
-        if let Some(col) = &metrics_arrays.unit {
-            if let Some(val) = col.str_at(index) {
-                result_buf.encode_string(METRIC_UNIT, val)?;
-            }
+        if let Some(col) = &metrics_arrays.unit
+            && let Some(val) = col.str_at(index)
+        {
+            result_buf.encode_string(METRIC_UNIT, val)?;
         }
 
         if let Some(metric_type_val) = &metrics_arrays.metric_type.value_at(index) {
@@ -692,18 +692,15 @@ impl MetricsProtoBytesEncoder {
             }
         }
 
-        if let Some(metrics_attrs) = metrics_data_arrays.metrics_attrs.as_ref() {
-            if let Some(id) = metrics_arrays.id.value_at(index) {
-                let attrs_index_iter = ChildIndexIter::new(
-                    id,
-                    &metrics_attrs.parent_id,
-                    &mut self.metrics_attrs_cursor,
-                );
-                for attr_index in attrs_index_iter {
-                    result_buf.encode_len_delimited(METRIC_METADATA, |result_buf| {
-                        encode_key_value(metrics_attrs, attr_index, result_buf)
-                    })?
-                }
+        if let Some(metrics_attrs) = metrics_data_arrays.metrics_attrs.as_ref()
+            && let Some(id) = metrics_arrays.id.value_at(index)
+        {
+            let attrs_index_iter =
+                ChildIndexIter::new(id, &metrics_attrs.parent_id, &mut self.metrics_attrs_cursor);
+            for attr_index in attrs_index_iter {
+                result_buf.encode_len_delimited(METRIC_METADATA, |result_buf| {
+                    encode_key_value(metrics_attrs, attr_index, result_buf)
+                })?
             }
         }
 

--- a/rust/otap-dataflow/crates/pdata/src/otlp/metrics/data_points/exp_histogram.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/metrics/data_points/exp_histogram.rs
@@ -174,58 +174,57 @@ pub(crate) fn proto_encode_exp_hist_data_point(
     exemplar_attrs_cursor: &mut SortedBatchCursor,
     result_buf: &mut ProtoBuffer,
 ) -> Result<()> {
-    if let Some(attrs) = attrs {
-        if let Some(id) = exp_hist_dp_arrays.id.value_at(index) {
-            let attrs_index_iter = ChildIndexIter::new(id, &attrs.parent_id, attrs_cursor);
-            for attrs_index in attrs_index_iter {
-                result_buf.encode_len_delimited(EXP_HISTOGRAM_DP_ATTRIBUTES, |result_buf| {
-                    encode_key_value(attrs, attrs_index, result_buf)
-                })?;
-            }
+    if let Some(attrs) = attrs
+        && let Some(id) = exp_hist_dp_arrays.id.value_at(index)
+    {
+        let attrs_index_iter = ChildIndexIter::new(id, &attrs.parent_id, attrs_cursor);
+        for attrs_index in attrs_index_iter {
+            result_buf.encode_len_delimited(EXP_HISTOGRAM_DP_ATTRIBUTES, |result_buf| {
+                encode_key_value(attrs, attrs_index, result_buf)
+            })?;
         }
     }
 
-    if let Some(col) = exp_hist_dp_arrays.start_time_unix_nano {
-        if let Some(val) = col.value_at(index) {
-            result_buf
-                .encode_field_tag(EXP_HISTOGRAM_DP_START_TIME_UNIX_NANO, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
+    if let Some(col) = exp_hist_dp_arrays.start_time_unix_nano
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(EXP_HISTOGRAM_DP_START_TIME_UNIX_NANO, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
     }
 
-    if let Some(col) = exp_hist_dp_arrays.time_unix_nano {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(EXP_HISTOGRAM_DP_TIME_UNIX_NANO, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
+    if let Some(col) = exp_hist_dp_arrays.time_unix_nano
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(EXP_HISTOGRAM_DP_TIME_UNIX_NANO, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
     }
 
-    if let Some(col) = exp_hist_dp_arrays.histogram_count {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(EXP_HISTOGRAM_DP_COUNT, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
+    if let Some(col) = exp_hist_dp_arrays.histogram_count
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(EXP_HISTOGRAM_DP_COUNT, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
     }
 
-    if let Some(col) = exp_hist_dp_arrays.histogram_sum {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(EXP_HISTOGRAM_DP_SUM, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
+    if let Some(col) = exp_hist_dp_arrays.histogram_sum
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(EXP_HISTOGRAM_DP_SUM, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
     }
 
-    if let Some(col) = exp_hist_dp_arrays.exp_histogram_scale {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(EXP_HISTOGRAM_DP_SCALE, wire_types::VARINT)?;
-            result_buf.encode_sint32(val)?;
-        }
+    if let Some(col) = exp_hist_dp_arrays.exp_histogram_scale
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(EXP_HISTOGRAM_DP_SCALE, wire_types::VARINT)?;
+        result_buf.encode_sint32(val)?;
     }
 
-    if let Some(col) = exp_hist_dp_arrays.exp_histogram_zero_count {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(EXP_HISTOGRAM_DP_ZERO_COUNT, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
+    if let Some(col) = exp_hist_dp_arrays.exp_histogram_zero_count
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(EXP_HISTOGRAM_DP_ZERO_COUNT, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
     }
 
     if let Some(bucket_arrays) = exp_hist_dp_arrays.exp_histogram_positive.as_ref() {
@@ -240,50 +239,50 @@ pub(crate) fn proto_encode_exp_hist_data_point(
         })?;
     }
 
-    if let Some(exemplar_arrays) = exemplar_arrays {
-        if let Some(id) = exp_hist_dp_arrays.id.value_at(index) {
-            let exemplar_index_iter =
-                ChildIndexIter::new(id, &exemplar_arrays.parent_id, exemplar_cursor);
-            for exemplar_index in exemplar_index_iter {
-                result_buf.encode_len_delimited(EXP_HISTOGRAM_DP_EXEMPLARS, |result_buf| {
-                    proto_encode_exemplar(
-                        exemplar_index,
-                        exemplar_arrays,
-                        exemplar_attr_arrays,
-                        exemplar_attrs_cursor,
-                        result_buf,
-                    )
-                })?;
-            }
+    if let Some(exemplar_arrays) = exemplar_arrays
+        && let Some(id) = exp_hist_dp_arrays.id.value_at(index)
+    {
+        let exemplar_index_iter =
+            ChildIndexIter::new(id, &exemplar_arrays.parent_id, exemplar_cursor);
+        for exemplar_index in exemplar_index_iter {
+            result_buf.encode_len_delimited(EXP_HISTOGRAM_DP_EXEMPLARS, |result_buf| {
+                proto_encode_exemplar(
+                    exemplar_index,
+                    exemplar_arrays,
+                    exemplar_attr_arrays,
+                    exemplar_attrs_cursor,
+                    result_buf,
+                )
+            })?;
         }
     }
 
-    if let Some(col) = exp_hist_dp_arrays.flags {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(EXP_HISTOGRAM_DP_FLAGS, wire_types::VARINT)?;
-            result_buf.encode_varint(val as u64)?;
-        }
+    if let Some(col) = exp_hist_dp_arrays.flags
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(EXP_HISTOGRAM_DP_FLAGS, wire_types::VARINT)?;
+        result_buf.encode_varint(val as u64)?;
     }
 
-    if let Some(col) = exp_hist_dp_arrays.histogram_min {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(EXP_HISTOGRAM_DP_MIN, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
+    if let Some(col) = exp_hist_dp_arrays.histogram_min
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(EXP_HISTOGRAM_DP_MIN, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
     }
 
-    if let Some(col) = exp_hist_dp_arrays.histogram_max {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(EXP_HISTOGRAM_DP_MAX, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
+    if let Some(col) = exp_hist_dp_arrays.histogram_max
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(EXP_HISTOGRAM_DP_MAX, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
     }
 
-    if let Some(col) = exp_hist_dp_arrays.zero_threshold {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(EXP_HISTOGRAM_DP_ZERO_THRESHOLD, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
+    if let Some(col) = exp_hist_dp_arrays.zero_threshold
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(EXP_HISTOGRAM_DP_ZERO_THRESHOLD, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
     }
 
     Ok(())

--- a/rust/otap-dataflow/crates/pdata/src/otlp/metrics/data_points/histogram.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/metrics/data_points/histogram.rs
@@ -149,130 +149,130 @@ pub(crate) fn proto_encode_histogram_data_point(
     exemplar_attrs_cursor: &mut SortedBatchCursor,
     result_buf: &mut ProtoBuffer,
 ) -> Result<()> {
-    if let Some(attrs) = attrs {
-        if let Some(id) = hist_dp_arrays.id.value_at(index) {
-            let attrs_index_iter = ChildIndexIter::new(id, &attrs.parent_id, attrs_cursor);
-            for attrs_index in attrs_index_iter {
-                result_buf.encode_len_delimited(HISTOGRAM_DP_ATTRIBUTES, |result_buf| {
-                    encode_key_value(attrs, attrs_index, result_buf)
-                })?;
-            }
+    if let Some(attrs) = attrs
+        && let Some(id) = hist_dp_arrays.id.value_at(index)
+    {
+        let attrs_index_iter = ChildIndexIter::new(id, &attrs.parent_id, attrs_cursor);
+        for attrs_index in attrs_index_iter {
+            result_buf.encode_len_delimited(HISTOGRAM_DP_ATTRIBUTES, |result_buf| {
+                encode_key_value(attrs, attrs_index, result_buf)
+            })?;
         }
     }
 
-    if let Some(col) = hist_dp_arrays.start_time_unix_nano {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(HISTOGRAM_DP_START_TIME_UNIX_NANO, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
+    if let Some(col) = hist_dp_arrays.start_time_unix_nano
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(HISTOGRAM_DP_START_TIME_UNIX_NANO, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
+    }
+
+    if let Some(col) = hist_dp_arrays.time_unix_nano
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(HISTOGRAM_DP_TIME_UNIX_NANO, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
+    }
+
+    if let Some(col) = hist_dp_arrays.histogram_count
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(HISTOGRAM_DP_COUNT, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
+    }
+
+    if let Some(col) = hist_dp_arrays.histogram_sum
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(HISTOGRAM_DP_SUM, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
+    }
+
+    if let Some(bucket_counts) = &hist_dp_arrays.histogram_bucket_counts
+        && bucket_counts.list.is_valid(index)
+    {
+        let value_offsets = bucket_counts.list.value_offsets();
+        let start = value_offsets[index] as usize;
+        let end = value_offsets[index + 1] as usize;
+        let values = bucket_counts.value.slice(start, end - start);
+
+        // encode using packed encoding for repeated primitive
+        // https://protobuf.dev/programming-guides/encoding/#repeated
+
+        // append tag & len
+        result_buf.encode_field_tag(HISTOGRAM_DP_BUCKET_COUNTS, wire_types::LEN)?;
+        let num_values = values.len() - values.null_count();
+        result_buf.encode_varint(8 * num_values as u64)?; // 8 bytes per value
+
+        // write values
+        values
+            .iter()
+            .flatten()
+            .map(u64::to_le_bytes)
+            .try_for_each(|bytes| result_buf.extend_from_slice(&bytes))?;
+    }
+
+    if let Some(explicit_bounds) = &hist_dp_arrays.histogram_explicit_bounds
+        && explicit_bounds.list.is_valid(index)
+    {
+        let value_offsets = explicit_bounds.list.value_offsets();
+        let start = value_offsets[index] as usize;
+        let end = value_offsets[index + 1] as usize;
+        let values = explicit_bounds.value.slice(start, end - start);
+
+        // encode using packed encoding for repeated primitive
+        // https://protobuf.dev/programming-guides/encoding/#repeated
+
+        // append tag & len
+        result_buf.encode_field_tag(HISTOGRAM_DP_EXPLICIT_BOUNDS, wire_types::LEN)?;
+        let num_values = values.len() - values.null_count();
+        result_buf.encode_varint(8 * num_values as u64)?; // 8 bytes per value
+
+        // write values
+        values
+            .iter()
+            .flatten()
+            .map(f64::to_le_bytes)
+            .try_for_each(|bytes| result_buf.extend_from_slice(&bytes))?;
+    }
+
+    if let Some(exemplar_arrays) = exemplar_arrays
+        && let Some(id) = hist_dp_arrays.id.value_at(index)
+    {
+        let exemplar_index_iter =
+            ChildIndexIter::new(id, &exemplar_arrays.parent_id, exemplar_cursor);
+        for exemplar_index in exemplar_index_iter {
+            result_buf.encode_len_delimited(HISTOGRAM_DP_EXEMPLARS, |result_buf| {
+                proto_encode_exemplar(
+                    exemplar_index,
+                    exemplar_arrays,
+                    exemplar_attr_arrays,
+                    exemplar_attrs_cursor,
+                    result_buf,
+                )
+            })?;
         }
     }
 
-    if let Some(col) = hist_dp_arrays.time_unix_nano {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(HISTOGRAM_DP_TIME_UNIX_NANO, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
+    if let Some(col) = hist_dp_arrays.flags
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(HISTOGRAM_DP_FLAGS, wire_types::VARINT)?;
+        result_buf.encode_varint(val as u64)?;
     }
 
-    if let Some(col) = hist_dp_arrays.histogram_count {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(HISTOGRAM_DP_COUNT, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
+    if let Some(col) = hist_dp_arrays.histogram_min
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(HISTOGRAM_DP_MIN, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
     }
 
-    if let Some(col) = hist_dp_arrays.histogram_sum {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(HISTOGRAM_DP_SUM, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
-    }
-
-    if let Some(bucket_counts) = &hist_dp_arrays.histogram_bucket_counts {
-        if bucket_counts.list.is_valid(index) {
-            let value_offsets = bucket_counts.list.value_offsets();
-            let start = value_offsets[index] as usize;
-            let end = value_offsets[index + 1] as usize;
-            let values = bucket_counts.value.slice(start, end - start);
-
-            // encode using packed encoding for repeated primitive
-            // https://protobuf.dev/programming-guides/encoding/#repeated
-
-            // append tag & len
-            result_buf.encode_field_tag(HISTOGRAM_DP_BUCKET_COUNTS, wire_types::LEN)?;
-            let num_values = values.len() - values.null_count();
-            result_buf.encode_varint(8 * num_values as u64)?; // 8 bytes per value
-
-            // write values
-            values
-                .iter()
-                .flatten()
-                .map(u64::to_le_bytes)
-                .try_for_each(|bytes| result_buf.extend_from_slice(&bytes))?;
-        }
-    }
-
-    if let Some(explicit_bounds) = &hist_dp_arrays.histogram_explicit_bounds {
-        if explicit_bounds.list.is_valid(index) {
-            let value_offsets = explicit_bounds.list.value_offsets();
-            let start = value_offsets[index] as usize;
-            let end = value_offsets[index + 1] as usize;
-            let values = explicit_bounds.value.slice(start, end - start);
-
-            // encode using packed encoding for repeated primitive
-            // https://protobuf.dev/programming-guides/encoding/#repeated
-
-            // append tag & len
-            result_buf.encode_field_tag(HISTOGRAM_DP_EXPLICIT_BOUNDS, wire_types::LEN)?;
-            let num_values = values.len() - values.null_count();
-            result_buf.encode_varint(8 * num_values as u64)?; // 8 bytes per value
-
-            // write values
-            values
-                .iter()
-                .flatten()
-                .map(f64::to_le_bytes)
-                .try_for_each(|bytes| result_buf.extend_from_slice(&bytes))?;
-        }
-    }
-
-    if let Some(exemplar_arrays) = exemplar_arrays {
-        if let Some(id) = hist_dp_arrays.id.value_at(index) {
-            let exemplar_index_iter =
-                ChildIndexIter::new(id, &exemplar_arrays.parent_id, exemplar_cursor);
-            for exemplar_index in exemplar_index_iter {
-                result_buf.encode_len_delimited(HISTOGRAM_DP_EXEMPLARS, |result_buf| {
-                    proto_encode_exemplar(
-                        exemplar_index,
-                        exemplar_arrays,
-                        exemplar_attr_arrays,
-                        exemplar_attrs_cursor,
-                        result_buf,
-                    )
-                })?;
-            }
-        }
-    }
-
-    if let Some(col) = hist_dp_arrays.flags {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(HISTOGRAM_DP_FLAGS, wire_types::VARINT)?;
-            result_buf.encode_varint(val as u64)?;
-        }
-    }
-
-    if let Some(col) = hist_dp_arrays.histogram_min {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(HISTOGRAM_DP_MIN, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
-    }
-
-    if let Some(col) = hist_dp_arrays.histogram_max {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(HISTOGRAM_DP_MAX, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
+    if let Some(col) = hist_dp_arrays.histogram_max
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(HISTOGRAM_DP_MAX, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
     }
 
     Ok(())

--- a/rust/otap-dataflow/crates/pdata/src/otlp/metrics/data_points/number.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/metrics/data_points/number.rs
@@ -68,72 +68,71 @@ pub(crate) fn proto_encode_number_data_point(
     exemplar_attrs_cursor: &mut SortedBatchCursor,
     result_buf: &mut ProtoBuffer,
 ) -> Result<()> {
-    if let Some(attrs) = attr_arrays {
-        if let Some(id) = number_dp_arrays.id.value_at(index) {
-            let attrs_index_iter = ChildIndexIter::new(id, &attrs.parent_id, attrs_cursor);
-            for attrs_index in attrs_index_iter {
-                result_buf.encode_len_delimited(NUMBER_DP_ATTRIBUTES, |result_buf| {
-                    encode_key_value(attrs, attrs_index, result_buf)
-                })?;
-            }
+    if let Some(attrs) = attr_arrays
+        && let Some(id) = number_dp_arrays.id.value_at(index)
+    {
+        let attrs_index_iter = ChildIndexIter::new(id, &attrs.parent_id, attrs_cursor);
+        for attrs_index in attrs_index_iter {
+            result_buf.encode_len_delimited(NUMBER_DP_ATTRIBUTES, |result_buf| {
+                encode_key_value(attrs, attrs_index, result_buf)
+            })?;
         }
     }
 
-    if let Some(col) = number_dp_arrays.start_time_unix_nano {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(NUMBER_DP_START_TIME_UNIX_NANO, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
+    if let Some(col) = number_dp_arrays.start_time_unix_nano
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(NUMBER_DP_START_TIME_UNIX_NANO, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
     }
 
-    if let Some(col) = number_dp_arrays.time_unix_nano {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(NUMBER_DP_TIME_UNIX_NANO, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
+    if let Some(col) = number_dp_arrays.time_unix_nano
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(NUMBER_DP_TIME_UNIX_NANO, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
     }
 
     let mut value_is_double = false;
-    if let Some(col) = number_dp_arrays.double_value {
-        if let Some(val) = col.value_at(index) {
-            value_is_double = true;
-            result_buf.encode_field_tag(NUMBER_DP_AS_DOUBLE, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
+    if let Some(col) = number_dp_arrays.double_value
+        && let Some(val) = col.value_at(index)
+    {
+        value_is_double = true;
+        result_buf.encode_field_tag(NUMBER_DP_AS_DOUBLE, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
+    }
+
+    if !value_is_double
+        && let Some(col) = number_dp_arrays.int_value
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(NUMBER_DP_AS_INT, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
+    }
+
+    if let Some(exemplar_arrays) = exemplar_arrays
+        && let Some(id) = number_dp_arrays.id.value_at(index)
+    {
+        let exemplar_index_iter =
+            ChildIndexIter::new(id, &exemplar_arrays.parent_id, exemplar_cursor);
+        for exemplar_index in exemplar_index_iter {
+            result_buf.encode_len_delimited(NUMBER_DP_EXEMPLARS, |result_buf| {
+                proto_encode_exemplar(
+                    exemplar_index,
+                    exemplar_arrays,
+                    exemplar_attr_arrays,
+                    exemplar_attrs_cursor,
+                    result_buf,
+                )
+            })?;
         }
     }
 
-    if !value_is_double {
-        if let Some(col) = number_dp_arrays.int_value {
-            if let Some(val) = col.value_at(index) {
-                result_buf.encode_field_tag(NUMBER_DP_AS_INT, wire_types::FIXED64)?;
-                result_buf.extend_from_slice(&val.to_le_bytes())?;
-            }
-        }
-    }
-
-    if let Some(exemplar_arrays) = exemplar_arrays {
-        if let Some(id) = number_dp_arrays.id.value_at(index) {
-            let exemplar_index_iter =
-                ChildIndexIter::new(id, &exemplar_arrays.parent_id, exemplar_cursor);
-            for exemplar_index in exemplar_index_iter {
-                result_buf.encode_len_delimited(NUMBER_DP_EXEMPLARS, |result_buf| {
-                    proto_encode_exemplar(
-                        exemplar_index,
-                        exemplar_arrays,
-                        exemplar_attr_arrays,
-                        exemplar_attrs_cursor,
-                        result_buf,
-                    )
-                })?;
-            }
-        }
-    }
-
-    if let Some(col) = number_dp_arrays.flags {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(NUMBER_DP_FLAGS, wire_types::VARINT)?;
-            result_buf.encode_varint(val as u64)?;
-        }
+    if let Some(col) = number_dp_arrays.flags
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(NUMBER_DP_FLAGS, wire_types::VARINT)?;
+        result_buf.encode_varint(val as u64)?;
     }
 
     Ok(())

--- a/rust/otap-dataflow/crates/pdata/src/otlp/metrics/data_points/summary.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/metrics/data_points/summary.rs
@@ -118,64 +118,64 @@ pub(crate) fn proto_encode_summary_data_point(
     attrs_cursor: &mut SortedBatchCursor,
     result_buf: &mut ProtoBuffer,
 ) -> Result<()> {
-    if let Some(attrs) = attr_arrays {
-        if let Some(id) = summary_dp_arrays.id.value_at(index) {
-            let attrs_index_iter = ChildIndexIter::new(id, &attrs.parent_id, attrs_cursor);
-            for attrs_index in attrs_index_iter {
-                result_buf.encode_len_delimited(SUMMARY_DP_ATTRIBUTES, |result_buf| {
-                    encode_key_value(attrs, attrs_index, result_buf)
-                })?;
-            }
+    if let Some(attrs) = attr_arrays
+        && let Some(id) = summary_dp_arrays.id.value_at(index)
+    {
+        let attrs_index_iter = ChildIndexIter::new(id, &attrs.parent_id, attrs_cursor);
+        for attrs_index in attrs_index_iter {
+            result_buf.encode_len_delimited(SUMMARY_DP_ATTRIBUTES, |result_buf| {
+                encode_key_value(attrs, attrs_index, result_buf)
+            })?;
         }
     }
 
-    if let Some(col) = summary_dp_arrays.start_time_unix_nano {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(SUMMARY_DP_START_TIME_UNIX_NANO, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
+    if let Some(col) = summary_dp_arrays.start_time_unix_nano
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(SUMMARY_DP_START_TIME_UNIX_NANO, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
+    }
+
+    if let Some(col) = summary_dp_arrays.time_unix_nano
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(SUMMARY_DP_TIME_UNIX_NANO, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
+    }
+
+    if let Some(col) = summary_dp_arrays.summary_count
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(SUMMARY_DP_COUNT, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
+    }
+
+    if let Some(col) = summary_dp_arrays.summary_sum
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(SUMMARY_DP_SUM, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
+    }
+
+    if let Some(quantile_arrays) = &summary_dp_arrays.summary_quantile_values
+        && quantile_arrays.list_array.is_valid(index)
+    {
+        let value_offsets = quantile_arrays.list_array.value_offsets();
+        let start = value_offsets[index];
+        let end = value_offsets[index + 1];
+
+        for i in start..end {
+            result_buf.encode_len_delimited(SUMMARY_DP_QUANTILE_VALUES, |result_buf| {
+                proto_encode_value_quantile(i as usize, quantile_arrays, result_buf)
+            })?;
         }
     }
 
-    if let Some(col) = summary_dp_arrays.time_unix_nano {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(SUMMARY_DP_TIME_UNIX_NANO, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
-    }
-
-    if let Some(col) = summary_dp_arrays.summary_count {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(SUMMARY_DP_COUNT, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
-    }
-
-    if let Some(col) = summary_dp_arrays.summary_sum {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(SUMMARY_DP_SUM, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
-    }
-
-    if let Some(quantile_arrays) = &summary_dp_arrays.summary_quantile_values {
-        if quantile_arrays.list_array.is_valid(index) {
-            let value_offsets = quantile_arrays.list_array.value_offsets();
-            let start = value_offsets[index];
-            let end = value_offsets[index + 1];
-
-            for i in start..end {
-                result_buf.encode_len_delimited(SUMMARY_DP_QUANTILE_VALUES, |result_buf| {
-                    proto_encode_value_quantile(i as usize, quantile_arrays, result_buf)
-                })?;
-            }
-        }
-    }
-
-    if let Some(col) = summary_dp_arrays.flags {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(SUMMARY_DP_FLAGS, wire_types::VARINT)?;
-            result_buf.encode_varint(val as u64)?;
-        }
+    if let Some(col) = summary_dp_arrays.flags
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(SUMMARY_DP_FLAGS, wire_types::VARINT)?;
+        result_buf.encode_varint(val as u64)?;
     }
 
     Ok(())

--- a/rust/otap-dataflow/crates/pdata/src/otlp/metrics/exemplar.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/metrics/exemplar.rs
@@ -69,52 +69,51 @@ pub(crate) fn proto_encode_exemplar(
     attrs_cursor: &mut SortedBatchCursor,
     result_buf: &mut ProtoBuffer,
 ) -> Result<()> {
-    if let Some(attrs) = attr_arrays {
-        if let Some(id) = exemplar_arrays.id.value_at(index) {
-            let attr_index_iter = ChildIndexIter::new(id, &attrs.parent_id, attrs_cursor);
-            for attrs_index in attr_index_iter {
-                result_buf.encode_len_delimited(EXEMPLAR_FILTERED_ATTRIBUTES, |result_buf| {
-                    encode_key_value(attrs, attrs_index, result_buf)
-                })?;
-            }
+    if let Some(attrs) = attr_arrays
+        && let Some(id) = exemplar_arrays.id.value_at(index)
+    {
+        let attr_index_iter = ChildIndexIter::new(id, &attrs.parent_id, attrs_cursor);
+        for attrs_index in attr_index_iter {
+            result_buf.encode_len_delimited(EXEMPLAR_FILTERED_ATTRIBUTES, |result_buf| {
+                encode_key_value(attrs, attrs_index, result_buf)
+            })?;
         }
     }
 
-    if let Some(col) = exemplar_arrays.time_unix_nano {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(EXEMPLAR_TIME_UNIX_NANO, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
+    if let Some(col) = exemplar_arrays.time_unix_nano
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(EXEMPLAR_TIME_UNIX_NANO, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
     }
 
     let mut value_is_double = false;
-    if let Some(col) = exemplar_arrays.double_value {
-        if let Some(val) = col.value_at(index) {
-            value_is_double = true;
-            result_buf.encode_field_tag(EXEMPLAR_AS_DOUBLE, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
+    if let Some(col) = exemplar_arrays.double_value
+        && let Some(val) = col.value_at(index)
+    {
+        value_is_double = true;
+        result_buf.encode_field_tag(EXEMPLAR_AS_DOUBLE, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
     }
 
-    if !value_is_double {
-        if let Some(col) = exemplar_arrays.int_value {
-            if let Some(val) = col.value_at(index) {
-                result_buf.encode_field_tag(EXEMPLAR_AS_INT, wire_types::FIXED64)?;
-                result_buf.extend_from_slice(&val.to_le_bytes())?;
-            }
-        }
+    if !value_is_double
+        && let Some(col) = exemplar_arrays.int_value
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(EXEMPLAR_AS_INT, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
     }
 
-    if let Some(col) = &exemplar_arrays.span_id {
-        if let Some(val) = col.slice_at(index) {
-            result_buf.encode_bytes(EXEMPLAR_SPAN_ID, val)?;
-        }
+    if let Some(col) = &exemplar_arrays.span_id
+        && let Some(val) = col.slice_at(index)
+    {
+        result_buf.encode_bytes(EXEMPLAR_SPAN_ID, val)?;
     }
 
-    if let Some(col) = &exemplar_arrays.trace_id {
-        if let Some(val) = col.slice_at(index) {
-            result_buf.encode_bytes(EXEMPLAR_TRACE_ID, val)?;
-        }
+    if let Some(col) = &exemplar_arrays.trace_id
+        && let Some(val) = col.slice_at(index)
+    {
+        result_buf.encode_bytes(EXEMPLAR_TRACE_ID, val)?;
     }
 
     Ok(())

--- a/rust/otap-dataflow/crates/pdata/src/otlp/traces.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/traces.rs
@@ -273,10 +273,10 @@ impl TracesProtoBytesEncoder {
         }
 
         // encode the schema url
-        if let Some(col) = &traces_data_arrays.resource_arrays.schema_url {
-            if let Some(val) = col.str_at(index) {
-                result_buf.encode_string(RESOURCE_SPANS_SCHEMA_URL, val)?;
-            }
+        if let Some(col) = &traces_data_arrays.resource_arrays.schema_url
+            && let Some(val) = col.str_at(index)
+        {
+            result_buf.encode_string(RESOURCE_SPANS_SCHEMA_URL, val)?;
         }
 
         Ok(())
@@ -332,10 +332,10 @@ impl TracesProtoBytesEncoder {
         }
 
         // encode the schema url
-        if let Some(col) = &traces_data_arrays.span_arrays.schema_url {
-            if let Some(val) = col.str_at(index) {
-                result_buf.encode_string(SCOPE_SPANS_SCHEMA_URL, val)?;
-            }
+        if let Some(col) = &traces_data_arrays.span_arrays.schema_url
+            && let Some(val) = col.str_at(index)
+        {
+            result_buf.encode_string(SCOPE_SPANS_SCHEMA_URL, val)?;
         }
 
         Ok(())
@@ -353,144 +353,143 @@ impl TracesProtoBytesEncoder {
 
         let span_arrays = &traces_data_arrays.span_arrays;
 
-        if let Some(col) = &span_arrays.trace_id {
-            if let Some(val) = col.slice_at(index) {
-                result_buf.encode_bytes(SPAN_TRACE_ID, val)?;
+        if let Some(col) = &span_arrays.trace_id
+            && let Some(val) = col.slice_at(index)
+        {
+            result_buf.encode_bytes(SPAN_TRACE_ID, val)?;
+        }
+
+        if let Some(col) = &span_arrays.span_id
+            && let Some(val) = col.slice_at(index)
+        {
+            result_buf.encode_bytes(SPAN_SPAN_ID, val)?;
+        }
+
+        if let Some(col) = &span_arrays.trace_state
+            && let Some(val) = col.str_at(index)
+        {
+            result_buf.encode_string(SPAN_TRACE_STATE, val)?;
+        }
+
+        if let Some(col) = &span_arrays.parent_span_id
+            && let Some(val) = col.slice_at(index)
+        {
+            result_buf.encode_bytes(SPAN_PARENT_SPAN_ID, val)?;
+        }
+
+        if let Some(col) = &span_arrays.flags
+            && let Some(val) = col.value_at(index)
+        {
+            result_buf.encode_field_tag(SPAN_FLAGS, wire_types::FIXED32)?;
+            result_buf.extend_from_slice(&val.to_le_bytes())?;
+        }
+
+        if let Some(col) = &span_arrays.name
+            && let Some(val) = col.str_at(index)
+        {
+            result_buf.encode_string(SPAN_NAME, val)?;
+        }
+
+        if let Some(col) = &span_arrays.kind
+            && let Some(val) = col.value_at(index)
+        {
+            result_buf.encode_field_tag(SPAN_KIND, wire_types::VARINT)?;
+            result_buf.encode_varint(val as u64)?;
+        }
+
+        if let Some(col) = &span_arrays.start_time_unix_nano
+            && let Some(start_time) = col.value_at(index)
+        {
+            result_buf.encode_field_tag(SPAN_START_TIME_UNIX_NANO, wire_types::FIXED64)?;
+            result_buf.extend_from_slice(&start_time.to_le_bytes())?;
+
+            // encode end time from start + duration
+            if let Some(col) = &span_arrays.duration_time_unix_nano
+                && let Some(duration) = col.value_at(index)
+            {
+                let end_time = start_time + duration;
+                result_buf.encode_field_tag(SPAN_END_TIME_UNIX_NANO, wire_types::FIXED64)?;
+                result_buf.extend_from_slice(&end_time.to_le_bytes())?;
             }
         }
 
-        if let Some(col) = &span_arrays.span_id {
-            if let Some(val) = col.slice_at(index) {
-                result_buf.encode_bytes(SPAN_SPAN_ID, val)?;
-            }
-        }
-
-        if let Some(col) = &span_arrays.trace_state {
-            if let Some(val) = col.str_at(index) {
-                result_buf.encode_string(SPAN_TRACE_STATE, val)?;
-            }
-        }
-
-        if let Some(col) = &span_arrays.parent_span_id {
-            if let Some(val) = col.slice_at(index) {
-                result_buf.encode_bytes(SPAN_PARENT_SPAN_ID, val)?;
-            }
-        }
-
-        if let Some(col) = &span_arrays.flags {
-            if let Some(val) = col.value_at(index) {
-                result_buf.encode_field_tag(SPAN_FLAGS, wire_types::FIXED32)?;
-                result_buf.extend_from_slice(&val.to_le_bytes())?;
-            }
-        }
-
-        if let Some(col) = &span_arrays.name {
-            if let Some(val) = col.str_at(index) {
-                result_buf.encode_string(SPAN_NAME, val)?;
-            }
-        }
-
-        if let Some(col) = &span_arrays.kind {
-            if let Some(val) = col.value_at(index) {
-                result_buf.encode_field_tag(SPAN_KIND, wire_types::VARINT)?;
-                result_buf.encode_varint(val as u64)?;
-            }
-        }
-
-        if let Some(col) = &span_arrays.start_time_unix_nano {
-            if let Some(start_time) = col.value_at(index) {
-                result_buf.encode_field_tag(SPAN_START_TIME_UNIX_NANO, wire_types::FIXED64)?;
-                result_buf.extend_from_slice(&start_time.to_le_bytes())?;
-
-                // encode end time from start + duration
-                if let Some(col) = &span_arrays.duration_time_unix_nano {
-                    if let Some(duration) = col.value_at(index) {
-                        let end_time = start_time + duration;
-                        result_buf
-                            .encode_field_tag(SPAN_END_TIME_UNIX_NANO, wire_types::FIXED64)?;
-                        result_buf.extend_from_slice(&end_time.to_le_bytes())?;
-                    }
-                }
-            }
-        }
-
-        if let Some(span_attrs) = &traces_data_arrays.span_attrs {
-            if let Some(id) = span_arrays.id.value_at(index) {
-                let attrs_index_iter =
-                    ChildIndexIter::new(id, &span_attrs.parent_id, &mut self.spans_attrs_cursor);
-                for attr_index in attrs_index_iter {
-                    result_buf.encode_len_delimited(SPAN_ATTRIBUTES, |result_buf| {
-                        encode_key_value(span_attrs, attr_index, result_buf)
-                    })?;
-                }
-            }
-        }
-
-        if let Some(col) = span_arrays.dropped_attributes_count {
-            if let Some(val) = col.value_at(index) {
-                result_buf.encode_field_tag(SPAN_DROPPED_ATTRIBUTES_COUNT, wire_types::VARINT)?;
-                result_buf.encode_varint(val as u64)?;
-            }
-        }
-
-        if let Some(span_events) = &traces_data_arrays.span_events {
-            if let Some(id) = span_arrays.id.value_at(index) {
-                let parent_ids = MaybeDictArrayAccessor::Native(span_events.parent_id);
-                let events_index_iter =
-                    ChildIndexIter::new(id, &parent_ids, &mut self.span_events_cursor);
-                for event_index in events_index_iter {
-                    result_buf.encode_len_delimited(SPAN_EVENTS, |result_buf| {
-                        encode_span_event(
-                            event_index,
-                            span_events,
-                            &mut self.span_events_attrs_cursor,
-                            traces_data_arrays.span_event_attrs.as_ref(),
-                            result_buf,
-                        )
-                    })?;
-                }
-            }
-        }
-
-        if let Some(col) = span_arrays.dropped_events_count {
-            if let Some(val) = col.value_at(index) {
-                result_buf.encode_field_tag(SPAN_DROPPED_EVENTS_COUNT, wire_types::VARINT)?;
-                result_buf.encode_varint(val as u64)?;
-            }
-        }
-
-        if let Some(span_links) = &traces_data_arrays.span_links {
-            if let Some(id) = span_arrays.id.value_at(index) {
-                let parent_ids = MaybeDictArrayAccessor::Native(span_links.parent_id);
-                let links_index_iter =
-                    ChildIndexIter::new(id, &parent_ids, &mut self.span_links_cursor);
-                for link_index in links_index_iter {
-                    result_buf.encode_len_delimited(SPAN_LINKS, |result_buf| {
-                        encode_span_link(
-                            link_index,
-                            span_links,
-                            &mut self.span_links_attrs_cursor,
-                            traces_data_arrays.span_link_attrs.as_ref(),
-                            result_buf,
-                        )
-                    })?;
-                }
-            }
-        }
-
-        if let Some(col) = span_arrays.dropped_links_count {
-            if let Some(val) = col.value_at(index) {
-                result_buf.encode_field_tag(SPAN_DROPPED_LINKS_COUNT, wire_types::VARINT)?;
-                result_buf.encode_varint(val as u64)?;
-            }
-        }
-
-        if let Some(status) = &span_arrays.status {
-            if status.status.is_valid(index) {
-                result_buf.encode_len_delimited(SPAN_STATUS, |result_buf| {
-                    self.encode_span_status(index, status, result_buf)
+        if let Some(span_attrs) = &traces_data_arrays.span_attrs
+            && let Some(id) = span_arrays.id.value_at(index)
+        {
+            let attrs_index_iter =
+                ChildIndexIter::new(id, &span_attrs.parent_id, &mut self.spans_attrs_cursor);
+            for attr_index in attrs_index_iter {
+                result_buf.encode_len_delimited(SPAN_ATTRIBUTES, |result_buf| {
+                    encode_key_value(span_attrs, attr_index, result_buf)
                 })?;
             }
+        }
+
+        if let Some(col) = span_arrays.dropped_attributes_count
+            && let Some(val) = col.value_at(index)
+        {
+            result_buf.encode_field_tag(SPAN_DROPPED_ATTRIBUTES_COUNT, wire_types::VARINT)?;
+            result_buf.encode_varint(val as u64)?;
+        }
+
+        if let Some(span_events) = &traces_data_arrays.span_events
+            && let Some(id) = span_arrays.id.value_at(index)
+        {
+            let parent_ids = MaybeDictArrayAccessor::Native(span_events.parent_id);
+            let events_index_iter =
+                ChildIndexIter::new(id, &parent_ids, &mut self.span_events_cursor);
+            for event_index in events_index_iter {
+                result_buf.encode_len_delimited(SPAN_EVENTS, |result_buf| {
+                    encode_span_event(
+                        event_index,
+                        span_events,
+                        &mut self.span_events_attrs_cursor,
+                        traces_data_arrays.span_event_attrs.as_ref(),
+                        result_buf,
+                    )
+                })?;
+            }
+        }
+
+        if let Some(col) = span_arrays.dropped_events_count
+            && let Some(val) = col.value_at(index)
+        {
+            result_buf.encode_field_tag(SPAN_DROPPED_EVENTS_COUNT, wire_types::VARINT)?;
+            result_buf.encode_varint(val as u64)?;
+        }
+
+        if let Some(span_links) = &traces_data_arrays.span_links
+            && let Some(id) = span_arrays.id.value_at(index)
+        {
+            let parent_ids = MaybeDictArrayAccessor::Native(span_links.parent_id);
+            let links_index_iter =
+                ChildIndexIter::new(id, &parent_ids, &mut self.span_links_cursor);
+            for link_index in links_index_iter {
+                result_buf.encode_len_delimited(SPAN_LINKS, |result_buf| {
+                    encode_span_link(
+                        link_index,
+                        span_links,
+                        &mut self.span_links_attrs_cursor,
+                        traces_data_arrays.span_link_attrs.as_ref(),
+                        result_buf,
+                    )
+                })?;
+            }
+        }
+
+        if let Some(col) = span_arrays.dropped_links_count
+            && let Some(val) = col.value_at(index)
+        {
+            result_buf.encode_field_tag(SPAN_DROPPED_LINKS_COUNT, wire_types::VARINT)?;
+            result_buf.encode_varint(val as u64)?;
+        }
+
+        if let Some(status) = &span_arrays.status
+            && status.status.is_valid(index)
+        {
+            result_buf.encode_len_delimited(SPAN_STATUS, |result_buf| {
+                self.encode_span_status(index, status, result_buf)
+            })?;
         }
 
         self.root_cursor.advance();
@@ -504,17 +503,17 @@ impl TracesProtoBytesEncoder {
         status_arrays: &SpanStatusArrays<'_>,
         result_buf: &mut ProtoBuffer,
     ) -> Result<()> {
-        if let Some(col) = &status_arrays.message {
-            if let Some(val) = col.str_at(index) {
-                result_buf.encode_string(SPAN_STATUS_MESSAGE, val)?;
-            }
+        if let Some(col) = &status_arrays.message
+            && let Some(val) = col.str_at(index)
+        {
+            result_buf.encode_string(SPAN_STATUS_MESSAGE, val)?;
         }
 
-        if let Some(col) = &status_arrays.code {
-            if let Some(val) = col.value_at(index) {
-                result_buf.encode_field_tag(SPAN_STATUS_CODE, wire_types::VARINT)?;
-                result_buf.encode_varint(val as u64)?;
-            }
+        if let Some(col) = &status_arrays.code
+            && let Some(val) = col.value_at(index)
+        {
+            result_buf.encode_field_tag(SPAN_STATUS_CODE, wire_types::VARINT)?;
+            result_buf.encode_varint(val as u64)?;
         }
 
         Ok(())

--- a/rust/otap-dataflow/crates/pdata/src/otlp/traces/span_event.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/traces/span_event.rs
@@ -57,36 +57,35 @@ pub fn encode_span_event(
     attrs_arrays: Option<&Attribute32Arrays<'_>>,
     result_buf: &mut ProtoBuffer,
 ) -> Result<()> {
-    if let Some(col) = &event_arrays.time_unix_nano {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(SPAN_EVENT_TIME_UNIX_NANO, wire_types::FIXED64)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
+    if let Some(col) = &event_arrays.time_unix_nano
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(SPAN_EVENT_TIME_UNIX_NANO, wire_types::FIXED64)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
+    }
+
+    if let Some(col) = &event_arrays.name
+        && let Some(val) = col.str_at(index)
+    {
+        result_buf.encode_string(SPAN_EVENT_NAME, val)?;
+    }
+
+    if let Some(attrs) = attrs_arrays
+        && let Some(id) = event_arrays.id.value_at(index)
+    {
+        let attrs_index_iter = ChildIndexIter::new(id, &attrs.parent_id, attrs_cursor);
+        for attrs_index in attrs_index_iter {
+            result_buf.encode_len_delimited(SPAN_EVENT_ATTRIBUTES, |result_buf| {
+                encode_key_value(attrs, attrs_index, result_buf)
+            })?;
         }
     }
 
-    if let Some(col) = &event_arrays.name {
-        if let Some(val) = col.str_at(index) {
-            result_buf.encode_string(SPAN_EVENT_NAME, val)?;
-        }
-    }
-
-    if let Some(attrs) = attrs_arrays {
-        if let Some(id) = event_arrays.id.value_at(index) {
-            let attrs_index_iter = ChildIndexIter::new(id, &attrs.parent_id, attrs_cursor);
-            for attrs_index in attrs_index_iter {
-                result_buf.encode_len_delimited(SPAN_EVENT_ATTRIBUTES, |result_buf| {
-                    encode_key_value(attrs, attrs_index, result_buf)
-                })?;
-            }
-        }
-    }
-
-    if let Some(col) = &event_arrays.dropped_attributes_count {
-        if let Some(val) = col.value_at(index) {
-            result_buf
-                .encode_field_tag(SPAN_EVENT_DROPPED_ATTRIBUTES_COUNTS, wire_types::VARINT)?;
-            result_buf.encode_varint(val as u64)?;
-        }
+    if let Some(col) = &event_arrays.dropped_attributes_count
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(SPAN_EVENT_DROPPED_ATTRIBUTES_COUNTS, wire_types::VARINT)?;
+        result_buf.encode_varint(val as u64)?;
     }
 
     Ok(())

--- a/rust/otap-dataflow/crates/pdata/src/otlp/traces/span_link.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otlp/traces/span_link.rs
@@ -67,47 +67,47 @@ pub fn encode_span_link(
     attrs_arrays: Option<&Attribute32Arrays<'_>>,
     result_buf: &mut ProtoBuffer,
 ) -> Result<()> {
-    if let Some(col) = &link_arrays.trace_id {
-        if let Some(val) = col.slice_at(index) {
-            result_buf.encode_bytes(SPAN_LINK_TRACE_ID, val)?;
+    if let Some(col) = &link_arrays.trace_id
+        && let Some(val) = col.slice_at(index)
+    {
+        result_buf.encode_bytes(SPAN_LINK_TRACE_ID, val)?;
+    }
+
+    if let Some(col) = &link_arrays.span_id
+        && let Some(val) = col.slice_at(index)
+    {
+        result_buf.encode_bytes(SPAN_LINK_SPAN_ID, val)?;
+    }
+
+    if let Some(col) = &link_arrays.trace_state
+        && let Some(val) = col.str_at(index)
+    {
+        result_buf.encode_string(SPAN_LINK_TRACE_STATE, val)?;
+    }
+
+    if let Some(attrs) = attrs_arrays
+        && let Some(id) = link_arrays.id.value_at(index)
+    {
+        let attrs_index_iter = ChildIndexIter::new(id, &attrs.parent_id, attrs_cursor);
+        for attrs_index in attrs_index_iter {
+            result_buf.encode_len_delimited(SPAN_LINK_ATTRIBUTES, |result_buf| {
+                encode_key_value(attrs, attrs_index, result_buf)
+            })?;
         }
     }
 
-    if let Some(col) = &link_arrays.span_id {
-        if let Some(val) = col.slice_at(index) {
-            result_buf.encode_bytes(SPAN_LINK_SPAN_ID, val)?;
-        }
+    if let Some(col) = &link_arrays.dropped_attributes_count
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(SPAN_DROPPED_ATTRIBUTES_COUNT, wire_types::VARINT)?;
+        result_buf.encode_varint(val as u64)?;
     }
 
-    if let Some(col) = &link_arrays.trace_state {
-        if let Some(val) = col.str_at(index) {
-            result_buf.encode_string(SPAN_LINK_TRACE_STATE, val)?;
-        }
-    }
-
-    if let Some(attrs) = attrs_arrays {
-        if let Some(id) = link_arrays.id.value_at(index) {
-            let attrs_index_iter = ChildIndexIter::new(id, &attrs.parent_id, attrs_cursor);
-            for attrs_index in attrs_index_iter {
-                result_buf.encode_len_delimited(SPAN_LINK_ATTRIBUTES, |result_buf| {
-                    encode_key_value(attrs, attrs_index, result_buf)
-                })?;
-            }
-        }
-    }
-
-    if let Some(col) = &link_arrays.dropped_attributes_count {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(SPAN_DROPPED_ATTRIBUTES_COUNT, wire_types::VARINT)?;
-            result_buf.encode_varint(val as u64)?;
-        }
-    }
-
-    if let Some(col) = &link_arrays.flags {
-        if let Some(val) = col.value_at(index) {
-            result_buf.encode_field_tag(SPAN_LINK_FLAGS, wire_types::FIXED32)?;
-            result_buf.extend_from_slice(&val.to_le_bytes())?;
-        }
+    if let Some(col) = &link_arrays.flags
+        && let Some(val) = col.value_at(index)
+    {
+        result_buf.encode_field_tag(SPAN_LINK_FLAGS, wire_types::FIXED32)?;
+        result_buf.extend_from_slice(&val.to_le_bytes())?;
     }
 
     Ok(())

--- a/rust/otap-dataflow/crates/pdata/src/testing/equiv/traces.rs
+++ b/rust/otap-dataflow/crates/pdata/src/testing/equiv/traces.rs
@@ -50,10 +50,10 @@ fn traces_canonicalize_singleton_in_place(traces_data: &mut TracesData) {
                 canonicalize_idvec(&mut span.span_id);
 
                 // Status default check
-                if let Some(status) = &span.status {
-                    if *status == Status::default() {
-                        span.status = None;
-                    }
+                if let Some(status) = &span.status
+                    && *status == Status::default()
+                {
+                    span.status = None;
                 }
 
                 // Canonicalize span attributes

--- a/rust/otap-dataflow/crates/pdata/src/views/otap/common.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otap/common.rs
@@ -501,19 +501,17 @@ pub(crate) fn build_attribute_index_u32(batch: &RecordBatch) -> BTreeMap<u32, Ve
     } else if let Some(dict_array) = parent_id_col
         .as_any()
         .downcast_ref::<arrow::array::DictionaryArray<arrow::datatypes::UInt8Type>>()
-    {
-        if let Some(values) = dict_array
+        && let Some(values) = dict_array
             .values()
             .as_any()
             .downcast_ref::<arrow::array::UInt32Array>()
-        {
-            for i in 0..batch.num_rows() {
-                if dict_array.is_valid(i) {
-                    let key = dict_array.keys().value(i) as usize;
-                    if values.is_valid(key) {
-                        let pid = values.value(key);
-                        index.entry(pid).or_default().push(i);
-                    }
+    {
+        for i in 0..batch.num_rows() {
+            if dict_array.is_valid(i) {
+                let key = dict_array.keys().value(i) as usize;
+                if values.is_valid(key) {
+                    let pid = values.value(key);
+                    index.entry(pid).or_default().push(i);
                 }
             }
         }

--- a/rust/otap-dataflow/crates/pdata/src/views/otap/metrics.rs
+++ b/rust/otap-dataflow/crates/pdata/src/views/otap/metrics.rs
@@ -1148,15 +1148,15 @@ impl<'a> NumberDataPointView for OtapNumberDataPointView<'a> {
     fn value(&self) -> Option<Value> {
         let arrays = self.view.number_dp_arrays.as_ref()?;
         // Prefer double over int (same logic as proto encoder)
-        if let Some(col) = arrays.double_value {
-            if let Some(val) = col.value_at(self.row_idx) {
-                return Some(Value::Double(val));
-            }
+        if let Some(col) = arrays.double_value
+            && let Some(val) = col.value_at(self.row_idx)
+        {
+            return Some(Value::Double(val));
         }
-        if let Some(col) = arrays.int_value {
-            if let Some(val) = col.value_at(self.row_idx) {
-                return Some(Value::Integer(val));
-            }
+        if let Some(col) = arrays.int_value
+            && let Some(val) = col.value_at(self.row_idx)
+        {
+            return Some(Value::Integer(val));
         }
         None
     }
@@ -1922,15 +1922,15 @@ impl<'a> ExemplarView for OtapExemplarView<'a> {
 
     #[inline]
     fn value(&self) -> Option<Value> {
-        if let Some(col) = self.exemplar_arrays.double_value {
-            if let Some(val) = col.value_at(self.row_idx) {
-                return Some(Value::Double(val));
-            }
+        if let Some(col) = self.exemplar_arrays.double_value
+            && let Some(val) = col.value_at(self.row_idx)
+        {
+            return Some(Value::Double(val));
         }
-        if let Some(col) = self.exemplar_arrays.int_value {
-            if let Some(val) = col.value_at(self.row_idx) {
-                return Some(Value::Integer(val));
-            }
+        if let Some(col) = self.exemplar_arrays.int_value
+            && let Some(val) = col.value_at(self.row_idx)
+        {
+            return Some(Value::Integer(val));
         }
         None
     }

--- a/rust/otap-dataflow/crates/query-engine-playground/src/main.rs
+++ b/rust/otap-dataflow/crates/query-engine-playground/src/main.rs
@@ -252,14 +252,14 @@ async fn execute_pipeline(req: ExecuteRequest) -> Result<ExecuteResponse, String
 fn build_arrow_tables(result: &OtapArrowRecords) -> HashMap<String, String> {
     let mut tables = HashMap::new();
     for payload_type in result.allowed_payload_types() {
-        if let Some(batch) = result.get(*payload_type) {
-            if batch.num_rows() > 0 {
-                let text = match pretty_format_batches(std::slice::from_ref(batch)) {
-                    Ok(formatted) => formatted.to_string(),
-                    Err(e) => format!("(formatting error: {e})"),
-                };
-                let _: Option<String> = tables.insert(payload_type.as_str_name().to_string(), text);
-            }
+        if let Some(batch) = result.get(*payload_type)
+            && batch.num_rows() > 0
+        {
+            let text = match pretty_format_batches(std::slice::from_ref(batch)) {
+                Ok(formatted) => formatted.to_string(),
+                Err(e) => format!("(formatting error: {e})"),
+            };
+            let _: Option<String> = tables.insert(payload_type.as_str_name().to_string(), text);
         }
     }
     tables

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/assign.rs
@@ -238,15 +238,14 @@ impl AssignPipelineStage {
             // ambiguous, which is the case for attributes/AnyValues, but we've handled AnyValue
             // above, so the remaining types are all concrete and safe to expect here
             .expect("dest column data type");
-
         // if we've received an AnyValue as the assignment source, but the destination is not an
         // AnyValue, we coerce attempt to coerce it into a single value
-        if let ColumnarValue::Array(values) = &scoped_value.values {
-            if is_any_value_data_type(values.data_type()) {
-                let coerced_value_col =
-                    attempt_coerce_value_column_from_any_value_struct_column(values)?;
-                scoped_value.values = ColumnarValue::Array(coerced_value_col);
-            }
+        if let ColumnarValue::Array(values) = &scoped_value.values
+            && is_any_value_data_type(values.data_type())
+        {
+            let coerced_value_col =
+                attempt_coerce_value_column_from_any_value_struct_column(values)?;
+            scoped_value.values = ColumnarValue::Array(coerced_value_col);
         }
 
         // coerce static scalar int: if the result was a static scalar integer, it will have been
@@ -268,12 +267,12 @@ impl AssignPipelineStage {
 
         // if it's dict encoded, check if the dict values match the expected type
         let column_supports_dict_encoding = root_field_supports_dict_encoding(dest_column_name);
-        if !type_compatible && column_supports_dict_encoding {
-            if let DataType::Dictionary(_, dict_val_type) = &eval_result_column_type {
-                if dict_val_type.as_ref() == &expected_column_data_type {
-                    type_compatible = true
-                }
-            }
+        if !type_compatible
+            && column_supports_dict_encoding
+            && let DataType::Dictionary(_, dict_val_type) = &eval_result_column_type
+            && dict_val_type.as_ref() == &expected_column_data_type
+        {
+            type_compatible = true
         }
 
         // if result is not type compatible, return error
@@ -522,24 +521,22 @@ impl AssignPipelineStage {
         let column_supports_dict_encoding =
             nested_struct_field_supports_dict_encoding(dest_column_name, dest_field_name);
 
-        if let ColumnarValue::Array(values) = &scoped_value.values {
-            if is_any_value_data_type(values.data_type()) {
-                let coerced = attempt_coerce_value_column_from_any_value_struct_column(values)?;
-                scoped_value.values = ColumnarValue::Array(coerced);
-            }
+        if let ColumnarValue::Array(values) = &scoped_value.values
+            && is_any_value_data_type(values.data_type())
+        {
+            let coerced = attempt_coerce_value_column_from_any_value_struct_column(values)?;
+            scoped_value.values = ColumnarValue::Array(coerced);
         }
 
         // Coerce static scalar integers to the destination field type (e.g. AnyInt literal -> UInt32).
         // Mirrors the same cast done in assign_to_root.
-        if let Some(dest_logical_type) = nested_struct_field_type(dest_field_name) {
-            if let Some(dest_arrow_type) = dest_logical_type.datatype() {
-                if scoped_value.scope == DataScope::StaticScalar
-                    && scoped_value.values.data_type().is_integer()
-                    && dest_arrow_type.is_integer()
-                {
-                    scoped_value.values = scoped_value.values.cast_to(&dest_arrow_type, None)?;
-                }
-            }
+        if let Some(dest_logical_type) = nested_struct_field_type(dest_field_name)
+            && let Some(dest_arrow_type) = dest_logical_type.datatype()
+            && scoped_value.scope == DataScope::StaticScalar
+            && scoped_value.values.data_type().is_integer()
+            && dest_arrow_type.is_integer()
+        {
+            scoped_value.values = scoped_value.values.cast_to(&dest_arrow_type, None)?;
         }
 
         let mut values = eval_result_to_array(
@@ -749,12 +746,12 @@ impl AssignPipelineStage {
             // Attempt to coerce the AnyValue into a single column. In this case, we do this as an
             // optimization: this makes the join faster because we can take fewer columns, and it
             // also makes it so we avoid entering `decompose_any_value_upsert` upsert.
-            if let ColumnarValue::Array(ref arr) = scoped_value.values {
-                if is_any_value_data_type(arr.data_type()) {
-                    let coerced_value_col =
-                        attempt_coerce_value_column_from_any_value_struct_column(arr)?;
-                    scoped_value.values = ColumnarValue::Array(coerced_value_col);
-                }
+            if let ColumnarValue::Array(ref arr) = scoped_value.values
+                && is_any_value_data_type(arr.data_type())
+            {
+                let coerced_value_col =
+                    attempt_coerce_value_column_from_any_value_struct_column(arr)?;
+                scoped_value.values = ColumnarValue::Array(coerced_value_col);
             }
 
             let aligned_values = if let ColumnarValue::Scalar(s) = scoped_value.values {
@@ -807,19 +804,18 @@ impl AssignPipelineStage {
             // If the expression produced an AnyValue struct and we were not already able to
             // coerce it into a single array of a single concrete type array, we split the upsert
             // for this attribute into multiple upserts for each type:
-            if let ColumnarValue::Array(ref arr) = aligned_values {
-                if is_any_value_data_type(arr.data_type()) {
-                    let type_filled_arr = fill_null_type_as_empty(arr)?;
-                    let per_type = decompose_any_value_upsert(
-                        attrs_key,
-                        &existing_key_mask,
-                        &type_filled_arr,
-                        &parent_ids,
-                    )?;
-                    attrs_upserts.extend(per_type);
-
-                    continue;
-                }
+            if let ColumnarValue::Array(ref arr) = aligned_values
+                && is_any_value_data_type(arr.data_type())
+            {
+                let type_filled_arr = fill_null_type_as_empty(arr)?;
+                let per_type = decompose_any_value_upsert(
+                    attrs_key,
+                    &existing_key_mask,
+                    &type_filled_arr,
+                    &parent_ids,
+                )?;
+                attrs_upserts.extend(per_type);
+                continue;
             }
 
             attrs_upserts.push(AttributeUpsert {
@@ -911,12 +907,12 @@ impl AssignPipelineStage {
                 .take()
                 .unwrap_or_else(|| ScopedValue::new_scalar(ScalarValue::Null));
 
-            if let ColumnarValue::Array(ref arr) = scoped_value.values {
-                if is_any_value_data_type(arr.data_type()) {
-                    let coerced_value_col =
-                        attempt_coerce_value_column_from_any_value_struct_column(arr)?;
-                    scoped_value.values = ColumnarValue::Array(coerced_value_col);
-                }
+            if let ColumnarValue::Array(ref arr) = scoped_value.values
+                && is_any_value_data_type(arr.data_type())
+            {
+                let coerced_value_col =
+                    attempt_coerce_value_column_from_any_value_struct_column(arr)?;
+                scoped_value.values = ColumnarValue::Array(coerced_value_col);
             }
 
             let aligned_values = if let ColumnarValue::Scalar(s) = scoped_value.values {
@@ -1481,13 +1477,12 @@ impl PipelineStage for AssignPipelineStage {
         // this pipeline stage may be seeing a different subset of the overall batch, but we need
         // to ensure the IDs that are assigned are not duplicated across branches. That is why we
         // add this extension.
-        if let ColumnAccessor::Attributes(attrs_id, _) = &self.dest_columns[0] {
-            if *attrs_id == AttributesIdentifier::Root
-                && exec_state.get_extension::<NextIdTracker>().is_none()
-            {
-                let next_id_tracker = NextIdTracker::try_new(otap_batch)?;
-                exec_state.set_extension(next_id_tracker);
-            }
+        if let ColumnAccessor::Attributes(attrs_id, _) = &self.dest_columns[0]
+            && *attrs_id == AttributesIdentifier::Root
+            && exec_state.get_extension::<NextIdTracker>().is_none()
+        {
+            let next_id_tracker = NextIdTracker::try_new(otap_batch)?;
+            exec_state.set_extension(next_id_tracker);
         }
 
         Ok(())

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/bitmap.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/bitmap.rs
@@ -221,21 +221,21 @@ fn scoped_value_to_id_mask(
                 // For attribute-scoped scalars, "all true" means "all rows that matched
                 // the key filter pass", not ALL rows in the batch. We need to build an
                 // IdMask from the parent_ids of the matching rows.
-                if matches!(sv.scope, DataScope::Attribute(_, _)) {
-                    if let Some(parent_ids) = &sv.parent_ids {
-                        let parent_id_col = parent_ids
-                            .as_any()
-                            .downcast_ref::<UInt16Array>()
-                            .ok_or_else(|| Error::ExecutionError {
-                                cause: format!(
-                                    "expected parent_id to be UInt16, found {:?}",
-                                    parent_ids.data_type()
-                                ),
-                            })?;
-                        let mut bitmap = pool.acquire();
-                        bitmap.populate(parent_id_col.values().iter().map(|pid| *pid as u32));
-                        return Ok(IdMask::Some(bitmap));
-                    }
+                if matches!(sv.scope, DataScope::Attribute(_, _))
+                    && let Some(parent_ids) = &sv.parent_ids
+                {
+                    let parent_id_col = parent_ids
+                        .as_any()
+                        .downcast_ref::<UInt16Array>()
+                        .ok_or_else(|| Error::ExecutionError {
+                            cause: format!(
+                                "expected parent_id to be UInt16, found {:?}",
+                                parent_ids.data_type()
+                            ),
+                        })?;
+                    let mut bitmap = pool.acquire();
+                    bitmap.populate(parent_id_col.values().iter().map(|pid| *pid as u32));
+                    return Ok(IdMask::Some(bitmap));
                 }
                 Ok(IdMask::All)
             }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/eval.rs
@@ -300,13 +300,12 @@ pub(super) fn join_and_eval_value(
                 }
             }
         };
-
         // Check for short-circuit: skip remaining children and the join when the
         // outcome is already determined by this child's result.
-        if let Some(strategy) = short_circuit {
-            if strategy.should_short_circuit(&result.scope, &result.values) {
-                return Ok(Some(strategy.value()));
-            }
+        if let Some(strategy) = short_circuit
+            && strategy.should_short_circuit(&result.scope, &result.values)
+        {
+            return Ok(Some(strategy.value()));
         }
 
         child_results.push(result)
@@ -445,16 +444,15 @@ fn coerce_nulls_for_predicate(
 ) -> ColumnarValue {
     match &result_vals {
         ColumnarValue::Array(arr) => {
-            if let Some(boolean_arr) = arr.as_boolean_opt() {
-                if let Some(nulls) = boolean_arr.nulls() {
-                    let combined = if missing_data_passes {
-                        boolean_arr.values().clone()
-                    } else {
-                        boolean_arr.values() & nulls.inner()
-                    };
-
-                    return ColumnarValue::Array(Arc::new(BooleanArray::new(combined, None)));
-                }
+            if let Some(boolean_arr) = arr.as_boolean_opt()
+                && let Some(nulls) = boolean_arr.nulls()
+            {
+                let combined = if missing_data_passes {
+                    boolean_arr.values().clone()
+                } else {
+                    boolean_arr.values() & nulls.inner()
+                };
+                return ColumnarValue::Array(Arc::new(BooleanArray::new(combined, None)));
             }
         }
         ColumnarValue::Scalar(ScalarValue::Boolean(None)) => {
@@ -618,23 +616,21 @@ pub(crate) fn scoped_value_to_join_input(
     };
 
     // for root-scoped results, extract scope_ids and resource_ids from the root batch
-    if is_root {
-        if let Some(root_rb) = otap_batch.root_record_batch() {
-            if let Ok(Some(resource_ids)) = get_optional_array_from_struct_array_from_record_batch(
-                root_rb,
-                consts::RESOURCE,
-                consts::ID,
-            ) {
-                result.resource_ids = Some(Arc::clone(resource_ids));
-            }
+    if is_root && let Some(root_rb) = otap_batch.root_record_batch() {
+        if let Ok(Some(resource_ids)) = get_optional_array_from_struct_array_from_record_batch(
+            root_rb,
+            consts::RESOURCE,
+            consts::ID,
+        ) {
+            result.resource_ids = Some(Arc::clone(resource_ids));
+        }
 
-            if let Ok(Some(scope_ids)) = get_optional_array_from_struct_array_from_record_batch(
-                root_rb,
-                consts::SCOPE,
-                consts::ID,
-            ) {
-                result.scope_ids = Some(Arc::clone(scope_ids));
-            }
+        if let Ok(Some(scope_ids)) = get_optional_array_from_struct_array_from_record_batch(
+            root_rb,
+            consts::SCOPE,
+            consts::ID,
+        ) {
+            result.scope_ids = Some(Arc::clone(scope_ids));
         }
     }
 

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/expr/planner.rs
@@ -480,10 +480,9 @@ impl ExprPlanner {
                         DataScope::AttributesAll(left_attrs_id),
                         DataScope::AttributesAll(right_attrs_id),
                     ) = (left_scope.as_ref(), right_scope.as_ref())
+                        && left_attrs_id == right_attrs_id
                     {
-                        if left_attrs_id == right_attrs_id {
-                            return Ok(ScopedExpr::BitmapOr(Box::new(left), Box::new(right)));
-                        }
+                        return Ok(ScopedExpr::BitmapOr(Box::new(left), Box::new(right)));
                     }
 
                     // When either side is attribute-scoped, align children to root
@@ -735,20 +734,20 @@ impl ExprPlanner {
         let invoke_arg_exprs = invoke_expr.get_arguments();
         let num_args = invoke_arg_exprs.len();
 
-        if let Some(arity_range) = arity_range(&df_udf.scalar_udf.signature().type_signature) {
-            if !arity_range.contains(&num_args) {
-                return Err(Error::InvalidPipelineError {
-                    cause: format!(
-                        "function '{func_name}' expects {} arguments. Received {num_args}",
-                        if arity_range.len() > 1 {
-                            format!("{}-{}", arity_range.start, arity_range.end - 1)
-                        } else {
-                            format!("{}", arity_range.start)
-                        }
-                    ),
-                    query_location: Some(invoke_expr.get_query_location().clone()),
-                });
-            }
+        if let Some(arity_range) = arity_range(&df_udf.scalar_udf.signature().type_signature)
+            && !arity_range.contains(&num_args)
+        {
+            return Err(Error::InvalidPipelineError {
+                cause: format!(
+                    "function '{func_name}' expects {} arguments. Received {num_args}",
+                    if arity_range.len() > 1 {
+                        format!("{}-{}", arity_range.start, arity_range.end - 1)
+                    } else {
+                        format!("{}", arity_range.start)
+                    }
+                ),
+                query_location: Some(invoke_expr.get_query_location().clone()),
+            });
         }
 
         let (arg_exprs, args_scope, data_scope, source_dict_downcast) = if invoke_arg_exprs
@@ -1085,15 +1084,15 @@ impl ExprPlanner {
         // Try fused attribute comparison optimization: when one side is an attribute
         // access and the other is a typed literal, skip the expensive key-filter +
         // value-projection materialization step.
-        if !self.plan_for_attributes {
-            if let Some(fused) = self.try_plan_fused_attr_comparison(
+        if !self.plan_for_attributes
+            && let Some(fused) = self.try_plan_fused_attr_comparison(
                 &mut left,
                 operator,
                 &mut right,
                 case_sensitive,
-            )? {
-                return Ok(fused);
-            }
+            )?
+        {
+            return Ok(fused);
         }
 
         // handle body field comparisons -- body is an AnyValue struct, so we need to
@@ -1349,13 +1348,12 @@ impl ExprPlanner {
     ) -> Result<ScopedExpr> {
         let mut haystack = self.plan_scalar(contains_expr.get_haystack(), functions)?;
         let mut needle = self.plan_scalar(contains_expr.get_needle(), functions)?;
-
         // Try fused attribute contains optimization: when haystack is attributes["key"]
         // and needle is a string literal.
-        if !self.plan_for_attributes {
-            if let Some(fused) = self.try_plan_fused_attr_contains(&haystack, &needle)? {
-                return Ok(fused);
-            }
+        if !self.plan_for_attributes
+            && let Some(fused) = self.try_plan_fused_attr_contains(&haystack, &needle)?
+        {
+            return Ok(fused);
         }
 
         // for body column, resolve to body.str for text contains
@@ -1495,13 +1493,12 @@ impl ExprPlanner {
         };
 
         let mut haystack = self.plan_scalar(matches_expr.get_haystack(), functions)?;
-
         // Try fused attribute matches optimization: when haystack is attributes["key"]
         // and pattern is a static regex.
-        if !self.plan_for_attributes {
-            if let Some(fused) = self.try_plan_fused_attr_matches(&haystack, &pattern)? {
-                return Ok(fused);
-            }
+        if !self.plan_for_attributes
+            && let Some(fused) = self.try_plan_fused_attr_matches(&haystack, &pattern)?
+        {
+            return Ok(fused);
         }
 
         // for body column, resolve to body.str for regex matching
@@ -2183,10 +2180,9 @@ fn escape_like_literals(planned: &mut PlannedOp) {
             },
         ..
     } = &mut planned.expr
+        && contains_like_pattern(s)
     {
-        if contains_like_pattern(s) {
-            *s = escape_like_pattern(s);
-        }
+        *s = escape_like_pattern(s);
     }
 }
 
@@ -2264,17 +2260,17 @@ fn is_attr_value_column(planned: &PlannedOp) -> bool {
 ///
 /// This replaces the `AttrValueColumnSelectionOptimizer` from the old filter planning path.
 fn resolve_attr_value_column_in_planned_ops(left: &mut PlannedOp, right: &mut PlannedOp) {
-    if is_attr_value_column(left) {
-        if let Some(col_name) = get_literal_any_val_field(right) {
-            rewrite_attr_value_column(left, col_name);
-            return;
-        }
+    if is_attr_value_column(left)
+        && let Some(col_name) = get_literal_any_val_field(right)
+    {
+        rewrite_attr_value_column(left, col_name);
+        return;
     }
 
-    if is_attr_value_column(right) {
-        if let Some(col_name) = get_literal_any_val_field(left) {
-            rewrite_attr_value_column(right, col_name);
-        }
+    if is_attr_value_column(right)
+        && let Some(col_name) = get_literal_any_val_field(left)
+    {
+        rewrite_attr_value_column(right, col_name);
     }
 }
 
@@ -2315,18 +2311,18 @@ fn rewrite_attr_value_column(planned: &mut PlannedOp, field_name: &str) {
 /// `col("body").field("str")` (or the appropriate sub-field based on the literal type).
 fn resolve_body_field_in_planned_ops(left: &mut PlannedOp, right: &mut PlannedOp) {
     // body == literal: rewrite body
-    if is_body_planned_op(left) {
-        if let Some(field_name) = get_literal_any_val_field(right) {
-            rewrite_body_expr(left, field_name);
-            return;
-        }
+    if is_body_planned_op(left)
+        && let Some(field_name) = get_literal_any_val_field(right)
+    {
+        rewrite_body_expr(left, field_name);
+        return;
     }
 
     // literal == body: rewrite body
-    if is_body_planned_op(right) {
-        if let Some(field_name) = get_literal_any_val_field(left) {
-            rewrite_body_expr(right, field_name);
-        }
+    if is_body_planned_op(right)
+        && let Some(field_name) = get_literal_any_val_field(left)
+    {
+        rewrite_body_expr(right, field_name);
     }
 }
 

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/murmur3.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/functions/murmur3.rs
@@ -20,10 +20,8 @@ use datafusion::scalar::ScalarValue;
 fn murmur3_32(data: &[u8]) -> i64 {
     const C1: u32 = 0xcc9e2d51;
     const C2: u32 = 0x1b873593;
-
     let mut h: u32 = 0;
-    let chunks = data.chunks_exact(4);
-    let remainder = chunks.remainder();
+    let (chunks, remainder) = data.as_chunks::<4>();
 
     for chunk in chunks {
         let mut k = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/project.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/project.rs
@@ -276,38 +276,37 @@ impl<'a> TreeNodeVisitor<'a> for ProjectedSchemaExprVisitor {
         // column. The way we reference these in the plans we build is using an expression like
         // `col("scope").field("name")` which produces a ScalarFunction expression invoking the
         // `GetFieldFunc` function with arguments ("scope", "name").
-        if let Expr::ScalarFunction(scalar_udf) = node {
-            if scalar_udf
+        if let Expr::ScalarFunction(scalar_udf) = node
+            && scalar_udf
                 .func
                 .as_ref()
                 .inner()
                 .as_any()
                 .is::<GetFieldFunc>()
-            {
-                let source = scalar_udf.args.first();
-                let field = scalar_udf.args.get(1);
-                match (source, field) {
-                    (
-                        Some(Expr::Column(col)),
-                        Some(Expr::Literal(ScalarValue::Utf8(Some(nested_col)), _)),
-                    ) => {
-                        let struct_fields = self
-                            .struct_columns
-                            .entry(col.name.clone())
-                            .or_insert(HashSet::new());
-                        _ = struct_fields.insert(nested_col.clone());
+        {
+            let source = scalar_udf.args.first();
+            let field = scalar_udf.args.get(1);
+            match (source, field) {
+                (
+                    Some(Expr::Column(col)),
+                    Some(Expr::Literal(ScalarValue::Utf8(Some(nested_col)), _)),
+                ) => {
+                    let struct_fields = self
+                        .struct_columns
+                        .entry(col.name.clone())
+                        .or_insert(HashSet::new());
+                    _ = struct_fields.insert(nested_col.clone());
 
-                        // don't continue as we've found a column. Otherwise this will continue
-                        // down the expression tree and we'll visit the Column expression twice.
-                        return Ok(TreeNodeRecursion::Jump);
-                    }
-                    unexpected_args => {
-                        let err_msg = format!(
-                            "Found unexpected arguments to `GetFieldFunc`. Expected (Col, Literal(Utf8)) found {:?}",
-                            unexpected_args
-                        );
-                        return Err(DataFusionError::Plan(err_msg));
-                    }
+                    // don't continue as we've found a column. Otherwise this will continue
+                    // down the expression tree and we'll visit the Column expression twice.
+                    return Ok(TreeNodeRecursion::Jump);
+                }
+                unexpected_args => {
+                    let err_msg = format!(
+                        "Found unexpected arguments to `GetFieldFunc`. Expected (Col, Literal(Utf8)) found {:?}",
+                        unexpected_args
+                    );
+                    return Err(DataFusionError::Plan(err_msg));
                 }
             }
         }

--- a/rust/otap-dataflow/crates/query-engine/src/pipeline/project/anyval.rs
+++ b/rust/otap-dataflow/crates/query-engine/src/pipeline/project/anyval.rs
@@ -659,10 +659,10 @@ fn stitch_as_any_value_struct(
     // We'll create one value column per distinct field name.
     let mut distinct_fields: Vec<(&'static str, AttributeValueType)> = Vec::new();
     for &(type_val, field_name) in &partition_type_info {
-        if let Some(field_name) = field_name {
-            if !distinct_fields.iter().any(|(n, _)| *n == field_name) {
-                distinct_fields.push((field_name, type_val));
-            }
+        if let Some(field_name) = field_name
+            && !distinct_fields.iter().any(|(n, _)| *n == field_name)
+        {
+            distinct_fields.push((field_name, type_val));
         }
     }
 

--- a/rust/otap-dataflow/crates/quiver-e2e/src/dashboard.rs
+++ b/rust/otap-dataflow/crates/quiver-e2e/src/dashboard.rs
@@ -127,10 +127,10 @@ fn read_process_rss_bytes() -> u64 {
         if let Some(val) = line.strip_prefix("VmRSS:") {
             // VmRSS is in kB, e.g., "VmRSS:    12345 kB"
             let val = val.trim();
-            if let Some(kb_str) = val.strip_suffix(" kB") {
-                if let Ok(kb) = kb_str.trim().parse::<u64>() {
-                    return kb * 1024; // Convert to bytes
-                }
+            if let Some(kb_str) = val.strip_suffix(" kB")
+                && let Ok(kb) = kb_str.trim().parse::<u64>()
+            {
+                return kb * 1024; // Convert to bytes
             }
         }
     }
@@ -254,12 +254,12 @@ impl Dashboard {
 
     /// Checks if user pressed 'q' to quit.
     pub fn check_quit(&self) -> io::Result<bool> {
-        if event::poll(Duration::from_millis(10))? {
-            if let Event::Key(key) = event::read()? {
-                if key.kind == KeyEventKind::Press && key.code == KeyCode::Char('q') {
-                    return Ok(true);
-                }
-            }
+        if event::poll(Duration::from_millis(10))?
+            && let Event::Key(key) = event::read()?
+            && key.kind == KeyEventKind::Press
+            && key.code == KeyCode::Char('q')
+        {
+            return Ok(true);
         }
         Ok(false)
     }

--- a/rust/otap-dataflow/crates/quiver-e2e/src/steady_state.rs
+++ b/rust/otap-dataflow/crates/quiver-e2e/src/steady_state.rs
@@ -373,10 +373,10 @@ pub async fn run(
         // Periodic cleanup of completed segments (all engines use their own cleanup)
         if last_cleanup.elapsed() >= cleanup_interval {
             for engine in &engines {
-                if let Ok(deleted) = engine.cleanup_completed_segments() {
-                    if deleted > 0 {
-                        let _ = total_cleaned.fetch_add(deleted as u64, Ordering::Relaxed);
-                    }
+                if let Ok(deleted) = engine.cleanup_completed_segments()
+                    && deleted > 0
+                {
+                    let _ = total_cleaned.fetch_add(deleted as u64, Ordering::Relaxed);
                 }
             }
             last_cleanup = Instant::now();
@@ -598,11 +598,11 @@ pub async fn run(
     }
 
     // Handle temp directory
-    if let Some(tmp) = tmp {
-        if config.keep_temp {
-            let kept_path = tmp.keep();
-            output.log(&format!("Keeping temp directory: {}", kept_path.display()));
-        }
+    if let Some(tmp) = tmp
+        && config.keep_temp
+    {
+        let kept_path = tmp.keep();
+        output.log(&format!("Keeping temp directory: {}", kept_path.display()));
     }
 
     // Check for concerning growth

--- a/rust/otap-dataflow/crates/quiver/src/segment_store.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment_store.rs
@@ -697,46 +697,46 @@ impl SegmentStore {
             })?;
 
             let path = entry.path();
-            if path.extension().is_some_and(|ext| ext == "qseg") {
-                if let Some(seq) = Self::parse_segment_filename(&path) {
-                    highest_seen =
-                        Some(highest_seen.map_or(seq, |highest: SegmentSeq| highest.max(seq)));
-                    let is_expired =
-                        cutoff.is_some_and(|cutoff| Self::is_file_before_cutoff(&path, cutoff));
+            if path.extension().is_some_and(|ext| ext == "qseg")
+                && let Some(seq) = Self::parse_segment_filename(&path)
+            {
+                highest_seen =
+                    Some(highest_seen.map_or(seq, |highest: SegmentSeq| highest.max(seq)));
+                let is_expired =
+                    cutoff.is_some_and(|cutoff| Self::is_file_before_cutoff(&path, cutoff));
 
-                    match self.register_existing_segment(seq) {
-                        Ok(bundle_count) => found.push((seq, bundle_count)),
-                        Err(e) if is_expired => {
-                            let file_size = std::fs::metadata(&path)
-                                .map(|metadata| metadata.len())
-                                .unwrap_or(0);
+                match self.register_existing_segment(seq) {
+                    Ok(bundle_count) => found.push((seq, bundle_count)),
+                    Err(e) if is_expired => {
+                        let file_size = std::fs::metadata(&path)
+                            .map(|metadata| metadata.len())
+                            .unwrap_or(0);
+                        otel_warn!(
+                            "quiver.segment.scan",
+                            path = %path.display(),
+                            error = %e,
+                            error_type = "invalid_metadata",
+                            message = "deleting corrupt expired segment without logical loss accounting",
+                        );
+                        if let Err(e) = Self::remove_readonly_file(&path) {
                             otel_warn!(
                                 "quiver.segment.scan",
                                 path = %path.display(),
                                 error = %e,
-                                error_type = "invalid_metadata",
-                                message = "deleting corrupt expired segment without logical loss accounting",
-                            );
-                            if let Err(e) = Self::remove_readonly_file(&path) {
-                                otel_warn!(
-                                    "quiver.segment.scan",
-                                    path = %path.display(),
-                                    error = %e,
-                                    error_type = "io",
-                                );
-                            } else {
-                                deleted.push((seq, file_size));
-                            }
-                        }
-                        Err(e) => {
-                            otel_error!(
-                                "quiver.segment.scan",
-                                path = %path.display(),
-                                error = %e,
                                 error_type = "io",
-                                message = "segment data is inaccessible and may indicate corruption",
                             );
+                        } else {
+                            deleted.push((seq, file_size));
                         }
+                    }
+                    Err(e) => {
+                        otel_error!(
+                            "quiver.segment.scan",
+                            path = %path.display(),
+                            error = %e,
+                            error_type = "io",
+                            message = "segment data is inaccessible and may indicate corruption",
+                        );
                     }
                 }
             }

--- a/rust/otap-dataflow/crates/quiver/src/subscriber/progress.rs
+++ b/rust/otap-dataflow/crates/quiver/src/subscriber/progress.rs
@@ -605,10 +605,10 @@ pub async fn write_progress_file(
 
     // Sync parent directory to ensure rename is durable
     #[cfg(unix)]
-    if let Some(parent) = final_path.parent() {
-        if let Ok(dir_file) = tokio::fs::File::open(parent).await {
-            let _ = dir_file.sync_all().await;
-        }
+    if let Some(parent) = final_path.parent()
+        && let Ok(dir_file) = tokio::fs::File::open(parent).await
+    {
+        let _ = dir_file.sync_all().await;
     }
 
     Ok(())

--- a/rust/otap-dataflow/crates/quiver/src/subscriber/registry.rs
+++ b/rust/otap-dataflow/crates/quiver/src/subscriber/registry.rs
@@ -530,10 +530,10 @@ impl<P: SegmentProvider> SubscriberRegistry<P> {
 
         loop {
             // Check for cancellation first
-            if let Some(token) = cancel {
-                if token.is_cancelled() {
-                    return Err(SubscriberError::cancelled("shutdown requested"));
-                }
+            if let Some(token) = cancel
+                && token.is_cancelled()
+            {
+                return Err(SubscriberError::cancelled("shutdown requested"));
             }
 
             // IMPORTANT: Register for notification BEFORE checking for bundles.

--- a/rust/otap-dataflow/crates/quiver/src/subscriber/state.rs
+++ b/rust/otap-dataflow/crates/quiver/src/subscriber/state.rs
@@ -243,10 +243,10 @@ impl SubscriberState {
     /// was already claimed or resolved.
     pub fn claim(&mut self, bundle_ref: BundleRef) -> bool {
         // Check if already resolved
-        if let Some(progress) = self.segments.get(&bundle_ref.segment_seq) {
-            if progress.is_resolved(bundle_ref.bundle_index) {
-                return false;
-            }
+        if let Some(progress) = self.segments.get(&bundle_ref.segment_seq)
+            && progress.is_resolved(bundle_ref.bundle_index)
+        {
+            return false;
         }
 
         // Try to claim

--- a/rust/otap-dataflow/crates/quiver/src/wal/cursor_sidecar.rs
+++ b/rust/otap-dataflow/crates/quiver/src/wal/cursor_sidecar.rs
@@ -285,10 +285,10 @@ impl CursorSidecar {
         // Sync parent directory for durability (on Unix)
         #[cfg(unix)]
         {
-            if let Some(parent) = path.parent() {
-                if let Ok(dir) = std::fs::File::open(parent) {
-                    let _ = dir.sync_data();
-                }
+            if let Some(parent) = path.parent()
+                && let Ok(dir) = std::fs::File::open(parent)
+            {
+                let _ = dir.sync_data();
             }
         }
         Ok(())

--- a/rust/otap-dataflow/crates/quiver/src/wal/writer.rs
+++ b/rust/otap-dataflow/crates/quiver/src/wal/writer.rs
@@ -1431,10 +1431,10 @@ impl WalCoordinator {
         cursor: &WalConsumerCursor,
     ) -> WalResult<()> {
         // Validate sequence monotonicity
-        if let Some(last_seq) = self.last_cursor_sequence {
-            if cursor.safe_sequence < last_seq {
-                return Err(WalError::InvalidConsumerCursor("safe sequence regressed"));
-            }
+        if let Some(last_seq) = self.last_cursor_sequence
+            && cursor.safe_sequence < last_seq
+        {
+            return Err(WalError::InvalidConsumerCursor("safe sequence regressed"));
         }
 
         // Validate WAL position monotonicity

--- a/rust/otap-dataflow/crates/state/src/store.rs
+++ b/rust/otap-dataflow/crates/state/src/store.rs
@@ -832,10 +832,11 @@ mod tests {
         // Wait until all cores appear in the state map.
         let pipeline_key = PipelineKey::new(Cow::Borrowed("group"), Cow::Borrowed("pipeline"));
         for _ in 0..200 {
-            if let Some(status) = handle.pipeline_status(&pipeline_key) {
-                if status.total_cores() == num_cores && status.running_cores() == num_cores {
-                    break;
-                }
+            if let Some(status) = handle.pipeline_status(&pipeline_key)
+                && status.total_cores() == num_cores
+                && status.running_cores() == num_cores
+            {
+                break;
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
@@ -929,10 +930,11 @@ mod tests {
         // Wait until all cores reach Running.
         let pipeline_key = PipelineKey::new(Cow::Borrowed("group"), Cow::Borrowed("pipeline"));
         for _ in 0..200 {
-            if let Some(status) = handle.pipeline_status(&pipeline_key) {
-                if status.total_cores() == num_cores && status.running_cores() == num_cores {
-                    break;
-                }
+            if let Some(status) = handle.pipeline_status(&pipeline_key)
+                && status.total_cores() == num_cores
+                && status.running_cores() == num_cores
+            {
+                break;
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }

--- a/rust/otap-dataflow/crates/telemetry-macros/src/lib.rs
+++ b/rust/otap-dataflow/crates/telemetry-macros/src/lib.rs
@@ -204,18 +204,16 @@ pub fn derive_metric_set_handler(input: TokenStream) -> TokenStream {
         // Collect doc comments for brief (concatenate all lines)
         let mut brief_lines: Vec<String> = Vec::new();
         for attr in &field.attrs {
-            if attr.meta.path().is_ident("doc") {
-                if let syn::Meta::NameValue(nv) = &attr.meta {
-                    if let syn::Expr::Lit(syn::ExprLit {
-                        lit: syn::Lit::Str(ls),
-                        ..
-                    }) = &nv.value
-                    {
-                        let line = ls.value().trim().to_string();
-                        if !line.is_empty() {
-                            brief_lines.push(line);
-                        }
-                    }
+            if attr.meta.path().is_ident("doc")
+                && let syn::Meta::NameValue(nv) = &attr.meta
+                && let syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Str(ls),
+                    ..
+                }) = &nv.value
+            {
+                let line = ls.value().trim().to_string();
+                if !line.is_empty() {
+                    brief_lines.push(line);
                 }
             }
         }
@@ -562,18 +560,16 @@ pub fn derive_attribute_set_handler(input: TokenStream) -> TokenStream {
         // Collect doc comments for description (concatenate all lines)
         let mut desc_lines: Vec<String> = Vec::new();
         for attr in &field.attrs {
-            if attr.meta.path().is_ident("doc") {
-                if let syn::Meta::NameValue(nv) = &attr.meta {
-                    if let syn::Expr::Lit(syn::ExprLit {
-                        lit: syn::Lit::Str(ls),
-                        ..
-                    }) = &nv.value
-                    {
-                        let line = ls.value().trim().to_string();
-                        if !line.is_empty() {
-                            desc_lines.push(line);
-                        }
-                    }
+            if attr.meta.path().is_ident("doc")
+                && let syn::Meta::NameValue(nv) = &attr.meta
+                && let syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Str(ls),
+                    ..
+                }) = &nv.value
+            {
+                let line = ls.value().trim().to_string();
+                if !line.is_empty() {
+                    desc_lines.push(line);
                 }
             }
         }
@@ -906,16 +902,14 @@ pub fn derive_attribute_enum(input: TokenStream) -> TokenStream {
         // Optional `#[attribute_value = "..."]` override for the variant string.
         let mut override_val: Option<String> = None;
         for attr in &variant.attrs {
-            if attr.path().is_ident("attribute_value") {
-                if let syn::Meta::NameValue(nv) = &attr.meta {
-                    if let syn::Expr::Lit(syn::ExprLit {
-                        lit: syn::Lit::Str(s),
-                        ..
-                    }) = &nv.value
-                    {
-                        override_val = Some(s.value());
-                    }
-                }
+            if attr.path().is_ident("attribute_value")
+                && let syn::Meta::NameValue(nv) = &attr.meta
+                && let syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Str(s),
+                    ..
+                }) = &nv.value
+            {
+                override_val = Some(s.value());
             }
         }
 

--- a/rust/otap-dataflow/crates/telemetry/src/event.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/event.rs
@@ -108,10 +108,8 @@ impl ObservedEventReporter {
             None => match self.sender.try_send(event) {
                 Ok(_) => {}
                 Err(err) => {
-                    if is_log {
-                        if let Some(drop_counter) = &self.drop_counter {
-                            drop_counter.increment();
-                        }
+                    if is_log && let Some(drop_counter) = &self.drop_counter {
+                        drop_counter.increment();
                     }
                     if !self.policy.console_fallback {
                         return;
@@ -129,10 +127,8 @@ impl ObservedEventReporter {
             Some(timeout) => match self.sender.send_timeout(event, timeout) {
                 Ok(_) => {}
                 Err(err) => {
-                    if is_log {
-                        if let Some(drop_counter) = &self.drop_counter {
-                            drop_counter.increment();
-                        }
+                    if is_log && let Some(drop_counter) = &self.drop_counter {
+                        drop_counter.increment();
                     }
                     if !self.policy.console_fallback {
                         return;

--- a/rust/otap-dataflow/crates/telemetry/src/self_tracing/formatter.rs
+++ b/rust/otap-dataflow/crates/telemetry/src/self_tracing/formatter.rs
@@ -706,15 +706,15 @@ mod tests {
             }
             result.push_str(&kv.key);
             result.push('=');
-            if let Some(ref v) = kv.value {
-                if let Some(ref val) = v.value {
-                    match val {
-                        Value::StringValue(s) => result.push_str(s),
-                        Value::IntValue(i) => result.push_str(&i.to_string()),
-                        Value::BoolValue(b) => result.push_str(if *b { "true" } else { "false" }),
-                        Value::DoubleValue(d) => result.push_str(&format!("{:.6}", d)),
-                        _ => unreachable!(),
-                    }
+            if let Some(ref v) = kv.value
+                && let Some(ref val) = v.value
+            {
+                match val {
+                    Value::StringValue(s) => result.push_str(s),
+                    Value::IntValue(i) => result.push_str(&i.to_string()),
+                    Value::BoolValue(b) => result.push_str(if *b { "true" } else { "false" }),
+                    Value::DoubleValue(d) => result.push_str(&format!("{:.6}", d)),
+                    _ => unreachable!(),
                 }
             }
         }

--- a/rust/otap-dataflow/crates/validation/src/simulate.rs
+++ b/rust/otap-dataflow/crates/validation/src/simulate.rs
@@ -255,10 +255,10 @@ fn validation_finished_and_passed(snapshot: &MetricsSnapshot) -> ValidationPollR
             return ValidationPollResult::NotFinished;
         }
         // Exporter is finished -- check its validation result in the same pass.
-        if metric_value(set, VALIDATION_METRIC_NAME).is_some_and(|v| v < 1) {
-            if let Some(label) = attribute_node_id(&set.attributes) {
-                failed_validation_exporters.push(label);
-            }
+        if metric_value(set, VALIDATION_METRIC_NAME).is_some_and(|v| v < 1)
+            && let Some(label) = attribute_node_id(&set.attributes)
+        {
+            failed_validation_exporters.push(label);
         }
     }
 

--- a/rust/otap-dataflow/crates/validation/src/validation_types/attributes.rs
+++ b/rust/otap-dataflow/crates/validation/src/validation_types/attributes.rs
@@ -154,16 +154,12 @@ fn collect_log_attrs<'a>(
     let include_signal = domains.contains(&AttributeDomain::Signal);
 
     for resource_logs in &logs.resource_logs {
-        if include_resource {
-            if let Some(resource) = resource_logs.resource.as_ref() {
-                out.push(resource.attributes.as_slice());
-            }
+        if include_resource && let Some(resource) = resource_logs.resource.as_ref() {
+            out.push(resource.attributes.as_slice());
         }
         for scope_logs in &resource_logs.scope_logs {
-            if include_scope {
-                if let Some(scope) = scope_logs.scope.as_ref() {
-                    out.push(scope.attributes.as_slice());
-                }
+            if include_scope && let Some(scope) = scope_logs.scope.as_ref() {
+                out.push(scope.attributes.as_slice());
             }
             if include_signal {
                 for record in &scope_logs.log_records {
@@ -186,16 +182,12 @@ fn collect_span_attrs<'a>(
     let include_signal = domains.contains(&AttributeDomain::Signal);
 
     for resource_spans in &traces.resource_spans {
-        if include_resource {
-            if let Some(resource) = resource_spans.resource.as_ref() {
-                out.push(resource.attributes.as_slice());
-            }
+        if include_resource && let Some(resource) = resource_spans.resource.as_ref() {
+            out.push(resource.attributes.as_slice());
         }
         for scope_spans in &resource_spans.scope_spans {
-            if include_scope {
-                if let Some(scope) = scope_spans.scope.as_ref() {
-                    out.push(scope.attributes.as_slice());
-                }
+            if include_scope && let Some(scope) = scope_spans.scope.as_ref() {
+                out.push(scope.attributes.as_slice());
             }
             if include_signal {
                 for span in &scope_spans.spans {
@@ -220,16 +212,12 @@ fn collect_metric_attrs<'a>(
     let include_signal = domains.contains(&AttributeDomain::Signal);
 
     for resource_metrics in &metrics.resource_metrics {
-        if include_resource {
-            if let Some(resource) = resource_metrics.resource.as_ref() {
-                out.push(resource.attributes.as_slice());
-            }
+        if include_resource && let Some(resource) = resource_metrics.resource.as_ref() {
+            out.push(resource.attributes.as_slice());
         }
         for scope_metrics in &resource_metrics.scope_metrics {
-            if include_scope {
-                if let Some(scope) = scope_metrics.scope.as_ref() {
-                    out.push(scope.attributes.as_slice());
-                }
+            if include_scope && let Some(scope) = scope_metrics.scope.as_ref() {
+                out.push(scope.attributes.as_slice());
             }
             if include_signal {
                 for metric in &scope_metrics.metrics {

--- a/rust/otap-dataflow/crates/validation/src/validation_types/batch.rs
+++ b/rust/otap-dataflow/crates/validation/src/validation_types/batch.rs
@@ -17,21 +17,21 @@ pub(crate) fn validate_batch_items(
     timeout: &Option<Duration>,
 ) -> bool {
     messages.iter().all(|(message, elapsed)| {
-        if let Some(t) = timeout {
-            if elapsed >= t {
-                return true;
-            }
+        if let Some(t) = timeout
+            && elapsed >= t
+        {
+            return true;
         }
         let batch_size = message.num_items();
-        if let Some(min) = min_items {
-            if &batch_size < min {
-                return false;
-            }
+        if let Some(min) = min_items
+            && &batch_size < min
+        {
+            return false;
         }
-        if let Some(max) = max_items {
-            if &batch_size > max {
-                return false;
-            }
+        if let Some(max) = max_items
+            && &batch_size > max
+        {
+            return false;
         }
         true
     })
@@ -46,23 +46,23 @@ pub(crate) fn validate_batch_bytes(
     timeout: &Option<Duration>,
 ) -> bool {
     messages.iter().all(|(message, elapsed)| {
-        if let Some(t) = timeout {
-            if elapsed >= t {
-                return true;
-            }
+        if let Some(t) = timeout
+            && elapsed >= t
+        {
+            return true;
         }
         let mut buf = Vec::new();
         let _ = message.encode(&mut buf);
         let byte_size = buf.len();
-        if let Some(min) = min_bytes {
-            if &byte_size < min {
-                return false;
-            }
+        if let Some(min) = min_bytes
+            && &byte_size < min
+        {
+            return false;
         }
-        if let Some(max) = max_bytes {
-            if &byte_size > max {
-                return false;
-            }
+        if let Some(max) = max_bytes
+            && &byte_size > max
+        {
+            return false;
         }
         true
     })

--- a/rust/otap-dataflow/crates/validation/src/validation_types/signal_dropped.rs
+++ b/rust/otap-dataflow/crates/validation/src/validation_types/signal_dropped.rs
@@ -24,16 +24,16 @@ pub(crate) fn validate_signal_drop(
 
     let drop_ratio = (control_total as f64 - suv_total as f64) / control_total as f64;
 
-    if let Some(min) = min_drop_ratio {
-        if drop_ratio < min {
-            return false;
-        }
+    if let Some(min) = min_drop_ratio
+        && drop_ratio < min
+    {
+        return false;
     }
 
-    if let Some(max) = max_drop_ratio {
-        if drop_ratio > max {
-            return false;
-        }
+    if let Some(max) = max_drop_ratio
+        && drop_ratio > max
+    {
+        return false;
     }
 
     true

--- a/rust/otap-dataflow/xtask/src/component_inventory.rs
+++ b/rust/otap-dataflow/xtask/src/component_inventory.rs
@@ -175,31 +175,31 @@ fn check_controlled_values(components: &[Component]) -> Vec<String> {
         if !is_first_party(&c.id) {
             continue;
         }
-        if let Some(v) = c.attributes.get("protocol") {
-            if Protocol::parse(v).is_custom() {
-                errors.push(format!(
-                    "{}:{}: {}: protocol value {v:?} is not in the known set \
-                     ({}); `Custom` values are only allowed for external \
-                     (non-urn:otel) components",
-                    c.file,
-                    c.line,
-                    c.id,
-                    Protocol::known_list()
-                ));
-            }
+        if let Some(v) = c.attributes.get("protocol")
+            && Protocol::parse(v).is_custom()
+        {
+            errors.push(format!(
+                "{}:{}: {}: protocol value {v:?} is not in the known set \
+                 ({}); `Custom` values are only allowed for external \
+                 (non-urn:otel) components",
+                c.file,
+                c.line,
+                c.id,
+                Protocol::known_list()
+            ));
         }
-        if let Some(v) = c.attributes.get("auth") {
-            if Auth::parse(v).is_custom() {
-                errors.push(format!(
-                    "{}:{}: {}: auth value {v:?} is not in the known set ({}); \
-                     `Custom` values are only allowed for external \
-                     (non-urn:otel) components",
-                    c.file,
-                    c.line,
-                    c.id,
-                    Auth::known_list()
-                ));
-            }
+        if let Some(v) = c.attributes.get("auth")
+            && Auth::parse(v).is_custom()
+        {
+            errors.push(format!(
+                "{}:{}: {}: auth value {v:?} is not in the known set ({}); \
+                 `Custom` values are only allowed for external \
+                 (non-urn:otel) components",
+                c.file,
+                c.line,
+                c.id,
+                Auth::known_list()
+            ));
         }
     }
     errors
@@ -476,17 +476,17 @@ fn extract_from_items(
 ) {
     for item in items {
         // Recurse into inline modules.
-        if let Item::Mod(m) = item {
-            if let Some((_, inner)) = &m.content {
-                extract_from_items(
-                    inner,
-                    rel_path,
-                    urn_table,
-                    components,
-                    missing,
-                    parse_errors,
-                );
-            }
+        if let Item::Mod(m) = item
+            && let Some((_, inner)) = &m.content
+        {
+            extract_from_items(
+                inner,
+                rel_path,
+                urn_table,
+                components,
+                missing,
+                parse_errors,
+            );
         }
 
         let Some((attrs, name_field)) = item_parts(item) else {
@@ -607,10 +607,10 @@ fn resolve_id(
 fn struct_field_expr(expr: &Expr, field: &str) -> Option<Expr> {
     if let Expr::Struct(s) = expr {
         for fv in &s.fields {
-            if let syn::Member::Named(ident) = &fv.member {
-                if ident == field {
-                    return Some(fv.expr.clone());
-                }
+            if let syn::Member::Named(ident) = &fv.member
+                && ident == field
+            {
+                return Some(fv.expr.clone());
             }
         }
     }
@@ -626,12 +626,12 @@ fn distributed_slice_otap(attrs: &[Attribute]) -> Option<String> {
         if let Meta::List(list) = &attr.meta {
             // The single argument is the slice path, e.g. `OTAP_RECEIVER_FACTORIES`
             // or `otel_arrow_dfe_otap::OTAP_RECEIVER_FACTORIES`.
-            if let Ok(path) = syn::parse2::<syn::Path>(list.tokens.clone()) {
-                if let Some(last) = path.segments.last() {
-                    let name = last.ident.to_string();
-                    if name.starts_with("OTAP_") {
-                        return Some(name);
-                    }
+            if let Ok(path) = syn::parse2::<syn::Path>(list.tokens.clone())
+                && let Some(last) = path.segments.last()
+            {
+                let name = last.ident.to_string();
+                if name.starts_with("OTAP_") {
+                    return Some(name);
                 }
             }
         }

--- a/rust/otap-dataflow/xtask/src/diagnostics.rs
+++ b/rust/otap-dataflow/xtask/src/diagnostics.rs
@@ -308,28 +308,27 @@ impl DiagnosticsCollector {
             );
         }
 
-        if let Some(test_step) = self.step_timings.iter().find(|step| step.name == "test") {
-            if let Some(test_compile_wall) = self
+        if let Some(test_step) = self.step_timings.iter().find(|step| step.name == "test")
+            && let Some(test_compile_wall) = self
                 .compile_reports
                 .iter()
                 .find(|report| report.step == "test")
                 .map(|report| report.compile_wall_time)
-            {
-                let approx_compile = std::cmp::min(test_compile_wall, test_step.duration);
-                let approx_execution = test_step.duration.saturating_sub(approx_compile);
-                println!(
-                    "  {} compile {}, execution {}",
-                    paint("test step split (approx.):", "36"),
-                    paint(
-                        &format_duration(approx_compile),
-                        metric_heat_color(approx_compile)
-                    ),
-                    paint(
-                        &format_duration(approx_execution),
-                        metric_heat_color(approx_execution)
-                    )
-                );
-            }
+        {
+            let approx_compile = std::cmp::min(test_compile_wall, test_step.duration);
+            let approx_execution = test_step.duration.saturating_sub(approx_compile);
+            println!(
+                "  {} compile {}, execution {}",
+                paint("test step split (approx.):", "36"),
+                paint(
+                    &format_duration(approx_compile),
+                    metric_heat_color(approx_compile)
+                ),
+                paint(
+                    &format_duration(approx_execution),
+                    metric_heat_color(approx_execution)
+                )
+            );
         }
     }
 

--- a/rust/otap-dataflow/xtask/src/main.rs
+++ b/rust/otap-dataflow/xtask/src/main.rs
@@ -161,10 +161,10 @@ fn run_structure_step(
         diagnostics.record_step("structure", duration, step_status_from_result(&result));
     }
 
-    if result.is_err() {
-        if let Some(diagnostics) = &mut diagnostics {
-            diagnostics.print_summary();
-        }
+    if result.is_err()
+        && let Some(diagnostics) = &mut diagnostics
+    {
+        diagnostics.print_summary();
     }
 
     result
@@ -188,10 +188,10 @@ fn run_component_inventory_step(
         );
     }
 
-    if result.is_err() {
-        if let Some(diagnostics) = &mut diagnostics {
-            diagnostics.print_summary();
-        }
+    if result.is_err()
+        && let Some(diagnostics) = &mut diagnostics
+    {
+        diagnostics.print_summary();
     }
 
     result
@@ -209,10 +209,10 @@ fn format_all(
         diagnostics.record_step("fmt", duration, step_status_from_result(&result));
     }
 
-    if result.is_err() {
-        if let Some(diagnostics) = &mut diagnostics {
-            diagnostics.print_summary();
-        }
+    if result.is_err()
+        && let Some(diagnostics) = &mut diagnostics
+    {
+        diagnostics.print_summary();
     }
 
     result?;


### PR DESCRIPTION
# Chore Summary

Raise the `otap-dataflow` Rust MSV to `1.88`

This aligns the workspace's compatibility contract with Azure SDK dependencies that require Rust 1.88.

This was actually already an issue:
- `otap` used a pinned Azure SDK Git revision and was not published to crates.io.
- CI built with Rust `1.98`, so Azure's Rust `1.88` minimum did not fail.
- Preparing `otap` crate for publication requires released registry dependencies.
- Reviewing that dependency contract exposed the advertised Rust `1.87` mismatch.

The overwhelming majority of changes in this PR are `clippy` fixes to make use of `let` chains.

### References

- [Rust 1.88 release announcement](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/) documents let-chain stabilization.
- [Clippy MSRV definitions](https://github.com/rust-lang/rust/blob/1.98.0/src/tools/clippy/clippy_utils/src/msrvs.rs#L30) assign both `LET_CHAINS` and `AS_CHUNKS` to Rust 1.88.
- [Clippy `collapsible_if` implementation](https://github.com/rust-lang/rust/blob/1.98.0/src/tools/clippy/clippy_lints/src/collapsible_if.rs#L219-L220) gates let-chain suggestions on the configured MSRV.
- [Clippy `collapsible_if` documentation](https://doc.rust-lang.org/stable/clippy/lints.html#collapsible_if) describes the lint.

## Related issue

Related to #1340 
