### PR TITLE
fix(controller): allow forced shutdown completion grace

### DIFF
--- a/rust/otap-dataflow/.chloggen/fix-reconciliation-drain-deadline.yaml
+++ b/rust/otap-dataflow/.chloggen/fix-reconciliation-drain-deadline.yaml
@@ -1,0 +1,21 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. engine, otap).
+# Must be one of the components listed in rust/otap-dataflow/.chloggen/config.yaml.
+component: engine
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Live pipeline reconciliation no longer fails when a runtime finishes forced shutdown just after its graceful drain deadline.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3266]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries. Breaking entries must include a `Migration:`
+# section with the specific action consumers must take. Keep notes to 200
+# characters and subtext to 300 characters.
+subtext: The drain timeout still bounds graceful processing. The controller now allows a separate bounded window for forced runtime and extension shutdown to report completion.

--- a/rust/otap-dataflow/crates/controller/src/live_control/execution.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/execution.rs
@@ -276,7 +276,7 @@ impl<
                     .next()
                     .map(|deployed_key| {
                         format!(
-                            "timed out waiting for pipeline {}:{} core={} generation={} to drain",
+                            "timed out waiting for pipeline {}:{} core={} generation={} to shut down",
                             deployed_key.pipeline_group_id.as_ref(),
                             deployed_key.pipeline_id.as_ref(),
                             deployed_key.core_id,

--- a/rust/otap-dataflow/crates/controller/src/live_control/execution.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/execution.rs
@@ -187,10 +187,13 @@ impl<
             shutdown.state = ShutdownLifecycleState::Running;
         });
 
+        let drain_deadline = Instant::now() + Duration::from_secs(plan.timeout_secs.max(1));
         for deployed_key in &plan.target_instances {
-            if let Err(message) =
-                self.request_instance_shutdown(deployed_key, plan.timeout_secs, "pipeline shutdown")
-            {
+            if let Err(message) = self.request_instance_shutdown_until(
+                deployed_key,
+                drain_deadline,
+                "pipeline shutdown",
+            ) {
                 self.update_shutdown(&plan.pipeline_key, &plan.shutdown.shutdown_id, |shutdown| {
                     shutdown.state = ShutdownLifecycleState::Failed;
                     shutdown.failure_reason = Some(message.clone());
@@ -217,7 +220,7 @@ impl<
             });
         }
 
-        let deadline = Instant::now() + Duration::from_secs(plan.timeout_secs);
+        let deadline = pipeline_shutdown_completion_deadline(drain_deadline);
         let mut remaining: HashSet<_> = plan.target_instances.iter().cloned().collect();
         while !remaining.is_empty() {
             let mut completed = Vec::new();

--- a/rust/otap-dataflow/crates/controller/src/live_control/mod.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/mod.rs
@@ -64,7 +64,7 @@ const PIPELINE_SHUTDOWN_COMPLETION_GRACE: Duration = Duration::from_secs(10);
 
 /// Short completion grace for unit tests that exercise both sides of the deadline.
 #[cfg(test)]
-const PIPELINE_SHUTDOWN_COMPLETION_GRACE: Duration = Duration::from_millis(250);
+const PIPELINE_SHUTDOWN_COMPLETION_GRACE: Duration = Duration::from_secs(1);
 
 /// Returns the controller deadline for observing an instance's terminal exit.
 fn pipeline_shutdown_completion_deadline(drain_deadline: Instant) -> Instant {

--- a/rust/otap-dataflow/crates/controller/src/live_control/mod.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/mod.rs
@@ -54,6 +54,23 @@ use self::state::{
 };
 pub(crate) use self::state::{PanicReport, RuntimeInstanceError, RuntimeInstanceExit};
 
+/// Bounded time for a runtime thread to finish after its graceful drain deadline.
+///
+/// The engine uses the drain deadline to force-stop unresolved node work, so the
+/// runtime thread can only report that forced exit after the deadline. Pipeline
+/// extensions may then consume their own bounded five-second shutdown window.
+#[cfg(not(test))]
+const PIPELINE_SHUTDOWN_COMPLETION_GRACE: Duration = Duration::from_secs(10);
+
+/// Short completion grace for unit tests that exercise both sides of the deadline.
+#[cfg(test)]
+const PIPELINE_SHUTDOWN_COMPLETION_GRACE: Duration = Duration::from_millis(250);
+
+/// Returns the controller deadline for observing an instance's terminal exit.
+fn pipeline_shutdown_completion_deadline(drain_deadline: Instant) -> Instant {
+    drain_deadline + PIPELINE_SHUTDOWN_COMPLETION_GRACE
+}
+
 /// Shared live-control runtime used by the admin control plane and workers.
 ///
 /// `ControllerRuntime` is the synchronization point for logical pipeline

--- a/rust/otap-dataflow/crates/controller/src/live_control/runtime.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/runtime.rs
@@ -1351,7 +1351,7 @@ impl<
 
             let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
                 return Err(format!(
-                    "timed out waiting for pipeline {}:{} core={} generation={} to drain",
+                    "timed out waiting for pipeline {}:{} core={} generation={} to shut down",
                     deployed_key.pipeline_group_id.as_ref(),
                     deployed_key.pipeline_id.as_ref(),
                     deployed_key.core_id,
@@ -1401,7 +1401,7 @@ impl<
 
             let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
                 return Err(format!(
-                    "timed out waiting for pipeline {} to drain before system observability shutdown",
+                    "timed out waiting for pipeline {} to shut down before system observability shutdown",
                     deployed_instance_label(deployed_key)
                 ));
             };
@@ -1637,7 +1637,7 @@ impl<
         }
         if !wait_failures.is_empty() {
             self.record_async_global_shutdown_failure(format!(
-                "producer drain failed before system observability shutdown: {}",
+                "producer shutdown failed before system observability shutdown: {}",
                 wait_failures.join("; ")
             ));
         }

--- a/rust/otap-dataflow/crates/controller/src/live_control/runtime.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/runtime.rs
@@ -1270,6 +1270,17 @@ impl<
         timeout_secs: u64,
         reason: &str,
     ) -> Result<(), String> {
+        let drain_deadline = Instant::now() + Duration::from_secs(timeout_secs.max(1));
+        self.request_instance_shutdown_until(deployed_key, drain_deadline, reason)
+    }
+
+    /// Sends shutdown with an absolute drain deadline.
+    pub(super) fn request_instance_shutdown_until(
+        &self,
+        deployed_key: &DeployedPipelineKey,
+        drain_deadline: Instant,
+        reason: &str,
+    ) -> Result<(), String> {
         let sender = {
             let state = self
                 .state
@@ -1304,10 +1315,7 @@ impl<
             })?
         };
 
-        if let Err(err) = sender.try_send_shutdown(
-            Instant::now() + Duration::from_secs(timeout_secs.max(1)),
-            reason.to_owned(),
-        ) {
+        if let Err(err) = sender.try_send_shutdown(drain_deadline, reason.to_owned()) {
             return match self.instance_exit(deployed_key) {
                 Some(RuntimeInstanceExit::Success) => Ok(()),
                 Some(RuntimeInstanceExit::Error(error)) => Err(error.message),
@@ -1412,10 +1420,11 @@ impl<
         timeout_secs: u64,
         reason: &str,
     ) -> Result<(), String> {
-        self.request_instance_shutdown(deployed_key, timeout_secs, reason)?;
+        let drain_deadline = Instant::now() + Duration::from_secs(timeout_secs.max(1));
+        self.request_instance_shutdown_until(deployed_key, drain_deadline, reason)?;
         self.wait_for_instance_exit(
             deployed_key,
-            Instant::now() + Duration::from_secs(timeout_secs.max(1)),
+            pipeline_shutdown_completion_deadline(drain_deadline),
         )
     }
 
@@ -1618,8 +1627,10 @@ impl<
         shutdown_timeout: Duration,
     ) {
         let mut wait_failures = Vec::new();
+        let producer_completion_deadline = pipeline_shutdown_completion_deadline(producer_deadline);
         for deployed_key in &producer_keys {
-            if let Err(error) = self.wait_for_global_shutdown_exit(deployed_key, producer_deadline)
+            if let Err(error) =
+                self.wait_for_global_shutdown_exit(deployed_key, producer_completion_deadline)
             {
                 wait_failures.push(error);
             }
@@ -1707,9 +1718,11 @@ impl<
             }
         }
 
+        let observability_completion_deadline =
+            pipeline_shutdown_completion_deadline(observability_deadline);
         for deployed_key in observability_keys {
             if let Err(error) =
-                self.wait_for_global_shutdown_exit(&deployed_key, observability_deadline)
+                self.wait_for_global_shutdown_exit(&deployed_key, observability_completion_deadline)
             {
                 self.record_async_global_shutdown_failure(format!(
                     "system observability shutdown did not complete: {error}"

--- a/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
@@ -4740,6 +4740,53 @@ fn explicit_shutdown_retains_initiator_in_status() {
     );
 }
 
+/// Scenario: an instance can only finish after the engine reaches its graceful
+/// drain deadline and force-stops unresolved node work.
+/// Guarantees: the controller allows bounded post-deadline completion time and
+/// does not falsely report the forced runtime exit as a drain timeout.
+#[test]
+fn shutdown_instance_waits_for_exit_after_graceful_drain_deadline() {
+    let config = engine_config_with_pipeline(simple_pipeline_yaml());
+    let runtime = test_runtime(&config);
+    register_existing_pipeline(&runtime, &config);
+    let deployed_key = deployed_key("g1", "p1", 0, 0);
+    let mut notifications =
+        register_runtime_instance(&runtime, "g1", "p1", 0, 0, RuntimeInstanceLifecycle::Active);
+    {
+        // A rollout retains the terminal runtime record long enough for its
+        // worker to observe the exit rather than compacting it immediately.
+        let mut state = runtime
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        _ = state.active_rollouts.insert(
+            PipelineKey::new("g1".into(), "p1".into()),
+            "deadline-completion-test".to_owned(),
+        );
+    }
+
+    let exit_runtime = Arc::clone(&runtime);
+    let exit_key = deployed_key.clone();
+    let exit_thread = thread::spawn(move || {
+        let RuntimeControlMsg::Shutdown { deadline, .. } =
+            wait_for_shutdown_message(&mut notifications)
+        else {
+            panic!("instance should receive shutdown");
+        };
+        thread::sleep(
+            deadline
+                .saturating_duration_since(Instant::now())
+                .saturating_add(Duration::from_millis(50)),
+        );
+        exit_runtime.note_instance_exit(exit_key, RuntimeInstanceExit::Success);
+    });
+
+    runtime
+        .shutdown_instance(&deployed_key, 1, "deadline completion test")
+        .expect("forced shutdown should complete during the controller grace period");
+    exit_thread.join().expect("exit reporter should not panic");
+}
+
 /// Scenario: a shutdown request targets one logical pipeline while other
 /// pipelines and exited instances still exist in the runtime registry.
 /// Guarantees: only active instances for the requested logical pipeline

--- a/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
@@ -4773,11 +4773,13 @@ fn shutdown_instance_waits_for_exit_after_graceful_drain_deadline() {
         else {
             panic!("instance should receive shutdown");
         };
-        thread::sleep(
-            deadline
-                .saturating_duration_since(Instant::now())
-                .saturating_add(Duration::from_millis(50)),
-        );
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            thread::sleep(remaining.min(Duration::from_millis(10)));
+        }
         exit_runtime.note_instance_exit(exit_key, RuntimeInstanceExit::Success);
     });
 


### PR DESCRIPTION
# Change summary

Fix a deadline race that could incorrectly mark pipeline reconciliation as failed when unresolved work was force-stopped at the graceful drain deadline.

The controller now allows a separate bounded completion window for the runtime thread and extensions to report shutdown after the drain deadline. The configured drain timeout continues to bound graceful processing.

The same handling applies to pipeline reconciliation, explicit pipeline shutdown, and global shutdown.

## Related issue

- NA

## Validation

- Manually reproduced the QA scenario with:
    - 10 pipeline cores.
    - A 500 MiB process memory threshold.
    - In-flight logs and metrics blocked behind retry.
    - A 60-second drain timeout.
    - Reconfiguration from the supplied initial pipeline to the replacement pipeline.

The rollout succeeded, all cores switched to the new generation, and the pipeline remained ready.

## User-facing changes

Pipeline reconciliation no longer reports a drain timeout when forced shutdown completes just after the graceful drain deadline.

Added .chloggen/fix-reconciliation-drain-deadline.yaml.
