### PR TITLE
chore(release): Add forecast command to display expected publish outcomes

### DIFF
--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -177,6 +177,11 @@ jobs:
         run: cargo xtask crates-publish preflight "${{ inputs.version }}"
         working-directory: rust/otap-dataflow
 
+      - name: Forecast Rust crates.io publish
+        if: inputs.dry_run
+        run: cargo xtask crates-publish forecast "${{ inputs.version }}" > /tmp/crates_publish_forecast.json
+        working-directory: rust/otap-dataflow
+
       - name: Extract changelog content for this release
         id: changelog
         run: |
@@ -259,6 +264,16 @@ jobs:
           - **Packages**: ${{ steps.changelog.outputs.package_count }} OTAP Dataflow crates in dependency order
           - **Authentication**: crates.io trusted publishing (OIDC)
           - Existing versions are detected and skipped.
+
+          ### Expected package actions
+
+          | Package | Registry state | Expected action |
+          | --- | --- | --- |
+          EOF
+          jq -r \
+            '.packages[] | "| `\(.name)@\(.version)` | \(.registry_state) | \(.expected_action) |"' \
+            /tmp/crates_publish_forecast.json >> "$GITHUB_STEP_SUMMARY"
+          cat >> "$GITHUB_STEP_SUMMARY" << 'EOF'
 
           ## GitHub Release
           - **Title**: Release v${{ inputs.version }}

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -21,6 +21,9 @@ concurrency:
   group: push-release
   cancel-in-progress: false
 
+env:
+  RELEASE_REPOSITORY: open-telemetry/otel-arrow
+
 jobs:
   push-release:
     permissions:
@@ -77,8 +80,9 @@ jobs:
           GH_TOKEN: ${{ inputs.dry_run && github.token || steps.app-token.outputs.token }}
         run: |
           BRANCH="otelbot/release-v${{ inputs.version }}"
+          RELEASE_REPOSITORY_OWNER="${RELEASE_REPOSITORY%%/*}"
           RELEASE_PRS=$(gh api \
-            "repos/${GITHUB_REPOSITORY}/pulls?state=closed&base=main&head=${GITHUB_REPOSITORY_OWNER}:${BRANCH}&per_page=100" \
+            "repos/${RELEASE_REPOSITORY}/pulls?state=closed&base=main&head=${RELEASE_REPOSITORY_OWNER}:${BRANCH}&per_page=100" \
             --jq '[.[] | select(.merged_at != null)]')
           RELEASE_PR_COUNT=$(jq 'length' <<< "$RELEASE_PRS")
 
@@ -90,14 +94,17 @@ jobs:
 
           RELEASE_PR=$(jq -r '.[0].number' <<< "$RELEASE_PRS")
           RELEASE_SHA=$(jq -r '.[0].merge_commit_sha' <<< "$RELEASE_PRS")
+          RELEASE_PR_URL=$(jq -r '.[0].html_url' <<< "$RELEASE_PRS")
 
           echo "pr_number=$RELEASE_PR" >> "$GITHUB_OUTPUT"
+          echo "pr_url=$RELEASE_PR_URL" >> "$GITHUB_OUTPUT"
+          echo "repository=$RELEASE_REPOSITORY" >> "$GITHUB_OUTPUT"
           echo "sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
-          echo "Resolved release PR #${RELEASE_PR} to commit ${RELEASE_SHA}"
+          echo "Resolved ${RELEASE_REPOSITORY}#${RELEASE_PR} to commit ${RELEASE_SHA}"
 
       - name: Check out release pull request commit
         run: |
-          git fetch --quiet origin main --tags
+          git fetch --quiet "https://github.com/${RELEASE_REPOSITORY}.git" main --tags
           git checkout --detach "${{ steps.release.outputs.sha }}"
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -251,7 +258,7 @@ jobs:
 
           ## Planned Operations
           - **Version to tag**: `v${{ inputs.version }}`
