### PR TITLE
feat(config): allow extensions in observability pipelines

### DIFF
--- a/rust/otap-dataflow/.chloggen/observability-pipeline-extensions.yaml
+++ b/rust/otap-dataflow/.chloggen/observability-pipeline-extensions.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: config
+note: Allow extensions to be declared in the engine observability pipeline.
+issues: [4035]

--- a/rust/otap-dataflow/.chloggen/observability-pipeline-extensions.yaml
+++ b/rust/otap-dataflow/.chloggen/observability-pipeline-extensions.yaml
@@ -1,4 +1,4 @@
 change_type: enhancement
-component: config
+component: engine
 note: Allow extensions to be declared in the engine observability pipeline.
 issues: [4035]

--- a/rust/otap-dataflow/crates/config/README.md
+++ b/rust/otap-dataflow/crates/config/README.md
@@ -328,9 +328,12 @@ Topic declaration precedence (for a pipeline in a given group):
 The dedicated engine internal telemetry pipeline is configured at:
 
 - `engine.observability.pipeline.nodes`
+- `engine.observability.pipeline.extensions`
 - `engine.observability.pipeline.connections`
 
-It is represented in resolved output as a role-tagged internal pipeline.
+Extensions are scoped to the observability pipeline and may provide capabilities
+to its nodes. The pipeline is represented in resolved output as a role-tagged
+internal pipeline.
 
 ## Node Type (`NodeUrn`)
 

--- a/rust/otap-dataflow/crates/config/src/engine.rs
+++ b/rust/otap-dataflow/crates/config/src/engine.rs
@@ -928,6 +928,8 @@ groups: {}
         let _config = OtelDataflowSpec::from_yaml(yaml).expect("ITS metrics config should parse");
     }
 
+    /// Scenario: an observability pipeline declares an extension and binds its capability.
+    /// Guarantees: parsing and conversion retain the pipeline-scoped extension.
     #[test]
     fn from_yaml_accepts_observability_pipeline_extensions_and_capability_bindings() {
         let yaml = r#"
@@ -948,7 +950,7 @@ engine:
             grpc_endpoint: "https://example.com:4317"
       extensions:
         auth:
-          type: "extension:azure_identity_auth"
+          type: "urn:microsoft:extension:azure_identity_auth"
           config:
             method: managed_identity
             scope: "https://example.com/.default"
@@ -966,6 +968,8 @@ groups: {}
         assert!(pipeline.extensions().contains_key("auth"));
     }
 
