### PR TITLE
feat(metrics): Unify telemetry interest bits and clarify `node.completion.duration`

### DIFF
--- a/rust/otap-dataflow/.chloggen/node-completion-duration-names.yaml
+++ b/rust/otap-dataflow/.chloggen/node-completion-duration-names.yaml
@@ -1,0 +1,6 @@
+change_type: breaking
+component: engine
+note: "Rename node completion duration and make node telemetry measurements independently selectable."
+issues: [3881]
+subtext: |
+  Migration: Query `node.completion.duration` instead of `node.input.duration` and `node.output.duration`. Per-node message, completion, duration, item, and size opt-ins now work at every runtime metric level.

--- a/rust/otap-dataflow/configs/README.md
+++ b/rust/otap-dataflow/configs/README.md
@@ -91,17 +91,16 @@ Demonstrates metric-name filtering:
 - Generates synthetic metrics -> filter processor by metric name -> debug processor
   -> noop exporter
 
-### `trafficgen-input-output-metrics.yaml`
+### `trafficgen-node-metrics.yaml`
 
-Compares universal node and flow input/output message, item, and logical
-payload size metrics:
+Compares node and flow input/output message, item, logical size, completion
+duration, and local duration metrics:
 
-- Runs three pipelines: a mixed-signal sampling flow with detailed metrics, the
-  same topology with per-node opt-ins, and a deterministic drop-all filter that
-  ACKs without sending
-- `runtime_metrics: detailed` enables item and size measurements for every
-  node; the second pipeline demonstrates per-node `item_counts: true` and
-  `size: true` opt-ins at the normal level.
+- Runs three pipelines: a mixed-signal sampling flow with detailed metrics, a
+  basic-level pipeline that assigns each per-node opt-in to a different node,
+  and a deterministic drop-all filter that ACKs without sending.
+- The `opt_in` pipeline demonstrates `messages`, `item_counts`,
+  `completion_duration`, `duration`, and `size` independently.
 - The `full` pipeline compares a sampler's `node.input` / `node.output`
   terminal outcomes with `flow.input` / `flow.output` forward-path
   measurements for the same processor range.

--- a/rust/otap-dataflow/configs/trafficgen-node-metrics.yaml
+++ b/rust/otap-dataflow/configs/trafficgen-node-metrics.yaml
@@ -1,66 +1,14 @@
-# Compares per-signal node and flow input/output metrics.
+# Demonstrates node and flow telemetry with three pipelines:
+#   - `full`: detailed node metrics including `node.completion.duration`, a
+#     one-processor flow around `sampler`, and processor compute duration.
+#   - `opt_in`: each per-node opt-in is assigned to a different node at the
+#     basic level.
+#   - `no_output`: a filter drops every log batch without sending.
 #
-# Three pipelines in the same engine:
-#   - `full`: detailed node metrics, a one-processor flow around `sampler`,
-#     and a pass-through filter that emits processor compute duration.
-#   - `partial`: only `sampler` opts into node item and size measurements.
-#   - `no_output`: a filter opts into component duration and drops every log
-#     batch without sending.
 # Distinguish them by the `pipeline.id` attribute on each metric set.
 #
-# The traffic generator emits a mix of all three signals (logs, metrics,
-# traces). Each pdata batch is homogeneous (exactly one signal), and the
-# measurements are stamped on the batch as it flows forward, then recorded on
-# each node during ack/nack unwinding. They are available uniformly on ALL node
-# kinds -- receivers, processors and exporters alike.
-#
-# Opt-in: item counting and logical payload sizing can require payload
-# inspection, so they are not enabled at the normal metric level by default.
-# A node emits them when either:
-#   - the pipeline sets `telemetry.runtime_metrics: detailed`, or
-#   - the node sets `policies.telemetry.item_counts: true` and/or
-#     `policies.telemetry.size: true`.
-# Component-owned duration has the same global/per-node model:
-#   - `runtime_metrics: detailed` enables it for every component, or
-#   - `policies.telemetry.duration: true` enables it for one node.
-# Per-node item and size opt-ins still require `runtime_metrics: normal` or
-# higher because these measurements extend the input/output metric sets.
-# Component duration can be enabled independently at any runtime metric level.
-#
-# The `full` pipeline lets you compare the sampler's terminal node outcomes
-# against forward-path measurements for the same processor range:
-#
-#   node.input.{messages,items,size,duration} {signal,outcome}
-#   node.output.{messages,items,size,duration} {signal,outcome}
-#   flow.input.{messages,items,size} {signal}
-#   flow.output.{messages,items,size} {signal}
-#   flow.compute.duration {signal}
-#   flow.dropped.items {signal}
-#   processor.compute.duration {outcome}
-#
-# What to look for:
-#   - In `full`, every node reports per-signal items and size. In `partial`,
-#     only the sampler does because the receiver and noop did not opt in.
-#   - receiver `node.output.items` is the per-signal accepted volume
-#     the traffic generator injected.
-#   - sampler `node.input.*` equals the receiver's output counts
-#     (everything the sampler received), while sampler
-#     `node.output.items{signal="logs"}` is LOWER because the sampler
-#     keeps only ~1/3 of log records; metrics and traces pass through unchanged
-#     (sampling only targets logs). This shows the per-signal accounting
-#     isolating the affected signal.
-#   - noop `node.input.*` reflects the surviving per-signal volume.
-#   - `duration_probe` emits `processor.compute.duration` because detailed
-#     runtime metrics enable component duration globally.
-#   - In `no_output`, the receiver, filter input, flow input, flow compute, and
-#     flow dropped metrics are present. Filter `node.output.*`,
-#     `flow.output.*`, and noop `node.input.*` are absent because no PData
-#     message is sent. `processor.compute.duration` is present because the
-#     filter opts in, while `node.input.duration` is absent because terminal
-#     node duration still requires `runtime_metrics: detailed`.
-#
 # Run with:
-#   cargo run -- --config configs/trafficgen-input-output-metrics.yaml
+#   .dev/run.sh trafficgen-node-metrics.yaml
 
 version: otel_dataflow/v1
 engine:
@@ -165,7 +113,7 @@ groups:
                   emit: 1
                   out_of: 3
 
-          duration_probe:
+          pass_through:
             type: processor:filter
             config: {}
 
@@ -177,13 +125,14 @@ groups:
           - from: receiver
             to: sampler
           - from: sampler
-            to: duration_probe
-          - from: duration_probe
+            to: pass_through
+          - from: pass_through
             to: noop
 
-      # Same topology, but only the sampler opts into items and size. The
-      # receiver and noop emit message outcomes but no optional measurements.
-      partial:
+      # Each node opts into one measurement at the basic runtime metric level.
+      # This demonstrates that the policies are independent of the level and
+      # of one another.
+      opt_in:
         policies:
           channel_capacity:
             control:
@@ -191,12 +140,14 @@ groups:
               pipeline: 100
             pdata: 128
           telemetry:
-            runtime_metrics: normal
+            runtime_metrics: basic
 
         nodes:
-          receiver:
+          messages_probe:
             type: receiver:traffic_generator
-            # No `policies` block: this node does not opt in.
+            policies:
+              telemetry:
+                messages: true
             config:
               traffic_config:
                 max_batch_size: 10
@@ -206,32 +157,50 @@ groups:
                 trace_weight: 20
               data_source: synthetic
 
-          sampler:
+          items_probe:
             type: processor:log_sampling
-            # Only this node opts in.
             policies:
               telemetry:
                 item_counts: true
-                size: true
             config:
               policy:
                 ratio:
                   emit: 1
                   out_of: 3
 
-          noop:
+          completion_duration_probe:
+            type: processor:filter
+            policies:
+              telemetry:
+                completion_duration: true
+            config: {}
+
+          duration_probe:
+            type: processor:filter
+            policies:
+              telemetry:
+                duration: true
+            config: {}
+
+          size_probe:
             type: exporter:noop
-            # No `policies` block: this node does not opt in.
+            policies:
+              telemetry:
+                size: true
             config:
 
         connections:
-          - from: receiver
-            to: sampler
-          - from: sampler
-            to: noop
+          - from: messages_probe
+            to: items_probe
+          - from: items_probe
+            to: completion_duration_probe
+          - from: completion_duration_probe
+            to: duration_probe
+          - from: duration_probe
+            to: size_probe
 
       # Every generated log is dropped. This exercises a processor that opts
-      # into component duration and ACKs without sending an output message.
+      # into local duration and ACKs without sending an output message.
       no_output:
         policies:
           channel_capacity:
@@ -272,6 +241,7 @@ groups:
             type: processor:filter
             policies:
               telemetry:
+                completion_duration: true
                 duration: true
                 item_counts: true
                 size: true

--- a/rust/otap-dataflow/configs/trafficgen-node-metrics.yaml
+++ b/rust/otap-dataflow/configs/trafficgen-node-metrics.yaml
@@ -8,7 +8,7 @@
 # Distinguish them by the `pipeline.id` attribute on each metric set.
 #
 # Run with:
-#   .dev/run.sh trafficgen-node-metrics.yaml
+#   cargo run -- --config configs/trafficgen-node-metrics.yaml
 
 version: otel_dataflow/v1
 engine:

