### PR TITLE
chore(release): Isolate pdata-views from release automation

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -12,6 +12,11 @@ on:
         required: true
         type: boolean
         default: true
+      include_pdata_views:
+        description: "Bump pdata-views too (requires dependent crates to support the new version)"
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -109,12 +114,29 @@ jobs:
 
       - name: Bump Rust crate versions
         run: |
-          # Rust crates currently track the same release version as Go.
-          # Replace the workspace/root package versions and same-release
-          # dependency constraints in the workspace manifest.
+          # Rust crates generally track the same release version as Go.
+          # pdata-views is independently versioned because it is a stable,
+          # dependency-free compatibility boundary.
           CURRENT_VERSION=$(sed -n 's/^version = "\([0-9]\+\.[0-9]\+\.[0-9]\+\)"/\1/p' rust/otap-dataflow/Cargo.toml | head -1)
+          PDATA_VIEWS_VERSION=$(sed -n 's/^version = "\([0-9]\+\.[0-9]\+\.[0-9]\+\)"/\1/p' rust/otap-dataflow/crates/pdata-views/Cargo.toml | head -1)
           CURRENT_VERSION_PATTERN=$(printf '%s' "${CURRENT_VERSION}" | sed 's/\./\\./g')
           sed -i "s/${CURRENT_VERSION_PATTERN}/${{ inputs.version }}/g" rust/otap-dataflow/Cargo.toml
+
+          if [ "${{ inputs.include_pdata_views }}" = "true" ]; then
+            sed -i \
+              "s/^version = \"${PDATA_VIEWS_VERSION}\"/version = \"${{ inputs.version }}\"/" \
+              rust/otap-dataflow/crates/pdata-views/Cargo.toml
+            sed -i \
+              '/^otel-arrow-dfe-pdata-views = / s/version = "[^"]*"/version = "${{ inputs.version }}"/' \
+              rust/otap-dataflow/Cargo.toml
+            echo "Included pdata-views in release ${{ inputs.version }}"
+          else
+            sed -i \
+              '/^otel-arrow-dfe-pdata-views = / s/version = "[^"]*"/version = "'"${PDATA_VIEWS_VERSION}"'"/' \
+              rust/otap-dataflow/Cargo.toml
+            echo "Kept pdata-views at independent version ${PDATA_VIEWS_VERSION}"
+          fi
+
           echo "Updated rust/otap-dataflow/Cargo.toml to ${{ inputs.version }}"
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -186,6 +208,7 @@ jobs:
           ## Planned Changes
           - **New version**: `${{ inputs.version }}`
           - **Last version**: `${{ steps.last_version.outputs.last_version }}`
+          - **Include pdata-views**: `${{ inputs.include_pdata_views }}`
 
           ## Git Operations
           - Create branch: `otelbot/release-v${{ inputs.version }}`
@@ -198,7 +221,7 @@ jobs:
           - `go/CHANGELOG.md` - Render pending `go/.chloggen/*.yaml` entries, or a repository parity note when empty, under `## v${{ inputs.version }}`
           - `rust/otap-dataflow/CHANGELOG.md` - Render pending `rust/otap-dataflow/.chloggen/*.yaml` entries, or a repository parity note when empty, under `## v${{ inputs.version }}`
           - `go/.chloggen/*.yaml`, `rust/otap-dataflow/.chloggen/*.yaml` - Consumed entries deleted