+    /// Scenario: a regular pipeline binds an extension declared by the observability pipeline.
+    /// Guarantees: validation rejects cross-pipeline capability binding.
     #[test]
     fn from_yaml_does_not_expose_observability_extensions_to_regular_pipelines() {
         let yaml = r#"
@@ -975,7 +979,7 @@ engine:
     pipeline:
       extensions:
         auth:
-          type: "extension:azure_identity_auth"
+          type: "urn:microsoft:extension:azure_identity_auth"
           config: {}
 groups:
   default:

--- a/rust/otap-dataflow/crates/config/src/engine.rs
+++ b/rust/otap-dataflow/crates/config/src/engine.rs
@@ -14,7 +14,7 @@ use crate::extension::ExtensionUserConfig;
 use crate::health::HealthPolicy;
 use crate::observed_state::ObservedStateSettings;
 use crate::pipeline::telemetry::TelemetryConfig;
-use crate::pipeline::{PipelineConfig, PipelineConnection, PipelineNodes};
+use crate::pipeline::{PipelineConfig, PipelineConnection, PipelineExtensions, PipelineNodes};
 use crate::pipeline_group::PipelineGroupConfig;
 use crate::policy::{ChannelCapacityPolicy, Policies, TelemetryPolicy};
 use crate::topic::{TopicImplSelectionPolicy, TopicSpec};
@@ -127,8 +127,8 @@ impl EngineConfig {
     /// - `controller.extensions` -- controller-owned extensions whose `config`
     ///   is the same opaque [`Value`] as a node's. See
     ///   [`ControllerExtensions::redacted_for_snapshot`].
-    /// - `observability.pipeline.nodes` -- the engine observability pipeline's
-    ///   node set. See [`PipelineNodes::redacted_for_snapshot`].
+    /// - `observability.pipeline.nodes` and `observability.pipeline.extensions`
+    ///   -- the engine observability pipeline's components.
     /// - `custom` -- opaque, freeform metadata the engine never interprets, but
     ///   the most likely place an embedder stashes arbitrary config (including
     ///   auth `headers`). The whole map is walked with the same
@@ -156,6 +156,11 @@ impl EngineConfig {
             .observability
             .pipeline
             .nodes
+            .redacted_for_snapshot();
+        redacted.observability.pipeline.extensions = redacted
+            .observability
+            .pipeline
+            .extensions
             .redacted_for_snapshot();
         // Redact `headers` anywhere in the freeform `custom` metadata. Wrap the
         // whole map into one `Value::Object` so a top-level key literally named
@@ -359,6 +364,10 @@ pub struct EngineObservabilityPipelineConfig {
     #[serde(default)]
     pub nodes: PipelineNodes,
 
+    /// Extensions scoped to the observability pipeline.
+    #[serde(default, skip_serializing_if = "PipelineExtensions::is_empty")]
+    pub extensions: PipelineExtensions,
+
     /// Explicit graph connections for observability nodes.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub connections: Vec<PipelineConnection>,
@@ -404,6 +413,7 @@ impl EngineObservabilityPipelineConfig {
             self.policies
                 .map(EngineObservabilityPolicies::into_policies),
             self.nodes,
+            self.extensions,
             self.connections,
         )
     }
@@ -564,6 +574,12 @@ engine:
             authorization: "Bearer controller-super-secret"
   observability:
     pipeline:
+      extensions:
+        obs_auth:
+          type: "urn:otel:extension:headers_setter"
+          config:
+            headers:
+              authorization: "Bearer observability-extension-super-secret"
       nodes:
         obs_exporter:
           type: "urn:otel:exporter:otlp"
@@ -584,6 +600,10 @@ engine:
             "observability node credential must not survive redaction: {redacted_json}"
         );
         assert!(
+            !redacted_json.contains("observability-extension-super-secret"),
+            "observability extension credential must not survive redaction: {redacted_json}"
+        );
+        assert!(
             redacted_json.contains(crate::node::REDACTED_HEADER_VALUE),
             "redaction placeholder should be present: {redacted_json}"
         );
@@ -593,7 +613,8 @@ engine:
         let original_json = serde_json::to_string(&spec).expect("spec serializes");
         assert!(
             original_json.contains("controller-super-secret")
-                && original_json.contains("observability-super-secret"),
+                && original_json.contains("observability-super-secret")
+                && original_json.contains("observability-extension-super-secret"),
             "original spec must retain the cleartext credentials: {original_json}"
         );
     }
@@ -905,6 +926,84 @@ groups: {}
 "#;
 
         let _config = OtelDataflowSpec::from_yaml(yaml).expect("ITS metrics config should parse");
+    }
+
+    #[test]
+    fn from_yaml_accepts_observability_pipeline_extensions_and_capability_bindings() {
+        let yaml = r#"
+version: otel_dataflow/v1
+engine:
+  observability:
+    pipeline:
+      nodes:
+        itr:
+          type: "receiver:internal_telemetry"
+          config:
+            metrics: {}
+        sink:
+          type: "exporter:otlp_grpc"
+          capabilities:
+            bearer_token_provider: auth
+          config:
+            grpc_endpoint: "https://example.com:4317"
+      extensions:
+        auth:
+          type: "extension:azure_identity_auth"
+          config:
+            method: managed_identity
+            scope: "https://example.com/.default"
+      connections:
+        - from: itr
+          to: sink
+groups: {}
+"#;
+
+        let config = OtelDataflowSpec::from_yaml(yaml)
+            .expect("observability extension and capability binding should be valid");
+        let pipeline = config.engine.observability.pipeline.into_pipeline_config();
+
+        assert_eq!(pipeline.extensions().len(), 1);
+        assert!(pipeline.extensions().contains_key("auth"));
+    }
+
+    #[test]
+    fn from_yaml_does_not_expose_observability_extensions_to_regular_pipelines() {
+        let yaml = r#"
+version: otel_dataflow/v1
+engine:
+  observability:
+    pipeline:
+      extensions:
+        auth:
+          type: "extension:azure_identity_auth"
+          config: {}
+groups:
+  default:
+    pipelines:
+      main:
+        nodes:
+          receiver:
+            type: "receiver:otlp"
+            config: {}
+          exporter:
+            type: "exporter:otlp_grpc"
+            capabilities:
+              bearer_token_provider: auth
+            config:
+              grpc_endpoint: "https://example.com:4317"
+        connections:
+          - from: receiver
+            to: exporter
+"#;
+
+        let error = OtelDataflowSpec::from_yaml(yaml)
+            .expect_err("regular pipeline must not see observability extension");
+        assert!(
+            error.to_string().contains(
+                "binds capability 'bearer_token_provider' to extension 'auth', but no extension"
+            ),
+            "unexpected validation error: {error}"
+        );
     }
 
     /// Scenario: a configuration uses the removed engine telemetry metrics field.