--- a/rust/otap-dataflow/crates/config/src/node.rs
+++ b/rust/otap-dataflow/crates/config/src/node.rs
@@ -188,8 +188,10 @@ pub struct NodeTelemetryPolicy {
     /// Opt this node into input/output message counters.
     ///
     /// This enables the applicable `node.input.messages` and
-    /// `node.output.messages` metrics. `runtime_metrics: normal` or `detailed`
-    /// enables message counters for every node without this flag.
+    /// `node.output.messages` metrics, plus shared
+    /// `receiver.received.messages` or `exporter.attempted.messages` metrics
+    /// for those node kinds. `runtime_metrics: normal` or `detailed` enables
+    /// message counters for every node without this flag.
     #[serde(default)]
     pub messages: bool,
 
@@ -221,8 +223,8 @@ pub struct NodeTelemetryPolicy {
     #[serde(default)]
     pub item_counts: bool,
 
-    /// Opt this node into node-implemented and per-signal input/output logical
-    /// payload size.
+    /// Opt this node into per-signal input/output logical payload size and
+    /// node-implemented encoded payload size at receiver/exporter boundaries.
     ///
     /// Off by default because measuring OTAP payloads requires walking their
     /// Arrow arrays and buffers. This option applies at any runtime metric

--- a/rust/otap-dataflow/crates/config/src/node.rs
+++ b/rust/otap-dataflow/crates/config/src/node.rs
@@ -185,35 +185,49 @@ pub struct NodePolicies {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct NodeTelemetryPolicy {
-    /// Opt this node into component-owned duration measurements, such as
+    /// Opt this node into input/output message counters.
+    ///
+    /// This enables the applicable `node.input.messages` and
+    /// `node.output.messages` metrics. `runtime_metrics: normal` or `detailed`
+    /// enables message counters for every node without this flag.
+    #[serde(default)]
+    pub messages: bool,
+
+    /// Opt this node into terminal Ack/Nack completion duration.
+    ///
+    /// This enables `node.completion.duration` without enabling node input or
+    /// output message counters. `runtime_metrics: detailed` enables completion
+    /// duration for every node without this flag.
+    #[serde(default)]
+    pub completion_duration: bool,
+
+    /// Opt this node into node-implemented local duration measurements, such as
     /// `receiver.processing.duration`, `processor.compute.duration`, or
     /// `exporter.attempted.duration`.
     ///
     /// Off by default because duration instrumentation requires clock reads on
-    /// the data path. `runtime_metrics: detailed` enables component duration
+    /// the data path. `runtime_metrics: detailed` enables local duration
     /// for every node without this flag.
     #[serde(default)]
     pub duration: bool,
 
-    /// Opt this node into component-owned item counts and, at `normal` or
-    /// higher, per-signal input/output item counts.
+    /// Opt this node into node-implemented and per-signal input/output item
+    /// counts.
     ///
     /// Off by default because counting items requires inspecting each batch,
-    /// which is expensive for OTLP payloads. Component-owned metrics can honor
-    /// this option at any runtime metric level. `node.input` / `node.output`
-    /// item counts also require `runtime_metrics: normal` or higher.
-    /// `runtime_metrics: detailed` enables it for every node without this flag.
+    /// which is expensive for OTLP payloads. This option applies at any runtime
+    /// metric level. `runtime_metrics: detailed` enables it for every node
+    /// without this flag.
     #[serde(default)]
     pub item_counts: bool,
 
-    /// Opt this node into component-owned logical payload size and, at `normal`
-    /// or higher, per-signal input/output logical payload size.
+    /// Opt this node into node-implemented and per-signal input/output logical
+    /// payload size.
     ///
     /// Off by default because measuring OTAP payloads requires walking their
-    /// Arrow arrays and buffers. Component-owned metrics can honor this option
-    /// at any runtime metric level. `node.input` / `node.output` size metrics
-    /// also require `runtime_metrics: normal` or higher.
-    /// `runtime_metrics: detailed` enables it for every node without this flag.
+    /// Arrow arrays and buffers. This option applies at any runtime metric
+    /// level. `runtime_metrics: detailed` enables it for every node without
+    /// this flag.
     #[serde(default)]
     pub size: bool,
 }
@@ -540,7 +554,7 @@ mod tests {
         assert!(cfg.outputs.is_empty());
     }
 
-    /// Scenario: a node config opts into duration, item counts, and payload size through its restricted policy block.
+    /// Scenario: a node config opts into every optional node measurement.
     /// Guarantees: node telemetry configuration stays namespaced under `policies` with independent measurement controls.
     #[test]
     fn node_user_config_parses_measurement_policy() {
@@ -548,6 +562,8 @@ mod tests {
 type: "processor:batch"
 policies:
   telemetry:
+    messages: true
+    completion_duration: true
     duration: true
     item_counts: true
     size: true
@@ -558,16 +574,20 @@ policies:
             .as_ref()
             .and_then(|policies| policies.telemetry.as_ref())
             .expect("node telemetry policy");
+        assert!(telemetry.messages);
+        assert!(telemetry.completion_duration);
         assert!(telemetry.duration);
         assert!(telemetry.item_counts);
         assert!(telemetry.size);
     }
 
     /// Scenario: a node telemetry policy omits every optional measurement.
-    /// Guarantees: component duration, item counts, and size measurements remain disabled by default.
+    /// Guarantees: messages, completion duration, local duration, item counts, and size remain disabled by default.
     #[test]
     fn node_telemetry_policy_defaults_optional_measurements_off() {
         let telemetry = NodeTelemetryPolicy::default();
+        assert!(!telemetry.messages);
+        assert!(!telemetry.completion_duration);
         assert!(!telemetry.duration);
         assert!(!telemetry.item_counts);
         assert!(!telemetry.size);

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/metrics.rs
@@ -108,7 +108,6 @@ impl ConsoleExporterMetrics {
 mod tests {
     use super::*;
     use otel_arrow_dfe_engine::Interests;
-    use otel_arrow_dfe_engine::context::ControllerContext;
     use otel_arrow_dfe_engine::testing::test_pipeline_ctx_with_interests;
     use otel_arrow_dfe_telemetry::registry::TelemetryRegistryHandle;
 
@@ -120,10 +119,8 @@ mod tests {
     fn new_test_metrics_with_registry(
         format: ConsoleOutputFormat,
     ) -> (TelemetryRegistryHandle, ConsoleExporterMetrics) {
-        let registry = TelemetryRegistryHandle::new();
-        let controller = ControllerContext::new(registry.clone());
-        let pipeline_ctx =
-            controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        let (pipeline_ctx, registry) =
+            test_pipeline_ctx_with_interests(Interests::NODE_INPUT_METRICS);
         (
             registry,
             ConsoleExporterMetrics::register(&pipeline_ctx, format),

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/console_exporter/metrics.rs
@@ -107,11 +107,14 @@ impl ConsoleExporterMetrics {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use otel_arrow_dfe_engine::Interests;
     use otel_arrow_dfe_engine::context::ControllerContext;
+    use otel_arrow_dfe_engine::testing::test_pipeline_ctx_with_interests;
     use otel_arrow_dfe_telemetry::registry::TelemetryRegistryHandle;
 
     fn new_test_metrics(format: ConsoleOutputFormat) -> ConsoleExporterMetrics {
-        new_test_metrics_with_registry(format).1
+        let (pipeline_ctx, _) = test_pipeline_ctx_with_interests(Interests::NODE_INPUT_METRICS);
+        ConsoleExporterMetrics::register(&pipeline_ctx, format)
     }
 
     fn new_test_metrics_with_registry(

--- a/rust/otap-dataflow/crates/engine/src/channel_metrics.rs
+++ b/rust/otap-dataflow/crates/engine/src/channel_metrics.rs
@@ -155,7 +155,7 @@ pub(crate) struct ControlChannelReceiverMetrics {
     pub(crate) capacity: Gauge<u64>,
 }
 
-/// Ack/nack metrics for consumed messages, owned exclusively by the runtime control manager.
+/// Ack/nack metrics for input messages, owned exclusively by the runtime control manager.
 /// Registered under the input channel entity key so they share the same
 /// channel attributes as the transport metrics.
 #[metric_set(
@@ -164,14 +164,22 @@ pub(crate) struct ControlChannelReceiverMetrics {
 )]
 #[derive(Debug, Default, Clone)]
 pub struct NodeInputMetrics {
-    /// Duration from node input until the corresponding terminal ack or nack
-    /// is routed, in seconds. Reported for processors and exporters at the
-    /// detailed level; receivers have no input and use `node.output.duration`.
-    #[metric(unit = "s")]
-    pub duration: HistogramNormal,
-    /// Consumed messages, grouped by `signal` and `outcome` datapoint attributes.
+    /// Input messages, grouped by `signal` and `outcome` datapoint attributes.
     #[metric(unit = "{message}")]
     pub messages: Counter<u64>,
+}
+
+/// Ack/nack completion duration associated with one node boundary.
+#[metric_set(
+    name = "node.completion",
+    measurement_attributes = SignalOutcomeAttributes
+)]
+#[derive(Debug, Default, Clone)]
+pub struct NodeCompletionMetrics {
+    /// Duration from the tracked node boundary until the corresponding
+    /// terminal ack or nack is routed, in seconds.
+    #[metric(unit = "s")]
+    pub duration: HistogramNormal,
 }
 
 /// Optional per-signal item metrics for a node input channel.
@@ -181,7 +189,7 @@ pub struct NodeInputMetrics {
 )]
 #[derive(Debug, Default, Clone)]
 pub struct NodeInputItemMetrics {
-    /// Consumed signal items, grouped by the `signal` datapoint attribute.
+    /// Input signal items, grouped by the `signal` datapoint attribute.
     #[metric(unit = "{item}")]
     pub items: Counter<u64>,
 }
@@ -193,12 +201,12 @@ pub struct NodeInputItemMetrics {
 )]
 #[derive(Debug, Default, Clone)]
 pub struct NodeInputSizeMetrics {
-    /// Consumed logical payload size, grouped by `signal` and `outcome`.
+    /// Input logical payload size, grouped by `signal` and `outcome`.
     #[metric(unit = "By")]
     pub size: Counter<u64>,
 }
 
-/// Ack/nack metrics for produced messages, owned exclusively by the runtime control manager.
+/// Ack/nack metrics for output messages, owned exclusively by the runtime control manager.
 /// Registered under the output channel entity key so they share the same
 /// channel attributes as the transport metrics.
 #[metric_set(
@@ -207,13 +215,7 @@ pub struct NodeInputSizeMetrics {
 )]
 #[derive(Debug, Default, Clone)]
 pub struct NodeOutputMetrics {
-    /// Duration from receiver output until the corresponding terminal ack or
-    /// nack is routed, in seconds. Reported only for receivers at the detailed
-    /// level. Processors and exporters use `node.input.duration` so each node
-    /// frame emits one terminal-latency observation rather than duplicating it.
-    #[metric(unit = "s")]
-    pub duration: HistogramNormal,
-    /// Produced messages, grouped by `signal` and `outcome` datapoint attributes.
+    /// Output messages, grouped by `signal` and `outcome` datapoint attributes.
     #[metric(unit = "{message}")]
     pub messages: Counter<u64>,
 }
@@ -225,7 +227,7 @@ pub struct NodeOutputMetrics {
 )]
 #[derive(Debug, Default, Clone)]
 pub struct NodeOutputItemMetrics {
-    /// Produced signal items, grouped by the `signal` datapoint attribute.
+    /// Output signal items, grouped by the `signal` datapoint attribute.
     #[metric(unit = "{item}")]
     pub items: Counter<u64>,
 }
@@ -237,7 +239,7 @@ pub struct NodeOutputItemMetrics {
 )]
 #[derive(Debug, Default, Clone)]
 pub struct NodeOutputSizeMetrics {
-    /// Produced logical payload size, grouped by `signal` and `outcome`.
+    /// Output logical payload size, grouped by `signal` and `outcome`.
     #[metric(unit = "By")]
     pub size: Counter<u64>,
 }

--- a/rust/otap-dataflow/crates/engine/src/control.rs
+++ b/rust/otap-dataflow/crates/engine/src/control.rs
@@ -143,19 +143,19 @@ pub struct Frame {
     /// The caller's node_id for routing.
     pub node_id: usize,
     /// Number of signal items produced (emitted) by the node at send time.
-    /// Stamped only when the node has `PRODUCER_METRICS` interest. Saturates
+    /// Stamped only when the node has `NODE_ITEM_COUNTS` interest. Saturates
     /// at `u32::MAX`.
-    pub produced_items: u32,
+    pub output_items: u32,
     /// Number of signal items consumed (received) by the node at receive time.
-    /// Stamped only when the node has `CONSUMER_METRICS` interest. Saturates
+    /// Stamped only when the node has `NODE_ITEM_COUNTS` interest. Saturates
     /// at `u32::MAX`.
-    pub consumed_items: u32,
+    pub input_items: u32,
     /// Logical payload size produced by the node at send time, in bytes.
     /// Zero means the measurement was disabled, unavailable, or empty.
-    pub produced_size: u64,
+    pub output_size: u64,
     /// Logical payload size consumed by the node at receive time, in bytes.
     /// Zero means the measurement was disabled, unavailable, or empty.
-    pub consumed_size: u64,
+    pub input_size: u64,
 }
 
 /// The ACK message.

--- a/rust/otap-dataflow/crates/engine/src/lib.rs
+++ b/rust/otap-dataflow/crates/engine/src/lib.rs
@@ -504,15 +504,15 @@ impl processor::FlowMetricHook for String {}
 /// Trait for setting exit information in the Context, for PData consumers.
 pub trait StampOutputPort {
     /// Called automatically when a PData message is sent on an output channel.
-    fn stamp_output_port_index(&mut self, index: u16);
+    fn stamp_output_port_index(&mut self, node_id: usize, index: u16);
 }
 
 impl StampOutputPort for () {
-    fn stamp_output_port_index(&mut self, _index: u16) {}
+    fn stamp_output_port_index(&mut self, _node_id: usize, _index: u16) {}
 }
 
 impl StampOutputPort for String {
-    fn stamp_output_port_index(&mut self, _index: u16) {}
+    fn stamp_output_port_index(&mut self, _node_id: usize, _index: u16) {}
 }
 
 /// Trait for forward-path flow_metric compute accumulation on PData.

--- a/rust/otap-dataflow/crates/engine/src/lib.rs
+++ b/rust/otap-dataflow/crates/engine/src/lib.rs
@@ -348,35 +348,35 @@ pub struct Interests: u16 {
     /// Return data
     const RETURN_DATA = 1 << 2;
 
-    /// Entry-timestamp should be recorded for detailed metrics.
-    const ENTRY_TIMESTAMP = 1 << 3;
+    /// Collect node completion duration through terminal Ack/Nack unwinding.
+    const NODE_COMPLETION_DURATION = 1 << 3;
 
-    /// Consumer metrics will be instrumented by recording the route
-    /// and optional timing.
-    const CONSUMER_METRICS = 1 << 4;
+    /// Instrument the node input metric family.
+    const NODE_INPUT_METRICS = 1 << 4;
 
-    /// Producer metrics will be instrumented by recording the route
-    /// and optional timing.
-    const PRODUCER_METRICS = 1 << 5;
+    /// Instrument the node output metric family.
+    const NODE_OUTPUT_METRICS = 1 << 5;
 
     /// Source-tagging requested. A frame with no other interests may be inserted.
     const SOURCE_TAGGING = 1 << 6;
 
-    /// Per-signal produced/consumed item counts requested. Opt-in (counting
-    /// items is expensive for OTLP payloads): enabled at the `Detailed` metric
-    /// level, or per node via `policies.telemetry.item_counts`.
-    const PRODUCED_CONSUMED_ITEM_COUNTS = 1 << 8;
+    /// Collect item counts for telemetry associated with this node. This feeds
+    /// engine-owned node input/output metrics and node-implemented metrics that
+    /// report item counts. Opt-in because counting OTLP items is expensive.
+    const NODE_ITEM_COUNTS = 1 << 8;
 
-    /// Per-signal produced/consumed logical payload size requested. Enabled at
-    /// the `Detailed` metric level, or per node via `policies.telemetry.size`.
-    const PRODUCED_CONSUMED_SIZE = 1 << 9;
+    /// Collect size measurements for telemetry associated with this node. This
+    /// feeds engine-owned logical PData size and node-implemented boundary
+    /// payload size metrics, each using the semantics of its metric contract.
+    const NODE_SIZE = 1 << 9;
 
-    /// Component-owned duration timing requested. Enabled at the `Detailed`
-    /// metric level, or per node via `policies.telemetry.duration`.
-    const COMPONENT_DURATION = 1 << 7;
+    /// Collect node-implemented local duration measurements. Engine-owned node
+    /// and flow timing is controlled separately by the pipeline metric
+    /// interests and `NODE_COMPLETION_DURATION`.
+    const NODE_LOCAL_DURATION = 1 << 7;
 
-    /// Pipeline-metrics is either CONSUMER_METRICS or PRODUCER_METRICS.
-    const PIPELINE_METRICS = Self::CONSUMER_METRICS.bits() | Self::PRODUCER_METRICS.bits();
+    /// Node metrics include either the input or output metric family.
+    const NODE_METRICS = Self::NODE_INPUT_METRICS.bits() | Self::NODE_OUTPUT_METRICS.bits();
 }
 }
 
@@ -385,21 +385,21 @@ impl Interests {
     ///
     /// None:     empty()
     /// Basic:    empty() with only channel metrics, no use of Context
-    /// Normal:   CONSUMER_METRICS | PRODUCER_METRICS
-    /// Detailed: CONSUMER_METRICS | PRODUCER_METRICS | ENTRY_TIMESTAMP
-    ///           | PRODUCED_CONSUMED_ITEM_COUNTS
-    ///           | PRODUCED_CONSUMED_SIZE | COMPONENT_DURATION
+    /// Normal:   NODE_INPUT_METRICS | NODE_OUTPUT_METRICS
+    /// Detailed: NODE_INPUT_METRICS | NODE_OUTPUT_METRICS
+    ///           | NODE_COMPLETION_DURATION | NODE_ITEM_COUNTS
+    ///           | NODE_SIZE | NODE_LOCAL_DURATION
     #[must_use]
     pub fn from_metric_level(level: MetricLevel) -> Self {
         match level {
             MetricLevel::None | MetricLevel::Basic => Self::empty(),
-            MetricLevel::Normal => Self::PIPELINE_METRICS,
+            MetricLevel::Normal => Self::NODE_METRICS,
             MetricLevel::Detailed => {
-                Self::PIPELINE_METRICS
-                    | Self::ENTRY_TIMESTAMP
-                    | Self::PRODUCED_CONSUMED_ITEM_COUNTS
-                    | Self::PRODUCED_CONSUMED_SIZE
-                    | Self::COMPONENT_DURATION
+                Self::NODE_METRICS
+                    | Self::NODE_COMPLETION_DURATION
+                    | Self::NODE_ITEM_COUNTS
+                    | Self::NODE_SIZE
+                    | Self::NODE_LOCAL_DURATION
             }
         }
     }
@@ -414,14 +414,20 @@ impl Interests {
             .as_ref()
             .and_then(|policies| policies.telemetry.as_ref())
         {
+            if telemetry.messages {
+                interests |= Self::NODE_METRICS;
+            }
+            if telemetry.completion_duration {
+                interests |= Self::NODE_COMPLETION_DURATION;
+            }
             if telemetry.item_counts {
-                interests |= Self::PRODUCED_CONSUMED_ITEM_COUNTS;
+                interests |= Self::NODE_ITEM_COUNTS;
             }
             if telemetry.size {
-                interests |= Self::PRODUCED_CONSUMED_SIZE;
+                interests |= Self::NODE_SIZE;
             }
             if telemetry.duration {
-                interests |= Self::COMPONENT_DURATION;
+                interests |= Self::NODE_LOCAL_DURATION;
             }
         }
         interests
@@ -2699,18 +2705,22 @@ mod test {
     use std::time::Duration;
 
     /// Scenario: runtime metric levels resolve optional data-path measurements.
-    /// Guarantees: detailed metrics enable component duration, item counts, and size while normal metrics enable none by default.
+    /// Guarantees: detailed metrics enable node duration, item counts, and size while normal metrics enable none by default.
     #[test]
     fn detailed_runtime_metrics_enable_optional_data_path_measurements() {
         let normal = Interests::from_metric_level(MetricLevel::Normal);
-        assert!(!normal.contains(Interests::COMPONENT_DURATION));
-        assert!(!normal.contains(Interests::PRODUCED_CONSUMED_ITEM_COUNTS));
-        assert!(!normal.contains(Interests::PRODUCED_CONSUMED_SIZE));
+        assert!(normal.contains(Interests::NODE_METRICS));
+        assert!(!normal.contains(Interests::NODE_COMPLETION_DURATION));
+        assert!(!normal.contains(Interests::NODE_LOCAL_DURATION));
+        assert!(!normal.contains(Interests::NODE_ITEM_COUNTS));
+        assert!(!normal.contains(Interests::NODE_SIZE));
 
         let detailed = Interests::from_metric_level(MetricLevel::Detailed);
-        assert!(detailed.contains(Interests::COMPONENT_DURATION));
-        assert!(detailed.contains(Interests::PRODUCED_CONSUMED_ITEM_COUNTS));
-        assert!(detailed.contains(Interests::PRODUCED_CONSUMED_SIZE));
+        assert!(detailed.contains(Interests::NODE_METRICS));
+        assert!(detailed.contains(Interests::NODE_COMPLETION_DURATION));
+        assert!(detailed.contains(Interests::NODE_LOCAL_DURATION));
+        assert!(detailed.contains(Interests::NODE_ITEM_COUNTS));
+        assert!(detailed.contains(Interests::NODE_SIZE));
     }
 
     /// Scenario: One node opts into optional measurements below the detailed metric level.
@@ -2720,6 +2730,8 @@ mod test {
         let mut node_config = NodeUserConfig::new_exporter_config("console");
         node_config.policies = Some(otel_arrow_dfe_config::node::NodePolicies {
             telemetry: Some(otel_arrow_dfe_config::node::NodeTelemetryPolicy {
+                messages: true,
+                completion_duration: true,
                 duration: true,
                 item_counts: true,
                 size: true,
@@ -2727,19 +2739,22 @@ mod test {
         });
 
         let interests = Interests::for_node(MetricLevel::Normal, &node_config);
-        assert!(interests.contains(Interests::PIPELINE_METRICS));
-        assert!(interests.contains(Interests::COMPONENT_DURATION));
-        assert!(interests.contains(Interests::PRODUCED_CONSUMED_ITEM_COUNTS));
-        assert!(interests.contains(Interests::PRODUCED_CONSUMED_SIZE));
+        assert!(interests.contains(Interests::NODE_METRICS));
+        assert!(interests.contains(Interests::NODE_COMPLETION_DURATION));
+        assert!(interests.contains(Interests::NODE_LOCAL_DURATION));
+        assert!(interests.contains(Interests::NODE_ITEM_COUNTS));
+        assert!(interests.contains(Interests::NODE_SIZE));
     }
 
-    /// Scenario: One node opts into optional component measurements at the basic metric level.
-    /// Guarantees: Component interests are enabled without enabling engine-owned node input or output metric sets.
+    /// Scenario: One node opts into optional telemetry measurements at the basic metric level.
+    /// Guarantees: all node telemetry interests, including message metrics, can be enabled below their default levels.
     #[test]
-    fn node_telemetry_policy_enables_component_interests_at_basic_level() {
+    fn node_telemetry_policy_enables_interests_at_basic_level() {
         let mut node_config = NodeUserConfig::new_exporter_config("console");
         node_config.policies = Some(otel_arrow_dfe_config::node::NodePolicies {
             telemetry: Some(otel_arrow_dfe_config::node::NodeTelemetryPolicy {
+                messages: true,
+                completion_duration: true,
                 duration: true,
                 item_counts: true,
                 size: true,
@@ -2747,10 +2762,11 @@ mod test {
         });
 
         let interests = Interests::for_node(MetricLevel::Basic, &node_config);
-        assert!(!interests.intersects(Interests::PIPELINE_METRICS));
-        assert!(interests.contains(Interests::COMPONENT_DURATION));
-        assert!(interests.contains(Interests::PRODUCED_CONSUMED_ITEM_COUNTS));
-        assert!(interests.contains(Interests::PRODUCED_CONSUMED_SIZE));
+        assert!(interests.contains(Interests::NODE_METRICS));
+        assert!(interests.contains(Interests::NODE_COMPLETION_DURATION));
+        assert!(interests.contains(Interests::NODE_LOCAL_DURATION));
+        assert!(interests.contains(Interests::NODE_ITEM_COUNTS));
+        assert!(interests.contains(Interests::NODE_SIZE));
     }
 
     fn admission_policy(unit: RateLimitUnit) -> RateLimiterPolicy {
@@ -2849,6 +2865,10 @@ mod test {
     #[test]
     fn test_interests() {
         assert_eq!(Interests::ACKS | Interests::NACKS, Interests::ACKS_OR_NACKS);
+        assert_eq!(
+            Interests::NODE_INPUT_METRICS | Interests::NODE_OUTPUT_METRICS,
+            Interests::NODE_METRICS
+        );
     }
 
     // -- resolve_capture_policy tests -----------------------------------------

--- a/rust/otap-dataflow/crates/engine/src/local/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/local/processor.rs
@@ -924,10 +924,10 @@ mod tests {
                     node_id,
                     interests: Interests::ACKS,
                     route: RouteData::default(),
-                    produced_items: 0,
-                    consumed_items: 0,
-                    produced_size: 0,
-                    consumed_size: 0,
+                    output_items: 0,
+                    input_items: 0,
+                    output_size: 0,
+                    input_size: 0,
                 }],
             }
         }
@@ -938,10 +938,10 @@ mod tests {
                     node_id,
                     interests: Interests::NACKS,
                     route: RouteData::default(),
-                    produced_items: 0,
-                    consumed_items: 0,
-                    produced_size: 0,
-                    consumed_size: 0,
+                    output_items: 0,
+                    input_items: 0,
+                    output_size: 0,
+                    input_size: 0,
                 }],
             }
         }

--- a/rust/otap-dataflow/crates/engine/src/output_router.rs
+++ b/rust/otap-dataflow/crates/engine/src/output_router.rs
@@ -186,7 +186,7 @@ where
     pub async fn send_default_stamped(&self, mut data: S::Data) -> Result<(), TypedError<S::Data>> {
         match &self.default {
             Some((_, sender, idx)) => {
-                data.stamp_output_port_index(*idx);
+                data.stamp_output_port_index(self.node_id.index, *idx);
                 sender
                     .output_send(data)
                     .await
@@ -203,7 +203,7 @@ where
     pub fn try_send_default_stamped(&self, mut data: S::Data) -> Result<(), TypedError<S::Data>> {
         match &self.default {
             Some((_, sender, idx)) => {
-                data.stamp_output_port_index(*idx);
+                data.stamp_output_port_index(self.node_id.index, *idx);
                 sender
                     .try_output_send(data)
                     .map_err(TypedError::ChannelSendError)
@@ -225,7 +225,7 @@ where
         let port_name: PortName = port.into();
         match self.ports.get(&port_name) {
             Some((sender, idx)) => {
-                data.stamp_output_port_index(*idx);
+                data.stamp_output_port_index(self.node_id.index, *idx);
                 sender
                     .output_send(data)
                     .await
@@ -249,7 +249,7 @@ where
         let port_name: PortName = port.into();
         match self.ports.get(&port_name) {
             Some((sender, idx)) => {
-                data.stamp_output_port_index(*idx);
+                data.stamp_output_port_index(self.node_id.index, *idx);
                 sender
                     .try_output_send(data)
                     .map_err(TypedError::ChannelSendError)

--- a/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
+++ b/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
@@ -809,9 +809,7 @@ impl<PData> RuntimeCtrlMsgManager<PData> {
             );
         }
 
-        if self.telemetry.runtime_metrics >= MetricLevel::Normal {
-            let _ = self.report_node_metrics();
-        }
+        let _ = self.report_node_metrics();
 
         Ok(())
     }
@@ -886,9 +884,7 @@ impl<PData> RuntimeCtrlMsgManager<PData> {
                 }
             }
         }
-        if self.telemetry.runtime_metrics >= MetricLevel::Normal
-            && let Err(err) = self.report_node_metrics()
-        {
+        if let Err(err) = self.report_node_metrics() {
             otel_warn!("node.metrics.reporting.fail", error = err.to_string());
         }
 
@@ -4054,6 +4050,43 @@ mod tests {
         // Exporter input contains 7 log records.
         let exp = &snapshots[&MetricLabel::ExpInputItems];
         assert_u64(exp, ITEMS, 7, "Exporter input logs");
+    }
+
+    /// Scenario: per-node metrics are enabled while the runtime metric level is basic.
+    /// Guarantees: periodic reporting exports opted-in node measurements below normal.
+    #[test]
+    fn node_metrics_report_at_basic_runtime_level() {
+        let mut harness = setup_test_manager_with_metrics();
+        harness.manager.telemetry.runtime_metrics = MetricLevel::Basic;
+        let processor_id = harness.nodes[1].index;
+        {
+            let mut handles = harness.node_metric_handles.borrow_mut();
+            let input = handles[processor_id]
+                .as_mut()
+                .and_then(|handles| handles.input.as_mut())
+                .expect("processor input metrics");
+            input
+                .with(SignalOutcomeAttributes {
+                    signal: SignalType::Logs,
+                    outcome: Outcome::Success,
+                })
+                .messages
+                .inc();
+        }
+
+        let mut pipeline_metrics_monitor = None;
+        harness
+            .manager
+            .handle_due_events(Instant::now(), &mut pipeline_metrics_monitor);
+
+        let snapshots = collect_snapshots(&harness.snapshot_rx, &harness.key_labels);
+        let processor_input = &snapshots[&MetricLabel::ProcInput];
+        assert_u64(
+            processor_input,
+            INPUT_MESSAGES,
+            1,
+            "basic-level node opt-in should be reported",
+        );
     }
 
     /// Scenario: nodes opt into payload size without enabling message or item metrics.

--- a/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
+++ b/rust/otap-dataflow/crates/engine/src/pipeline_ctrl.rs
@@ -10,8 +10,8 @@
 //! Note 2: Other runtime-control messages coordinate shutdown and completion flow.
 
 use crate::channel_metrics::{
-    NodeInputItemMetrics, NodeInputMetrics, NodeInputSizeMetrics, NodeOutputItemMetrics,
-    NodeOutputMetrics, NodeOutputSizeMetrics,
+    NodeCompletionMetrics, NodeInputItemMetrics, NodeInputMetrics, NodeInputSizeMetrics,
+    NodeOutputItemMetrics, NodeOutputMetrics, NodeOutputSizeMetrics,
 };
 use crate::clock;
 use crate::completion_emission_metrics::CompletionEmissionMetricsHandle;
@@ -160,21 +160,25 @@ fn opt_min<T: Ord>(a: Option<T>, b: Option<T>) -> Option<T> {
     }
 }
 
-/// Per-node metrics handles for recording consumed/produced outcomes.
+/// Per-node metrics handles for recording input/output outcomes.
 pub(crate) struct NodeMetricHandles {
     /// Registry handle for automatic unregistration on drop.
     pub(crate) registry: TelemetryRegistryHandle,
-    /// Consumed-message metrics for the node's input channel.
+    /// Message metrics for the node's input channel.
     pub(crate) input: Option<MeasurementMetricSet<NodeInputMetrics>>,
-    /// Optional consumed-item metrics for the node's input channel.
+    /// Completion duration measured from the node's input boundary.
+    pub(crate) input_completion: Option<MeasurementMetricSet<NodeCompletionMetrics>>,
+    /// Optional item metrics for the node's input channel.
     pub(crate) input_items: Option<MeasurementMetricSet<NodeInputItemMetrics>>,
-    /// Optional consumed-size metrics for the node's input channel.
+    /// Optional size metrics for the node's input channel.
     pub(crate) input_size: Option<MeasurementMetricSet<NodeInputSizeMetrics>>,
-    /// Produced-message metrics indexed by output port.
+    /// Message metrics indexed by output port.
     pub(crate) outputs: Vec<MeasurementMetricSet<NodeOutputMetrics>>,
-    /// Optional produced-item metrics indexed by output port.
+    /// Completion duration measured from output boundaries, indexed by port.
+    pub(crate) output_completion: Vec<MeasurementMetricSet<NodeCompletionMetrics>>,
+    /// Optional item metrics indexed by output port.
     pub(crate) output_items: Vec<MeasurementMetricSet<NodeOutputItemMetrics>>,
-    /// Optional produced-size metrics indexed by output port.
+    /// Optional size metrics indexed by output port.
     pub(crate) output_size: Vec<MeasurementMetricSet<NodeOutputSizeMetrics>>,
     /// Completion-emission metrics for completions routed by the node.
     pub(crate) completion_emission: Option<CompletionEmissionMetricsHandle>,
@@ -189,6 +193,9 @@ pub(crate) fn report_node_metrics_with_handles(
         if let Some(input) = &mut handles.input {
             metrics_reporter.report_measurement(input)?;
         }
+        if let Some(input_completion) = &mut handles.input_completion {
+            metrics_reporter.report_measurement(input_completion)?;
+        }
         if let Some(input_items) = &mut handles.input_items {
             metrics_reporter.report_measurement(input_items)?;
         }
@@ -197,6 +204,9 @@ pub(crate) fn report_node_metrics_with_handles(
         }
         for output in &mut handles.outputs {
             metrics_reporter.report_measurement(output)?;
+        }
+        for output_completion in &mut handles.output_completion {
+            metrics_reporter.report_measurement(output_completion)?;
         }
         for output_items in &mut handles.output_items {
             metrics_reporter.report_measurement(output_items)?;
@@ -224,6 +234,9 @@ pub(crate) fn snapshot_node_metrics_with_handles(
         if let Some(input) = &mut handles.input {
             snapshots.extend(input.terminal_snapshots());
         }
+        if let Some(input_completion) = &mut handles.input_completion {
+            snapshots.extend(input_completion.terminal_snapshots());
+        }
         if let Some(input_items) = &mut handles.input_items {
             snapshots.extend(input_items.terminal_snapshots());
         }
@@ -232,6 +245,9 @@ pub(crate) fn snapshot_node_metrics_with_handles(
         }
         for output in &mut handles.outputs {
             snapshots.extend(output.terminal_snapshots());
+        }
+        for output_completion in &mut handles.output_completion {
+            snapshots.extend(output_completion.terminal_snapshots());
         }
         for output_items in &mut handles.output_items {
             snapshots.extend(output_items.terminal_snapshots());
@@ -256,6 +272,11 @@ impl Drop for NodeMetricHandles {
         if let Some(input) = self.input.take() {
             let _ = self.registry.unregister_metric_set(input.metric_set_key());
         }
+        if let Some(input_completion) = self.input_completion.take() {
+            let _ = self
+                .registry
+                .unregister_metric_set(input_completion.metric_set_key());
+        }
         if let Some(input_items) = self.input_items.take() {
             let _ = self
                 .registry
@@ -268,6 +289,11 @@ impl Drop for NodeMetricHandles {
         }
         for output in self.outputs.drain(..) {
             let _ = self.registry.unregister_metric_set(output.metric_set_key());
+        }
+        for output_completion in self.output_completion.drain(..) {
+            let _ = self
+                .registry
+                .unregister_metric_set(output_completion.metric_set_key());
         }
         for output_items in self.output_items.drain(..) {
             let _ = self
@@ -313,7 +339,7 @@ pub struct RuntimeCtrlMsgManager<PData> {
     /// Admission refusal metrics handles for periodic reporting.
     admission_metrics: Vec<crate::admission::metrics::AdmissionMetricsHandle>,
 
-    /// Per-node metrics handles for recording consumed/produced outcomes.
+    /// Per-node metrics handles for recording input/output outcomes.
     node_metric_handles: Rc<RefCell<Vec<Option<NodeMetricHandles>>>>,
 
     /// Flags controlling capture of internal engine metrics.
@@ -871,7 +897,7 @@ impl<PData> RuntimeCtrlMsgManager<PData> {
         }
     }
 
-    /// Report all per-node consumed/produced metric sets.
+    /// Report all per-node input/output metric sets.
     fn report_node_metrics(&mut self) -> Result<(), TelemetryError> {
         report_node_metrics_with_handles(&self.node_metric_handles, &mut self.metrics_reporter)
     }
@@ -1047,87 +1073,73 @@ impl<PData> PipelineCompletionMsgDispatcher<PData> {
         interests: Interests,
         route: &RouteData,
         signal: Option<SignalType>,
-        produced_items: u32,
-        consumed_items: u32,
-        produced_size: u64,
-        consumed_size: u64,
+        output_items: u32,
+        input_items: u32,
+        output_size: u64,
+        input_size: u64,
         outcome: RequestOutcome,
         now_ns: u64,
     ) {
         let mut handles_guard = self.node_metric_handles.borrow_mut();
-        if let Some(Some(handles)) = handles_guard.get_mut(node_id) {
-            if interests.contains(Interests::CONSUMER_METRICS)
+        if let Some(Some(handles)) = handles_guard.get_mut(node_id)
+            && let Some(signal) = signal
+        {
+            let outcome = match outcome {
+                RequestOutcome::Success => Outcome::Success,
+                RequestOutcome::Failure => Outcome::Failure,
+                RequestOutcome::Refused => Outcome::Refused,
+            };
+            let attributes = SignalOutcomeAttributes { signal, outcome };
+
+            if interests.contains(Interests::NODE_INPUT_METRICS)
                 && let Some(input) = &mut handles.input
-                && let Some(signal) = signal
             {
-                let outcome = match outcome {
-                    RequestOutcome::Success => Outcome::Success,
-                    RequestOutcome::Failure => Outcome::Failure,
-                    RequestOutcome::Refused => Outcome::Refused,
-                };
-                let input = input.with(SignalOutcomeAttributes { signal, outcome });
-                input.messages.inc();
-                if consumed_items > 0
-                    && let Some(input_items) = &mut handles.input_items
-                {
-                    input_items
-                        .with(SignalOutcomeAttributes { signal, outcome })
-                        .items
-                        .add(consumed_items as u64);
-                }
-                if consumed_size > 0
-                    && let Some(input_size) = &mut handles.input_size
-                {
-                    input_size
-                        .with(SignalOutcomeAttributes { signal, outcome })
-                        .size
-                        .add(consumed_size);
-                }
-                if route.entry_time_ns > 0 && now_ns > 0 {
-                    let duration_ns = now_ns.saturating_sub(route.entry_time_ns);
-                    input
-                        .duration
-                        .record(Duration::from_nanos(duration_ns).as_secs_f64());
-                }
+                input.with(attributes).messages.inc();
+            }
+            if input_items > 0
+                && let Some(input_item_metrics) = &mut handles.input_items
+            {
+                input_item_metrics
+                    .with(attributes)
+                    .items
+                    .add(input_items as u64);
+            }
+            if input_size > 0
+                && let Some(input_size_metrics) = &mut handles.input_size
+            {
+                input_size_metrics.with(attributes).size.add(input_size);
             }
 
-            if interests.contains(Interests::PRODUCER_METRICS) {
-                let port = route.output_port_index as usize;
-                if let Some(output) = handles.outputs.get_mut(port)
-                    && let Some(signal) = signal
-                {
-                    let outcome = match outcome {
-                        RequestOutcome::Success => Outcome::Success,
-                        RequestOutcome::Failure => Outcome::Failure,
-                        RequestOutcome::Refused => Outcome::Refused,
-                    };
-                    let output = output.with(SignalOutcomeAttributes { signal, outcome });
-                    output.messages.inc();
-                    if produced_items > 0
-                        && let Some(output_items) = handles.output_items.get_mut(port)
-                    {
-                        output_items
-                            .with(SignalOutcomeAttributes { signal, outcome })
-                            .items
-                            .add(produced_items as u64);
-                    }
-                    if produced_size > 0
-                        && let Some(output_size) = handles.output_size.get_mut(port)
-                    {
-                        output_size
-                            .with(SignalOutcomeAttributes { signal, outcome })
-                            .size
-                            .add(produced_size);
-                    }
-                    if !interests.contains(Interests::CONSUMER_METRICS)
-                        && route.entry_time_ns > 0
-                        && now_ns > 0
-                    {
-                        let duration_ns = now_ns.saturating_sub(route.entry_time_ns);
-                        output
-                            .duration
-                            .record(Duration::from_nanos(duration_ns).as_secs_f64());
-                    }
+            let port = route.output_port_index as usize;
+            if interests.contains(Interests::NODE_OUTPUT_METRICS)
+                && let Some(output) = handles.outputs.get_mut(port)
+            {
+                output.with(attributes).messages.inc();
+            }
+            if output_items > 0
+                && let Some(output_item_metrics) = handles.output_items.get_mut(port)
+            {
+                output_item_metrics
+                    .with(attributes)
+                    .items
+                    .add(output_items as u64);
+            }
+            if output_size > 0
+                && let Some(output_size_metrics) = handles.output_size.get_mut(port)
+            {
+                output_size_metrics.with(attributes).size.add(output_size);
+            }
+
+            if interests.contains(Interests::NODE_COMPLETION_DURATION)
+                && route.entry_time_ns > 0
+                && now_ns > 0
+            {
+                let duration =
+                    Duration::from_nanos(now_ns.saturating_sub(route.entry_time_ns)).as_secs_f64();
+                if let Some(input_completion) = &mut handles.input_completion {
+                    input_completion.with(attributes).duration.record(duration);
+                } else if let Some(output_completion) = handles.output_completion.get_mut(port) {
+                    output_completion.with(attributes).duration.record(duration);
                 }
             }
         }
@@ -1237,20 +1249,25 @@ impl<PData: Unwindable> PipelineCompletionMsgDispatcher<PData> {
                 None => return (None, unwind_depth),
                 Some(frame) => {
                     unwind_depth += 1;
-                    // Every popped frame may still contribute produced/consumed
+                    // Every popped frame may still contribute input/output
                     // outcome metrics even if it is not the next Ack/Nack
                     // subscriber. Unwinding therefore serves both routing and
                     // per-node accounting.
-                    if frame.interests.intersects(Interests::PIPELINE_METRICS) {
+                    if frame.interests.intersects(
+                        Interests::NODE_METRICS
+                            | Interests::NODE_COMPLETION_DURATION
+                            | Interests::NODE_ITEM_COUNTS
+                            | Interests::NODE_SIZE,
+                    ) {
                         self.record_frame_metrics(
                             frame.node_id,
                             frame.interests,
                             &frame.route,
                             signal,
-                            frame.produced_items,
-                            frame.consumed_items,
-                            frame.produced_size,
-                            frame.consumed_size,
+                            frame.output_items,
+                            frame.input_items,
+                            frame.output_size,
+                            frame.input_size,
                             outcome,
                             now_ns,
                         );
@@ -1349,7 +1366,8 @@ mod tests {
     use super::*;
     use crate::attributes::{ChannelImplementation, ChannelKind, ChannelMode, ChannelType};
     use crate::channel_metrics::{
-        NodeInputItemMetrics, NodeInputMetrics, NodeOutputItemMetrics, NodeOutputMetrics,
+        NodeCompletionMetrics, NodeInputItemMetrics, NodeInputMetrics, NodeOutputItemMetrics,
+        NodeOutputMetrics,
     };
     use crate::context::{ControllerContext, PipelineContextParams};
     use crate::control::{AckMsg, Frame, NackMsg, RouteData, nanos_since_birth};
@@ -2849,18 +2867,21 @@ mod tests {
     /// Labels for identifying metric set snapshots by their MetricSetKey.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     enum MetricLabel {
-        RecvProduced,
-        RecvProducedItems,
-        RecvProducedSize,
-        ProcConsumed,
-        ProcConsumedItems,
-        ProcConsumedSize,
-        ProcProduced,
-        ProcProducedItems,
-        ProcProducedSize,
-        ExpConsumed,
-        ExpConsumedItems,
-        ExpConsumedSize,
+        RecvOutput,
+        RecvCompletion,
+        RecvOutputItems,
+        RecvOutputSize,
+        ProcInput,
+        ProcCompletion,
+        ProcInputItems,
+        ProcInputSize,
+        ProcOutput,
+        ProcOutputItems,
+        ProcOutputSize,
+        ExpInput,
+        ExpCompletion,
+        ExpInputItems,
+        ExpInputSize,
     }
 
     /// Return value from setup_test_manager_with_metrics.
@@ -2953,69 +2974,75 @@ mod tests {
             ChannelImplementation::Internal,
         );
 
-        let recv_produced: MeasurementMetricSet<NodeOutputMetrics> =
+        let recv_output: MeasurementMetricSet<NodeOutputMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(recv_out_key);
-        let recv_produced_items: MeasurementMetricSet<NodeOutputItemMetrics> =
+        let recv_completion: MeasurementMetricSet<NodeCompletionMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(recv_out_key);
-        let recv_produced_size: MeasurementMetricSet<NodeOutputSizeMetrics> =
+        let recv_output_items: MeasurementMetricSet<NodeOutputItemMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(recv_out_key);
-        let proc_consumed: MeasurementMetricSet<NodeInputMetrics> =
+        let recv_output_size: MeasurementMetricSet<NodeOutputSizeMetrics> =
+            registry.register_metric_set_with_measurement_attributes_for_entity(recv_out_key);
+        let proc_input: MeasurementMetricSet<NodeInputMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(proc_in_key);
-        let proc_consumed_items: MeasurementMetricSet<NodeInputItemMetrics> =
+        let proc_completion: MeasurementMetricSet<NodeCompletionMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(proc_in_key);
-        let proc_consumed_size: MeasurementMetricSet<NodeInputSizeMetrics> =
+        let proc_input_items: MeasurementMetricSet<NodeInputItemMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(proc_in_key);
-        let proc_produced: MeasurementMetricSet<NodeOutputMetrics> =
+        let proc_input_size: MeasurementMetricSet<NodeInputSizeMetrics> =
+            registry.register_metric_set_with_measurement_attributes_for_entity(proc_in_key);
+        let proc_output: MeasurementMetricSet<NodeOutputMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(proc_out_key);
-        let proc_produced_items: MeasurementMetricSet<NodeOutputItemMetrics> =
+        let proc_output_items: MeasurementMetricSet<NodeOutputItemMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(proc_out_key);
-        let proc_produced_size: MeasurementMetricSet<NodeOutputSizeMetrics> =
+        let proc_output_size: MeasurementMetricSet<NodeOutputSizeMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(proc_out_key);
-        let exp_consumed: MeasurementMetricSet<NodeInputMetrics> =
+        let exp_input: MeasurementMetricSet<NodeInputMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(exp_in_key);
-        let exp_consumed_items: MeasurementMetricSet<NodeInputItemMetrics> =
+        let exp_completion: MeasurementMetricSet<NodeCompletionMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(exp_in_key);
-        let exp_consumed_size: MeasurementMetricSet<NodeInputSizeMetrics> =
+        let exp_input_items: MeasurementMetricSet<NodeInputItemMetrics> =
+            registry.register_metric_set_with_measurement_attributes_for_entity(exp_in_key);
+        let exp_input_size: MeasurementMetricSet<NodeInputSizeMetrics> =
             registry.register_metric_set_with_measurement_attributes_for_entity(exp_in_key);
 
         // Save metric set keys for snapshot identification.
         let mut key_labels = HashMap::new();
-        let _ = key_labels.insert(recv_produced.metric_set_key(), MetricLabel::RecvProduced);
+        let _ = key_labels.insert(recv_output.metric_set_key(), MetricLabel::RecvOutput);
         let _ = key_labels.insert(
-            recv_produced_items.metric_set_key(),
-            MetricLabel::RecvProducedItems,
+            recv_completion.metric_set_key(),
+            MetricLabel::RecvCompletion,
         );
         let _ = key_labels.insert(
-            recv_produced_size.metric_set_key(),
-            MetricLabel::RecvProducedSize,
-        );
-        let _ = key_labels.insert(proc_consumed.metric_set_key(), MetricLabel::ProcConsumed);
-        let _ = key_labels.insert(
-            proc_consumed_items.metric_set_key(),
-            MetricLabel::ProcConsumedItems,
+            recv_output_items.metric_set_key(),
+            MetricLabel::RecvOutputItems,
         );
         let _ = key_labels.insert(
-            proc_consumed_size.metric_set_key(),
-            MetricLabel::ProcConsumedSize,
+            recv_output_size.metric_set_key(),
+            MetricLabel::RecvOutputSize,
         );
-        let _ = key_labels.insert(proc_produced.metric_set_key(), MetricLabel::ProcProduced);
+        let _ = key_labels.insert(proc_input.metric_set_key(), MetricLabel::ProcInput);
         let _ = key_labels.insert(
-            proc_produced_items.metric_set_key(),
-            MetricLabel::ProcProducedItems,
-        );
-        let _ = key_labels.insert(
-            proc_produced_size.metric_set_key(),
-            MetricLabel::ProcProducedSize,
-        );
-        let _ = key_labels.insert(exp_consumed.metric_set_key(), MetricLabel::ExpConsumed);
-        let _ = key_labels.insert(
-            exp_consumed_items.metric_set_key(),
-            MetricLabel::ExpConsumedItems,
+            proc_completion.metric_set_key(),
+            MetricLabel::ProcCompletion,
         );
         let _ = key_labels.insert(
-            exp_consumed_size.metric_set_key(),
-            MetricLabel::ExpConsumedSize,
+            proc_input_items.metric_set_key(),
+            MetricLabel::ProcInputItems,
         );
+        let _ = key_labels.insert(proc_input_size.metric_set_key(), MetricLabel::ProcInputSize);
+        let _ = key_labels.insert(proc_output.metric_set_key(), MetricLabel::ProcOutput);
+        let _ = key_labels.insert(
+            proc_output_items.metric_set_key(),
+            MetricLabel::ProcOutputItems,
+        );
+        let _ = key_labels.insert(
+            proc_output_size.metric_set_key(),
+            MetricLabel::ProcOutputSize,
+        );
+        let _ = key_labels.insert(exp_input.metric_set_key(), MetricLabel::ExpInput);
+        let _ = key_labels.insert(exp_completion.metric_set_key(), MetricLabel::ExpCompletion);
+        let _ = key_labels.insert(exp_input_items.metric_set_key(), MetricLabel::ExpInputItems);
+        let _ = key_labels.insert(exp_input_size.metric_set_key(), MetricLabel::ExpInputSize);
 
         let mut node_metric_handles: Vec<Option<NodeMetricHandles>> = Vec::new();
         let max_idx = nodes.iter().map(|n| n.index).max().unwrap_or(0);
@@ -3025,29 +3052,35 @@ mod tests {
         node_metric_handles[nodes[0].index] = Some(NodeMetricHandles {
             registry: registry.clone(),
             input: None,
+            input_completion: None,
             input_items: None,
             input_size: None,
-            outputs: vec![recv_produced],
-            output_items: vec![recv_produced_items],
-            output_size: vec![recv_produced_size],
+            outputs: vec![recv_output],
+            output_completion: vec![recv_completion],
+            output_items: vec![recv_output_items],
+            output_size: vec![recv_output_size],
             completion_emission: None,
         });
         node_metric_handles[nodes[1].index] = Some(NodeMetricHandles {
             registry: registry.clone(),
-            input: Some(proc_consumed),
-            input_items: Some(proc_consumed_items),
-            input_size: Some(proc_consumed_size),
-            outputs: vec![proc_produced],
-            output_items: vec![proc_produced_items],
-            output_size: vec![proc_produced_size],
+            input: Some(proc_input),
+            input_completion: Some(proc_completion),
+            input_items: Some(proc_input_items),
+            input_size: Some(proc_input_size),
+            outputs: vec![proc_output],
+            output_completion: Vec::new(),
+            output_items: vec![proc_output_items],
+            output_size: vec![proc_output_size],
             completion_emission: None,
         });
         node_metric_handles[nodes[2].index] = Some(NodeMetricHandles {
             registry: registry.clone(),
-            input: Some(exp_consumed),
-            input_items: Some(exp_consumed_items),
-            input_size: Some(exp_consumed_size),
+            input: Some(exp_input),
+            input_completion: Some(exp_completion),
+            input_items: Some(exp_input_items),
+            input_size: Some(exp_input_size),
             outputs: Vec::new(),
+            output_completion: Vec::new(),
             output_items: Vec::new(),
             output_size: Vec::new(),
             completion_emission: None,
@@ -3181,12 +3214,10 @@ mod tests {
         }
     }
 
-    // ConsumedMetrics field indices (defined by #[metric_set] field order):
-    const CONSUMER_DURATION: usize = 0;
-    const CONSUMER_REQUESTS: usize = 1;
-    // ProducedMetrics field indices:
-    const PRODUCER_DURATION: usize = 0;
-    const PRODUCER_REQUESTS: usize = 1;
+    // Metric set field indices:
+    const COMPLETION_DURATION: usize = 0;
+    const INPUT_MESSAGES: usize = 0;
+    const OUTPUT_MESSAGES: usize = 0;
     // Item metric set field index:
     const ITEMS: usize = 0;
     // Size metric set field index:
@@ -3574,22 +3605,22 @@ mod tests {
         let mut pdata = TestPData::new();
         pdata.signal = Some(SignalType::Logs);
 
-        // Node 0 (receiver): producer metrics + acks/nacks (receives the ack back)
+        // Node 0 (receiver): output metrics + acks/nacks (receives the ack back)
         pdata.push_frame(Frame {
             node_id: nodes[0].index,
-            interests: Interests::PRODUCER_METRICS | Interests::ACKS | Interests::NACKS,
+            interests: Interests::NODE_OUTPUT_METRICS | Interests::ACKS | Interests::NACKS,
             route: RouteData {
                 calldata: Default::default(),
                 entry_time_ns: 0,
                 output_port_index: 0,
             },
-            produced_items: 10,
-            consumed_items: 0,
-            produced_size: 100,
-            consumed_size: 0,
+            output_items: 10,
+            input_items: 0,
+            output_size: 100,
+            input_size: 0,
         });
 
-        // Node 1 (processor): consumer + producer metrics + acks/nacks
+        // Node 1 (processor): input + output metrics + acks/nacks
         let entry_time_ns = if with_timestamp {
             nanos_since_birth()
         } else {
@@ -3597,9 +3628,9 @@ mod tests {
         };
         pdata.push_frame(Frame {
             node_id: nodes[1].index,
-            interests: Interests::CONSUMER_METRICS
-                | Interests::PRODUCER_METRICS
-                | Interests::ENTRY_TIMESTAMP
+            interests: Interests::NODE_INPUT_METRICS
+                | Interests::NODE_OUTPUT_METRICS
+                | Interests::NODE_COMPLETION_DURATION
                 | Interests::ACKS
                 | Interests::NACKS,
             route: RouteData {
@@ -3607,13 +3638,13 @@ mod tests {
                 entry_time_ns,
                 output_port_index: 0,
             },
-            produced_items: 7,
-            consumed_items: 10,
-            produced_size: 70,
-            consumed_size: 100,
+            output_items: 7,
+            input_items: 10,
+            output_size: 70,
+            input_size: 100,
         });
 
-        // Node 2 (exporter): consumer metrics only (no acks subscription -- terminal node)
+        // Node 2 (exporter): input metrics only (no acks subscription -- terminal node)
         let entry_time_ns = if with_timestamp {
             nanos_since_birth()
         } else {
@@ -3621,16 +3652,16 @@ mod tests {
         };
         pdata.push_frame(Frame {
             node_id: nodes[2].index,
-            interests: Interests::CONSUMER_METRICS | Interests::ENTRY_TIMESTAMP,
+            interests: Interests::NODE_INPUT_METRICS | Interests::NODE_COMPLETION_DURATION,
             route: RouteData {
                 calldata: Default::default(),
                 entry_time_ns,
                 output_port_index: 0,
             },
-            produced_items: 0,
-            consumed_items: 7,
-            produced_size: 0,
-            consumed_size: 70,
+            output_items: 0,
+            input_items: 7,
+            output_size: 0,
+            input_size: 70,
         });
 
         pdata
@@ -3639,12 +3670,12 @@ mod tests {
     /// Build a TestPData with frames simulating a 3-node pipeline where
     /// NO node subscribes to acks/nacks (all frames are metrics-only).
     /// This lets the controller unwind all frames in a single pass,
-    /// including the receiver's producer-only frame.
+    /// including the receiver's output-only frame.
     fn build_3node_pdata_no_subscribers(nodes: &[NodeId], with_timestamp: bool) -> TestPData {
         let mut pdata = TestPData::new();
         pdata.signal = Some(SignalType::Logs);
 
-        // Node 0 (receiver): producer metrics only -- no ACKS/NACKS, no CONSUMER_METRICS.
+        // Node 0 (receiver): output metrics only -- no ACKS/NACKS or input metrics.
         let entry_time_ns = if with_timestamp {
             nanos_since_birth()
         } else {
@@ -3652,19 +3683,19 @@ mod tests {
         };
         pdata.push_frame(Frame {
             node_id: nodes[0].index,
-            interests: Interests::PRODUCER_METRICS | Interests::ENTRY_TIMESTAMP,
+            interests: Interests::NODE_OUTPUT_METRICS | Interests::NODE_COMPLETION_DURATION,
             route: RouteData {
                 calldata: Default::default(),
                 entry_time_ns,
                 output_port_index: 0,
             },
-            produced_items: 10,
-            consumed_items: 0,
-            produced_size: 100,
-            consumed_size: 0,
+            output_items: 10,
+            input_items: 0,
+            output_size: 100,
+            input_size: 0,
         });
 
-        // Node 1 (processor): consumer + producer metrics, no ACKS/NACKS.
+        // Node 1 (processor): input + output metrics, no ACKS/NACKS.
         let entry_time_ns = if with_timestamp {
             nanos_since_birth()
         } else {
@@ -3672,21 +3703,21 @@ mod tests {
         };
         pdata.push_frame(Frame {
             node_id: nodes[1].index,
-            interests: Interests::CONSUMER_METRICS
-                | Interests::PRODUCER_METRICS
-                | Interests::ENTRY_TIMESTAMP,
+            interests: Interests::NODE_INPUT_METRICS
+                | Interests::NODE_OUTPUT_METRICS
+                | Interests::NODE_COMPLETION_DURATION,
             route: RouteData {
                 calldata: Default::default(),
                 entry_time_ns,
                 output_port_index: 0,
             },
-            produced_items: 7,
-            consumed_items: 10,
-            produced_size: 70,
-            consumed_size: 100,
+            output_items: 7,
+            input_items: 10,
+            output_size: 70,
+            input_size: 100,
         });
 
-        // Node 2 (exporter): consumer metrics only.
+        // Node 2 (exporter): input metrics only.
         let entry_time_ns = if with_timestamp {
             nanos_since_birth()
         } else {
@@ -3694,16 +3725,16 @@ mod tests {
         };
         pdata.push_frame(Frame {
             node_id: nodes[2].index,
-            interests: Interests::CONSUMER_METRICS | Interests::ENTRY_TIMESTAMP,
+            interests: Interests::NODE_INPUT_METRICS | Interests::NODE_COMPLETION_DURATION,
             route: RouteData {
                 calldata: Default::default(),
                 entry_time_ns,
                 output_port_index: 0,
             },
-            produced_items: 0,
-            consumed_items: 7,
-            produced_size: 0,
-            consumed_size: 70,
+            output_items: 0,
+            input_items: 7,
+            output_size: 0,
+            input_size: 70,
         });
 
         pdata
@@ -3776,7 +3807,7 @@ mod tests {
     /// Scenario: a successful acknowledgment unwinds a receiver, processor, and exporter.
     /// Guarantees: each unwound node records one request in its `outcome=success` bucket.
     #[tokio::test]
-    async fn test_ack_lifecycle_consumed_produced_metrics() {
+    async fn test_ack_lifecycle_input_output_metrics() {
         let harness = setup_test_manager_with_metrics();
         let nodes_clone = harness.nodes.clone();
         let snapshots = run_and_collect(harness, |nodes| {
@@ -3787,23 +3818,23 @@ mod tests {
         })
         .await;
 
-        // Exporter consumed one successful request.
-        let exp = &snapshots[&MetricLabel::ExpConsumed];
-        assert_u64(exp, CONSUMER_REQUESTS, 1, "Exporter consumed requests");
+        // Exporter records one successful input message.
+        let exp = &snapshots[&MetricLabel::ExpInput];
+        assert_u64(exp, INPUT_MESSAGES, 1, "Exporter input messages");
 
-        // Processor consumed one successful request.
-        let proc_c = &snapshots[&MetricLabel::ProcConsumed];
-        assert_u64(proc_c, CONSUMER_REQUESTS, 1, "Processor consumed requests");
+        // Processor records one successful input message.
+        let proc_c = &snapshots[&MetricLabel::ProcInput];
+        assert_u64(proc_c, INPUT_MESSAGES, 1, "Processor input messages");
 
-        // Processor produced one successful request.
-        let proc_p = &snapshots[&MetricLabel::ProcProduced];
-        assert_u64(proc_p, PRODUCER_REQUESTS, 1, "Processor produced requests");
+        // Processor records one successful output message.
+        let proc_p = &snapshots[&MetricLabel::ProcOutput];
+        assert_u64(proc_p, OUTPUT_MESSAGES, 1, "Processor output messages");
 
-        // Receiver produced: unwind_ack delivers to first ACKS subscriber (processor)
+        // Receiver output: unwind_ack delivers to first ACKS subscriber (processor)
         // so receiver frame is never popped -> no metrics recorded.
         assert!(
-            !snapshots.contains_key(&MetricLabel::RecvProduced),
-            "Receiver produced should have no metrics (ack delivered at processor)"
+            !snapshots.contains_key(&MetricLabel::RecvOutput),
+            "Receiver output should have no metrics (ack delivered at processor)"
         );
 
         drop(nodes_clone);
@@ -3822,14 +3853,14 @@ mod tests {
         })
         .await;
 
-        let exp = &snapshots[&MetricLabel::ExpConsumed];
-        assert_u64(exp, CONSUMER_REQUESTS, 1, "Exporter consumed requests");
+        let exp = &snapshots[&MetricLabel::ExpInput];
+        assert_u64(exp, INPUT_MESSAGES, 1, "Exporter input messages");
 
-        let proc_c = &snapshots[&MetricLabel::ProcConsumed];
-        assert_u64(proc_c, CONSUMER_REQUESTS, 1, "Processor consumed requests");
+        let proc_c = &snapshots[&MetricLabel::ProcInput];
+        assert_u64(proc_c, INPUT_MESSAGES, 1, "Processor input messages");
 
-        let proc_p = &snapshots[&MetricLabel::ProcProduced];
-        assert_u64(proc_p, PRODUCER_REQUESTS, 1, "Processor produced requests");
+        let proc_p = &snapshots[&MetricLabel::ProcOutput];
+        assert_u64(proc_p, OUTPUT_MESSAGES, 1, "Processor output messages");
     }
 
     /// Scenario: a permanent nack unwinds a processor and exporter.
@@ -3845,18 +3876,18 @@ mod tests {
         })
         .await;
 
-        let exp = &snapshots[&MetricLabel::ExpConsumed];
-        assert_u64(exp, CONSUMER_REQUESTS, 1, "Exporter consumed requests");
+        let exp = &snapshots[&MetricLabel::ExpInput];
+        assert_u64(exp, INPUT_MESSAGES, 1, "Exporter input messages");
 
-        let proc_c = &snapshots[&MetricLabel::ProcConsumed];
-        assert_u64(proc_c, CONSUMER_REQUESTS, 1, "Processor consumed requests");
+        let proc_c = &snapshots[&MetricLabel::ProcInput];
+        assert_u64(proc_c, INPUT_MESSAGES, 1, "Processor input messages");
 
-        let proc_p = &snapshots[&MetricLabel::ProcProduced];
-        assert_u64(proc_p, PRODUCER_REQUESTS, 1, "Processor produced requests");
+        let proc_p = &snapshots[&MetricLabel::ProcOutput];
+        assert_u64(proc_p, OUTPUT_MESSAGES, 1, "Processor output messages");
     }
 
     /// Scenario: An acknowledgement unwinds frames with valid entry and return timestamps.
-    /// Guarantees: Consumed durations are recorded as normal-tier histograms in seconds.
+    /// Guarantees: completion durations are recorded as normal-tier histograms in seconds.
     #[tokio::test]
     async fn test_ack_lifecycle_duration_histogram() {
         const ENTRY_TIME_NS: u64 = 1_000_000_000;
@@ -3877,41 +3908,69 @@ mod tests {
         })
         .await;
 
-        let exp = &snapshots[&MetricLabel::ExpConsumed];
+        let exp = &snapshots[&MetricLabel::ExpCompletion];
         assert_duration_seconds(
             exp,
-            CONSUMER_DURATION,
+            COMPLETION_DURATION,
             EXPECTED_DURATION_SECONDS,
-            "Exporter consumed duration",
+            "Exporter completion duration",
         );
 
-        let proc_c = &snapshots[&MetricLabel::ProcConsumed];
+        let proc_c = &snapshots[&MetricLabel::ProcCompletion];
         assert_duration_seconds(
             proc_c,
-            CONSUMER_DURATION,
+            COMPLETION_DURATION,
             EXPECTED_DURATION_SECONDS,
-            "Processor consumed duration",
+            "Processor completion duration",
         );
 
-        // Processor produced duration: should be 0 observations because the
-        // processor frame has CONSUMER_METRICS, so produced duration is
-        // suppressed.
-        let proc_p = &snapshots[&MetricLabel::ProcProduced];
-        let (count, _, _, _) = assert_dist_is_normal_histogram(
-            proc_p,
-            PRODUCER_DURATION,
-            "Processor produced duration",
+        assert!(!snapshots.contains_key(&MetricLabel::RecvCompletion));
+    }
+
+    /// Scenario: one exporter enables completion duration without message metrics.
+    /// Guarantees: completion timing is recorded without emitting an input message series.
+    #[tokio::test]
+    async fn test_completion_duration_records_without_message_metrics() {
+        const ENTRY_TIME_NS: u64 = 1_000_000_000;
+        const RETURN_TIME_NS: u64 = 1_250_000_000;
+        const EXPECTED_DURATION_SECONDS: f64 = 0.25;
+
+        let harness = setup_test_manager_with_metrics();
+        let snapshots = run_and_collect(harness, |nodes| {
+            let mut pdata = TestPData::new();
+            pdata.signal = Some(SignalType::Logs);
+            pdata.push_frame(Frame {
+                node_id: nodes[2].index,
+                interests: Interests::NODE_COMPLETION_DURATION,
+                route: RouteData {
+                    entry_time_ns: ENTRY_TIME_NS,
+                    ..Default::default()
+                },
+                output_items: 0,
+                input_items: 0,
+                output_size: 0,
+                input_size: 0,
+            });
+            let mut ack = AckMsg::new(pdata);
+            ack.unwind.return_time_ns = RETURN_TIME_NS;
+            vec![PipelineCompletionMsg::DeliverAck { ack }]
+        })
+        .await;
+
+        let completion = &snapshots[&MetricLabel::ExpCompletion];
+        assert_duration_seconds(
+            completion,
+            COMPLETION_DURATION,
+            EXPECTED_DURATION_SECONDS,
+            "Exporter completion duration",
         );
-        assert_eq!(
-            count, 0,
-            "Processor should have 0 produced duration observations (suppressed by CONSUMER_METRICS)"
-        );
+        assert!(!snapshots.contains_key(&MetricLabel::ExpInput));
     }
 
     /// Scenario: An acknowledgement unwinds receiver-only and processor frames.
-    /// Guarantees: Produced duration is recorded only when no consumed duration owns the frame.
+    /// Guarantees: receiver completion duration is recorded from its output boundary.
     #[tokio::test]
-    async fn test_ack_lifecycle_produced_duration_histogram() {
+    async fn test_ack_lifecycle_receiver_completion_duration() {
         const ENTRY_TIME_NS: u64 = 1_000_000_000;
         const RETURN_TIME_NS: u64 = 1_250_000_000;
         const EXPECTED_DURATION_SECONDS: f64 = 0.25;
@@ -3928,91 +3987,118 @@ mod tests {
         })
         .await;
 
-        let recv_p = &snapshots[&MetricLabel::RecvProduced];
+        let recv_p = &snapshots[&MetricLabel::RecvCompletion];
         assert_duration_seconds(
             recv_p,
-            PRODUCER_DURATION,
+            COMPLETION_DURATION,
             EXPECTED_DURATION_SECONDS,
-            "Receiver produced duration",
+            "Receiver completion duration",
         );
 
-        // Processor produced duration: 0 observations
-        // (merged frame has CONSUMER_METRICS -> produced_duration suppressed)
-        let proc_p = &snapshots[&MetricLabel::ProcProduced];
-        let (count, _, _, _) = assert_dist_is_normal_histogram(
-            proc_p,
-            PRODUCER_DURATION,
-            "Processor produced duration",
-        );
-        assert_eq!(
-            count, 0,
-            "Processor should have 0 produced duration observations"
-        );
-
-        // Processor consumed duration: 1 observation (still works)
-        let proc_c = &snapshots[&MetricLabel::ProcConsumed];
+        // Processor completion duration is recorded from its input boundary.
+        let proc_c = &snapshots[&MetricLabel::ProcCompletion];
         let (count, _, _, _) = assert_dist_is_normal_histogram(
             proc_c,
-            CONSUMER_DURATION,
-            "Processor consumed duration",
+            COMPLETION_DURATION,
+            "Processor completion duration",
         );
         assert_eq!(
             count, 1,
-            "Processor should have 1 consumed duration observation"
+            "Processor should have 1 completion duration observation"
         );
     }
 
-    /// Scenario: a logs batch flows through receiver, processor, and exporter nodes.
-    /// Guarantees: each node reports its produced or consumed item count in the `signal=logs` bucket.
+    /// Scenario: nodes opt into item counts without enabling message or size metrics.
+    /// Guarantees: item-only frames unwind and report each input/output count.
     #[tokio::test]
     async fn test_per_signal_item_counts() {
         let harness = setup_test_manager_with_metrics();
+        for handles in harness
+            .node_metric_handles
+            .borrow_mut()
+            .iter_mut()
+            .flatten()
+        {
+            let _ = handles.input.take();
+            let _ = handles.input_completion.take();
+            let _ = handles.input_size.take();
+            handles.outputs.clear();
+            handles.output_completion.clear();
+            handles.output_size.clear();
+        }
         let snapshots = run_and_collect(harness, |nodes| {
-            let pdata = build_3node_pdata_no_subscribers(nodes, false);
+            let mut pdata = build_3node_pdata_no_subscribers(nodes, false);
+            for frame in &mut pdata.frames {
+                frame.interests = Interests::NODE_ITEM_COUNTS;
+                frame.input_size = 0;
+                frame.output_size = 0;
+            }
             vec![PipelineCompletionMsg::DeliverAck {
                 ack: AckMsg::new(pdata),
             }]
         })
         .await;
 
-        // Receiver produced 10 log records.
-        let recv_p = &snapshots[&MetricLabel::RecvProducedItems];
-        assert_u64(recv_p, ITEMS, 10, "Receiver produced logs");
+        assert!(!snapshots.contains_key(&MetricLabel::RecvOutput));
 
-        // Processor consumed 10, produced 7 (filtering drop of 3).
-        let proc_c = &snapshots[&MetricLabel::ProcConsumedItems];
-        assert_u64(proc_c, ITEMS, 10, "Processor consumed logs");
-        let proc_p = &snapshots[&MetricLabel::ProcProducedItems];
-        assert_u64(proc_p, ITEMS, 7, "Processor produced logs");
+        // Receiver output contains 10 log records.
+        let recv_p = &snapshots[&MetricLabel::RecvOutputItems];
+        assert_u64(recv_p, ITEMS, 10, "Receiver output logs");
 
-        // Exporter consumed 7 log records.
-        let exp = &snapshots[&MetricLabel::ExpConsumedItems];
-        assert_u64(exp, ITEMS, 7, "Exporter consumed logs");
+        // Processor input contains 10 and output contains 7 after filtering.
+        let proc_c = &snapshots[&MetricLabel::ProcInputItems];
+        assert_u64(proc_c, ITEMS, 10, "Processor input logs");
+        let proc_p = &snapshots[&MetricLabel::ProcOutputItems];
+        assert_u64(proc_p, ITEMS, 7, "Processor output logs");
+
+        // Exporter input contains 7 log records.
+        let exp = &snapshots[&MetricLabel::ExpInputItems];
+        assert_u64(exp, ITEMS, 7, "Exporter input logs");
     }
 
-    /// Scenario: a logs batch flows through receiver, processor, and exporter nodes.
-    /// Guarantees: each node reports its produced or consumed logical payload size in the `signal=logs` bucket.
+    /// Scenario: nodes opt into payload size without enabling message or item metrics.
+    /// Guarantees: size-only frames unwind and report each input/output size.
     #[tokio::test]
     async fn test_per_signal_payload_size() {
         let harness = setup_test_manager_with_metrics();
+        for handles in harness
+            .node_metric_handles
+            .borrow_mut()
+            .iter_mut()
+            .flatten()
+        {
+            let _ = handles.input.take();
+            let _ = handles.input_completion.take();
+            let _ = handles.input_items.take();
+            handles.outputs.clear();
+            handles.output_completion.clear();
+            handles.output_items.clear();
+        }
         let snapshots = run_and_collect(harness, |nodes| {
-            let pdata = build_3node_pdata_no_subscribers(nodes, false);
+            let mut pdata = build_3node_pdata_no_subscribers(nodes, false);
+            for frame in &mut pdata.frames {
+                frame.interests = Interests::NODE_SIZE;
+                frame.input_items = 0;
+                frame.output_items = 0;
+            }
             vec![PipelineCompletionMsg::DeliverAck {
                 ack: AckMsg::new(pdata),
             }]
         })
         .await;
 
-        let recv_p = &snapshots[&MetricLabel::RecvProducedSize];
-        assert_u64(recv_p, SIZE, 100, "Receiver produced size");
+        assert!(!snapshots.contains_key(&MetricLabel::RecvOutput));
 
-        let proc_c = &snapshots[&MetricLabel::ProcConsumedSize];
-        assert_u64(proc_c, SIZE, 100, "Processor consumed size");
-        let proc_p = &snapshots[&MetricLabel::ProcProducedSize];
-        assert_u64(proc_p, SIZE, 70, "Processor produced size");
+        let recv_p = &snapshots[&MetricLabel::RecvOutputSize];
+        assert_u64(recv_p, SIZE, 100, "Receiver output size");
 
-        let exp = &snapshots[&MetricLabel::ExpConsumedSize];
-        assert_u64(exp, SIZE, 70, "Exporter consumed size");
+        let proc_c = &snapshots[&MetricLabel::ProcInputSize];
+        assert_u64(proc_c, SIZE, 100, "Processor input size");
+        let proc_p = &snapshots[&MetricLabel::ProcOutputSize];
+        assert_u64(proc_p, SIZE, 70, "Processor output size");
+
+        let exp = &snapshots[&MetricLabel::ExpInputSize];
+        assert_u64(exp, SIZE, 70, "Exporter input size");
     }
 
     /// Scenario: request metrics are enabled while per-signal item counting is not.
@@ -4039,14 +4125,14 @@ mod tests {
         .await;
 
         assert!(
-            snapshots.contains_key(&MetricLabel::RecvProduced),
+            snapshots.contains_key(&MetricLabel::RecvOutput),
             "Request metrics should remain enabled"
         );
         assert!(
-            !snapshots.contains_key(&MetricLabel::RecvProducedItems)
-                && !snapshots.contains_key(&MetricLabel::ProcConsumedItems)
-                && !snapshots.contains_key(&MetricLabel::ProcProducedItems)
-                && !snapshots.contains_key(&MetricLabel::ExpConsumedItems),
+            !snapshots.contains_key(&MetricLabel::RecvOutputItems)
+                && !snapshots.contains_key(&MetricLabel::ProcInputItems)
+                && !snapshots.contains_key(&MetricLabel::ProcOutputItems)
+                && !snapshots.contains_key(&MetricLabel::ExpInputItems),
             "Item metrics should be absent when item counting is disabled"
         );
     }
@@ -4075,25 +4161,25 @@ mod tests {
         .await;
 
         assert!(
-            snapshots.contains_key(&MetricLabel::RecvProduced),
+            snapshots.contains_key(&MetricLabel::RecvOutput),
             "Request metrics should remain enabled"
         );
         assert!(
-            !snapshots.contains_key(&MetricLabel::RecvProducedSize)
-                && !snapshots.contains_key(&MetricLabel::ProcConsumedSize)
-                && !snapshots.contains_key(&MetricLabel::ProcProducedSize)
-                && !snapshots.contains_key(&MetricLabel::ExpConsumedSize),
+            !snapshots.contains_key(&MetricLabel::RecvOutputSize)
+                && !snapshots.contains_key(&MetricLabel::ProcInputSize)
+                && !snapshots.contains_key(&MetricLabel::ProcOutputSize)
+                && !snapshots.contains_key(&MetricLabel::ExpInputSize),
             "Size metrics should be absent when payload sizing is disabled"
         );
     }
 
     /// Scenario: one processor records successful logs and failed traces.
-    /// Guarantees: produced and consumed request and item snapshots retain distinct `signal` and `outcome` datapoint attributes.
+    /// Guarantees: input and output request and item snapshots retain distinct `signal` and `outcome` datapoint attributes.
     #[test]
     fn node_metrics_export_signal_and_outcome_attributes() {
         let mut harness = setup_test_manager_with_metrics();
         let processor_id = harness.nodes[1].index;
-        let interests = Interests::CONSUMER_METRICS | Interests::PRODUCER_METRICS;
+        let interests = Interests::NODE_INPUT_METRICS | Interests::NODE_OUTPUT_METRICS;
         let route = RouteData::default();
         let (_completion_tx, completion_rx) = pipeline_completion_msg_channel::<TestPData>(1);
         let mut dispatcher = PipelineCompletionMsgDispatcher::new(
@@ -4150,10 +4236,10 @@ mod tests {
                 snapshot.get_metrics().to_vec(),
             );
             match label {
-                MetricLabel::ProcConsumed | MetricLabel::ProcProduced => {
+                MetricLabel::ProcInput | MetricLabel::ProcOutput => {
                     request_snapshots.push(snapshot);
                 }
-                MetricLabel::ProcConsumedItems | MetricLabel::ProcProducedItems => {
+                MetricLabel::ProcInputItems | MetricLabel::ProcOutputItems => {
                     item_snapshots.push(snapshot);
                 }
                 _ => {}
@@ -4186,91 +4272,91 @@ mod tests {
                     .expect("expected datapoint attribute bucket")
             };
 
-        let consumed_logs = find(
+        let input_logs = find(
             &request_snapshots,
-            MetricLabel::ProcConsumed,
+            MetricLabel::ProcInput,
             "logs",
             "success",
         );
         assert_u64(
-            &consumed_logs,
-            CONSUMER_REQUESTS,
+            &input_logs,
+            INPUT_MESSAGES,
             1,
-            "logs success consumed requests",
+            "logs success input messages",
         );
 
-        let consumed_traces = find(
+        let input_traces = find(
             &request_snapshots,
-            MetricLabel::ProcConsumed,
+            MetricLabel::ProcInput,
             "traces",
             "failure",
         );
         assert_u64(
-            &consumed_traces,
-            CONSUMER_REQUESTS,
+            &input_traces,
+            INPUT_MESSAGES,
             1,
-            "traces failure consumed requests",
+            "traces failure input messages",
         );
 
-        let produced_logs = find(
+        let output_logs = find(
             &request_snapshots,
-            MetricLabel::ProcProduced,
+            MetricLabel::ProcOutput,
             "logs",
             "success",
         );
         assert_u64(
-            &produced_logs,
-            PRODUCER_REQUESTS,
+            &output_logs,
+            OUTPUT_MESSAGES,
             1,
-            "logs success produced requests",
+            "logs success output messages",
         );
 
-        let produced_traces = find(
+        let output_traces = find(
             &request_snapshots,
-            MetricLabel::ProcProduced,
+            MetricLabel::ProcOutput,
             "traces",
             "failure",
         );
         assert_u64(
-            &produced_traces,
-            PRODUCER_REQUESTS,
+            &output_traces,
+            OUTPUT_MESSAGES,
             1,
-            "traces failure produced requests",
+            "traces failure output messages",
         );
-        let consumed_logs = find(
+        let input_logs = find(
             &item_snapshots,
-            MetricLabel::ProcConsumedItems,
+            MetricLabel::ProcInputItems,
             "logs",
             "success",
         );
-        assert_u64(&consumed_logs, ITEMS, 5, "logs success consumed items");
-        let consumed_traces = find(
+        assert_u64(&input_logs, ITEMS, 5, "logs success input items");
+        let input_traces = find(
             &item_snapshots,
-            MetricLabel::ProcConsumedItems,
+            MetricLabel::ProcInputItems,
             "traces",
             "failure",
         );
-        assert_u64(&consumed_traces, ITEMS, 7, "traces failure consumed items");
-        let produced_logs = find(
+        assert_u64(&input_traces, ITEMS, 7, "traces failure input items");
+        let output_logs = find(
             &item_snapshots,
-            MetricLabel::ProcProducedItems,
+            MetricLabel::ProcOutputItems,
             "logs",
             "success",
         );
-        assert_u64(&produced_logs, ITEMS, 4, "logs success produced items");
-        let produced_traces = find(
+        assert_u64(&output_logs, ITEMS, 4, "logs success output items");
+        let output_traces = find(
             &item_snapshots,
-            MetricLabel::ProcProducedItems,
+            MetricLabel::ProcOutputItems,
             "traces",
             "failure",
         );
-        assert_u64(&produced_traces, ITEMS, 6, "traces failure produced items");
+        assert_u64(&output_traces, ITEMS, 6, "traces failure output items");
     }
 
-    /// Scenario: A producer-only frame has no entry timestamp.
-    /// Guarantees: No produced duration observation is recorded.
+    /// Scenario: an output-only frame has no entry timestamp.
+    /// Guarantees: no completion duration observation is recorded.
     #[tokio::test]
-    async fn test_produced_duration_not_recorded_without_timestamp() {
+    async fn test_completion_duration_not_recorded_without_timestamp() {
         let harness = setup_test_manager_with_metrics();
         let snapshots = run_and_collect(harness, |nodes| {
             let pdata = build_3node_pdata_no_subscribers(nodes, false);
@@ -4280,21 +4366,12 @@ mod tests {
         })
         .await;
 
-        // Receiver produced duration: 0 observations (no timestamp)
-        let recv_p = &snapshots[&MetricLabel::RecvProduced];
-        let (count, _, _, _) = assert_dist_is_normal_histogram(
-            recv_p,
-            PRODUCER_DURATION,
-            "Receiver produced duration",
-        );
-        assert_eq!(
-            count, 0,
-            "No produced duration should be recorded when entry_time_ns == 0"
-        );
+        // Receiver completion duration: 0 observations (no timestamp)
+        assert!(!snapshots.contains_key(&MetricLabel::RecvCompletion));
     }
 
     /// Scenario: An acknowledgement unwinds frames without entry timestamps.
-    /// Guarantees: No consumed duration observations are recorded.
+    /// Guarantees: no completion duration observations are recorded.
     #[tokio::test]
     async fn test_ack_lifecycle_no_duration_without_timestamp() {
         let harness = setup_test_manager_with_metrics();
@@ -4306,21 +4383,8 @@ mod tests {
         })
         .await;
 
-        let exp = &snapshots[&MetricLabel::ExpConsumed];
-        let (count, _, _, _) =
-            assert_dist_is_normal_histogram(exp, CONSUMER_DURATION, "Exporter duration");
-        assert_eq!(
-            count, 0,
-            "No duration should be recorded when entry_time_ns == 0"
-        );
-
-        let proc_c = &snapshots[&MetricLabel::ProcConsumed];
-        let (count, _, _, _) =
-            assert_dist_is_normal_histogram(proc_c, CONSUMER_DURATION, "Processor duration");
-        assert_eq!(
-            count, 0,
-            "No duration should be recorded when entry_time_ns == 0"
-        );
+        assert!(!snapshots.contains_key(&MetricLabel::ExpCompletion));
+        assert!(!snapshots.contains_key(&MetricLabel::ProcCompletion));
     }
 
     /// Scenario: three successful acknowledgments unwind the same nodes.
@@ -4340,29 +4404,19 @@ mod tests {
         })
         .await;
 
-        let exp = &snapshots[&MetricLabel::ExpConsumed];
+        let exp = &snapshots[&MetricLabel::ExpInput];
         assert_u64(
             exp,
-            CONSUMER_REQUESTS,
+            INPUT_MESSAGES,
             3,
-            "Exporter 3 consumed requests after 3 acks",
+            "Exporter 3 input messages after 3 acks",
         );
 
-        let proc_c = &snapshots[&MetricLabel::ProcConsumed];
-        assert_u64(
-            proc_c,
-            CONSUMER_REQUESTS,
-            3,
-            "Processor 3 consumed requests",
-        );
+        let proc_c = &snapshots[&MetricLabel::ProcInput];
+        assert_u64(proc_c, INPUT_MESSAGES, 3, "Processor 3 input messages");
 
-        let proc_p = &snapshots[&MetricLabel::ProcProduced];
-        assert_u64(
-            proc_p,
-            PRODUCER_REQUESTS,
-            3,
-            "Processor 3 produced requests",
-        );
+        let proc_p = &snapshots[&MetricLabel::ProcOutput];
+        assert_u64(proc_p, OUTPUT_MESSAGES, 3, "Processor 3 output messages");
     }
 
     /// Scenario: successful, retryable, and permanent completions unwind the same nodes.
@@ -4385,17 +4439,17 @@ mod tests {
         })
         .await;
 
-        // Exporter consumed one request for each outcome.
-        let exp = &snapshots[&MetricLabel::ExpConsumed];
-        assert_u64(exp, CONSUMER_REQUESTS, 3, "Exporter consumed requests");
+        // Exporter records one input message for each outcome.
+        let exp = &snapshots[&MetricLabel::ExpInput];
+        assert_u64(exp, INPUT_MESSAGES, 3, "Exporter input messages");
 
-        // Processor consumed one request for each outcome.
-        let proc_c = &snapshots[&MetricLabel::ProcConsumed];
-        assert_u64(proc_c, CONSUMER_REQUESTS, 3, "Processor consumed requests");
+        // Processor records one input message for each outcome.
+        let proc_c = &snapshots[&MetricLabel::ProcInput];
+        assert_u64(proc_c, INPUT_MESSAGES, 3, "Processor input messages");
 
-        // Processor produced one request for each outcome.
-        let proc_p = &snapshots[&MetricLabel::ProcProduced];
-        assert_u64(proc_p, PRODUCER_REQUESTS, 3, "Processor produced requests");
+        // Processor records one output message for each outcome.
+        let proc_p = &snapshots[&MetricLabel::ProcOutput];
+        assert_u64(proc_p, OUTPUT_MESSAGES, 3, "Processor output messages");
     }
 
     /// Scenario: a receiver->processor->exporter acknowledgment requires two unwind passes.
@@ -4404,11 +4458,11 @@ mod tests {
     /// Pass 1: full stack [recv, proc, exp] -- unwinds exp and proc frames,
     ///         delivers ack to processor (first ACKS subscriber).
     /// Pass 2: processor re-notifies with just the receiver frame -- unwinds recv,
-    ///         recording producer duration on the receiver's output.
+    ///         recording completion duration on the receiver's output.
     ///
-    /// This is the scenario where producer.duration must be recorded for the receiver.
+    /// This is the scenario where node completion duration must be recorded for the receiver.
     #[tokio::test]
-    async fn test_two_pass_unwind_receiver_produced_duration() {
+    async fn test_two_pass_unwind_receiver_completion_duration() {
         let harness = setup_test_manager_with_metrics();
         let snapshots = run_and_collect(harness, |nodes| {
             // --- Pass 1: full 3-node stack (processor subscribes to ACKS) ---
@@ -4421,16 +4475,16 @@ mod tests {
             pdata_recv_only.signal = Some(SignalType::Logs);
             pdata_recv_only.push_frame(Frame {
                 node_id: nodes[0].index,
-                interests: Interests::PRODUCER_METRICS | Interests::ENTRY_TIMESTAMP,
+                interests: Interests::NODE_OUTPUT_METRICS | Interests::NODE_COMPLETION_DURATION,
                 route: RouteData {
                     calldata: Default::default(),
                     entry_time_ns: nanos_since_birth(),
                     output_port_index: 0,
                 },
-                produced_items: 0,
-                consumed_items: 0,
-                produced_size: 0,
-                consumed_size: 0,
+                output_items: 0,
+                input_items: 0,
+                output_size: 0,
+                input_size: 0,
             });
             let mut ack2 = AckMsg::new(pdata_recv_only);
             ack2.unwind.return_time_ns = nanos_since_birth();
@@ -4442,40 +4496,46 @@ mod tests {
         })
         .await;
 
-        // From pass 1: exporter and processor consumer metrics are recorded.
-        let exp = &snapshots[&MetricLabel::ExpConsumed];
-        assert_u64(exp, CONSUMER_REQUESTS, 1, "Exporter consumed requests");
-        let (count, _, min, _) =
-            assert_dist_is_normal_histogram(exp, CONSUMER_DURATION, "Exporter consumed duration");
-        assert_eq!(count, 1, "Exporter should have 1 consumed duration");
-        assert!(min > 0.0, "Exporter consumed duration > 0");
-
-        let proc_c = &snapshots[&MetricLabel::ProcConsumed];
-        assert_u64(proc_c, CONSUMER_REQUESTS, 1, "Processor consumed requests");
-        let (count, _, _, _) = assert_dist_is_normal_histogram(
-            proc_c,
-            CONSUMER_DURATION,
-            "Processor consumed duration",
-        );
-        assert_eq!(count, 1, "Processor should have 1 consumed duration");
-
-        // From pass 1: processor produced counter recorded.
-        let proc_p = &snapshots[&MetricLabel::ProcProduced];
-        assert_u64(proc_p, PRODUCER_REQUESTS, 1, "Processor produced requests");
-
-        // From pass 2: receiver produced counter AND duration recorded.
-        let recv_p = &snapshots[&MetricLabel::RecvProduced];
-        assert_u64(recv_p, PRODUCER_REQUESTS, 1, "Receiver produced requests");
+        // From pass 1: exporter and processor input metrics are recorded.
+        let exp = &snapshots[&MetricLabel::ExpInput];
+        assert_u64(exp, INPUT_MESSAGES, 1, "Exporter input messages");
+        let exp_completion = &snapshots[&MetricLabel::ExpCompletion];
         let (count, _, min, _) = assert_dist_is_normal_histogram(
-            recv_p,
-            PRODUCER_DURATION,
-            "Receiver produced duration",
+            exp_completion,
+            COMPLETION_DURATION,
+            "Exporter completion duration",
+        );
+        assert_eq!(count, 1, "Exporter should have 1 completion duration");
+        assert!(min > 0.0, "Exporter completion duration > 0");
+
+        let proc_c = &snapshots[&MetricLabel::ProcInput];
+        assert_u64(proc_c, INPUT_MESSAGES, 1, "Processor input messages");
+        let proc_completion = &snapshots[&MetricLabel::ProcCompletion];
+        let (count, _, _, _) = assert_dist_is_normal_histogram(
+            proc_completion,
+            COMPLETION_DURATION,
+            "Processor completion duration",
+        );
+        assert_eq!(count, 1, "Processor should have 1 completion duration");
+
+        // From pass 1: processor output counter recorded.
+        let proc_p = &snapshots[&MetricLabel::ProcOutput];
+        assert_u64(proc_p, OUTPUT_MESSAGES, 1, "Processor output messages");
+
+        // From pass 2: receiver output counter and completion duration recorded.
+        let recv_p = &snapshots[&MetricLabel::RecvOutput];
+        assert_u64(recv_p, OUTPUT_MESSAGES, 1, "Receiver output messages");
+        let recv_completion = &snapshots[&MetricLabel::RecvCompletion];
+        let (count, _, min, _) = assert_dist_is_normal_histogram(
+            recv_completion,
+            COMPLETION_DURATION,
+            "Receiver completion duration",
         );
         assert_eq!(
             count, 1,
-            "Receiver should have 1 produced duration observation from two-pass unwind"
+            "Receiver should have 1 completion duration observation from two-pass unwind"
         );
-        assert!(min > 0.0, "Receiver produced duration should be > 0");
+        assert!(min > 0.0, "Receiver completion duration should be > 0");
     }
 
     // Shutdown of a receiver+processor pipeline should first stop ingress, then
@@ -6098,10 +6158,10 @@ mod tests {
                     entry_time_ns: 0,
                     output_port_index: 0,
                 },
-                produced_items: 0,
-                consumed_items: 0,
-                produced_size: 0,
-                consumed_size: 0,
+                output_items: 0,
+                input_items: 0,
+                output_size: 0,
+                input_size: 0,
             });
             pdata
         }
@@ -6232,10 +6292,10 @@ mod tests {
                     entry_time_ns: 0,
                     output_port_index: 0,
                 },
-                produced_items: 0,
-                consumed_items: 0,
-                produced_size: 0,
-                consumed_size: 0,
+                output_items: 0,
+                input_items: 0,
+                output_size: 0,
+                input_size: 0,
             });
             pdata
         }
@@ -6371,10 +6431,10 @@ mod tests {
                     entry_time_ns: 0,
                     output_port_index: 0,
                 },
-                produced_items: 0,
-                consumed_items: 0,
-                produced_size: 0,
-                consumed_size: 0,
+                output_items: 0,
+                input_items: 0,
+                output_size: 0,
+                input_size: 0,
             });
             pdata
         }

--- a/rust/otap-dataflow/crates/engine/src/process_duration.rs
+++ b/rust/otap-dataflow/crates/engine/src/process_duration.rs
@@ -6,7 +6,7 @@
 //! Processors that perform meaningful synchronous compute can add a
 //! [`ComputeDuration`] field and call [`ComputeDuration::timed`] to
 //! measure the wall-clock duration of that work.  Timing is gated on
-//! the `COMPONENT_DURATION` interest at the detailed metric level or through
+//! the `NODE_LOCAL_DURATION` interest at the detailed metric level or through
 //! the node's `policies.telemetry.duration` opt-in.
 //!
 //! Duration is grouped by outcome so operators can distinguish compute time
@@ -69,7 +69,7 @@ impl ComputeDuration {
     }
 
     /// Time a synchronous, fallible closure for the process-duration outcome
-    /// split if interests includes `COMPONENT_DURATION`, otherwise just call
+    /// split if interests includes `NODE_LOCAL_DURATION`, otherwise just call
     /// `f` directly.
     ///
     /// The elapsed time is recorded into the `success` or `failed`
@@ -88,7 +88,7 @@ impl ComputeDuration {
         interests: Interests,
         f: impl FnOnce() -> Result<T, E>,
     ) -> Result<T, E> {
-        if interests.contains(Interests::COMPONENT_DURATION) {
+        if interests.contains(Interests::NODE_LOCAL_DURATION) {
             let timer = Timer::start();
             let result = f();
             let elapsed_seconds = timer.elapsed_nanos() / 1e9;
@@ -139,7 +139,7 @@ mod tests {
     fn timed_splits_by_outcome() {
         let (ctx, _) = test_pipeline_ctx();
         let cd = ComputeDuration::new(&ctx);
-        let active = Interests::COMPONENT_DURATION;
+        let active = Interests::NODE_LOCAL_DURATION;
 
         // Two Ok results and one Err.
         let _ = cd.timed(active, || Ok::<_, &str>(std::hint::black_box(42)));
@@ -155,7 +155,7 @@ mod tests {
         assert!(failed_min >= 0.0);
     }
 
-    /// Scenario: processor compute timing runs without the component-duration interest.
+    /// Scenario: processor compute timing runs without the node-duration interest.
     /// Guarantees: the closure executes without recording any duration observations.
     #[test]
     fn timed_noop_when_disabled() {
@@ -175,7 +175,7 @@ mod tests {
     fn report_emits_expected_metric_names() {
         let (ctx, _) = test_pipeline_ctx();
         let mut cd = ComputeDuration::new(&ctx);
-        let active = Interests::COMPONENT_DURATION;
+        let active = Interests::NODE_LOCAL_DURATION;
 
         let _ = cd.timed(active, || Ok::<_, &str>(1));
         let _ = cd.timed(active, || Err::<i32, _>("fail"));

--- a/rust/otap-dataflow/crates/engine/src/processor.rs
+++ b/rust/otap-dataflow/crates/engine/src/processor.rs
@@ -1522,7 +1522,7 @@ mod tests {
                             runtime_ctrl_tx,
                             completion_tx,
                             metrics_reporter,
-                            crate::Interests::COMPONENT_DURATION,
+                            crate::Interests::NODE_LOCAL_DURATION,
                             None,
                             true,
                             true,
@@ -1563,10 +1563,10 @@ mod tests {
                 processor_task.abort();
                 let _ = processor_task.await;
 
-                let [MetricValue::U64(consumed_items)] = snapshot.get_metrics() else {
+                let [MetricValue::U64(input_items)] = snapshot.get_metrics() else {
                     panic!("expected one flow input-item metric");
                 };
-                assert_eq!(*consumed_items, 1);
+                assert_eq!(*input_items, 1);
 
                 let snapshot =
                     tokio::time::timeout(Duration::from_secs(1), metrics_rx.recv_async())
@@ -1590,10 +1590,10 @@ mod tests {
                         .await
                         .expect("flow output-item metric should be reported")
                         .expect("metrics channel should remain open");
-                let [MetricValue::U64(produced_items)] = snapshot.get_metrics() else {
+                let [MetricValue::U64(output_items)] = snapshot.get_metrics() else {
                     panic!("expected flow output-item metric");
                 };
-                assert_eq!(*produced_items, 1);
+                assert_eq!(*output_items, 1);
             })
             .await;
     }

--- a/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
+++ b/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
@@ -7,8 +7,8 @@ use crate::Interests;
 use crate::ReceivedAtNode;
 use crate::Unwindable;
 use crate::channel_metrics::{
-    ChannelMetricsHandle, NodeInputItemMetrics, NodeInputMetrics, NodeInputSizeMetrics,
-    NodeOutputItemMetrics, NodeOutputMetrics, NodeOutputSizeMetrics,
+    ChannelMetricsHandle, NodeCompletionMetrics, NodeInputItemMetrics, NodeInputMetrics,
+    NodeInputSizeMetrics, NodeOutputItemMetrics, NodeOutputMetrics, NodeOutputSizeMetrics,
 };
 use crate::completion_emission_metrics::{
     CompletionEmissionMetricsHandle, make_completion_emission_metrics,
@@ -59,9 +59,9 @@ const EXTENSION_MONITOR_TICK_INTERVAL: Duration = Duration::from_secs(1);
 /// to active extensions so they can refresh their own metric sets.
 const EXTENSION_MONITOR_COLLECT_TELEMETRY_INTERVAL: Duration = Duration::from_secs(10);
 
-/// Build produced-request metric sets indexed by sorted output port name,
+/// Build output-message metric sets indexed by sorted output port name,
 /// matching the `output_port_index` layout used in `RouteData`.
-fn make_produced_metrics(
+fn make_output_metrics(
     telemetry_handle: &Option<NodeTelemetryHandle>,
     pipeline_context: &PipelineContext,
 ) -> Vec<MeasurementMetricSet<NodeOutputMetrics>> {
@@ -81,8 +81,29 @@ fn make_produced_metrics(
         .unwrap_or_default()
 }
 
-/// Build optional produced-item metric sets indexed by sorted output port name.
-fn make_produced_item_metrics(
+/// Build completion-duration metric sets indexed by sorted output port name.
+fn make_output_completion_metrics(
+    telemetry_handle: &Option<NodeTelemetryHandle>,
+    pipeline_context: &PipelineContext,
+) -> Vec<MeasurementMetricSet<NodeCompletionMetrics>> {
+    telemetry_handle
+        .as_ref()
+        .map(|h| {
+            let mut keys = h.output_channel_keys();
+            keys.sort_by(|a, b| a.0.cmp(&b.0));
+            keys.iter()
+                .map(|(_, key)| {
+                    NodeCompletionMetrics::register(
+                        &pipeline_context.metric_set_registrar_for_entity(*key),
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Build optional output-item metric sets indexed by sorted output port name.
+fn make_output_item_metrics(
     telemetry_handle: &Option<NodeTelemetryHandle>,
     pipeline_context: &PipelineContext,
 ) -> Vec<MeasurementMetricSet<NodeOutputItemMetrics>> {
@@ -102,7 +123,7 @@ fn make_produced_item_metrics(
         .unwrap_or_default()
 }
 
-/// Build optional produced-size metric sets indexed by sorted output port name.
+/// Build optional output-size metric sets indexed by sorted output port name.
 fn make_output_size_metrics(
     telemetry_handle: &Option<NodeTelemetryHandle>,
     pipeline_context: &PipelineContext,
@@ -125,8 +146,8 @@ fn make_output_size_metrics(
 
 /// Build per-node metric handles for the runtime control manager.
 ///
-/// - `has_input`: whether to register consumed-request metrics (false for receivers).
-/// - `has_outputs`: whether to register produced-request metrics (false for exporters).
+/// - `has_input`: whether to register input metrics (false for receivers).
+/// - `has_outputs`: whether to register output metrics (false for exporters).
 /// - `node_interests`: the effective metric interests for this node.
 fn make_node_metric_handles(
     telemetry_handle: &Option<NodeTelemetryHandle>,
@@ -136,14 +157,14 @@ fn make_node_metric_handles(
     node_interests: Interests,
     completion_emission: Option<CompletionEmissionMetricsHandle>,
 ) -> NodeMetricHandles {
-    let consumer_metrics_enabled =
-        has_input && node_interests.contains(Interests::CONSUMER_METRICS);
-    let producer_metrics_enabled =
-        has_outputs && node_interests.contains(Interests::PRODUCER_METRICS);
-    let item_counts_enabled = node_interests.contains(Interests::PRODUCED_CONSUMED_ITEM_COUNTS);
-    let size_enabled = node_interests.contains(Interests::PRODUCED_CONSUMED_SIZE);
+    let input_metrics_enabled = has_input && node_interests.contains(Interests::NODE_INPUT_METRICS);
+    let output_metrics_enabled =
+        has_outputs && node_interests.contains(Interests::NODE_OUTPUT_METRICS);
+    let completion_duration_enabled = node_interests.contains(Interests::NODE_COMPLETION_DURATION);
+    let item_counts_enabled = node_interests.contains(Interests::NODE_ITEM_COUNTS);
+    let size_enabled = node_interests.contains(Interests::NODE_SIZE);
 
-    let consumed = if consumer_metrics_enabled {
+    let input = if input_metrics_enabled {
         telemetry_handle
             .as_ref()
             .and_then(|h| h.input_channel_key())
@@ -153,7 +174,19 @@ fn make_node_metric_handles(
     } else {
         None
     };
-    let input_size = if size_enabled && consumer_metrics_enabled {
+    let input_completion = if completion_duration_enabled && has_input {
+        telemetry_handle
+            .as_ref()
+            .and_then(|h| h.input_channel_key())
+            .map(|key| {
+                NodeCompletionMetrics::register(
+                    &pipeline_context.metric_set_registrar_for_entity(key),
+                )
+            })
+    } else {
+        None
+    };
+    let input_size = if size_enabled && has_input {
         telemetry_handle
             .as_ref()
             .and_then(|h| h.input_channel_key())
@@ -165,7 +198,7 @@ fn make_node_metric_handles(
     } else {
         None
     };
-    let input_items = if item_counts_enabled && consumer_metrics_enabled {
+    let input_items = if item_counts_enabled && has_input {
         telemetry_handle
             .as_ref()
             .and_then(|h| h.input_channel_key())
@@ -177,27 +210,34 @@ fn make_node_metric_handles(
     } else {
         None
     };
-    let produced = if producer_metrics_enabled {
-        make_produced_metrics(telemetry_handle, pipeline_context)
+    let outputs = if output_metrics_enabled {
+        make_output_metrics(telemetry_handle, pipeline_context)
     } else {
         Vec::new()
     };
-    let output_items = if item_counts_enabled && producer_metrics_enabled {
-        make_produced_item_metrics(telemetry_handle, pipeline_context)
+    let output_completion = if completion_duration_enabled && has_outputs && !has_input {
+        make_output_completion_metrics(telemetry_handle, pipeline_context)
     } else {
         Vec::new()
     };
-    let output_size = if size_enabled && producer_metrics_enabled {
+    let output_items = if item_counts_enabled && has_outputs {
+        make_output_item_metrics(telemetry_handle, pipeline_context)
+    } else {
+        Vec::new()
+    };
+    let output_size = if size_enabled && has_outputs {
         make_output_size_metrics(telemetry_handle, pipeline_context)
     } else {
         Vec::new()
     };
     NodeMetricHandles {
         registry: pipeline_context.metrics_registry(),
-        input: consumed,
+        input,
+        input_completion,
         input_items,
         input_size,
-        outputs: produced,
+        outputs,
+        output_completion,
         output_items,
         output_size,
         completion_emission,
@@ -1150,10 +1190,10 @@ mod tests {
     use otel_arrow_dfe_telemetry::registry::TelemetryRegistryHandle;
     use otel_arrow_dfe_telemetry::{InternalTelemetrySystem, LogContext};
 
-    /// Scenario: optional node measurement interests are present without the normal-level message interests.
-    /// Guarantees: no consumed or produced message, item, or size metric sets are registered below normal.
+    /// Scenario: completion duration, item counts, and size are enabled without message interests.
+    /// Guarantees: optional node measurements register independently without input/output message sets.
     #[test]
-    fn node_metrics_require_direction_interests() {
+    fn optional_node_metrics_do_not_require_direction_interests() {
         let (pipeline_context, registry) = crate::testing::test_pipeline_ctx();
         let node_entity_key = pipeline_context.register_node_entity();
         let telemetry_handle = NodeTelemetryHandle::new(registry.clone(), node_entity_key);
@@ -1182,17 +1222,21 @@ mod tests {
             &pipeline_context,
             true,
             true,
-            Interests::PRODUCED_CONSUMED_ITEM_COUNTS | Interests::PRODUCED_CONSUMED_SIZE,
+            Interests::NODE_COMPLETION_DURATION
+                | Interests::NODE_ITEM_COUNTS
+                | Interests::NODE_SIZE,
             None,
         );
 
         assert!(handles.input.is_none());
-        assert!(handles.input_items.is_none());
-        assert!(handles.input_size.is_none());
+        assert!(handles.input_completion.is_some());
+        assert!(handles.input_items.is_some());
+        assert!(handles.input_size.is_some());
         assert!(handles.outputs.is_empty());
-        assert!(handles.output_items.is_empty());
-        assert!(handles.output_size.is_empty());
-        assert_eq!(registry.metric_set_count(), 0);
+        assert!(handles.output_completion.is_empty());
+        assert_eq!(handles.output_items.len(), 1);
+        assert_eq!(handles.output_size.len(), 1);
+        assert_eq!(registry.metric_set_count(), 5);
     }
 
     /// Scenario: a pipeline has pending terminal metrics when telemetry cleanup starts.

--- a/rust/otap-dataflow/crates/engine/src/testing/dst/common.rs
+++ b/rust/otap-dataflow/crates/engine/src/testing/dst/common.rs
@@ -86,10 +86,10 @@ pub(super) fn frame(node_id: usize, interests: Interests, tag: u64) -> Frame {
             entry_time_ns: clock::nanos_since_birth(),
             output_port_index: 0,
         },
-        produced_items: 0,
-        consumed_items: 0,
-        produced_size: 0,
-        consumed_size: 0,
+        output_items: 0,
+        input_items: 0,
+        output_size: 0,
+        input_size: 0,
     }
 }
 

--- a/rust/otap-dataflow/crates/engine/src/testing/dst/control_plane.rs
+++ b/rust/otap-dataflow/crates/engine/src/testing/dst/control_plane.rs
@@ -92,7 +92,7 @@ async fn run_control_plane_seed(seed: u64) {
         let ack = AckMsg::new(DstPData::with_frames(
             100,
             vec![
-                frame(receiver_id.index, Interests::PRODUCER_METRICS, 1),
+                frame(receiver_id.index, Interests::NODE_OUTPUT_METRICS, 1),
                 frame(
                     processor_id.index,
                     Interests::ACKS
@@ -104,7 +104,7 @@ async fn run_control_plane_seed(seed: u64) {
                         },
                     2,
                 ),
-                frame(exporter_id.index, Interests::CONSUMER_METRICS, 3),
+                frame(exporter_id.index, Interests::NODE_INPUT_METRICS, 3),
             ],
         ));
         completion_tx
@@ -119,9 +119,9 @@ async fn run_control_plane_seed(seed: u64) {
                 DstPData::with_frames(
                     101,
                     vec![
-                        frame(receiver_id.index, Interests::PRODUCER_METRICS, 4),
+                        frame(receiver_id.index, Interests::NODE_OUTPUT_METRICS, 4),
                         frame(processor_id.index, Interests::NACKS, 5),
-                        frame(exporter_id.index, Interests::CONSUMER_METRICS, 6),
+                        frame(exporter_id.index, Interests::NODE_INPUT_METRICS, 6),
                     ],
                 ),
             )
@@ -131,9 +131,9 @@ async fn run_control_plane_seed(seed: u64) {
                 DstPData::with_frames(
                     101,
                     vec![
-                        frame(receiver_id.index, Interests::PRODUCER_METRICS, 4),
+                        frame(receiver_id.index, Interests::NODE_OUTPUT_METRICS, 4),
                         frame(processor_id.index, Interests::NACKS, 5),
-                        frame(exporter_id.index, Interests::CONSUMER_METRICS, 6),
+                        frame(exporter_id.index, Interests::NODE_INPUT_METRICS, 6),
                     ],
                 ),
             )

--- a/rust/otap-dataflow/crates/engine/src/testing/dst/heavy_ingress.rs
+++ b/rust/otap-dataflow/crates/engine/src/testing/dst/heavy_ingress.rs
@@ -138,7 +138,7 @@ async fn run_backpressure_interblock_seed(seed: u64) {
                         vec![
                             frame(
                                 receiver_id.index,
-                                Interests::PRODUCER_METRICS,
+                                Interests::NODE_OUTPUT_METRICS,
                                 msg_id * 10 + 1,
                             ),
                             frame(
@@ -154,7 +154,7 @@ async fn run_backpressure_interblock_seed(seed: u64) {
                             ),
                             frame(
                                 exporter_id.index,
-                                Interests::CONSUMER_METRICS,
+                                Interests::NODE_INPUT_METRICS,
                                 msg_id * 10 + 3,
                             ),
                         ],

--- a/rust/otap-dataflow/crates/engine/telemetry.md
+++ b/rust/otap-dataflow/crates/engine/telemetry.md
@@ -33,18 +33,21 @@ control-plane metrics. Its default value is `basic`.
 | --- | --- |
 | `none` | No channel or node input/output metrics. |
 | `basic` | `channel.*` metrics. |
-| `normal` | `basic`, plus `node.input.messages` and `node.output.messages`. A node can also opt into item and size metrics. |
-| `detailed` | `normal`, plus node duration, component duration, item, and size metrics for every node. |
+| `normal` | `basic`, plus `node.input.messages` and `node.output.messages`. |
+| `detailed` | `normal`, plus completion duration, local duration, item, and size metrics for every node. |
 
-At any level, enable component-owned optional measurements on an individual
+At any level, enable optional measurements on an individual
 node with
+`policies.telemetry.messages: true`,
+`policies.telemetry.completion_duration: true`,
 `policies.telemetry.duration: true`,
 `policies.telemetry.item_counts: true`, and/or
-`policies.telemetry.size: true`. These flags always affect component-owned
-metrics. Item counts and size additionally affect engine-owned node input/output
-metrics only when `runtime_metrics` is `normal` or higher. The duration option
-controls component-owned metrics such as `receiver.processing.duration` and
-`exporter.attempted.duration`, as well as `processor.compute.duration`.
+`policies.telemetry.size: true`. Completion duration enables only
+`node.completion.duration`. Messages, item counts, and size independently
+enable the corresponding engine-managed node input/output metrics. The
+duration option controls node-implemented metrics such as
+`receiver.processing.duration`, `exporter.attempted.duration`, and
+`processor.compute.duration`.
 
 Node kind determines which side exists:
 
@@ -78,19 +81,18 @@ counts, see [Node and Flow Metrics](../../docs/node-and-flow-metrics.md#flow-met
 | `channel.receiver.messages` | Number of messages successfully dequeued, grouped by `signal` for PData channels. | `runtime_metrics` is `basic` or higher and a data or control message is dequeued. Empty polls and channel closure are not counted. |
 | `channel.receiver.queue.depth` | Current number of messages buffered in the channel. | `runtime_metrics` is `basic` or higher and the channel exists; sampled on the reporting interval. |
 | `channel.receiver.capacity` | Configured channel buffer capacity. | `runtime_metrics` is `basic` or higher and the channel exists; sampled on the reporting interval. |
-| `node.input.duration` | Duration from entry until the corresponding ack or nack is routed, in seconds (histogram). | `runtime_metrics` is `detailed`, a processor or exporter consumes PData, and its terminal ack or nack unwinds. |
+| `node.completion.duration` | Duration from the tracked node boundary until the corresponding ack or nack is routed, in seconds (histogram). | `runtime_metrics` is `detailed` or that node sets `policies.telemetry.completion_duration: true`, and the terminal ack or nack unwinds. The boundary is receiver output or processor/exporter input. |
 | `node.input.messages` | Messages received by the node, grouped by the `signal` and `outcome` datapoint attributes. | `runtime_metrics` is `normal` or `detailed`, a processor or exporter consumes PData, and its terminal ack or nack unwinds. |
-| `node.input.items` | Signal items received by an item-count-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | Input message conditions are met and either the level is `detailed` or that processor/exporter sets `policies.telemetry.item_counts: true`. |
-| `node.input.size` | Logical payload bytes received by a size-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | Input message conditions are met and either the level is `detailed` or that processor/exporter sets `policies.telemetry.size: true`. |
-| `node.output.duration` | Duration from output until the corresponding ack or nack is routed, in seconds (histogram). | `runtime_metrics` is `detailed`, a receiver emits PData, and its terminal ack or nack unwinds. Processor latency is recorded in `node.input.duration`. |
+| `node.input.items` | Signal items received by an item-count-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | The level is `detailed` or that processor/exporter sets `policies.telemetry.item_counts: true`, and the terminal ack or nack unwinds. |
+| `node.input.size` | Logical payload bytes received by a size-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | The level is `detailed` or that processor/exporter sets `policies.telemetry.size: true`, and the terminal ack or nack unwinds. |
 | `node.output.messages` | Messages emitted by the node, grouped by the `signal` and `outcome` datapoint attributes. | `runtime_metrics` is `normal` or `detailed`, a receiver or processor sends PData, and its terminal ack or nack unwinds. A processor that drops a whole message produces no output datapoint for it. |
-| `node.output.items` | Signal items emitted by an item-count-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | Output message conditions are met and either the level is `detailed` or that receiver/processor sets `policies.telemetry.item_counts: true`. |
-| `node.output.size` | Logical payload bytes emitted by a size-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | Output message conditions are met and either the level is `detailed` or that receiver/processor sets `policies.telemetry.size: true`. |
-| `receiver.received.messages` | Classified external messages whose receiver-local handling reached a terminal local outcome, grouped by `signal` and `outcome`. | A receiver implements the shared receiver contract and finishes handling a message. |
+| `node.output.items` | Signal items emitted by an item-count-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | The level is `detailed` or that receiver/processor sets `policies.telemetry.item_counts: true`, and the terminal ack or nack unwinds. |
+| `node.output.size` | Logical payload bytes emitted by a size-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | The level is `detailed` or that receiver/processor sets `policies.telemetry.size: true`, and the terminal ack or nack unwinds. |
+| `receiver.received.messages` | Classified external messages whose receiver-local handling reached a terminal local outcome, grouped by `signal` and `outcome`. | The receiver implements the shared receiver contract, message metrics are enabled, and local handling finishes. |
 | `receiver.received.payload.size` | Encoded application payload bytes observed at the receiver boundary, grouped by `signal` and `outcome`. | A receiver implements the shared receiver contract and finishes handling a message. |
-| `receiver.processing.duration` | Receiver-local processing duration in seconds, grouped by `signal`. | The receiver implements the shared contract and component duration is enabled. The documented boundary ends before downstream handoff or wait. |
-| `exporter.attempted.messages` | Component-local delivery attempts, including preparation failures and each backend retry, grouped by `signal` and `outcome`. This is distinct from PData messages counted by `node.input.messages`. | An exporter implements the shared exporter contract and an attempt reaches a terminal local or backend result. |
-| `exporter.attempted.duration` | Export attempt duration in seconds, grouped by `signal` and `outcome`. | The exporter implements the shared contract and component duration is enabled. Encoding and backend latency are included; Ack/Nack notification delivery is excluded. |
+| `receiver.processing.duration` | Receiver-local processing duration in seconds, grouped by `signal`. | The receiver implements the shared contract and local duration is enabled. The documented boundary ends before downstream handoff or wait. |
+| `exporter.attempted.messages` | Node-local delivery attempts, including preparation failures and each backend retry, grouped by `signal` and `outcome`. This is distinct from PData messages counted by `node.input.messages`. | The exporter implements the shared exporter contract, message metrics are enabled, and an attempt reaches a terminal local or backend result. |
+| `exporter.attempted.duration` | Export attempt duration in seconds, grouped by `signal` and `outcome`. | The exporter implements the shared contract and local duration is enabled. Encoding and backend latency are included; Ack/Nack notification delivery is excluded. |
 | `exporter.attempted.payload.size` | Encoded application payload bytes produced or submitted by exporter attempts, grouped by `signal` and `outcome`. | The exporter implements the shared contract, size measurement is enabled, and encoded size is available. |
 | `exporter.attempted.items` | Signal items handled by exporter attempts, grouped by `signal` and `outcome`. | The exporter implements the shared contract and item counting is enabled. |
 | `flow.input.messages` | PData messages entering an opted-in processor flow, grouped by the `signal` datapoint attribute. | A configured flow enables `input_messages` and a message enters its start processor. |

--- a/rust/otap-dataflow/crates/engine/telemetry.md
+++ b/rust/otap-dataflow/crates/engine/telemetry.md
@@ -36,8 +36,8 @@ control-plane metrics. Its default value is `basic`.
 | `normal` | `basic`, plus `node.input.messages` and `node.output.messages`. |
 | `detailed` | `normal`, plus completion duration, local duration, item, and size metrics for every node. |
 
-At any level, enable optional measurements on an individual
-node with
+Runtime levels provide defaults. At any level, override those defaults for an
+individual node with
 `policies.telemetry.messages: true`,
 `policies.telemetry.completion_duration: true`,
 `policies.telemetry.duration: true`,
@@ -82,14 +82,14 @@ counts, see [Node and Flow Metrics](../../docs/node-and-flow-metrics.md#flow-met
 | `channel.receiver.queue.depth` | Current number of messages buffered in the channel. | `runtime_metrics` is `basic` or higher and the channel exists; sampled on the reporting interval. |
 | `channel.receiver.capacity` | Configured channel buffer capacity. | `runtime_metrics` is `basic` or higher and the channel exists; sampled on the reporting interval. |
 | `node.completion.duration` | Duration from the tracked node boundary until the corresponding ack or nack is routed, in seconds (histogram). | `runtime_metrics` is `detailed` or that node sets `policies.telemetry.completion_duration: true`, and the terminal ack or nack unwinds. The boundary is receiver output or processor/exporter input. |
-| `node.input.messages` | Messages received by the node, grouped by the `signal` and `outcome` datapoint attributes. | `runtime_metrics` is `normal` or `detailed`, a processor or exporter consumes PData, and its terminal ack or nack unwinds. |
+| `node.input.messages` | Messages received by the node, grouped by the `signal` and `outcome` datapoint attributes. | `runtime_metrics` is `normal` or `detailed`, or that processor/exporter sets `policies.telemetry.messages: true`; the node consumes PData and its terminal ack or nack unwinds. |
 | `node.input.items` | Signal items received by an item-count-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | The level is `detailed` or that processor/exporter sets `policies.telemetry.item_counts: true`, and the terminal ack or nack unwinds. |
 | `node.input.size` | Logical payload bytes received by a size-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | The level is `detailed` or that processor/exporter sets `policies.telemetry.size: true`, and the terminal ack or nack unwinds. |
-| `node.output.messages` | Messages emitted by the node, grouped by the `signal` and `outcome` datapoint attributes. | `runtime_metrics` is `normal` or `detailed`, a receiver or processor sends PData, and its terminal ack or nack unwinds. A processor that drops a whole message produces no output datapoint for it. |
+| `node.output.messages` | Messages emitted by the node, grouped by the `signal` and `outcome` datapoint attributes. | `runtime_metrics` is `normal` or `detailed`, or that receiver/processor sets `policies.telemetry.messages: true`; the node sends PData and its terminal ack or nack unwinds. A processor that drops a whole message produces no output datapoint for it. |
 | `node.output.items` | Signal items emitted by an item-count-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | The level is `detailed` or that receiver/processor sets `policies.telemetry.item_counts: true`, and the terminal ack or nack unwinds. |
 | `node.output.size` | Logical payload bytes emitted by a size-enabled node, grouped by the `signal` and `outcome` datapoint attributes. | The level is `detailed` or that receiver/processor sets `policies.telemetry.size: true`, and the terminal ack or nack unwinds. |
 | `receiver.received.messages` | Classified external messages whose receiver-local handling reached a terminal local outcome, grouped by `signal` and `outcome`. | The receiver implements the shared receiver contract, message metrics are enabled, and local handling finishes. |
-| `receiver.received.payload.size` | Encoded application payload bytes observed at the receiver boundary, grouped by `signal` and `outcome`. | A receiver implements the shared receiver contract and finishes handling a message. |
+| `receiver.received.payload.size` | Encoded application payload bytes observed at the receiver boundary, grouped by `signal` and `outcome`. | The receiver implements the shared receiver contract, size measurement is enabled, encoded size is available, and local handling finishes. |
 | `receiver.processing.duration` | Receiver-local processing duration in seconds, grouped by `signal`. | The receiver implements the shared contract and local duration is enabled. The documented boundary ends before downstream handoff or wait. |
 | `exporter.attempted.messages` | Node-local delivery attempts, including preparation failures and each backend retry, grouped by `signal` and `outcome`. This is distinct from PData messages counted by `node.input.messages`. | The exporter implements the shared exporter contract, message metrics are enabled, and an attempt reaches a terminal local or backend result. |
 | `exporter.attempted.duration` | Export attempt duration in seconds, grouped by `signal` and `outcome`. | The exporter implements the shared contract and local duration is enabled. Encoding and backend latency are included; Ack/Nack notification delivery is excluded. |

--- a/rust/otap-dataflow/crates/engine/telemetry.md
+++ b/rust/otap-dataflow/crates/engine/telemetry.md
@@ -29,7 +29,9 @@ but has not yet recorded a value.
 `policies.telemetry.runtime_metrics` controls channel, node, and shared
 control-plane metrics. Its default value is `basic`.
 
-| Level | Data-path metrics enabled |
+The runtime metric level provides these data-path defaults:
+
+| Level | Data-path metrics enabled by default |
 | --- | --- |
 | `none` | No channel or node input/output metrics. |
 | `basic` | `channel.*` metrics. |

--- a/rust/otap-dataflow/crates/otap/src/accessory/context/split_contexts.rs
+++ b/rust/otap-dataflow/crates/otap/src/accessory/context/split_contexts.rs
@@ -435,7 +435,7 @@ mod test {
     fn test_with_metrics_only_context() {
         let mut contexts = new_contexts();
         let pdata = create_test_pdata().test_subscribe_to(
-            otel_arrow_dfe_engine::Interests::PRODUCER_METRICS,
+            otel_arrow_dfe_engine::Interests::NODE_OUTPUT_METRICS,
             smallvec::smallvec![],
             1,
         );

--- a/rust/otap-dataflow/crates/otap/src/metrics.rs
+++ b/rust/otap-dataflow/crates/otap/src/metrics.rs
@@ -146,9 +146,9 @@ impl ReceiverMetrics {
     #[must_use]
     pub fn processing(&self) -> ReceiverProcessing {
         ReceiverProcessing {
-            measure_duration: self.interests.contains(Interests::COMPONENT_DURATION),
+            measure_duration: self.interests.contains(Interests::NODE_LOCAL_DURATION),
             payload_size: None,
-            accepts_payload_size: self.interests.contains(Interests::PRODUCED_CONSUMED_SIZE),
+            accepts_payload_size: self.interests.contains(Interests::NODE_SIZE),
         }
     }
 
@@ -166,7 +166,9 @@ impl ReceiverMetrics {
             signal,
             outcome: completed.outcome,
         };
-        self.received.with(attributes).record();
+        if self.interests.contains(Interests::NODE_OUTPUT_METRICS) {
+            self.received.with(attributes).record();
+        }
         if let Some(payload_size) = completed.payload_size {
             self.payload.with(attributes).record(payload_size);
         }
@@ -248,14 +250,14 @@ impl ReceiverProcessing {
     }
 }
 
-/// Individual component-local delivery attempts from an exporter.
+/// Individual node-local delivery attempts from an exporter.
 #[metric_set(
     name = "exporter.attempted",
     measurement_attributes = SignalOutcomeAttributes
 )]
 #[derive(Debug, Default, Clone)]
 struct ExporterAttemptedMetrics {
-    /// Number of component-local delivery attempts.
+    /// Number of node-local delivery attempts.
     ///
     /// Retries count again. This differs from `node.input.messages`, which
     /// counts PData messages entering the exporter.
@@ -331,7 +333,7 @@ impl ExporterAttemptedItemsMetrics {
     }
 }
 
-/// Prepared instrumentation for one component-local exporter attempt.
+/// Prepared instrumentation for one node-local exporter attempt.
 #[derive(Debug)]
 pub struct ExporterAttempt {
     signal: SignalType,
@@ -377,21 +379,19 @@ impl ExporterMetrics {
         }
     }
 
-    /// Starts instrumentation for one component-local exporter attempt.
+    /// Starts instrumentation for one node-local exporter attempt.
     #[must_use]
     pub fn attempt(&self, signal: SignalType) -> ExporterAttempt {
         ExporterAttempt {
             signal,
             started_at: self
                 .interests
-                .contains(Interests::COMPONENT_DURATION)
+                .contains(Interests::NODE_LOCAL_DURATION)
                 .then(Instant::now),
             items: None,
-            accepts_item_count: self
-                .interests
-                .contains(Interests::PRODUCED_CONSUMED_ITEM_COUNTS),
+            accepts_item_count: self.interests.contains(Interests::NODE_ITEM_COUNTS),
             payload_size: None,
-            accepts_payload_size: self.interests.contains(Interests::PRODUCED_CONSUMED_SIZE),
+            accepts_payload_size: self.interests.contains(Interests::NODE_SIZE),
         }
     }
 
@@ -401,7 +401,9 @@ impl ExporterMetrics {
             signal: completed.signal,
             outcome: completed.outcome,
         };
-        self.attempted.with(attributes).record();
+        if self.interests.contains(Interests::NODE_INPUT_METRICS) {
+            self.attempted.with(attributes).record();
+        }
         if let Some(duration) = completed.duration {
             self.duration.with(attributes).record(duration);
         }
@@ -496,7 +498,7 @@ impl ExporterAttempt {
 /// Completed export operations.
 ///
 /// This set will be deprecated after exporters migrate to
-/// the shared exporter attempt metrics and node-consumer terminal accounting.
+/// the shared exporter attempt metrics and node-input terminal accounting.
 #[metric_set(
     name = "exporter.exports",
     measurement_attributes = SignalOutcomeAttributes
@@ -836,8 +838,8 @@ mod tests {
         );
     }
 
-    /// Scenario: Optional exporter measurements are disabled for one node.
-    /// Guarantees: Item inspection, clock timing, and payload-size snapshots are skipped while the attempt message is recorded.
+    /// Scenario: all exporter measurements are disabled for one node.
+    /// Guarantees: item inspection, message counting, clock timing, and payload-size snapshots are skipped.
     #[tokio::test]
     async fn exporter_helper_skips_disabled_optional_measurements() {
         let (pipeline_ctx, _) = test_pipeline_ctx_with_interests(Interests::empty());
@@ -863,25 +865,17 @@ mod tests {
 
         assert!(!item_count_called.get());
         assert!(!payload_size_called.get());
-        let snapshots = metrics.terminal_snapshots();
-        assert_eq!(snapshots.len(), 1);
-        assert_eq!(snapshots[0].descriptor().name, "exporter.attempted");
-        assert!(
-            snapshots[0]
-                .descriptor()
-                .metrics
-                .iter()
-                .any(|metric| metric.name == "messages")
-        );
+        assert!(metrics.terminal_snapshots().is_empty());
     }
 
     /// Scenario: All optional exporter measurements are enabled for one node.
     /// Guarantees: One attempt records duration, encoded payload size, and lazily counted items under the same signal and outcome.
     #[tokio::test]
     async fn exporter_helper_records_enabled_optional_measurements() {
-        let interests = Interests::COMPONENT_DURATION
-            | Interests::PRODUCED_CONSUMED_ITEM_COUNTS
-            | Interests::PRODUCED_CONSUMED_SIZE;
+        let interests = Interests::NODE_INPUT_METRICS
+            | Interests::NODE_LOCAL_DURATION
+            | Interests::NODE_ITEM_COUNTS
+            | Interests::NODE_SIZE;
         let (pipeline_ctx, _) = test_pipeline_ctx_with_interests(interests);
         let mut metrics = ExporterMetrics::register(&pipeline_ctx);
         let item_count_called = Cell::new(false);
@@ -921,8 +915,8 @@ mod tests {
         }
     }
 
-    /// Scenario: Optional receiver measurements are disabled for one node.
-    /// Guarantees: Terminal message accounting emits without a duration or zero-valued payload-size snapshot.
+    /// Scenario: all receiver measurements are disabled for one node.
+    /// Guarantees: message counting, clock timing, and payload-size snapshots are skipped.
     #[test]
     fn receiver_helper_skips_disabled_optional_measurements() {
         let (pipeline_ctx, _) = test_pipeline_ctx_with_interests(Interests::empty());
@@ -939,23 +933,15 @@ mod tests {
         metrics.record(completed).expect("processing succeeds");
 
         assert!(!payload_size_called.get());
-        let snapshots = metrics.terminal_snapshots();
-        assert_eq!(snapshots.len(), 1);
-        assert_eq!(snapshots[0].descriptor().name, "receiver.received");
-        assert!(
-            snapshots[0]
-                .descriptor()
-                .metrics
-                .iter()
-                .any(|metric| metric.name == "messages")
-        );
+        assert!(metrics.terminal_snapshots().is_empty());
     }
 
     /// Scenario: Receiver duration and payload-size measurements are enabled for one node.
     /// Guarantees: Processing and terminal received metrics remain separate and preserve their intended attributes.
     #[test]
     fn receiver_helper_records_enabled_optional_measurements() {
-        let interests = Interests::COMPONENT_DURATION | Interests::PRODUCED_CONSUMED_SIZE;
+        let interests =
+            Interests::NODE_OUTPUT_METRICS | Interests::NODE_LOCAL_DURATION | Interests::NODE_SIZE;
         let (pipeline_ctx, _) = test_pipeline_ctx_with_interests(interests);
         let mut metrics = ReceiverMetrics::register(&pipeline_ctx);
         let payload_size_called = Cell::new(false);
@@ -995,7 +981,8 @@ mod tests {
     /// Guarantees: The received message and processing duration are recorded without a synthetic zero-byte payload observation.
     #[test]
     fn receiver_helper_omits_unavailable_payload_size() {
-        let interests = Interests::COMPONENT_DURATION | Interests::PRODUCED_CONSUMED_SIZE;
+        let interests =
+            Interests::NODE_OUTPUT_METRICS | Interests::NODE_LOCAL_DURATION | Interests::NODE_SIZE;
         let (pipeline_ctx, _) = test_pipeline_ctx_with_interests(interests);
         let mut metrics = ReceiverMetrics::register(&pipeline_ctx);
 
@@ -1046,7 +1033,8 @@ mod tests {
     /// Guarantees: The error and optional measurements are recorded with the refused outcome.
     #[test]
     fn receiver_helper_records_explicit_refused_outcome() {
-        let interests = Interests::COMPONENT_DURATION | Interests::PRODUCED_CONSUMED_SIZE;
+        let interests =
+            Interests::NODE_OUTPUT_METRICS | Interests::NODE_LOCAL_DURATION | Interests::NODE_SIZE;
         let (pipeline_ctx, _) = test_pipeline_ctx_with_interests(interests);
         let mut metrics = ReceiverMetrics::register(&pipeline_ctx);
 
@@ -1072,7 +1060,7 @@ mod tests {
     /// Guarantees: The original error is returned and the attempt is recorded as refused.
     #[tokio::test]
     async fn exporter_helper_records_explicit_refused_outcome() {
-        let (pipeline_ctx, _) = test_pipeline_ctx_with_interests(Interests::empty());
+        let (pipeline_ctx, _) = test_pipeline_ctx_with_interests(Interests::NODE_INPUT_METRICS);
         let mut metrics = ExporterMetrics::register(&pipeline_ctx);
 
         let completed = metrics
@@ -1105,7 +1093,7 @@ mod tests {
     /// Guarantees: The discarded refusal cannot classify the returned fallback error as refused.
     #[tokio::test]
     async fn exporter_helper_keeps_outcome_attached_to_returned_error() {
-        let (pipeline_ctx, _) = test_pipeline_ctx_with_interests(Interests::empty());
+        let (pipeline_ctx, _) = test_pipeline_ctx_with_interests(Interests::NODE_INPUT_METRICS);
         let mut metrics = ExporterMetrics::register(&pipeline_ctx);
 
         let completed = metrics

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -68,7 +68,7 @@ pub struct Context {
     /// active at a time (non-overlapping ranges).
     flow_compute_ns: Option<NonZeroU64>,
     /// Signal type of the payload, captured on the forward path to attribute
-    /// per-signal produced/consumed metrics during ack/nack unwinding.
+    /// per-signal input/output metrics during ack/nack unwinding.
     ///
     /// A pdata batch is homogeneous, so signal is a pdata-level property stored
     /// once here rather than duplicated on every routing frame. It is captured
@@ -109,7 +109,7 @@ impl Context {
             // Different node -> inherit RETURN_DATA from predecessor.
             interests |= top.interests & Interests::RETURN_DATA;
         }
-        let entry_time_ns = if interests.contains(Interests::ENTRY_TIMESTAMP) {
+        let entry_time_ns = if interests.contains(Interests::NODE_COMPLETION_DURATION) {
             nanos_since_birth()
         } else {
             0
@@ -122,10 +122,10 @@ impl Context {
                 entry_time_ns,
                 ..Default::default()
             },
-            produced_items: 0,
-            consumed_items: 0,
-            produced_size: 0,
-            consumed_size: 0,
+            output_items: 0,
+            input_items: 0,
+            output_size: 0,
+            input_size: 0,
         });
     }
 
@@ -173,7 +173,7 @@ impl Context {
         self.stack.iter().any(|frame| {
             frame
                 .interests
-                .intersects(Interests::ACKS_OR_NACKS | Interests::PIPELINE_METRICS)
+                .intersects(Interests::ACKS_OR_NACKS | Interests::NODE_METRICS)
         })
     }
 
@@ -200,7 +200,10 @@ impl Context {
     #[must_use]
     fn has_timing(&self, subscriber_interest: Interests) -> bool {
         for frame in self.stack.iter().rev() {
-            if frame.interests.intersects(Interests::ENTRY_TIMESTAMP) {
+            if frame
+                .interests
+                .intersects(Interests::NODE_COMPLETION_DURATION)
+            {
                 return true;
             }
             if frame.interests.intersects(subscriber_interest) {
@@ -233,10 +236,10 @@ impl Context {
             interests,
             node_id,
             route: RouteData::default(),
-            produced_items: 0,
-            consumed_items: 0,
-            produced_size: 0,
-            consumed_size: 0,
+            output_items: 0,
+            input_items: 0,
+            output_size: 0,
+            input_size: 0,
         });
     }
 
@@ -254,30 +257,30 @@ impl Context {
     /// are merged without touching user calldata.  Otherwise a new frame
     /// is pushed, inheriting `RETURN_DATA` from the predecessor.
     ///
-    /// When `ENTRY_TIMESTAMP` is present in `interests`, the frame's
-    /// entry timestamp is captured automatically.
+    /// When `NODE_COMPLETION_DURATION` is present in `interests`, the frame's
+    /// entry timestamp is captured for terminal Ack/Nack duration measurement.
     fn update_send_context(&mut self, node_id: usize, interests: Interests) {
-        if let Some(top) = self.stack.last_mut()
-            && top.node_id == node_id
-        {
-            top.interests |= interests;
-            if interests.contains(Interests::ENTRY_TIMESTAMP | Interests::PRODUCER_METRICS)
-                && top.route.entry_time_ns == 0
-            {
-                // Note: This update is only for receivers which need
-                // to capture timestamp here in case they did not use
-                // subscribe_to. If they called called subscribe_to,
-                // this will be skipped by a non-zero timestamp.
-                top.route.entry_time_ns = nanos_since_birth();
+        if let Some(top) = self.stack.last_mut() {
+            if top.node_id == node_id {
+                top.interests |= interests;
+                if interests.contains(Interests::NODE_COMPLETION_DURATION)
+                    && top.route.entry_time_ns == 0
+                {
+                    // Note: This update is only for receivers which need
+                    // to capture timestamp here in case they did not use
+                    // subscribe_to. If they called called subscribe_to,
+                    // this will be skipped by a non-zero timestamp.
+                    top.route.entry_time_ns = nanos_since_birth();
+                }
+                return;
             }
-            return;
         }
         // Different node (or empty stack) -> push new frame.
         let mut frame_interests = interests;
         if let Some(last) = self.stack.last() {
             frame_interests |= last.interests & Interests::RETURN_DATA;
         }
-        let time_ns = if interests.contains(Interests::ENTRY_TIMESTAMP) {
+        let time_ns = if interests.contains(Interests::NODE_COMPLETION_DURATION) {
             nanos_since_birth()
         } else {
             0
@@ -290,55 +293,55 @@ impl Context {
                 entry_time_ns: time_ns,
                 ..Default::default()
             },
-            produced_items: 0,
-            consumed_items: 0,
-            produced_size: 0,
-            consumed_size: 0,
+            output_items: 0,
+            input_items: 0,
+            output_size: 0,
+            input_size: 0,
         });
     }
 
     /// Stamp the top frame's output port index.
     /// Called at send time so each clone sent through a different port
-    /// carries the correct producer output port index on the return path.
+    /// carries the correct output port index on the return path.
     pub(crate) fn stamp_output_port_index(&mut self, index: u16) {
         if let Some(top) = self.stack.last_mut() {
             top.route.output_port_index = index;
         }
     }
 
-    /// Record the per-signal item count produced by the current node at send
+    /// Record the per-signal item count emitted by the current node at send
     /// time onto the top frame, and remember the pdata's signal on the context.
-    /// Called only when the node has `PRODUCED_CONSUMED_ITEM_COUNTS` interest.
-    pub(crate) fn stamp_produced_items(&mut self, items: u32, signal: SignalType) {
+    /// Called only when the node has `NODE_ITEM_COUNTS` interest.
+    pub(crate) fn stamp_output_items(&mut self, items: u32, signal: SignalType) {
         self.capture_signal(signal);
         if let Some(top) = self.stack.last_mut() {
-            top.produced_items = items;
+            top.output_items = items;
         }
     }
 
-    /// Record the per-signal item count consumed by the current node at receive
+    /// Record the per-signal item count received by the current node
     /// time onto the top frame, and remember the pdata's signal on the context.
-    /// Called only when the node has `PRODUCED_CONSUMED_ITEM_COUNTS` interest.
-    pub(crate) fn stamp_consumed_items(&mut self, items: u32, signal: SignalType) {
+    /// Called only when the node has `NODE_ITEM_COUNTS` interest.
+    pub(crate) fn stamp_input_items(&mut self, items: u32, signal: SignalType) {
         self.capture_signal(signal);
         if let Some(top) = self.stack.last_mut() {
-            top.consumed_items = items;
+            top.input_items = items;
         }
     }
 
-    /// Record the logical payload size produced by the current node at send
+    /// Record the logical payload size emitted by the current node at send
     /// time onto the top frame.
-    pub(crate) fn stamp_produced_size(&mut self, size: u64) {
+    pub(crate) fn stamp_output_size(&mut self, size: u64) {
         if let Some(top) = self.stack.last_mut() {
-            top.produced_size = size;
+            top.output_size = size;
         }
     }
 
-    /// Record the logical payload size consumed by the current node at receive
+    /// Record the logical payload size received by the current node
     /// time onto the top frame.
-    pub(crate) fn stamp_consumed_size(&mut self, size: u64) {
+    pub(crate) fn stamp_input_size(&mut self, size: u64) {
         if let Some(top) = self.stack.last_mut() {
-            top.consumed_size = size;
+            top.input_size = size;
         }
     }
 
@@ -355,21 +358,29 @@ impl Context {
         self.signal
     }
 
-    /// Push an entry frame for a queue-consumer node (processor/exporter).
+    /// Push an entry frame for a node with a queue input (processor/exporter).
     /// The frame inherits RETURN_DATA from the predecessor.
     pub(crate) fn push_entry_frame(&mut self, node_id: usize, node_interests: Interests) {
-        // No frame needed when the engine has no consumer metrics interest.
-        if !node_interests.intersects(Interests::CONSUMER_METRICS | Interests::ENTRY_TIMESTAMP) {
+        // No frame needed when the engine has no input-side telemetry interest.
+        if !node_interests.intersects(
+            Interests::NODE_INPUT_METRICS
+                | Interests::NODE_COMPLETION_DURATION
+                | Interests::NODE_ITEM_COUNTS
+                | Interests::NODE_SIZE,
+        ) {
             return;
         }
         let mut interests = Interests::empty();
         if let Some(last) = self.stack.last() {
             interests = last.interests & Interests::RETURN_DATA;
         }
-        // Propagate consumer-metrics and entry-timestamp bits from the node.
-        interests |= node_interests & (Interests::CONSUMER_METRICS | Interests::ENTRY_TIMESTAMP);
-        // Timestamp: only when ENTRY_TIMESTAMP is requested.
-        let time_ns = if node_interests.contains(Interests::ENTRY_TIMESTAMP) {
+        interests |= node_interests
+            & (Interests::NODE_INPUT_METRICS
+                | Interests::NODE_COMPLETION_DURATION
+                | Interests::NODE_ITEM_COUNTS
+                | Interests::NODE_SIZE);
+        // Capture a timestamp only when completion duration is requested.
+        let time_ns = if node_interests.contains(Interests::NODE_COMPLETION_DURATION) {
             nanos_since_birth()
         } else {
             0
@@ -382,10 +393,10 @@ impl Context {
                 entry_time_ns: time_ns,
                 ..Default::default()
             },
-            produced_items: 0,
-            consumed_items: 0,
-            produced_size: 0,
-            consumed_size: 0,
+            output_items: 0,
+            input_items: 0,
+            output_size: 0,
+            input_size: 0,
         });
     }
 
@@ -442,7 +453,7 @@ impl Context {
     }
 
     /// Returns a reference to the top frame on the context stack.
-    /// Used by consumer metrics to read the current node's entry frame.
+    /// Used by input metrics to read the current node's entry frame.
     #[must_use]
     pub fn peek_top(&self) -> Option<&Frame> {
         self.stack.last()
@@ -777,38 +788,43 @@ impl OtapPdata {
 
     /// Prepare the context for a message-source send.
     ///
-    /// When `node_interests` includes `SOURCE_TAGGING`, `PRODUCER_METRICS`,
-    /// or `ENTRY_TIMESTAMP`, a source frame is ensured for `node_id` and
-    /// the relevant interests are merged into it.
+    /// When `node_interests` includes source tagging or output-side telemetry,
+    /// a source frame is ensured for `node_id` and the relevant interests are
+    /// merged into it.
     fn prepare_source_send(&mut self, node_interests: Interests, node_id: usize) {
         let trigger = node_interests
             & (Interests::SOURCE_TAGGING
-                | Interests::PRODUCER_METRICS
-                | Interests::ENTRY_TIMESTAMP);
+                | Interests::NODE_OUTPUT_METRICS
+                | Interests::NODE_COMPLETION_DURATION
+                | Interests::NODE_ITEM_COUNTS
+                | Interests::NODE_SIZE);
         if !trigger.is_empty() {
             self.context.update_send_context(
                 node_id,
-                node_interests & (Interests::PRODUCER_METRICS | Interests::ENTRY_TIMESTAMP),
+                node_interests
+                    & (Interests::NODE_OUTPUT_METRICS
+                        | Interests::NODE_COMPLETION_DURATION
+                        | Interests::NODE_ITEM_COUNTS
+                        | Interests::NODE_SIZE),
             );
-            if node_interests.contains(Interests::PRODUCER_METRICS) {
+            if node_interests.intersects(
+                Interests::NODE_OUTPUT_METRICS
+                    | Interests::NODE_COMPLETION_DURATION
+                    | Interests::NODE_ITEM_COUNTS
+                    | Interests::NODE_SIZE,
+            ) {
                 self.context.capture_signal(self.signal_type());
             }
-            // Produced counts are only recorded under PRODUCER_METRICS, so only
-            // pay the num_items() parse when that interest is also present
-            // (e.g. avoid it for a source-tagging-only frame).
-            if node_interests.contains(Interests::PRODUCED_CONSUMED_ITEM_COUNTS)
-                && node_interests.contains(Interests::PRODUCER_METRICS)
-            {
+            if node_interests.contains(Interests::NODE_ITEM_COUNTS) {
                 let items = u32::try_from(self.num_items()).unwrap_or(u32::MAX);
                 let signal = self.signal_type();
-                self.context.stamp_produced_items(items, signal);
+                self.context.stamp_output_items(items, signal);
             }
-            if node_interests.contains(Interests::PRODUCED_CONSUMED_SIZE)
-                && node_interests.contains(Interests::PRODUCER_METRICS)
+            if node_interests.contains(Interests::NODE_SIZE)
                 && let Some(size) = self.num_bytes()
             {
                 self.context
-                    .stamp_produced_size(u64::try_from(size).unwrap_or(u64::MAX));
+                    .stamp_output_size(u64::try_from(size).unwrap_or(u64::MAX));
             }
         }
     }
@@ -877,7 +893,10 @@ macro_rules! impl_producer_ext {
         impl ProducerEffectHandlerExtension<OtapPdata> for $handler {
             fn subscribe_to(&self, int: Interests, ctx: CallData, data: &mut OtapPdata) {
                 let engine_int = self.node_interests()
-                    & (Interests::PRODUCER_METRICS | Interests::ENTRY_TIMESTAMP);
+                    & (Interests::NODE_OUTPUT_METRICS
+                        | Interests::NODE_COMPLETION_DURATION
+                        | Interests::NODE_ITEM_COUNTS
+                        | Interests::NODE_SIZE);
                 data.context
                     .subscribe_to(int | engine_int, ctx, self.$id_method().index);
             }
@@ -904,7 +923,7 @@ impl_producer_ext!(
 
 /* -------- Consumer effect handler extensions (shared, local) -------- */
 
-// All metric recording (consumer and producer) is handled by the pipeline
+// All input/output metric recording is handled by the pipeline
 // controller during context unwinding. route_ack/route_nack skip sending
 // when the context stack is empty (nothing to unwind).
 
@@ -1121,25 +1140,24 @@ impl_message_source_ext!(
 impl otel_arrow_dfe_engine::ReceivedAtNode for OtapPdata {
     fn received_at_node(&mut self, node_id: usize, node_interests: Interests) {
         self.context.push_entry_frame(node_id, node_interests);
-        if node_interests.contains(Interests::CONSUMER_METRICS) {
+        if node_interests.intersects(
+            Interests::NODE_INPUT_METRICS
+                | Interests::NODE_COMPLETION_DURATION
+                | Interests::NODE_ITEM_COUNTS
+                | Interests::NODE_SIZE,
+        ) {
             self.context.capture_signal(self.signal_type());
         }
-        // Consumed counts are only recorded under CONSUMER_METRICS, so only pay
-        // the num_items() parse when that interest is also present (e.g. avoid
-        // it for a per-node opt-in below the `normal` metric level).
-        if node_interests.contains(Interests::PRODUCED_CONSUMED_ITEM_COUNTS)
-            && node_interests.contains(Interests::CONSUMER_METRICS)
-        {
+        if node_interests.contains(Interests::NODE_ITEM_COUNTS) {
             let items = u32::try_from(self.num_items()).unwrap_or(u32::MAX);
             let signal = self.signal_type();
-            self.context.stamp_consumed_items(items, signal);
+            self.context.stamp_input_items(items, signal);
         }
-        if node_interests.contains(Interests::PRODUCED_CONSUMED_SIZE)
-            && node_interests.contains(Interests::CONSUMER_METRICS)
+        if node_interests.contains(Interests::NODE_SIZE)
             && let Some(size) = self.num_bytes()
         {
             self.context
-                .stamp_consumed_size(u64::try_from(size).unwrap_or(u64::MAX));
+                .stamp_input_size(u64::try_from(size).unwrap_or(u64::MAX));
         }
     }
 }
@@ -1299,7 +1317,7 @@ mod test {
     }
 
     /// Scenario: PData traverses the start and end boundaries of an active flow.
-    /// Guarantees: the hooks record consumed and produced item totals at their boundaries.
+    /// Guarantees: the hooks record input and output item totals at their boundaries.
     #[test]
     fn flow_hooks_record_start_and_end_signal_counts() {
         let mut pdata = create_test_pdata();
@@ -1329,7 +1347,7 @@ mod test {
     }
 
     /// Scenario: a flow start or end boundary receives a zero-item batch.
-    /// Guarantees: the hooks invoke the consumed and produced item recorders
+    /// Guarantees: the hooks invoke the input and output item recorders
     /// with zero while compute-duration accumulation continues for the
     /// traversal. Zero-delta counters are intentionally omitted from exports.
     #[test]
@@ -1348,7 +1366,7 @@ mod test {
         assert_eq!(start_handler.stop_signals_calls.get(), 0);
 
         // Stop node: before_processor_send must record both
-        // compute.duration and produced = 0.
+        // compute.duration and output = 0.
         let end_handler = FakeFlowMetricHandler::end(7);
         pdata.after_processor_receive(&end_handler);
         pdata.before_processor_send(&end_handler);
@@ -1913,43 +1931,43 @@ mod test {
         assert_eq!(frames[0].interests, Interests::empty());
     }
 
-    /// Scenario: a node records normal-level consumed messages without item-count opt-in.
-    /// Guarantees: the real pdata retains its signal for message metric attribution without parsing item counts.
+    /// Scenario: a node records input messages and independently opts into input item counts.
+    /// Guarantees: input item counts work with or without the input message metric interest.
     #[test]
-    fn test_received_at_node_stamps_consumed_items() {
+    fn test_received_at_node_stamps_input_items() {
         use otel_arrow_dfe_engine::{ReceivedAtNode, Unwindable};
 
-        // CONSUMER_METRICS + item counts: entry frame carries consumed count.
+        // Input metrics plus item counts: the entry frame carries the input count.
         let mut pdata = create_test_pdata();
         let n = pdata.num_items() as u32;
         assert!(n > 0);
         pdata.received_at_node(
             42,
-            Interests::CONSUMER_METRICS | Interests::PRODUCED_CONSUMED_ITEM_COUNTS,
+            Interests::NODE_INPUT_METRICS | Interests::NODE_ITEM_COUNTS,
         );
         let frames = pdata.context.frames();
         assert_eq!(frames.len(), 1);
         assert_eq!(frames[0].node_id, 42);
-        assert_eq!(frames[0].consumed_items, n);
+        assert_eq!(frames[0].input_items, n);
         assert_eq!(pdata.context.signal(), Some(SignalType::Logs));
 
-        // CONSUMER_METRICS without item-count interest: no consumed count stamped,
+        // Input metrics without item-count interest: no input count is stamped,
         // but the signal remains available for normal-level message metrics.
         let mut pdata_cm = create_test_pdata();
-        pdata_cm.received_at_node(43, Interests::CONSUMER_METRICS);
+        pdata_cm.received_at_node(43, Interests::NODE_INPUT_METRICS);
         let f_cm = pdata_cm.context.frames();
         assert_eq!(f_cm.len(), 1);
-        assert_eq!(f_cm[0].consumed_items, 0);
+        assert_eq!(f_cm[0].input_items, 0);
         assert_eq!(pdata_cm.context.signal(), Some(SignalType::Logs));
         assert_eq!(pdata_cm.signal(), Some(SignalType::Logs));
 
-        // ENTRY_TIMESTAMP only (no CONSUMER_METRICS): no consumed count stamped.
+        // Completion duration only: capture the signal without stamping an input count.
         let mut pdata2 = create_test_pdata();
-        pdata2.received_at_node(7, Interests::ENTRY_TIMESTAMP);
+        pdata2.received_at_node(7, Interests::NODE_COMPLETION_DURATION);
         let f2 = pdata2.context.frames();
         assert_eq!(f2.len(), 1);
-        assert_eq!(f2[0].consumed_items, 0);
-        assert_eq!(pdata2.context.signal(), None);
+        assert_eq!(f2[0].input_items, 0);
+        assert_eq!(pdata2.context.signal(), Some(SignalType::Logs));
 
         // Neither interest: no frame pushed at all.
         let mut pdata3 = create_test_pdata();
@@ -1957,128 +1975,156 @@ mod test {
         assert_eq!(pdata3.context.frames().len(), 0);
 
         // Opt-in bit alone (e.g. per-node opt-in below the `normal` level):
-        // no frame, no stamp, and no num_items() parse.
+        // capture the signal and item count without enabling message metrics.
         let mut pdata4 = create_test_pdata();
-        pdata4.received_at_node(11, Interests::PRODUCED_CONSUMED_ITEM_COUNTS);
-        assert_eq!(pdata4.context.frames().len(), 0);
-        assert_eq!(pdata4.context.signal(), None);
+        pdata4.received_at_node(11, Interests::NODE_ITEM_COUNTS);
+        let f4 = pdata4.context.frames();
+        assert_eq!(f4.len(), 1);
+        assert_eq!(f4[0].input_items, n);
+        assert_eq!(pdata4.context.signal(), Some(SignalType::Logs));
     }
 
-    /// Scenario: a node opts into consumed payload size at the normal runtime metric level.
-    /// Guarantees: the receive frame captures size only when both consumer metrics and size measurement are enabled.
+    /// Scenario: a node independently opts into input payload size.
+    /// Guarantees: input size works with or without the input message metric interest.
     #[test]
-    fn test_received_at_node_stamps_consumed_size() {
+    fn test_received_at_node_stamps_input_size() {
         use otel_arrow_dfe_engine::ReceivedAtNode;
 
         let mut pdata = create_test_pdata();
         let size =
             u64::try_from(pdata.num_bytes().expect("test payload size")).expect("size fits u64");
         assert!(size > 0);
-        pdata.received_at_node(
-            42,
-            Interests::CONSUMER_METRICS | Interests::PRODUCED_CONSUMED_SIZE,
-        );
+        pdata.received_at_node(42, Interests::NODE_INPUT_METRICS | Interests::NODE_SIZE);
         let frame = pdata.context.frames().last().expect("consumer frame");
-        assert_eq!(frame.consumed_size, size);
+        assert_eq!(frame.input_size, size);
 
         let mut pdata_no_optin = create_test_pdata();
-        pdata_no_optin.received_at_node(43, Interests::CONSUMER_METRICS);
+        pdata_no_optin.received_at_node(43, Interests::NODE_INPUT_METRICS);
         let frame_no_optin = pdata_no_optin
             .context
             .frames()
             .last()
             .expect("consumer frame");
-        assert_eq!(frame_no_optin.consumed_size, 0);
+        assert_eq!(frame_no_optin.input_size, 0);
 
         let mut pdata_without_metrics = create_test_pdata();
-        pdata_without_metrics.received_at_node(44, Interests::PRODUCED_CONSUMED_SIZE);
-        assert!(pdata_without_metrics.context.frames().is_empty());
-    }
-
-    /// Scenario: a source records normal-level produced messages without item-count opt-in.
-    /// Guarantees: the real pdata retains its signal for message metric attribution without parsing item counts.
-    #[test]
-    fn test_prepare_source_send_stamps_produced_items() {
-        // PRODUCER_METRICS | PRODUCED_CONSUMED_ITEM_COUNTS: source frame carries
-        // the produced count.
-        let mut pdata = create_test_pdata();
-        let n = pdata.num_items() as u32;
-        assert!(n > 0);
-        pdata.prepare_source_send(
-            Interests::PRODUCER_METRICS | Interests::PRODUCED_CONSUMED_ITEM_COUNTS,
-            5,
-        );
-        let frame = pdata.context.frames().last().expect("source frame");
-        assert_eq!(frame.node_id, 5);
-        assert_eq!(frame.produced_items, n);
-        assert_eq!(pdata.context.signal(), Some(SignalType::Logs));
-
-        // PRODUCER_METRICS without the opt-in bit: no produced count stamped.
-        let mut pdata_no_optin = create_test_pdata();
-        pdata_no_optin.prepare_source_send(Interests::PRODUCER_METRICS, 7);
-        let frame_no_optin = pdata_no_optin
-            .context
-            .frames()
-            .last()
-            .expect("source frame");
-        assert_eq!(frame_no_optin.produced_items, 0);
-        assert_eq!(pdata_no_optin.context.signal(), Some(SignalType::Logs));
-
-        // SOURCE_TAGGING only (no PRODUCER_METRICS): no produced count stamped.
-        let mut pdata2 = create_test_pdata();
-        pdata2.prepare_source_send(Interests::SOURCE_TAGGING, 6);
-        let frame2 = pdata2.context.frames().last().expect("source frame");
-        assert_eq!(frame2.produced_items, 0);
-        assert_eq!(pdata2.context.signal(), None);
-
-        // SOURCE_TAGGING | opt-in bit but no PRODUCER_METRICS (e.g. a tagging
-        // receiver opting in below the `normal` level): a frame is pushed for
-        // tagging, but no produced count is stamped and no num_items() parse.
-        let mut pdata3 = create_test_pdata();
-        pdata3.prepare_source_send(
-            Interests::SOURCE_TAGGING | Interests::PRODUCED_CONSUMED_ITEM_COUNTS,
-            8,
-        );
-        let frame3 = pdata3.context.frames().last().expect("source frame");
-        assert_eq!(frame3.produced_items, 0);
-        assert_eq!(pdata3.context.signal(), None);
-    }
-
-    /// Scenario: a source opts into produced payload size at the normal runtime metric level.
-    /// Guarantees: the source frame captures size only when both producer metrics and size measurement are enabled.
-    #[test]
-    fn test_prepare_source_send_stamps_produced_size() {
-        let mut pdata = create_test_pdata();
-        let size =
-            u64::try_from(pdata.num_bytes().expect("test payload size")).expect("size fits u64");
-        assert!(size > 0);
-        pdata.prepare_source_send(
-            Interests::PRODUCER_METRICS | Interests::PRODUCED_CONSUMED_SIZE,
-            5,
-        );
-        let frame = pdata.context.frames().last().expect("source frame");
-        assert_eq!(frame.produced_size, size);
-
-        let mut pdata_no_optin = create_test_pdata();
-        pdata_no_optin.prepare_source_send(Interests::PRODUCER_METRICS, 6);
-        let frame_no_optin = pdata_no_optin
-            .context
-            .frames()
-            .last()
-            .expect("source frame");
-        assert_eq!(frame_no_optin.produced_size, 0);
-
-        let mut pdata_without_metrics = create_test_pdata();
-        pdata_without_metrics.prepare_source_send(
-            Interests::SOURCE_TAGGING | Interests::PRODUCED_CONSUMED_SIZE,
-            7,
-        );
+        pdata_without_metrics.received_at_node(44, Interests::NODE_SIZE);
         let frame_without_metrics = pdata_without_metrics
             .context
             .frames()
             .last()
-            .expect("source tagging frame");
-        assert_eq!(frame_without_metrics.produced_size, 0);
+            .expect("size-only input frame");
+        assert_eq!(frame_without_metrics.input_size, size);
+        assert_eq!(
+            pdata_without_metrics.context.signal(),
+            Some(SignalType::Logs)
+        );
+    }
+
+    /// Scenario: a source records output messages and independently opts into output item counts.
+    /// Guarantees: output item counts work with or without the output message metric interest.
+    #[test]
+    fn test_prepare_source_send_stamps_output_items() {
+        // NODE_OUTPUT_METRICS | NODE_ITEM_COUNTS: source frame carries the output count.
+        let mut pdata = create_test_pdata();
+        let n = pdata.num_items() as u32;
+        assert!(n > 0);
+        pdata.prepare_source_send(
+            Interests::NODE_OUTPUT_METRICS | Interests::NODE_ITEM_COUNTS,
+            5,
+        );
+        let frame = pdata.context.frames().last().expect("source frame");
+        assert_eq!(frame.node_id, 5);
+        assert_eq!(frame.output_items, n);
+        assert_eq!(pdata.context.signal(), Some(SignalType::Logs));
+
+        // Output metrics without the opt-in bit: no output count is stamped.
+        let mut pdata_no_optin = create_test_pdata();
+        pdata_no_optin.prepare_source_send(Interests::NODE_OUTPUT_METRICS, 7);
+        let frame_no_optin = pdata_no_optin
+            .context
+            .frames()
+            .last()
+            .expect("source frame");
+        assert_eq!(frame_no_optin.output_items, 0);
+        assert_eq!(pdata_no_optin.context.signal(), Some(SignalType::Logs));
+
+        // SOURCE_TAGGING only (no output metrics): no output count is stamped.
+        let mut pdata2 = create_test_pdata();
+        pdata2.prepare_source_send(Interests::SOURCE_TAGGING, 6);
+        let frame2 = pdata2.context.frames().last().expect("source frame");
+        assert_eq!(frame2.output_items, 0);
+        assert_eq!(pdata2.context.signal(), None);
+
+        // The opt-in bit alone (e.g. below the `normal` level) records output
+        // items without enabling output message metrics.
+        let mut pdata3 = create_test_pdata();
+        pdata3.prepare_source_send(Interests::NODE_ITEM_COUNTS, 8);
+        let frame3 = pdata3.context.frames().last().expect("source frame");
+        assert_eq!(frame3.output_items, n);
+        assert_eq!(pdata3.context.signal(), Some(SignalType::Logs));
+    }
+
+    /// Scenario: a source independently opts into output payload size.
+    /// Guarantees: output size works with or without the output message metric interest.
+    #[test]
+    fn test_prepare_source_send_stamps_output_size() {
+        let mut pdata = create_test_pdata();
+        let size =
+            u64::try_from(pdata.num_bytes().expect("test payload size")).expect("size fits u64");
+        assert!(size > 0);
+        pdata.prepare_source_send(Interests::NODE_OUTPUT_METRICS | Interests::NODE_SIZE, 5);
+        let frame = pdata.context.frames().last().expect("source frame");
+        assert_eq!(frame.output_size, size);
+
+        let mut pdata_no_optin = create_test_pdata();
+        pdata_no_optin.prepare_source_send(Interests::NODE_OUTPUT_METRICS, 6);
+        let frame_no_optin = pdata_no_optin
+            .context
+            .frames()
+            .last()
+            .expect("source frame");
+        assert_eq!(frame_no_optin.output_size, 0);
+
+        let mut pdata_without_metrics = create_test_pdata();
+        pdata_without_metrics.prepare_source_send(Interests::NODE_SIZE, 7);
+        let frame_without_metrics = pdata_without_metrics
+            .context
+            .frames()
+            .last()
+            .expect("size-only output frame");
+        assert_eq!(frame_without_metrics.output_size, size);
+        assert_eq!(
+            pdata_without_metrics.context.signal(),
+            Some(SignalType::Logs)
+        );
+    }
+
+    /// Scenario: a source send follows a context frame owned by a different node.
+    /// Guarantees: the source gets a new frame and inherits the predecessor's return-data interest.
+    #[test]
+    fn test_prepare_source_send_pushes_frame_for_different_node() {
+        let mut pdata = create_test_pdata().test_subscribe_to(
+            Interests::ACKS | Interests::RETURN_DATA,
+            CallData::default(),
+            1,
+        );
+        let items = pdata.num_items() as u32;
+
+        pdata.prepare_source_send(
+            Interests::NODE_OUTPUT_METRICS | Interests::NODE_ITEM_COUNTS,
+            2,
+        );
+
+        let frames = pdata.context.frames();
+        assert_eq!(frames.len(), 2);
+        assert_eq!(frames[0].node_id, 1);
+        assert_eq!(frames[0].output_items, 0);
+        assert_eq!(frames[1].node_id, 2);
+        assert!(frames[1].interests.contains(Interests::RETURN_DATA));
+        assert!(frames[1].interests.contains(Interests::NODE_OUTPUT_METRICS));
+        assert!(frames[1].interests.contains(Interests::NODE_ITEM_COUNTS));
+        assert_eq!(frames[1].output_items, items);
     }
 
     #[test]
@@ -2456,27 +2502,27 @@ mod test {
 
     #[test]
     fn push_entry_frame_pipeline_metrics_auto_subscribes() {
-        // CONSUMER_METRICS sets CONSUMER_METRICS in the entry frame (not ACKS_OR_NACKS).
+        // NODE_INPUT_METRICS is retained in the entry frame, not ACKS_OR_NACKS.
         // The controller handles metrics-only frames during context unwinding.
         let mut ctx = Context::default();
-        ctx.push_entry_frame(1, Interests::CONSUMER_METRICS);
+        ctx.push_entry_frame(1, Interests::NODE_INPUT_METRICS);
         let frames = ctx.frames();
         assert_eq!(frames.len(), 1);
         assert!(
-            frames[0].interests.contains(Interests::CONSUMER_METRICS),
-            "CONSUMER_METRICS should be set in entry frame"
+            frames[0].interests.contains(Interests::NODE_INPUT_METRICS),
+            "NODE_INPUT_METRICS should be set in entry frame"
         );
         assert!(
             !frames[0].interests.contains(Interests::ACKS),
-            "CONSUMER_METRICS should NOT auto-subscribe ACKS"
+            "NODE_INPUT_METRICS should NOT auto-subscribe ACKS"
         );
         assert!(
             !frames[0].interests.contains(Interests::NACKS),
-            "CONSUMER_METRICS should NOT auto-subscribe NACKS"
+            "NODE_INPUT_METRICS should NOT auto-subscribe NACKS"
         );
         assert_eq!(
             frames[0].route.entry_time_ns, 0,
-            "CONSUMER_METRICS alone should not stamp time"
+            "NODE_INPUT_METRICS alone should not stamp time"
         );
     }
 
@@ -2491,7 +2537,7 @@ mod test {
         assert!(!empty.needs_completion_tracking());
 
         let mut metrics = Context::default();
-        metrics.push_entry_frame(1, Interests::CONSUMER_METRICS);
+        metrics.push_entry_frame(1, Interests::NODE_INPUT_METRICS);
         assert!(metrics.needs_completion_tracking());
 
         let mut subscriber = Context::default();
@@ -2501,30 +2547,33 @@ mod test {
 
     #[test]
     fn push_entry_frame_pipeline_metrics_no_timestamp() {
-        // CONSUMER_METRICS without ENTRY_TIMESTAMP should not capture a timestamp.
+        // Input metrics without completion duration should not capture a timestamp.
         let mut ctx = Context::default();
-        ctx.push_entry_frame(1, Interests::CONSUMER_METRICS);
+        ctx.push_entry_frame(1, Interests::NODE_INPUT_METRICS);
         let frames = ctx.frames();
         assert_eq!(frames.len(), 1);
-        assert!(frames[0].interests.contains(Interests::CONSUMER_METRICS));
+        assert!(frames[0].interests.contains(Interests::NODE_INPUT_METRICS));
         assert!(!frames[0].interests.contains(Interests::ACKS_OR_NACKS));
         assert_eq!(
             frames[0].route.entry_time_ns, 0,
-            "Entry frame without ENTRY_TIMESTAMP should not stamp time"
+            "Entry frame without completion duration should not stamp time"
         );
     }
 
     #[test]
-    fn push_entry_frame_entry_timestamp_stamps_time() {
-        // CONSUMER_METRICS | ENTRY_TIMESTAMP stamps a non-zero timestamp.
+    fn push_entry_frame_completion_duration_stamps_time() {
+        // Completion duration stamps a non-zero timestamp.
         let mut ctx = Context::default();
-        ctx.push_entry_frame(1, Interests::CONSUMER_METRICS | Interests::ENTRY_TIMESTAMP);
+        ctx.push_entry_frame(
+            1,
+            Interests::NODE_INPUT_METRICS | Interests::NODE_COMPLETION_DURATION,
+        );
         let frames = ctx.frames();
         assert_eq!(frames.len(), 1);
-        assert!(frames[0].interests.contains(Interests::CONSUMER_METRICS));
+        assert!(frames[0].interests.contains(Interests::NODE_INPUT_METRICS));
         assert!(
             frames[0].route.entry_time_ns > 0,
-            "Entry frame with ENTRY_TIMESTAMP should stamp non-zero time"
+            "Entry frame with completion duration should stamp non-zero time"
         );
     }
 
@@ -2533,8 +2582,8 @@ mod test {
         let mut ctx = Context::default();
         // Source subscribes with RETURN_DATA.
         ctx.subscribe_to(Interests::ACKS | Interests::RETURN_DATA, CallData::new(), 0);
-        // Entry frame with CONSUMER_METRICS inherits RETURN_DATA from predecessor.
-        ctx.push_entry_frame(1, Interests::CONSUMER_METRICS);
+        // An input-metrics frame inherits RETURN_DATA from its predecessor.
+        ctx.push_entry_frame(1, Interests::NODE_INPUT_METRICS);
         let frames = ctx.frames();
         assert_eq!(frames.len(), 2);
         assert!(
@@ -2542,8 +2591,8 @@ mod test {
             "entry frame should inherit RETURN_DATA"
         );
         assert!(
-            frames[1].interests.contains(Interests::CONSUMER_METRICS),
-            "entry frame should have CONSUMER_METRICS"
+            frames[1].interests.contains(Interests::NODE_INPUT_METRICS),
+            "entry frame should have NODE_INPUT_METRICS"
         );
         assert!(
             !frames[1].interests.contains(Interests::ACKS),
@@ -2553,9 +2602,12 @@ mod test {
 
     #[test]
     fn subscribe_to_merges_into_entry_frame() {
-        // CONSUMER_METRICS | ENTRY_TIMESTAMP stamps time, then subscribe merges.
+        // Completion duration stamps time, then subscribe merges.
         let mut ctx = Context::default();
-        ctx.push_entry_frame(1, Interests::CONSUMER_METRICS | Interests::ENTRY_TIMESTAMP);
+        ctx.push_entry_frame(
+            1,
+            Interests::NODE_INPUT_METRICS | Interests::NODE_COMPLETION_DURATION,
+        );
         let original_time = ctx.frames()[0].route.entry_time_ns;
         assert!(original_time > 0);
 
@@ -2579,9 +2631,9 @@ mod test {
 
     #[test]
     fn processor_subscribe_stamps_time() {
-        // For processors without ENTRY_TIMESTAMP, time can still be stamped manually.
+        // For processors without completion duration, time can still be stamped manually.
         let mut ctx = Context::default();
-        ctx.push_entry_frame(1, Interests::CONSUMER_METRICS);
+        ctx.push_entry_frame(1, Interests::NODE_INPUT_METRICS);
         assert_eq!(ctx.frames()[0].route.entry_time_ns, 0, "initially no time");
 
         // Simulate processor subscribe_to stamping time.
@@ -2609,19 +2661,19 @@ mod test {
 
     #[test]
     fn pipeline_metrics_ack_routable() {
-        // CONSUMER_METRICS does NOT auto-subscribe ACKS, so next_ack skips
+        // NODE_INPUT_METRICS does not auto-subscribe ACKS, so next_ack skips
         // the metrics-only entry frame and routes to the real subscriber.
         let (test_data, mut pdata) = create_test();
         pdata = pdata.test_subscribe_to(Interests::ACKS | Interests::NACKS, test_data.into(), 0);
         pdata
             .context
-            .push_entry_frame(1, Interests::CONSUMER_METRICS);
+            .push_entry_frame(1, Interests::NODE_INPUT_METRICS);
 
         let ack = AckMsg::new(pdata);
         let (node_id, _) = next_ack(ack).expect("should find node 0");
         assert_eq!(
             node_id, 0,
-            "CONSUMER_METRICS entry frame is skipped; ack routes to subscriber at node 0"
+            "NODE_INPUT_METRICS entry frame is skipped; ack routes to subscriber at node 0"
         );
     }
 
@@ -2629,19 +2681,19 @@ mod test {
     // notify_ack/nack stamps return_time_ns; raw route_ack/nack does not
     // -----------------------------------------------------------------------
 
-    /// Helper: build an OtapPdata with ENTRY_TIMESTAMP | ACKS so has_timing(ACKS) is true.
+    /// Helper: build an OtapPdata with completion duration and ACKS so has_timing(ACKS) is true.
     fn pdata_with_timed_ack_frame() -> OtapPdata {
         create_test_pdata().test_subscribe_to(
-            Interests::ENTRY_TIMESTAMP | Interests::ACKS,
+            Interests::NODE_COMPLETION_DURATION | Interests::ACKS,
             CallData::default(),
             42,
         )
     }
 
-    /// Helper: build an OtapPdata with ENTRY_TIMESTAMP | NACKS so has_timing(NACKS) is true.
+    /// Helper: build an OtapPdata with completion duration and NACKS so has_timing(NACKS) is true.
     fn pdata_with_timed_nack_frame() -> OtapPdata {
         create_test_pdata().test_subscribe_to(
-            Interests::ENTRY_TIMESTAMP | Interests::NACKS,
+            Interests::NODE_COMPLETION_DURATION | Interests::NACKS,
             CallData::default(),
             42,
         )

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -795,36 +795,29 @@ impl OtapPdata {
     /// When `node_interests` includes source tagging or output-side telemetry,
     /// a source frame is ensured for `node_id` and the relevant interests are
     /// merged into it.
-    fn prepare_source_send(&mut self, node_interests: Interests, node_id: usize) {
-        let trigger = node_interests
-            & (Interests::SOURCE_TAGGING
-                | Interests::NODE_OUTPUT_METRICS
-                | Interests::NODE_COMPLETION_DURATION
-                | Interests::NODE_ITEM_COUNTS
-                | Interests::NODE_SIZE);
+    fn prepare_source_send(
+        &mut self,
+        node_interests: Interests,
+        node_id: usize,
+        completion_from_output: bool,
+    ) {
+        let mut output_interests = node_interests
+            & (Interests::NODE_OUTPUT_METRICS | Interests::NODE_ITEM_COUNTS | Interests::NODE_SIZE);
+        if completion_from_output {
+            output_interests |= node_interests & Interests::NODE_COMPLETION_DURATION;
+        }
+        let trigger = (node_interests & Interests::SOURCE_TAGGING) | output_interests;
         if !trigger.is_empty() {
-            self.context.update_send_context(
-                node_id,
-                node_interests
-                    & (Interests::NODE_OUTPUT_METRICS
-                        | Interests::NODE_COMPLETION_DURATION
-                        | Interests::NODE_ITEM_COUNTS
-                        | Interests::NODE_SIZE),
-            );
-            if node_interests.intersects(
-                Interests::NODE_OUTPUT_METRICS
-                    | Interests::NODE_COMPLETION_DURATION
-                    | Interests::NODE_ITEM_COUNTS
-                    | Interests::NODE_SIZE,
-            ) {
+            self.context.update_send_context(node_id, output_interests);
+            if !output_interests.is_empty() {
                 self.context.capture_signal(self.signal_type());
             }
-            if node_interests.contains(Interests::NODE_ITEM_COUNTS) {
+            if output_interests.contains(Interests::NODE_ITEM_COUNTS) {
                 let items = u32::try_from(self.num_items()).unwrap_or(u32::MAX);
                 let signal = self.signal_type();
                 self.context.stamp_output_items(items, signal);
             }
-            if node_interests.contains(Interests::NODE_SIZE)
+            if output_interests.contains(Interests::NODE_SIZE)
                 && let Some(size) = self.num_bytes()
             {
                 self.context
@@ -892,15 +885,17 @@ impl OtapPdata {
 /// Implements `ProducerEffectHandlerExtension<OtapPdata>` for an EffectHandler type.
 /// `$id_method` is `processor_id` or `receiver_id`.
 macro_rules! impl_producer_ext {
-    ($handler:ty, $id_method:ident) => {
+    ($handler:ty, $id_method:ident, $completion_from_output:expr) => {
         #[async_trait(?Send)]
         impl ProducerEffectHandlerExtension<OtapPdata> for $handler {
             fn subscribe_to(&self, int: Interests, ctx: CallData, data: &mut OtapPdata) {
-                let engine_int = self.node_interests()
+                let mut engine_int = self.node_interests()
                     & (Interests::NODE_OUTPUT_METRICS
-                        | Interests::NODE_COMPLETION_DURATION
                         | Interests::NODE_ITEM_COUNTS
                         | Interests::NODE_SIZE);
+                if $completion_from_output {
+                    engine_int |= self.node_interests() & Interests::NODE_COMPLETION_DURATION;
+                }
                 data.context
                     .subscribe_to(int | engine_int, ctx, self.$id_method().index);
             }
@@ -910,19 +905,23 @@ macro_rules! impl_producer_ext {
 
 impl_producer_ext!(
     otel_arrow_dfe_engine::local::processor::EffectHandler<OtapPdata>,
-    processor_id
+    processor_id,
+    false
 );
 impl_producer_ext!(
     otel_arrow_dfe_engine::local::receiver::EffectHandler<OtapPdata>,
-    receiver_id
+    receiver_id,
+    true
 );
 impl_producer_ext!(
     otel_arrow_dfe_engine::shared::processor::EffectHandler<OtapPdata>,
-    processor_id
+    processor_id,
+    false
 );
 impl_producer_ext!(
     otel_arrow_dfe_engine::shared::receiver::EffectHandler<OtapPdata>,
-    receiver_id
+    receiver_id,
+    true
 );
 
 /* -------- Consumer effect handler extensions (shared, local) -------- */
@@ -1060,14 +1059,25 @@ macro_rules! maybe_processor_send_hook {
 }
 
 macro_rules! impl_message_source_ext {
-    ($async_attr:meta, $trait_name:ident, $handler:ty, $id_method:ident, $hook:ident) => {
+    (
+        $async_attr:meta,
+        $trait_name:ident,
+        $handler:ty,
+        $id_method:ident,
+        $hook:ident,
+        $completion_from_output:expr
+    ) => {
         #[$async_attr]
         impl $trait_name<OtapPdata> for $handler {
             async fn send_message_with_source_node(
                 &self,
                 mut data: OtapPdata,
             ) -> Result<(), TypedError<OtapPdata>> {
-                data.prepare_source_send(self.node_interests(), self.$id_method().index);
+                data.prepare_source_send(
+                    self.node_interests(),
+                    self.$id_method().index,
+                    $completion_from_output,
+                );
                 maybe_processor_send_hook!($hook, self, &mut data);
                 self.router.send_default_stamped(data).await
             }
@@ -1076,7 +1086,11 @@ macro_rules! impl_message_source_ext {
                 &self,
                 mut data: OtapPdata,
             ) -> Result<(), TypedError<OtapPdata>> {
-                data.prepare_source_send(self.node_interests(), self.$id_method().index);
+                data.prepare_source_send(
+                    self.node_interests(),
+                    self.$id_method().index,
+                    $completion_from_output,
+                );
                 maybe_processor_send_hook!($hook, self, &mut data);
                 self.router.try_send_default_stamped(data)
             }
@@ -1089,7 +1103,11 @@ macro_rules! impl_message_source_ext {
             where
                 P: Into<PortName> + Send + 'static,
             {
-                data.prepare_source_send(self.node_interests(), self.$id_method().index);
+                data.prepare_source_send(
+                    self.node_interests(),
+                    self.$id_method().index,
+                    $completion_from_output,
+                );
                 maybe_processor_send_hook!($hook, self, &mut data);
                 self.router.send_to_stamped(port, data).await
             }
@@ -1102,7 +1120,11 @@ macro_rules! impl_message_source_ext {
             where
                 P: Into<PortName> + Send + 'static,
             {
-                data.prepare_source_send(self.node_interests(), self.$id_method().index);
+                data.prepare_source_send(
+                    self.node_interests(),
+                    self.$id_method().index,
+                    $completion_from_output,
+                );
                 maybe_processor_send_hook!($hook, self, &mut data);
                 self.router.try_send_to_stamped(port, data)
             }
@@ -1115,28 +1137,32 @@ impl_message_source_ext!(
     MessageSourceLocalEffectHandlerExtension,
     otel_arrow_dfe_engine::local::processor::EffectHandler<OtapPdata>,
     processor_id,
-    with_hook
+    with_hook,
+    false
 );
 impl_message_source_ext!(
     async_trait(?Send),
     MessageSourceLocalEffectHandlerExtension,
     otel_arrow_dfe_engine::local::receiver::EffectHandler<OtapPdata>,
     receiver_id,
-    no_hook
+    no_hook,
+    true
 );
 impl_message_source_ext!(
     async_trait,
     MessageSourceSharedEffectHandlerExtension,
     otel_arrow_dfe_engine::shared::processor::EffectHandler<OtapPdata>,
     processor_id,
-    with_hook
+    with_hook,
+    false
 );
 impl_message_source_ext!(
     async_trait,
     MessageSourceSharedEffectHandlerExtension,
     otel_arrow_dfe_engine::shared::receiver::EffectHandler<OtapPdata>,
     receiver_id,
-    no_hook
+    no_hook,
+    true
 );
 
 /* -------- ReceivedAtNode implementation -------- */
@@ -2036,6 +2062,7 @@ mod test {
         pdata.prepare_source_send(
             Interests::NODE_OUTPUT_METRICS | Interests::NODE_ITEM_COUNTS,
             5,
+            true,
         );
         let frame = pdata.context.frames().last().expect("source frame");
         assert_eq!(frame.node_id, 5);
@@ -2044,7 +2071,7 @@ mod test {
 
         // Output metrics without the opt-in bit: no output count is stamped.
         let mut pdata_no_optin = create_test_pdata();
-        pdata_no_optin.prepare_source_send(Interests::NODE_OUTPUT_METRICS, 7);
+        pdata_no_optin.prepare_source_send(Interests::NODE_OUTPUT_METRICS, 7, true);
         let frame_no_optin = pdata_no_optin
             .context
             .frames()
@@ -2055,7 +2082,7 @@ mod test {
 
         // SOURCE_TAGGING only (no output metrics): no output count is stamped.
         let mut pdata2 = create_test_pdata();
-        pdata2.prepare_source_send(Interests::SOURCE_TAGGING, 6);
+        pdata2.prepare_source_send(Interests::SOURCE_TAGGING, 6, true);
         let frame2 = pdata2.context.frames().last().expect("source frame");
         assert_eq!(frame2.output_items, 0);
         assert_eq!(pdata2.context.signal(), None);
@@ -2063,7 +2090,7 @@ mod test {
         // The opt-in bit alone (e.g. below the `normal` level) records output
         // items without enabling output message metrics.
         let mut pdata3 = create_test_pdata();
-        pdata3.prepare_source_send(Interests::NODE_ITEM_COUNTS, 8);
+        pdata3.prepare_source_send(Interests::NODE_ITEM_COUNTS, 8, true);
         let frame3 = pdata3.context.frames().last().expect("source frame");
         assert_eq!(frame3.output_items, n);
         assert_eq!(pdata3.context.signal(), Some(SignalType::Logs));
@@ -2077,12 +2104,16 @@ mod test {
         let size =
             u64::try_from(pdata.num_bytes().expect("test payload size")).expect("size fits u64");
         assert!(size > 0);
-        pdata.prepare_source_send(Interests::NODE_OUTPUT_METRICS | Interests::NODE_SIZE, 5);
+        pdata.prepare_source_send(
+            Interests::NODE_OUTPUT_METRICS | Interests::NODE_SIZE,
+            5,
+            true,
+        );
         let frame = pdata.context.frames().last().expect("source frame");
         assert_eq!(frame.output_size, size);
 
         let mut pdata_no_optin = create_test_pdata();
-        pdata_no_optin.prepare_source_send(Interests::NODE_OUTPUT_METRICS, 6);
+        pdata_no_optin.prepare_source_send(Interests::NODE_OUTPUT_METRICS, 6, true);
         let frame_no_optin = pdata_no_optin
             .context
             .frames()
@@ -2091,7 +2122,7 @@ mod test {
         assert_eq!(frame_no_optin.output_size, 0);
 
         let mut pdata_without_metrics = create_test_pdata();
-        pdata_without_metrics.prepare_source_send(Interests::NODE_SIZE, 7);
+        pdata_without_metrics.prepare_source_send(Interests::NODE_SIZE, 7, true);
         let frame_without_metrics = pdata_without_metrics
             .context
             .frames()
@@ -2118,6 +2149,7 @@ mod test {
         pdata.prepare_source_send(
             Interests::NODE_OUTPUT_METRICS | Interests::NODE_ITEM_COUNTS,
             2,
+            true,
         );
 
         let frames = pdata.context.frames();
@@ -2129,6 +2161,27 @@ mod test {
         assert!(frames[1].interests.contains(Interests::NODE_OUTPUT_METRICS));
         assert!(frames[1].interests.contains(Interests::NODE_ITEM_COUNTS));
         assert_eq!(frames[1].output_items, items);
+    }
+
+    /// Scenario: a processor and receiver create fresh output from completion-enabled nodes.
+    /// Guarantees: only the receiver creates an output-boundary completion frame.
+    #[test]
+    fn test_prepare_source_send_applies_completion_only_at_receiver_output() {
+        let mut processor_output = create_test_pdata();
+        processor_output.prepare_source_send(Interests::NODE_COMPLETION_DURATION, 1, false);
+        assert!(processor_output.context.frames().is_empty());
+
+        let mut receiver_output = create_test_pdata();
+        receiver_output.prepare_source_send(Interests::NODE_COMPLETION_DURATION, 2, true);
+        let frames = receiver_output.context.frames();
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].node_id, 2);
+        assert!(
+            frames[0]
+                .interests
+                .contains(Interests::NODE_COMPLETION_DURATION)
+        );
+        assert!(frames[0].route.entry_time_ns > 0);
     }
 
     #[test]
@@ -2562,6 +2615,8 @@ mod test {
         assert!(subscriber.needs_completion_tracking());
     }
 
+    /// Scenario: an input metric frame is created without completion timing.
+    /// Guarantees: input message accounting does not capture a completion timestamp.
     #[test]
     fn push_entry_frame_pipeline_metrics_no_timestamp() {
         // Input metrics without completion duration should not capture a timestamp.
@@ -2577,6 +2632,8 @@ mod test {
         );
     }
 
+    /// Scenario: an input frame enables node completion duration.
+    /// Guarantees: the frame captures a non-zero entry timestamp for terminal timing.
     #[test]
     fn push_entry_frame_completion_duration_stamps_time() {
         // Completion duration stamps a non-zero timestamp.

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -304,11 +304,13 @@ impl Context {
         });
     }
 
-    /// Stamp the top frame's output port index.
+    /// Stamp the sending node's top frame with its output port index.
     /// Called at send time so each clone sent through a different port
     /// carries the correct output port index on the return path.
-    pub(crate) fn stamp_output_port_index(&mut self, index: u16) {
-        if let Some(top) = self.stack.last_mut() {
+    pub(crate) fn stamp_output_port_index(&mut self, node_id: usize, index: u16) {
+        if let Some(top) = self.stack.last_mut()
+            && top.node_id == node_id
+        {
             top.route.output_port_index = index;
         }
     }
@@ -565,8 +567,8 @@ impl otel_arrow_dfe_engine::Unwindable for OtapPdata {
 }
 
 impl otel_arrow_dfe_engine::StampOutputPort for OtapPdata {
-    fn stamp_output_port_index(&mut self, index: u16) {
-        self.context.stamp_output_port_index(index);
+    fn stamp_output_port_index(&mut self, node_id: usize, index: u16) {
+        self.context.stamp_output_port_index(node_id, index);
     }
 }
 
@@ -2182,6 +2184,21 @@ mod test {
                 .contains(Interests::NODE_COMPLETION_DURATION)
         );
         assert!(frames[0].route.entry_time_ns > 0);
+    }
+
+    /// Scenario: an uninstrumented processor forwards data carrying an upstream node frame.
+    /// Guarantees: its output-port stamp cannot overwrite the upstream frame's port index.
+    #[test]
+    fn test_output_port_stamp_requires_frame_owner() {
+        let mut pdata = create_test_pdata();
+        pdata.prepare_source_send(Interests::NODE_OUTPUT_METRICS, 1, true);
+        pdata.context.stamp_output_port_index(1, 1);
+
+        pdata.context.stamp_output_port_index(2, 0);
+
+        let frame = pdata.context.frames().last().expect("upstream frame");
+        assert_eq!(frame.node_id, 1);
+        assert_eq!(frame.route.output_port_index, 1);
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/otap/src/pdata.rs
+++ b/rust/otap-dataflow/crates/otap/src/pdata.rs
@@ -171,9 +171,13 @@ impl Context {
     #[must_use]
     pub fn needs_completion_tracking(&self) -> bool {
         self.stack.iter().any(|frame| {
-            frame
-                .interests
-                .intersects(Interests::ACKS_OR_NACKS | Interests::NODE_METRICS)
+            frame.interests.intersects(
+                Interests::ACKS_OR_NACKS
+                    | Interests::NODE_METRICS
+                    | Interests::NODE_COMPLETION_DURATION
+                    | Interests::NODE_ITEM_COUNTS
+                    | Interests::NODE_SIZE,
+            )
         })
     }
 
@@ -260,20 +264,20 @@ impl Context {
     /// When `NODE_COMPLETION_DURATION` is present in `interests`, the frame's
     /// entry timestamp is captured for terminal Ack/Nack duration measurement.
     fn update_send_context(&mut self, node_id: usize, interests: Interests) {
-        if let Some(top) = self.stack.last_mut() {
-            if top.node_id == node_id {
-                top.interests |= interests;
-                if interests.contains(Interests::NODE_COMPLETION_DURATION)
-                    && top.route.entry_time_ns == 0
-                {
-                    // Note: This update is only for receivers which need
-                    // to capture timestamp here in case they did not use
-                    // subscribe_to. If they called called subscribe_to,
-                    // this will be skipped by a non-zero timestamp.
-                    top.route.entry_time_ns = nanos_since_birth();
-                }
-                return;
+        if let Some(top) = self.stack.last_mut()
+            && top.node_id == node_id
+        {
+            top.interests |= interests;
+            if interests.contains(Interests::NODE_COMPLETION_DURATION)
+                && top.route.entry_time_ns == 0
+            {
+                // Note: This update is only for receivers which need
+                // to capture timestamp here in case they did not use
+                // subscribe_to. If they called called subscribe_to,
+                // this will be skipped by a non-zero timestamp.
+                top.route.entry_time_ns = nanos_since_birth();
             }
+            return;
         }
         // Different node (or empty stack) -> push new frame.
         let mut frame_interests = interests;
@@ -2526,8 +2530,8 @@ mod test {
         );
     }
 
-    /// Scenario: Contexts contain no frames, source-tagging only, pipeline metrics, or Ack interests.
-    /// Guarantees: Completion tracking is required only for pipeline metrics and Ack/Nack routing.
+    /// Scenario: Contexts contain no frames, source tagging, node measurements, or Ack interests.
+    /// Guarantees: Every frame-dependent node measurement and Ack/Nack routing retains the context.
     #[test]
     fn needs_completion_tracking_matches_completion_interests() {
         let mut empty = Context::default();
@@ -2539,6 +2543,19 @@ mod test {
         let mut metrics = Context::default();
         metrics.push_entry_frame(1, Interests::NODE_INPUT_METRICS);
         assert!(metrics.needs_completion_tracking());
+
+        for interest in [
+            Interests::NODE_COMPLETION_DURATION,
+            Interests::NODE_ITEM_COUNTS,
+            Interests::NODE_SIZE,
+        ] {
+            let mut optional_only = Context::default();
+            optional_only.push_entry_frame(1, interest);
+            assert!(
+                optional_only.needs_completion_tracking(),
+                "{interest:?} must retain its context for metrics unwinding"
+            );
+        }
 
         let mut subscriber = Context::default();
         subscriber.subscribe_to(Interests::ACKS, CallData::new(), 1);

--- a/rust/otap-dataflow/docs/node-and-flow-metrics.md
+++ b/rust/otap-dataflow/docs/node-and-flow-metrics.md
@@ -34,26 +34,34 @@ configuration.
 
 ## Node Metrics
 
-With `policies.telemetry.runtime_metrics: normal` or `detailed`, every node
-emits message outcome counters on its `node.input` and `node.output`
-metric sets:
+A **message** is the PData batch that moves between nodes. An **item** is an
+individual log record, metric data point, or span in that batch. One message
+can contain multiple items. **Logical size** is the byte size of the current
+in-memory payload representation. **Payload size** is the encoded application
+payload observed at a receiver or exporter boundary.
 
-### Messages, Items, and Size
+**Completion duration** measures from a node boundary until the terminal ACK
+or NACK: from input for processors and exporters, and from output for
+receivers. **Local duration** measures work performed by the node itself. Use
+`flow.compute.duration` instead for compute time across a processor range.
 
-A message is the PData batch that moves between nodes. An item is an individual
-log record, metric data point, or span in that batch. One message can contain
-multiple items, so message counts measure batch traffic while item counts
-measure the number of telemetry records inside those batches. Size measures the
-logical byte size of the current payload representation.
+**`none`** and **`basic`** enable no node metrics by default. **`normal`** adds
+message measurements, and **`detailed`** adds every optional measurement. A
+**per-node policy** enables its measurement at any runtime metric level.
 
-| Metric | Meaning | Emitted by | Availability |
-| --- | --- | --- | --- |
-| `node.input.messages` | Messages received by a node | `node.input` | `normal` or `detailed` |
-| `node.output.messages` | Messages emitted by a node | `node.output` | `normal` or `detailed` |
-| `node.input.items` | Items a node receives | `node.input` | `detailed`, or `normal` plus item-count opt-in |
-| `node.output.items` | Items a node emits | `node.output` | `detailed`, or `normal` plus item-count opt-in |
-| `node.input.size` | Logical payload bytes a node receives | `node.input` | `detailed`, or `normal` plus size opt-in |
-| `node.output.size` | Logical payload bytes a node emits | `node.output` | `detailed`, or `normal` plus size opt-in |
+| Measurement | Engine-managed metrics | Node-implemented metrics | Default level | Per-node policy |
+| --- | --- | --- | --- | --- |
+| Messages | `node.input.messages`, `node.output.messages` | `receiver.received.messages`, `exporter.attempted.messages` | `normal` | `messages: true` |
+| Items | `node.input.items`, `node.output.items` | `exporter.attempted.items` | `detailed` | `item_counts: true` |
+| Logical size | `node.input.size`, `node.output.size` | - | `detailed` | `size: true` |
+| Payload size | - | `receiver.received.payload.size`, `exporter.attempted.payload.size` | `detailed` | `size: true` |
+| Completion duration | `node.completion.duration` | - | `detailed` | `completion_duration: true` |
+| Local duration | - | `receiver.processing.duration`, `processor.compute.duration`, `exporter.attempted.duration` | `detailed` | `duration: true` |
+
+The `node.input.*` metrics apply to processors and exporters.
+`node.output.*` metrics apply to receivers and processors. Node-implemented
+metrics require the implementation to use the corresponding shared
+instrumentation.
 
 Message, item, and size counters have bounded `signal` and `outcome` data-point
 attributes. `signal` is one of `logs`, `metrics`, or `traces`; `outcome` is
@@ -61,32 +69,13 @@ attributes. `signal` is one of `logs`, `metrics`, or `traces`; `outcome` is
 unwinding. The metric-set entity attributes identify the pipeline and node, so
 group by those attributes when comparing nodes.
 
-At the detailed level, node metrics also report terminal latency in seconds.
-`node.input.duration` measures from node input until the terminal ACK or NACK
-for processors and exporters. Receivers have no input, so
-`node.output.duration` measures from receiver output until that terminal
-outcome. This is downstream completion latency, not processor compute time;
-use `flow.compute.duration` for compute time across a processor range.
-
-Component-owned duration is also detailed by default. A processor that
-supports local compute timing emits `processor.compute.duration`, grouped by
-`outcome`. Enable component duration globally with `runtime_metrics: detailed`
-or for one node with `policies.telemetry.duration: true`. This per-node option
-does not enable the terminal `node.input.duration` or `node.output.duration`
-metrics.
-
-### Enable Item Counts and Size
-
-Item counting and logical payload sizing are disabled at the normal level
-because they can require payload inspection. They require
-`policies.telemetry.runtime_metrics: detailed` or `normal` with a per-node opt
-in.
+### Enable Optional Measurements
 
 > [!WARNING]
-> Item counting and sizing add work to the data path. Their cost depends on the
-> payload representation and structure. Measure the impact on a representative
-> workload before enabling them broadly. Prefer per-node opt-in when only a
-> specific stage needs these measurements.
+> Item counting and sizing may inspect the payload; completion and local
+> duration add timing and bookkeeping. Measure the impact on a representative
+> workload before enabling these measurements broadly. Prefer per-node opt-in
+> when only a specific stage needs them.
 
 To enable it for every node in a pipeline, use `detailed`:
 
@@ -96,13 +85,9 @@ policies:
     runtime_metrics: detailed
 ```
 
-To enable it only for selected nodes, use `normal` at the pipeline and opt in
-the relevant nodes:
+To enable it only for selected nodes, opt in the relevant nodes:
 
 ```yaml
-policies:
-  telemetry:
-    runtime_metrics: normal
 nodes:
   sampler:
     type: processor:log_sampling
@@ -121,15 +106,15 @@ for every node without node-level settings.
 
 For a linear topology, a node's `output.items` normally matches the next
 node's `input.items` for the same signal. A filtering or sampling processor
-can produce fewer items than it consumes; a fan-out processor can produce an
-item on more than one output. Compare counts only along the particular edge or
+can emit fewer items than it receives; a fan-out processor can emit an item on
+more than one output. Compare counts only along the particular edge or
 topology behavior being investigated.
 
 Node metrics are the right choice when operators need to locate where a signal
 count changes, including receiver admission, processors, and exporter output.
 Use the runnable
-[`trafficgen-input-output-metrics.yaml`](../configs/trafficgen-input-output-metrics.yaml)
-example to inspect the metrics on every node, compare component duration with
+[`trafficgen-node-metrics.yaml`](../configs/trafficgen-node-metrics.yaml)
+example to inspect the metrics on every node, compare local duration with
 flow duration, or observe an individually opted-in processor.
 
 ## Flow Metrics
@@ -212,5 +197,5 @@ later decision, so per-node kept counts are not additive. Use the flow's
 `flow.output.items` as the flow-wide surviving count.
 
 See
-[`trafficgen-input-output-metrics.yaml`](../configs/trafficgen-input-output-metrics.yaml)
+[`trafficgen-node-metrics.yaml`](../configs/trafficgen-node-metrics.yaml)
 for a runnable comparison of node and flow metrics around a sampling processor.

--- a/rust/otap-dataflow/docs/node-and-flow-metrics.md
+++ b/rust/otap-dataflow/docs/node-and-flow-metrics.md
@@ -42,7 +42,8 @@ payload observed at a receiver or exporter boundary.
 
 **Completion duration** measures from a node boundary until the terminal ACK
 or NACK: from input for processors and exporters, and from output for
-receivers. **Local duration** measures work performed by the node itself. Use
+receivers. **Local duration** uses the boundary defined by each node
+instrument, which may include encoding or backend latency. Use
 `flow.compute.duration` instead for compute time across a processor range.
 
 **`none`** and **`basic`** enable no node metrics by default. **`normal`** adds

--- a/rust/otap-dataflow/docs/telemetry/metrics-guide.md
+++ b/rust/otap-dataflow/docs/telemetry/metrics-guide.md
@@ -231,7 +231,7 @@ metrics.
 | `receiver.received.messages` | Record one classified external message when receiver-local handling reaches its terminal local outcome. |
 | `receiver.received.payload.size` | Record the encoded application payload bytes observed at the receiver boundary. |
 | `receiver.processing.duration` | Measure the receiver's documented local processing boundary, ending before downstream handoff or channel wait. |
-| `exporter.attempted.messages` | Record every component-local delivery attempt, including attempts that fail during preparation and each backend retry, grouped by terminal attempt outcome. |
+| `exporter.attempted.messages` | Record every node-local delivery attempt, including attempts that fail during preparation and each backend retry, grouped by terminal attempt outcome. |
 | `exporter.attempted.duration` | Measure from attempt start through the terminal local or backend result, excluding Ack/Nack notification delivery. |
 | `exporter.attempted.payload.size` | Record the encoded application payload bytes produced or submitted by the attempt when available. |
 | `exporter.attempted.items` | Record the signal items handled by the attempt. |
@@ -260,16 +260,15 @@ effective node interests when the helper is registered. Constructing an
 exporter attempt starts its optional duration measurement so synchronous
 preparation before an in-flight request is included.
 
-`runtime_metrics: detailed` enables all shared optional component
-measurements. A node can instead opt into component duration, item counts,
-and/or payload size at any runtime metric level with its
-`policies.telemetry` flags. These per-node flags do not enable the engine-owned
-`node.input` or `node.output` metric sets below `runtime_metrics: normal`;
-therefore, at `none` or `basic`, only the opted-in component measurements are
-emitted.
+`runtime_metrics: detailed` enables all shared optional node
+measurements. A node can instead opt into messages, local duration, item
+counts, and/or payload size at any runtime metric level with its
+`policies.telemetry` flags. `completion_duration` independently enables
+`node.completion.duration`. Each opt-in enables only its corresponding
+measurements.
 
-Components with additional diagnostics should compose the shared helper into
-their component metrics aggregate under a `boundary` field. The aggregate owns
+Nodes with additional diagnostics should compose the shared helper into
+their metrics aggregate under a `boundary` field. The aggregate owns
 combined reporting and terminal snapshots, while operation lifecycle calls go
 directly through `boundary`.
 
@@ -356,7 +355,7 @@ Return ordinary failures through `attempt.failed(error)`. Use
 `attempt.refused(error)` instead for a validation, policy, admission, or
 capacity rejection.
 
-`exporter.attempted.messages` counts component-local delivery attempts,
+`exporter.attempted.messages` counts node-local delivery attempts,
 including attempts that fail before a backend call. Each physical retry starts
 a new attempt and records the items and any available encoded payload bytes
 again. Use `node.input.messages` to count PData messages entering the exporter;


### PR DESCRIPTION
# Change summary

Align telemetry interest bits with the engine's `node` terminology.

This unifies the metric story across nodes, receivers, processors, and exporters. Runtime metric levels continue to provide convenient defaults, while per-node policies can independently enable `messages`, `item_counts`, `size`, `completion_duration`, or `duration` at any level.

Telemetry interests now use a consistent `NODE_*` input/output vocabulary. Node completion timing is unified as `node.completion.duration` and remains distinct from node-local duration. Existing interest bit values and runtime-level defaults are unchanged.

## Related issue

* Closes #3881
* Follow-up from https://github.com/open-telemetry/otel-arrow/pull/3983#discussion_r3972107259

## Validation

Running the file `trafficgen-node-metrics.yaml`:

| Scenario | Configuration | What it demonstrates |
| --- | --- | --- |
| Detailed defaults | A full receiver, processor, and exporter pipeline at `detailed` | The metric level enables every applicable standard measurement without per-node configuration. |
| Independent opt-ins | Separate nodes at `basic` opt into `messages`, `item_counts`, `size`, `completion_duration`, or `duration` | Each measurement family can be enabled independently of the runtime metric level and of the other families. |
| No output | A processor receives and drops every message | Input and completion measurements are recorded, while output and downstream input measurements are absent. |

## User-facing changes

Migration: Query `node.completion.duration` instead of `node.input.duration` and `node.output.duration`. Per-node message, completion, duration, item, and size opt-ins now work at every runtime metric level.