-          - `rust/otap-dataflow/Cargo.toml` - Bump workspace and root package version to ${{ inputs.version }}
+          - `rust/otap-dataflow/Cargo.toml` - Bump workspace, root package, and same-release dependency versions to ${{ inputs.version }}
 
           ## Release Notes Preview
           ```
@@ -248,7 +271,8 @@ jobs:
 
           ### Changes included:
           - Rendered pending chloggen entries into \`go/CHANGELOG.md\` and \`rust/otap-dataflow/CHANGELOG.md\`
-          - Bumped \`rust/otap-dataflow/Cargo.toml\` (workspace + root package)
+          - Bumped Rust workspace crates to ${{ inputs.version }}
+          - Include \`otel-arrow-dfe-pdata-views\` in this release: ${{ inputs.include_pdata_views }}
 
           ${CHANGELOG_CONTENT}
 

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -229,10 +229,10 @@ jobs:
               echo "_No Rust changes in this release._"
             fi
           } > /tmp/release_content.txt
-          echo "package_count=$(jq --arg version "${{ inputs.version }}" \
+          PACKAGE_COUNT=$(jq --arg version "${{ inputs.version }}" \
             '[.packages[] | select(.version == $version)] | length' \
-            /tmp/crates_publish_plan.json)" \
-            >> "$GITHUB_OUTPUT"
+            /tmp/crates_publish_plan.json)
+          echo "package_count=${PACKAGE_COUNT}" >> "$GITHUB_OUTPUT"
 
       - name: Dry run - Show planned changes
         if: inputs.dry_run

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -208,7 +208,7 @@ jobs:
             (cd rust/otap-dataflow && cargo xtask crates-publish plan) \
               > /tmp/crates_publish_plan.json
             jq -r --arg version "${{ inputs.version }}" \
-              '.packages[] | "- `\(.name)@\($version)`"' \
+              '.packages[] | select(.version == $version) | "- `\(.name)@\(.version)`"' \
               /tmp/crates_publish_plan.json
             echo ""
             echo "The Rust workspace is tagged as \`rust/otap-dataflow/v${{ inputs.version }}\`."
@@ -229,7 +229,9 @@ jobs:
               echo "_No Rust changes in this release._"
             fi
           } > /tmp/release_content.txt
-          echo "package_count=$(jq '.packages | length' /tmp/crates_publish_plan.json)" \
+          echo "package_count=$(jq --arg version "${{ inputs.version }}" \
+            '[.packages[] | select(.version == $version)] | length' \
+            /tmp/crates_publish_plan.json)" \
             >> "$GITHUB_OUTPUT"
 
       - name: Dry run - Show planned changes

--- a/.github/workflows/scripts/create-release-branch.sh
+++ b/.github/workflows/scripts/create-release-branch.sh
@@ -66,7 +66,7 @@ git add .
 git commit -m "Prepare release v$VERSION
 
 - Render chloggen entries into go/CHANGELOG.md and rust/otap-dataflow/CHANGELOG.md
-- Bump rust/otap-dataflow/Cargo.toml workspace + root package version to v$VERSION
+- Bump selected Rust workspace crate versions to v$VERSION
 
 This commit prepares the repository for release v$VERSION."
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -76,6 +76,9 @@ make chlog-preview
 4. Fill in the required inputs:
    - **Version**: The new version number (e.g., `0.48.0`).
    - **Dry run**: Check this box to preview changes without making them.
+   - **Include pdata-views**: Leave unchecked for normal releases.
+     Select it only for a coordinated `otel-arrow-dfe-pdata-views` release
+     after external consumers support the new version.
 
 ### Step 3: Review Dry Run (Recommended)
 
@@ -102,7 +105,8 @@ Before making actual changes, run the workflow in dry-run mode:
      entries.
    - Bump the Rust workspace + root package versions in
      `rust/otap-dataflow/Cargo.toml`, including same-release dependency
-     constraints.
+     constraints. `otel-arrow-dfe-pdata-views` keeps its independent version
+     unless explicitly included.
    - Regenerate `rust/otap-dataflow/Cargo.lock`.
    - Validate the crates.io allowlist, dependency graph, semantic version
      requirements, and package contents.
@@ -117,6 +121,8 @@ Before making actual changes, run the workflow in dry-run mode:
      the expected entries.
    - `rust/otap-dataflow/Cargo.toml` reflects the new workspace version and
      uses that version for same-release crate dependencies.
+   - `otel-arrow-dfe-pdata-views` retains its previous version unless the
+     release intentionally included it.
    - `cargo xtask crates-publish plan`, run from `rust/otap-dataflow`, lists
      the intended crates in dependency order.
 3. Ensure all CI checks pass.

--- a/rust/otap-dataflow/crates/pdata-views/Cargo.toml
+++ b/rust/otap-dataflow/crates/pdata-views/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "otel-arrow-dfe-pdata-views"
-version.workspace = true
+version = "0.54.1"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/rust/otap-dataflow/crates/pdata-views/README.md
+++ b/rust/otap-dataflow/crates/pdata-views/README.md
@@ -46,3 +46,13 @@ fn resource_group_count(metrics: &impl MetricsView) -> usize {
 ## Dependencies
 
 Intentionally none.
+
+## Release policy
+
+This crate is versioned independently from the rest of the OTAP Dataflow
+workspace and is not bumped during normal releases. Version changes must be
+coordinated with external consumers such as `geneva-uploader`.
+
+Cargo treats traits from different versions of a crate as distinct types, so
+an uncoordinated version bump can prevent those consumers from accepting the
+workspace's view implementations.

--- a/rust/otap-dataflow/xtask/src/crates_publish.rs
+++ b/rust/otap-dataflow/xtask/src/crates_publish.rs
@@ -16,11 +16,10 @@ use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::publish_policy::PUBLISH_PACKAGES;
+use crate::publish_policy::{INDEPENDENT_VERSION_PACKAGES, PUBLISH_PACKAGES};
 
 const CRATES_IO_API: &str = "https://crates.io/api/v1";
 const VISIBILITY_DELAYS: [u64; 8] = [0, 5, 10, 20, 40, 80, 160, 300];
-const INDEPENDENT_VERSION_PACKAGES: &[&str] = &["otel-arrow-dfe-pdata-views"];
 
 #[derive(Debug, Deserialize)]
 struct CargoMetadata {

--- a/rust/otap-dataflow/xtask/src/crates_publish.rs
+++ b/rust/otap-dataflow/xtask/src/crates_publish.rs
@@ -20,6 +20,7 @@ use crate::publish_policy::PUBLISH_PACKAGES;
 
 const CRATES_IO_API: &str = "https://crates.io/api/v1";
 const VISIBILITY_DELAYS: [u64; 8] = [0, 5, 10, 20, 40, 80, 160, 300];
+const INDEPENDENT_VERSION_PACKAGES: &[&str] = &["otel-arrow-dfe-pdata-views"];
 
 #[derive(Debug, Deserialize)]
 struct CargoMetadata {
@@ -255,11 +256,10 @@ fn build_plan(
 }
 
 fn ensure_plan_version(plan: &PublishPlan, expected_version: &str) -> anyhow::Result<()> {
-    if let Some(package) = plan
-        .packages
-        .iter()
-        .find(|package| package.version != expected_version)
-    {
+    if let Some(package) = plan.packages.iter().find(|package| {
+        package.version != expected_version
+            && !INDEPENDENT_VERSION_PACKAGES.contains(&package.name.as_str())
+    }) {
         bail!(
             "publish plan version {} for {} does not match requested version {expected_version}",
             package.version,
@@ -286,6 +286,19 @@ fn preflight(expected_version: &str) -> anyhow::Result<PublishPlan> {
     ensure_plan_version(&plan, expected_version)?;
 
     for package in &plan.packages {
+        if package.version != expected_version {
+            let Some(version) = crates_io_version(&package.name, &package.version)? else {
+                bail!(
+                    "independently versioned package {} {} is not published; include it in \
+                     release {expected_version} or publish it separately",
+                    package.name,
+                    package.version
+                );
+            };
+            ensure_not_yanked(&package.name, &package.version, version.yanked)?;
+            continue;
+        }
+
         match crates_io_version(&package.name, &package.version)? {
             Some(version) => {
                 ensure_not_yanked(&package.name, &package.version, version.yanked)?;
@@ -301,10 +314,12 @@ fn preflight(expected_version: &str) -> anyhow::Result<PublishPlan> {
         }
     }
 
-    println!(
-        "preflight passed for {} crates at version {expected_version}",
-        plan.packages.len()
-    );
+    let release_package_count = plan
+        .packages
+        .iter()
+        .filter(|package| package.version == expected_version)
+        .count();
+    println!("preflight passed for {release_package_count} crates at version {expected_version}");
     Ok(plan)
 }
 
@@ -312,6 +327,14 @@ fn publish(expected_version: &str) -> anyhow::Result<()> {
     let plan = preflight(expected_version)?;
 
     for package in &plan.packages {
+        if package.version != expected_version {
+            println!(
+                "{} {} is independently versioned and excluded from release {}; skipping",
+                package.name, package.version, expected_version
+            );
+            continue;
+        }
+
         let expected_checksum = package_checksum(package, &plan.target_directory)?;
         if let Some(version) = crates_io_version(&package.name, &package.version)? {
             ensure_not_yanked(&package.name, &package.version, version.yanked)?;
@@ -717,6 +740,45 @@ mod tests {
         let error = build_plan(packages, PathBuf::from("/target"))
             .expect_err("self dependencies must be rejected");
         assert!(error.to_string().contains("depends on itself"));
+    }
+
+    /// Scenario: a stable boundary crate keeps an independent version.
+    /// Guarantees: release preflight accepts pdata-views outside the workspace release version.
+    #[test]
+    fn plan_version_allows_independent_pdata_views_version() {
+        let plan = PublishPlan {
+            packages: vec![
+                PublishPackage {
+                    name: "otel-arrow-dfe-pdata-views".to_owned(),
+                    version: "0.54.1".to_owned(),
+                    has_publish_dependencies: false,
+                },
+                PublishPackage {
+                    name: "otel-arrow-dfe-pdata".to_owned(),
+                    version: "0.55.0".to_owned(),
+                    has_publish_dependencies: true,
+                },
+            ],
+            target_directory: PathBuf::from("/target"),
+        };
+
+        assert!(ensure_plan_version(&plan, "0.55.0").is_ok());
+    }
+
+    /// Scenario: a regular publishable crate differs from the requested release version.
+    /// Guarantees: only explicitly independent crates may opt out of a release bump.
+    #[test]
+    fn plan_version_rejects_other_mismatched_versions() {
+        let plan = PublishPlan {
+            packages: vec![PublishPackage {
+                name: "otel-arrow-dfe-pdata".to_owned(),
+                version: "0.54.1".to_owned(),
+                has_publish_dependencies: true,
+            }],
+            target_directory: PathBuf::from("/target"),
+        };
+
+        assert!(ensure_plan_version(&plan, "0.55.0").is_err());
     }
 
     /// Scenario: dependency requirements use abbreviated, ranged, exact, and excluding syntax.

--- a/rust/otap-dataflow/xtask/src/publish_policy.rs
+++ b/rust/otap-dataflow/xtask/src/publish_policy.rs
@@ -3,6 +3,8 @@
 
 //! Shared crates.io publication policy.
 
+pub(crate) const INDEPENDENT_VERSION_PACKAGES: &[&str] = &["otel-arrow-dfe-pdata-views"];
+
 pub(crate) const PUBLISH_PACKAGES: &[&str] = &[
     "otel-arrow-dfe-admin",
     "otel-arrow-dfe-admin-types",

--- a/rust/otap-dataflow/xtask/src/structure_check.rs
+++ b/rust/otap-dataflow/xtask/src/structure_check.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use anyhow::Error;
 use toml::{Table, Value};
 
-use crate::publish_policy::PUBLISH_PACKAGES;
+use crate::publish_policy::{INDEPENDENT_VERSION_PACKAGES, PUBLISH_PACKAGES};
 
 /// Validates the entire structure of the project.
 ///
@@ -169,7 +169,7 @@ fn check_package<P: AsRef<Path>>(cargo_toml_path: P, toml: &Table) -> anyhow::Re
         ));
     }
 
-    check_path_is_true(cargo_toml_path.as_ref(), &["version", "workspace"], package)?;
+    check_package_version(cargo_toml_path.as_ref(), package_name, package)?;
     check_path_is_true(cargo_toml_path.as_ref(), &["authors", "workspace"], package)?;
     check_path_is_true(
         cargo_toml_path.as_ref(),
@@ -186,6 +186,34 @@ fn check_package<P: AsRef<Path>>(cargo_toml_path: P, toml: &Table) -> anyhow::Re
     )?;
 
     Ok(())
+}
+
+fn check_package_version(
+    cargo_toml_path: &Path,
+    package_name: &str,
+    package: &Value,
+) -> anyhow::Result<()> {
+    if INDEPENDENT_VERSION_PACKAGES.contains(&package_name) {
+        let version = package
+            .get("version")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "\u{274C} Independently versioned package {package_name} must have an explicit \
+                     `package.version` in {}",
+                    cargo_toml_path.display()
+                )
+            })?;
+        semver::Version::parse(version).map_err(|error| {
+            anyhow::anyhow!(
+                "\u{274C} Invalid `package.version` {version:?} in {}: {error}",
+                cargo_toml_path.display()
+            )
+        })?;
+        return Ok(());
+    }
+
+    check_path_is_true(cargo_toml_path, &["version", "workspace"], package)
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -294,6 +322,68 @@ mod tests {
                 &manifest
             )
             .is_err()
+        );
+    }
+
+    /// Scenario: pdata-views declares its independently managed package version.
+    /// Guarantees: structure validation accepts a valid explicit semantic version.
+    #[test]
+    fn package_version_accepts_independent_version() {
+        let manifest = package(
+            r#"
+            [package]
+            name = "otel-arrow-dfe-pdata-views"
+            version = "0.54.1"
+            "#,
+        );
+
+        assert!(
+            check_package_version(
+                Path::new("Cargo.toml"),
+                "otel-arrow-dfe-pdata-views",
+                &manifest
+            )
+            .is_ok()
+        );
+    }
+
+    /// Scenario: pdata-views inherits the workspace release version.
+    /// Guarantees: independently versioned crates must declare an explicit version.
+    #[test]
+    fn package_version_rejects_workspace_version_for_independent_crate() {
+        let manifest = package(
+            r#"
+            [package]
+            name = "otel-arrow-dfe-pdata-views"
+            version.workspace = true
+            "#,
+        );
+
+        assert!(
+            check_package_version(
+                Path::new("Cargo.toml"),
+                "otel-arrow-dfe-pdata-views",
+                &manifest
+            )
+            .is_err()
+        );
+    }
+
+    /// Scenario: a regular workspace crate declares an independent package version.
+    /// Guarantees: only approved independent crates may opt out of workspace versioning.
+    #[test]
+    fn package_version_rejects_independent_version_for_regular_crate() {
+        let manifest = package(
+            r#"
+            [package]
+            name = "otel-arrow-dfe-config"
+            version = "0.54.1"
+            "#,
+        );
+
+        assert!(
+            check_package_version(Path::new("Cargo.toml"), "otel-arrow-dfe-config", &manifest)
+                .is_err()
         );
     }
 }


### PR DESCRIPTION
# Chore Summary

Address release problem identified in https://github.com/open-telemetry/otel-arrow/pull/4022. This is caused by `contrib` `geneva_exporter` usage of a library that has its own dependency on the `pdata-views` crate.

- Keep `otel-arrow-dfe-pdata-views` at its current independent version during normal releases
- Add a Prepare Release opt-in for coordinated `pdata-views` version bumps
- Allow crates.io publication tooling to validate and skip independently versioned crates outside the requested release
- List only crates matching the requested version in generated release notes
- Document the independent release policy and external-consumer compatibility requirement

Moving forward, we should think about declaring `1.0.0` stability on this crate so consumers can depend on `1` (meaning `>= 1.0.0 and < 2.0.0`).

## Related issue

N/A