--- a/rust/otap-dataflow/crates/config/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline.rs
@@ -542,6 +542,16 @@ impl PipelineExtensions {
     pub fn keys(&self) -> impl Iterator<Item = &ExtensionId> {
         self.0.keys()
     }
+
+    /// Returns a clone with credential header values redacted for config snapshots.
+    #[must_use]
+    pub(crate) fn redacted_for_snapshot(&self) -> Self {
+        let mut redacted = self.clone();
+        for extension in redacted.0.values_mut() {
+            *extension = Arc::new(extension.redacted_for_snapshot());
+        }
+        redacted
+    }
 }
 
 impl IntoIterator for PipelineExtensions {
@@ -654,9 +664,7 @@ impl PipelineConfig {
         for node in redacted.nodes.0.values_mut() {
             *node = Arc::new(node.redacted_for_snapshot());
         }
-        for extension in redacted.extensions.0.values_mut() {
-            *extension = Arc::new(extension.redacted_for_snapshot());
-        }
+        redacted.extensions = redacted.extensions.redacted_for_snapshot();
         redacted
     }
 
@@ -782,13 +790,14 @@ impl PipelineConfig {
     pub fn for_observability_pipeline(
         policies: Option<Policies>,
         nodes: PipelineNodes,
+        extensions: PipelineExtensions,
         connections: Vec<PipelineConnection>,
     ) -> Self {
         Self {
             r#type: PipelineType::Otap,
             policies,
             nodes,
-            extensions: PipelineExtensions::default(),
+            extensions,
             connections,
         }
     }
@@ -2004,10 +2013,16 @@ sink:
         )
         .expect("connections should parse");
 
-        let config = super::PipelineConfig::for_observability_pipeline(None, nodes, connections);
+        let config = super::PipelineConfig::for_observability_pipeline(
+            None,
+            nodes,
+            super::PipelineExtensions::default(),
+            connections,
+        );
         assert_eq!(config.node_iter().count(), 2);
         assert_eq!(config.connection_iter().count(), 1);
         assert!(config.policies().is_none());
+        assert!(config.extensions().is_empty());
     }
 
     #[test]

--- a/rust/otap-dataflow/docs/configuration.md
+++ b/rust/otap-dataflow/docs/configuration.md
@@ -462,27 +462,26 @@ engine:
                     config: {}
                 otlp:
                     type: exporter:otlp_grpc
-                capabilities:
-                  bearer_token_provider: auth
+                    capabilities:
+                        bearer_token_provider: auth
                     config: {}
             extensions:
-              auth:
-                type: extension:oauth2_client_auth
-                config: {}
+                auth:
+                    type: extension:oauth2_client_auth
+                    config: {}
             connections:
                 - from: internal
                   to: otlp
 ```
 
 Observability pipelines use the same node and connection model as regular
-pipelines. Extensions declared under
-`engine.observability.pipeline.extensions` are scoped to that pipeline and can
-provide capabilities to its nodes. They support `channel_capacity`, `health`,
-and `telemetry` policies, but resource policies are intentionally not supported
-there. The pipeline is mandatory and must contain exactly one connected
-internal telemetry receiver. The receiver defaults to
-`signals: [logs, metrics]`, while either signal can be selected independently.
-Logs must remain enabled
+pipelines. Pipeline-scoped extensions can provide capabilities to observability
+nodes and are declared in the pipeline's `extensions` section. They support
+`channel_capacity`, `health`, and `telemetry` policies, but resource policies
+are intentionally not supported there. The pipeline is mandatory and must
+contain exactly one connected internal telemetry receiver. The receiver
+defaults to `signals: [logs, metrics]`, while either signal can be selected
+independently. Logs must remain enabled
 when a log provider uses `its`. Optional `metrics.interval` and `metrics.views`
 fields customize periodic export when metrics are selected. A logs-only
 receiver drains the private ITS metric accumulator without converting or

--- a/rust/otap-dataflow/docs/configuration.md
+++ b/rust/otap-dataflow/docs/configuration.md
@@ -462,18 +462,27 @@ engine:
                     config: {}
                 otlp:
                     type: exporter:otlp_grpc
+                capabilities:
+                  bearer_token_provider: auth
                     config: {}
+            extensions:
+              auth:
+                type: extension:oauth2_client_auth
+                config: {}
             connections:
                 - from: internal
                   to: otlp
 ```
 
 Observability pipelines use the same node and connection model as regular
-pipelines. They support `channel_capacity`, `health`, and `telemetry` policies,
-but resource policies are intentionally not supported there. The pipeline is
-mandatory and must contain exactly one connected internal telemetry receiver.
-The receiver defaults to `signals: [logs, metrics]`, while either signal can be
-selected independently. Logs must remain enabled
+pipelines. Extensions declared under
+`engine.observability.pipeline.extensions` are scoped to that pipeline and can
+provide capabilities to its nodes. They support `channel_capacity`, `health`,
+and `telemetry` policies, but resource policies are intentionally not supported
+there. The pipeline is mandatory and must contain exactly one connected
+internal telemetry receiver. The receiver defaults to
+`signals: [logs, metrics]`, while either signal can be selected independently.
+Logs must remain enabled
 when a log provider uses `its`. Optional `metrics.interval` and `metrics.views`
 fields customize periodic export when metrics are selected. A logs-only
 receiver drains the private ITS metric accumulator without converting or


### PR DESCRIPTION
# Change summary

feat(config): allow extensions in observability pipelines

## Related issue

* Closes #4035

## Validation

- Unit tests

## User-facing changes

Users can now declare extensions in their observability pipeline config. 