-          - **Release PR**: `#${{ steps.release.outputs.pr_number }}`
+          - **Release PR**: [${{ steps.release.outputs.repository }}#${{ steps.release.outputs.pr_number }}](${{ steps.release.outputs.pr_url }})
           - **Commit to tag**: `${{ steps.release.outputs.sha }}`
           - **Last version**: `v${{ steps.last_version.outputs.last_version }}`
 
@@ -388,7 +395,7 @@ jobs:
             echo ""
             echo "Release details:"
             echo "- Version: v${{ inputs.version }}"
-            echo "- Release PR: #${{ steps.release.outputs.pr_number }}"
+            echo "- Release PR: ${{ steps.release.outputs.repository }}#${{ steps.release.outputs.pr_number }}"
             echo "- Tagged commit: ${{ steps.release.outputs.sha }}"
             echo "- GitHub release: https://github.com/open-telemetry/otel-arrow/releases/tag/v${{ inputs.version }}"
             echo ""

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -281,9 +281,13 @@ jobs:
           | Package | Registry state | Expected action |
           | --- | --- | --- |
           EOF
-          jq -r \
-            '.packages[] | "| `\(.name)@\(.version)` | \(.registry_state) | \(.expected_action) |"' \
-            /tmp/crates_publish_forecast.json >> "$GITHUB_STEP_SUMMARY"
+          if [ -s /tmp/crates_publish_forecast.json ]; then
+            jq -r \
+              '.packages[] | "| `\(.name)@\(.version)` | \(.registry_state) | \(.expected_action) |"' \
+              /tmp/crates_publish_forecast.json >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "| _Unavailable_ | Report not generated | Blocked |" >> "$GITHUB_STEP_SUMMARY"
+          fi
           cat >> "$GITHUB_STEP_SUMMARY" << 'EOF'
 
           ## GitHub Release

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -181,12 +181,16 @@ jobs:
           done
 
       - name: Preflight Rust crates.io publish
-        run: cargo xtask crates-publish preflight "${{ inputs.version }}"
-        working-directory: rust/otap-dataflow
-
-      - name: Forecast Rust crates.io publish
-        if: inputs.dry_run
-        run: cargo xtask crates-publish forecast "${{ inputs.version }}" > /tmp/crates_publish_forecast.json
+        id: crates-preflight
+        continue-on-error: ${{ inputs.dry_run }}
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            cargo xtask crates-publish preflight \
+              "${{ inputs.version }}" \
+              /tmp/crates_publish_forecast.json
+          else
+            cargo xtask crates-publish preflight "${{ inputs.version }}"
+          fi
         working-directory: rust/otap-dataflow
 
       - name: Extract changelog content for this release
@@ -247,7 +251,7 @@ jobs:
           echo "package_count=${PACKAGE_COUNT}" >> "$GITHUB_OUTPUT"
 
       - name: Dry run - Show planned changes
-        if: inputs.dry_run
+        if: inputs.dry_run && (success() || steps.crates-preflight.outcome == 'failure')
         run: |
           # Write to GitHub Step Summary
           cat >> $GITHUB_STEP_SUMMARY << 'EOF'
@@ -309,6 +313,12 @@ jobs:
           ---
           **Note**: This is a dry run. To execute the actual release push, set `dry_run` to `false`.
           EOF
+
+      - name: Check Rust crates.io preflight result
+        if: inputs.dry_run && steps.crates-preflight.outcome == 'failure'
+        run: |
+          echo "Error: Rust crates.io preflight failed; review the package actions above"
+          exit 1
 
       - name: Authenticate to crates.io with trusted publishing
         if: "!inputs.dry_run"
@@ -397,7 +407,7 @@ jobs:
             echo "- Version: v${{ inputs.version }}"
             echo "- Release PR: ${{ steps.release.outputs.repository }}#${{ steps.release.outputs.pr_number }}"
             echo "- Tagged commit: ${{ steps.release.outputs.sha }}"
-            echo "- GitHub release: https://github.com/open-telemetry/otel-arrow/releases/tag/v${{ inputs.version }}"
+            echo "- GitHub release: https://github.com/${{ steps.release.outputs.repository }}/releases/tag/v${{ inputs.version }}"
             echo ""
             echo "Git tags created:"
             echo "- v${{ inputs.version }}"

--- a/rust/otap-dataflow/xtask/src/crates_publish.rs
+++ b/rust/otap-dataflow/xtask/src/crates_publish.rs
@@ -540,6 +540,10 @@ fn parse_crates_io_existence(output: &Output) -> anyhow::Result<bool> {
     let (body, status) = stdout
         .rsplit_once('\n')
         .context("crates.io response did not include an HTTP status")?;
+    parse_crates_io_existence_response(body, status)
+}
+
+fn parse_crates_io_existence_response(body: &str, status: &str) -> anyhow::Result<bool> {
     match status {
         "200" => Ok(true),
         "404" => Ok(false),
@@ -1026,6 +1030,36 @@ mod tests {
 
         assert_eq!(forecast.registry_state, "Version yanked");
         assert_eq!(forecast.expected_action, "Blocked");
+    }
+
+    /// Scenario: crates.io returns success for a crate lookup.
+    /// Guarantees: the existence parser reports that the crate is present.
+    #[test]
+    fn crate_existence_accepts_http_200() {
+        assert!(
+            parse_crates_io_existence_response("{}", "200")
+                .expect("HTTP 200 should indicate existence")
+        );
+    }
+
+    /// Scenario: crates.io returns not found for a crate lookup.
+    /// Guarantees: the existence parser reports that the crate is absent.
+    #[test]
+    fn crate_existence_accepts_http_404() {
+        assert!(
+            !parse_crates_io_existence_response("{}", "404")
+                .expect("HTTP 404 should indicate absence")
+        );
+    }
+
+    /// Scenario: crates.io returns an unexpected HTTP status for a crate lookup.
+    /// Guarantees: the existence parser surfaces the response instead of guessing crate state.
+    #[test]
+    fn crate_existence_rejects_unexpected_http_status() {
+        let error = parse_crates_io_existence_response("rate limited", "429")
+            .expect_err("unexpected HTTP status should fail the lookup");
+
+        assert!(error.to_string().contains("HTTP 429: rate limited"));
     }
 
     /// Scenario: dependency requirements use abbreviated, ranged, exact, and excluding syntax.

--- a/rust/otap-dataflow/xtask/src/crates_publish.rs
+++ b/rust/otap-dataflow/xtask/src/crates_publish.rs
@@ -4,7 +4,7 @@
 //! Publication policy and release commands for OTAP Dataflow crates.
 
 use std::collections::{HashMap, HashSet};
-use std::fs::File;
+use std::fs::{File, write};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -63,7 +63,7 @@ struct PublishForecast {
     packages: Vec<ForecastPackage>,
 }
 
-#[derive(Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 struct ForecastPackage {
     name: String,
     version: String,
@@ -94,14 +94,18 @@ pub fn run(args: &[String]) -> anyhow::Result<()> {
             Ok(())
         }
         [command, version] if command == "preflight" => {
-            preflight(version)?;
+            preflight(version, None)?;
+            Ok(())
+        }
+        [command, version, forecast_path] if command == "preflight" => {
+            preflight(version, Some(Path::new(forecast_path)))?;
             Ok(())
         }
         [command, version] if command == "forecast" => print_forecast(version),
         [command, version] if command == "publish" => publish(version),
         _ => bail!(
             "Usage: cargo xtask crates-publish \
-             <plan|check|forecast VERSION|preflight VERSION|publish VERSION>"
+             <plan|check|forecast VERSION|preflight VERSION [FORECAST_PATH]|publish VERSION>"
         ),
     }
 }
@@ -117,12 +121,12 @@ fn print_forecast(expected_version: &str) -> anyhow::Result<()> {
 
     let mut packages = Vec::with_capacity(plan.packages.len());
     for package in &plan.packages {
-        let version_exists = crates_io_version(&package.name, &package.version)?.is_some();
-        let crate_exists = version_exists || crates_io_crate_exists(&package.name)?;
+        let version = crates_io_version(&package.name, &package.version)?;
+        let crate_exists = version.is_some() || crates_io_crate_exists(&package.name)?;
         packages.push(forecast_package(
             package,
             expected_version,
-            version_exists,
+            version.as_ref(),
             crate_exists,
         ));
     }
@@ -137,10 +141,12 @@ fn print_forecast(expected_version: &str) -> anyhow::Result<()> {
 fn forecast_package(
     package: &PublishPackage,
     expected_version: &str,
-    version_exists: bool,
+    version: Option<&CratesIoVersion>,
     crate_exists: bool,
 ) -> ForecastPackage {
-    let (registry_state, expected_action) = if version_exists {
+    let (registry_state, expected_action) = if version.is_some_and(|version| version.yanked) {
+        ("Version yanked", "Blocked")
+    } else if version.is_some() {
         if package.version == expected_version {
             ("Version present", "Skip after preflight verification")
         } else {
@@ -160,6 +166,14 @@ fn forecast_package(
         registry_state,
         expected_action,
     }
+}
+
+fn write_forecast(path: &Path, packages: &[ForecastPackage]) -> anyhow::Result<()> {
+    let json = serde_json::to_string_pretty(&PublishForecast {
+        packages: packages.to_vec(),
+    })?;
+    write(path, format!("{json}\n"))
+        .with_context(|| format!("failed to write forecast to {}", path.display()))
 }
 
 fn load_plan() -> anyhow::Result<PublishPlan> {
@@ -346,13 +360,29 @@ fn check_package(package: &PublishPackage, allow_dirty: bool) -> anyhow::Result<
     run_cargo(&args)
 }
 
-fn preflight(expected_version: &str) -> anyhow::Result<PublishPlan> {
+fn preflight(expected_version: &str, forecast_path: Option<&Path>) -> anyhow::Result<PublishPlan> {
     let plan = load_plan()?;
     ensure_plan_version(&plan, expected_version)?;
+    let mut forecast = Vec::with_capacity(plan.packages.len());
+    if let Some(path) = forecast_path {
+        write_forecast(path, &forecast)?;
+    }
 
     for package in &plan.packages {
+        let version = crates_io_version(&package.name, &package.version)?;
+        if let Some(path) = forecast_path {
+            let crate_exists = version.is_some() || crates_io_crate_exists(&package.name)?;
+            forecast.push(forecast_package(
+                package,
+                expected_version,
+                version.as_ref(),
+                crate_exists,
+            ));
+            write_forecast(path, &forecast)?;
+        }
+
         if package.version != expected_version {
-            let Some(version) = crates_io_version(&package.name, &package.version)? else {
+            let Some(version) = version else {
                 bail!(
                     "independently versioned package {} {} is not published; include it in \
                      release {expected_version} or publish it separately",
@@ -364,7 +394,7 @@ fn preflight(expected_version: &str) -> anyhow::Result<PublishPlan> {
             continue;
         }
 
-        match crates_io_version(&package.name, &package.version)? {
+        match version {
             Some(version) => {
                 ensure_not_yanked(&package.name, &package.version, version.yanked)?;
                 let expected_checksum = package_checksum(package, &plan.target_directory)?;
@@ -389,7 +419,7 @@ fn preflight(expected_version: &str) -> anyhow::Result<PublishPlan> {
 }
 
 fn publish(expected_version: &str) -> anyhow::Result<()> {
-    let plan = preflight(expected_version)?;
+    let plan = preflight(expected_version, None)?;
 
     for package in &plan.packages {
         if package.version != expected_version {
@@ -898,7 +928,11 @@ mod tests {
             has_publish_dependencies: false,
         };
 
-        let forecast = forecast_package(&package, "0.55.0", true, true);
+        let version = CratesIoVersion {
+            checksum: String::new(),
+            yanked: false,
+        };
+        let forecast = forecast_package(&package, "0.55.0", Some(&version), true);
 
         assert_eq!(forecast.registry_state, "Version present");
         assert_eq!(
@@ -917,7 +951,7 @@ mod tests {
             has_publish_dependencies: false,
         };
 
-        let forecast = forecast_package(&package, "0.55.0", false, true);
+        let forecast = forecast_package(&package, "0.55.0", None, true);
 
         assert_eq!(forecast.registry_state, "Version missing");
         assert_eq!(forecast.expected_action, "Publish");
@@ -933,10 +967,66 @@ mod tests {
             has_publish_dependencies: true,
         };
 
-        let forecast = forecast_package(&package, "0.55.0", false, false);
+        let forecast = forecast_package(&package, "0.55.0", None, false);
 
         assert_eq!(forecast.registry_state, "Crate not yet created");
         assert_eq!(forecast.expected_action, "Bootstrap required");
+    }
+
+    /// Scenario: an independently versioned crate already exists on crates.io.
+    /// Guarantees: the forecast reports that the release will skip the independent version.
+    #[test]
+    fn forecast_skips_existing_independent_version() {
+        let package = PublishPackage {
+            name: "otel-arrow-dfe-pdata-views".to_owned(),
+            version: "0.54.1".to_owned(),
+            has_publish_dependencies: false,
+        };
+        let version = CratesIoVersion {
+            checksum: String::new(),
+            yanked: false,
+        };
+
+        let forecast = forecast_package(&package, "0.55.0", Some(&version), true);
+
+        assert_eq!(forecast.registry_state, "Version present");
+        assert_eq!(forecast.expected_action, "Skip independent version");
+    }
+
+    /// Scenario: an independently versioned crate is missing from an existing crates.io package.
+    /// Guarantees: the forecast reports that the release is blocked until the version is published.
+    #[test]
+    fn forecast_blocks_missing_independent_version() {
+        let package = PublishPackage {
+            name: "otel-arrow-dfe-pdata-views".to_owned(),
+            version: "0.54.1".to_owned(),
+            has_publish_dependencies: false,
+        };
+
+        let forecast = forecast_package(&package, "0.55.0", None, true);
+
+        assert_eq!(forecast.registry_state, "Independent version missing");
+        assert_eq!(forecast.expected_action, "Blocked");
+    }
+
+    /// Scenario: crates.io reports an independently versioned crate as yanked.
+    /// Guarantees: the forecast matches preflight by reporting the yanked version as blocked.
+    #[test]
+    fn forecast_blocks_yanked_version() {
+        let package = PublishPackage {
+            name: "otel-arrow-dfe-pdata-views".to_owned(),
+            version: "0.54.1".to_owned(),
+            has_publish_dependencies: false,
+        };
+        let version = CratesIoVersion {
+            checksum: String::new(),
+            yanked: true,
+        };
+
+        let forecast = forecast_package(&package, "0.55.0", Some(&version), true);
+
+        assert_eq!(forecast.registry_state, "Version yanked");
+        assert_eq!(forecast.expected_action, "Blocked");
     }
 
     /// Scenario: dependency requirements use abbreviated, ranged, exact, and excluding syntax.

--- a/rust/otap-dataflow/xtask/src/crates_publish.rs
+++ b/rust/otap-dataflow/xtask/src/crates_publish.rs
@@ -152,6 +152,21 @@ fn write_forecast(path: &Path, packages: &[ForecastPackage]) -> anyhow::Result<(
         .with_context(|| format!("failed to write forecast to {}", path.display()))
 }
 
+fn record_lookup_failure(
+    path: &Path,
+    forecast: &mut Vec<ForecastPackage>,
+    package: &PublishPackage,
+    registry_state: &'static str,
+) -> anyhow::Result<()> {
+    forecast.push(ForecastPackage {
+        name: package.name.clone(),
+        version: package.version.clone(),
+        registry_state,
+        expected_action: "Blocked",
+    });
+    write_forecast(path, forecast)
+}
+
 fn load_plan() -> anyhow::Result<PublishPlan> {
     let output = Command::new("cargo")
         .args(["metadata", "--no-deps", "--format-version", "1"])
@@ -379,9 +394,27 @@ fn preflight(expected_version: &str, forecast_path: Option<&Path>) -> anyhow::Re
     }
 
     for package in &plan.packages {
-        let version = crates_io_version(&package.name, &package.version)?;
+        let version = match crates_io_version(&package.name, &package.version) {
+            Ok(version) => version,
+            Err(error) => {
+                if let Some(path) = forecast_path {
+                    record_lookup_failure(path, &mut forecast, package, "Version lookup failed")?;
+                }
+                return Err(error);
+            }
+        };
         if let Some(path) = forecast_path {
-            let crate_exists = version.is_some() || crates_io_crate_exists(&package.name)?;
+            let crate_exists = if version.is_some() {
+                true
+            } else {
+                match crates_io_crate_exists(&package.name) {
+                    Ok(crate_exists) => crate_exists,
+                    Err(error) => {
+                        record_lookup_failure(path, &mut forecast, package, "Crate lookup failed")?;
+                        return Err(error);
+                    }
+                }
+            };
             forecast.push(forecast_package(
                 package,
                 expected_version,
@@ -1030,6 +1063,49 @@ mod tests {
 
         assert_eq!(forecast.registry_state, "Version yanked");
         assert_eq!(forecast.expected_action, "Blocked");
+    }
+
+    /// Scenario: a registry lookup fails after earlier packages were forecast successfully.
+    /// Guarantees: the report retains earlier rows and adds the failed package as blocked.
+    #[test]
+    fn forecast_preserves_report_on_lookup_failure() {
+        let path = std::env::temp_dir().join(format!(
+            "otel-arrow-crates-publish-forecast-{}.json",
+            std::process::id()
+        ));
+        let mut forecast = vec![ForecastPackage {
+            name: "otel-arrow-dfe-config".to_owned(),
+            version: "0.55.0".to_owned(),
+            registry_state: "Version present",
+            expected_action: "Skip after preflight verification",
+        }];
+        let failed_package = PublishPackage {
+            name: "otel-arrow-dfe-otap".to_owned(),
+            version: "0.55.0".to_owned(),
+            has_publish_dependencies: true,
+        };
+
+        record_lookup_failure(
+            &path,
+            &mut forecast,
+            &failed_package,
+            "Version lookup failed",
+        )
+        .expect("lookup failure should be written to the forecast");
+
+        let report = std::fs::read_to_string(&path).expect("forecast should be readable");
+        let report: serde_json::Value =
+            serde_json::from_str(&report).expect("forecast should contain valid JSON");
+        let packages = report["packages"]
+            .as_array()
+            .expect("forecast should contain packages");
+        assert_eq!(packages.len(), 2);
+        assert_eq!(packages[0]["name"], "otel-arrow-dfe-config");
+        assert_eq!(packages[1]["name"], "otel-arrow-dfe-otap");
+        assert_eq!(packages[1]["registry_state"], "Version lookup failed");
+        assert_eq!(packages[1]["expected_action"], "Blocked");
+
+        std::fs::remove_file(path).expect("forecast should be removable");
     }
 
     /// Scenario: crates.io returns success for a crate lookup.

--- a/rust/otap-dataflow/xtask/src/crates_publish.rs
+++ b/rust/otap-dataflow/xtask/src/crates_publish.rs
@@ -58,6 +58,19 @@ struct PublishPackage {
     has_publish_dependencies: bool,
 }
 
+#[derive(Debug, Eq, PartialEq, Serialize)]
+struct PublishForecast {
+    packages: Vec<ForecastPackage>,
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+struct ForecastPackage {
+    name: String,
+    version: String,
+    registry_state: &'static str,
+    expected_action: &'static str,
+}
+
 #[derive(Debug, Deserialize)]
 struct CratesIoResponse {
     version: CratesIoVersion,
@@ -84,9 +97,11 @@ pub fn run(args: &[String]) -> anyhow::Result<()> {
             preflight(version)?;
             Ok(())
         }
+        [command, version] if command == "forecast" => print_forecast(version),
         [command, version] if command == "publish" => publish(version),
         _ => bail!(
-            "Usage: cargo xtask crates-publish <plan|check|preflight VERSION|publish VERSION>"
+            "Usage: cargo xtask crates-publish \
+             <plan|check|forecast VERSION|preflight VERSION|publish VERSION>"
         ),
     }
 }
@@ -94,6 +109,57 @@ pub fn run(args: &[String]) -> anyhow::Result<()> {
 fn print_plan() -> anyhow::Result<()> {
     println!("{}", serde_json::to_string_pretty(&load_plan()?)?);
     Ok(())
+}
+
+fn print_forecast(expected_version: &str) -> anyhow::Result<()> {
+    let plan = load_plan()?;
+    ensure_plan_version(&plan, expected_version)?;
+
+    let mut packages = Vec::with_capacity(plan.packages.len());
+    for package in &plan.packages {
+        let version_exists = crates_io_version(&package.name, &package.version)?.is_some();
+        let crate_exists = version_exists || crates_io_crate_exists(&package.name)?;
+        packages.push(forecast_package(
+            package,
+            expected_version,
+            version_exists,
+            crate_exists,
+        ));
+    }
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&PublishForecast { packages })?
+    );
+    Ok(())
+}
+
+fn forecast_package(
+    package: &PublishPackage,
+    expected_version: &str,
+    version_exists: bool,
+    crate_exists: bool,
+) -> ForecastPackage {
+    let (registry_state, expected_action) = if version_exists {
+        if package.version == expected_version {
+            ("Version present", "Skip after preflight verification")
+        } else {
+            ("Version present", "Skip independent version")
+        }
+    } else if !crate_exists {
+        ("Crate not yet created", "Bootstrap required")
+    } else if package.version == expected_version {
+        ("Version missing", "Publish")
+    } else {
+        ("Independent version missing", "Blocked")
+    };
+
+    ForecastPackage {
+        name: package.name.clone(),
+        version: package.version.clone(),
+        registry_state,
+        expected_action,
+    }
 }
 
 fn load_plan() -> anyhow::Result<PublishPlan> {
@@ -408,6 +474,48 @@ fn crates_io_version(name: &str, version: &str) -> anyhow::Result<Option<CratesI
         .output()
         .context("failed to query crates.io")?;
     parse_crates_io_response(&output)
+}
+
+fn crates_io_crate_exists(name: &str) -> anyhow::Result<bool> {
+    let url = format!("{CRATES_IO_API}/crates/{name}");
+    let output = Command::new("curl")
+        .args([
+            "--silent",
+            "--show-error",
+            "--location",
+            "--connect-timeout",
+            "10",
+            "--max-time",
+            "30",
+            "--user-agent",
+            "otel-arrow-release-publisher",
+            "--write-out",
+            "\n%{http_code}",
+            &url,
+        ])
+        .output()
+        .context("failed to query crates.io")?;
+    parse_crates_io_existence(&output)
+}
+
+fn parse_crates_io_existence(output: &Output) -> anyhow::Result<bool> {
+    if !output.status.success() {
+        bail!(
+            "crates.io request failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let stdout = String::from_utf8(output.stdout.clone())
+        .context("crates.io returned a non-UTF-8 response")?;
+    let (body, status) = stdout
+        .rsplit_once('\n')
+        .context("crates.io response did not include an HTTP status")?;
+    match status {
+        "200" => Ok(true),
+        "404" => Ok(false),
+        _ => bail!("crates.io returned HTTP {status}: {}", body.trim()),
+    }
 }
 
 fn parse_crates_io_response(output: &Output) -> anyhow::Result<Option<CratesIoVersion>> {
@@ -778,6 +886,57 @@ mod tests {
         };
 
         assert!(ensure_plan_version(&plan, "0.55.0").is_err());
+    }
+
+    /// Scenario: a release version already exists on crates.io.
+    /// Guarantees: the forecast reports that publishing will skip it after preflight verification.
+    #[test]
+    fn forecast_skips_existing_release_version() {
+        let package = PublishPackage {
+            name: "otel-arrow-dfe-config".to_owned(),
+            version: "0.55.0".to_owned(),
+            has_publish_dependencies: false,
+        };
+
+        let forecast = forecast_package(&package, "0.55.0", true, true);
+
+        assert_eq!(forecast.registry_state, "Version present");
+        assert_eq!(
+            forecast.expected_action,
+            "Skip after preflight verification"
+        );
+    }
+
+    /// Scenario: an existing crate does not have the requested release version.
+    /// Guarantees: the forecast reports that the workflow will publish the missing version.
+    #[test]
+    fn forecast_publishes_missing_release_version() {
+        let package = PublishPackage {
+            name: "otel-arrow-dfe-config".to_owned(),
+            version: "0.55.0".to_owned(),
+            has_publish_dependencies: false,
+        };
+
+        let forecast = forecast_package(&package, "0.55.0", false, true);
+
+        assert_eq!(forecast.registry_state, "Version missing");
+        assert_eq!(forecast.expected_action, "Publish");
+    }
+
+    /// Scenario: a newly allowlisted crate does not exist on crates.io.
+    /// Guarantees: the forecast identifies the required first-publication bootstrap.
+    #[test]
+    fn forecast_identifies_bootstrap_requirement() {
+        let package = PublishPackage {
+            name: "otel-arrow-dfe-otap".to_owned(),
+            version: "0.55.0".to_owned(),
+            has_publish_dependencies: true,
+        };
+
+        let forecast = forecast_package(&package, "0.55.0", false, false);
+
+        assert_eq!(forecast.registry_state, "Crate not yet created");
+        assert_eq!(forecast.expected_action, "Bootstrap required");
     }
 
     /// Scenario: dependency requirements use abbreviated, ranged, exact, and excluding syntax.

--- a/rust/otap-dataflow/xtask/src/crates_publish.rs
+++ b/rust/otap-dataflow/xtask/src/crates_publish.rs
@@ -101,40 +101,16 @@ pub fn run(args: &[String]) -> anyhow::Result<()> {
             preflight(version, Some(Path::new(forecast_path)))?;
             Ok(())
         }
-        [command, version] if command == "forecast" => print_forecast(version),
         [command, version] if command == "publish" => publish(version),
         _ => bail!(
             "Usage: cargo xtask crates-publish \
-             <plan|check|forecast VERSION|preflight VERSION [FORECAST_PATH]|publish VERSION>"
+             <plan|check|preflight VERSION [FORECAST_PATH]|publish VERSION>"
         ),
     }
 }
 
 fn print_plan() -> anyhow::Result<()> {
     println!("{}", serde_json::to_string_pretty(&load_plan()?)?);
-    Ok(())
-}
-
-fn print_forecast(expected_version: &str) -> anyhow::Result<()> {
-    let plan = load_plan()?;
-    ensure_plan_version(&plan, expected_version)?;
-
-    let mut packages = Vec::with_capacity(plan.packages.len());
-    for package in &plan.packages {
-        let version = crates_io_version(&package.name, &package.version)?;
-        let crate_exists = version.is_some() || crates_io_crate_exists(&package.name)?;
-        packages.push(forecast_package(
-            package,
-            expected_version,
-            version.as_ref(),
-            crate_exists,
-        ));
-    }
-
-    println!(
-        "{}",
-        serde_json::to_string_pretty(&PublishForecast { packages })?
-    );
     Ok(())
 }
 
@@ -360,6 +336,40 @@ fn check_package(package: &PublishPackage, allow_dirty: bool) -> anyhow::Result<
     run_cargo(&args)
 }
 
+fn preflight_package(
+    package: &PublishPackage,
+    expected_version: &str,
+    target_directory: &Path,
+    version: Option<&CratesIoVersion>,
+) -> anyhow::Result<()> {
+    if package.version != expected_version {
+        let Some(version) = version else {
+            bail!(
+                "independently versioned package {} {} is not published; include it in \
+                 release {expected_version} or publish it separately",
+                package.name,
+                package.version
+            );
+        };
+        ensure_not_yanked(&package.name, &package.version, version.yanked)?;
+        return Ok(());
+    }
+
+    match version {
+        Some(version) => {
+            ensure_not_yanked(&package.name, &package.version, version.yanked)?;
+            let expected_checksum = package_checksum(package, target_directory)?;
+            verify_checksum(
+                &package.name,
+                &package.version,
+                &expected_checksum,
+                &version.checksum,
+            )
+        }
+        None => check_package(package, false),
+    }
+}
+
 fn preflight(expected_version: &str, forecast_path: Option<&Path>) -> anyhow::Result<PublishPlan> {
     let plan = load_plan()?;
     ensure_plan_version(&plan, expected_version)?;
@@ -381,31 +391,20 @@ fn preflight(expected_version: &str, forecast_path: Option<&Path>) -> anyhow::Re
             write_forecast(path, &forecast)?;
         }
 
-        if package.version != expected_version {
-            let Some(version) = version else {
-                bail!(
-                    "independently versioned package {} {} is not published; include it in \
-                     release {expected_version} or publish it separately",
-                    package.name,
-                    package.version
-                );
-            };
-            ensure_not_yanked(&package.name, &package.version, version.yanked)?;
-            continue;
-        }
-
-        match version {
-            Some(version) => {
-                ensure_not_yanked(&package.name, &package.version, version.yanked)?;
-                let expected_checksum = package_checksum(package, &plan.target_directory)?;
-                verify_checksum(
-                    &package.name,
-                    &package.version,
-                    &expected_checksum,
-                    &version.checksum,
-                )?;
+        if let Err(error) = preflight_package(
+            package,
+            expected_version,
+            &plan.target_directory,
+            version.as_ref(),
+        ) {
+            if let Some(path) = forecast_path {
+                forecast
+                    .last_mut()
+                    .expect("the current package was added to the forecast")
+                    .expected_action = "Blocked";
+                write_forecast(path, &forecast)?;
             }
-            None => check_package(package, false)?,
+            return Err(error);
         }
     }
 

--- a/rust/otap-dataflow/xtask/src/main.rs
+++ b/rust/otap-dataflow/xtask/src/main.rs
@@ -80,7 +80,7 @@ Tasks:
   - structure-check: Validate the entire structure of the project.
   - compile-proto: Compile the protobufs files
   - component-inventory [--check <baseline>] [--update-baseline] [--format <table|json|yaml>]: Manage and verify the component inventory baseline.
-  - crates-publish <plan|check|forecast VERSION|preflight VERSION [FORECAST_PATH]|publish VERSION>: Plan, validate, forecast, preflight, or publish crates.io packages.
+  - crates-publish <plan|check|preflight VERSION [FORECAST_PATH]|publish VERSION>: Plan, validate, preflight, or publish crates.io packages.
 "
     );
     Ok(())

--- a/rust/otap-dataflow/xtask/src/main.rs
+++ b/rust/otap-dataflow/xtask/src/main.rs
@@ -80,7 +80,7 @@ Tasks:
   - structure-check: Validate the entire structure of the project.
   - compile-proto: Compile the protobufs files
   - component-inventory [--check <baseline>] [--update-baseline] [--format <table|json|yaml>]: Manage and verify the component inventory baseline.
-  - crates-publish <plan|check|forecast VERSION|preflight VERSION|publish VERSION>: Plan, validate, forecast, preflight, or publish crates.io packages.
+  - crates-publish <plan|check|forecast VERSION|preflight VERSION [FORECAST_PATH]|publish VERSION>: Plan, validate, forecast, preflight, or publish crates.io packages.
 "
     );
     Ok(())

--- a/rust/otap-dataflow/xtask/src/main.rs
+++ b/rust/otap-dataflow/xtask/src/main.rs
@@ -80,7 +80,7 @@ Tasks:
   - structure-check: Validate the entire structure of the project.
   - compile-proto: Compile the protobufs files
   - component-inventory [--check <baseline>] [--update-baseline] [--format <table|json|yaml>]: Manage and verify the component inventory baseline.
-  - crates-publish <plan|check|preflight VERSION|publish VERSION>: Plan, validate, preflight, or publish crates.io packages.
+  - crates-publish <plan|check|forecast VERSION|preflight VERSION|publish VERSION>: Plan, validate, forecast, preflight, or publish crates.io packages.
 "
     );
     Ok(())


### PR DESCRIPTION
# Chore Summary

- Generate crates.io package actions from the existing preflight pass.
- Preserve dry-run package status when preflight fails.
- Report yanked and missing independent versions as blocked.
- Use the configured release repository consistently in release output.

## Sample output

```text
$ cargo xtask crates-publish preflight 0.55.0
{
  "packages": [
    {
      "name": "otel-arrow-dfe-config",
      "version": "0.55.0",
      "registry_state": "Version missing",
      "expected_action": "Publish"
    },
    {
      "name": "otel-arrow-dfe-pdata-views",
      "version": "0.54.1",
      "registry_state": "Version present",
      "expected_action": "Skip independent version"
    },
    {
      "name": "otel-arrow-dfe-otap",
      "version": "0.55.0",
      "registry_state": "Crate not yet created",
      "expected_action": "Bootstrap required"
    }
  ]
}
```

## Related issue

Related to #1340 
