### PR TITLE
chore(release): publish admin API crate

### DIFF
--- a/rust/otap-dataflow/.chloggen/publish-admin-api-crate.yaml
+++ b/rust/otap-dataflow/.chloggen/publish-admin-api-crate.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: engine
+note: "Publish the public admin API SDK as the `otel-arrow-dfe-admin-api` crate on crates.io."
+issues: [4038]
+subtext:

--- a/rust/otap-dataflow/Cargo.toml
+++ b/rust/otap-dataflow/Cargo.toml
@@ -54,7 +54,7 @@ cfg-if.workspace = true
 tikv-jemallocator = { workspace = true, optional = true }
 
 [workspace.dependencies]
-otel-arrow-dfe-admin-api = { path = "crates/admin-api" }
+otel-arrow-dfe-admin-api = { version = "0.55.0", path = "crates/admin-api" }
 otel-arrow-dfe-admin-types = { version = "0.55.0", path = "crates/admin-types" }
 otel-arrow-dfe-pdata-otlp-macros = { version = "0.55.0", path = "./crates/pdata/src/otlp/macros"}
 otel-arrow-dfe-pdata-otlp-model = { version = "0.55.0", path = "./crates/pdata/src/otlp/model"}

--- a/rust/otap-dataflow/crates/admin-api/Cargo.toml
+++ b/rust/otap-dataflow/crates/admin-api/Cargo.toml
@@ -5,7 +5,10 @@ version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
-publish.workspace = true
+readme = "README.md"
+publish = true
+keywords = ["telemetry", "opentelemetry", "otlp", "otap", "admin"]
+categories = ["api-bindings"]
 edition.workspace = true
 rust-version.workspace = true
 

--- a/rust/otap-dataflow/crates/admin-api/README.md
+++ b/rust/otap-dataflow/crates/admin-api/README.md
@@ -1,4 +1,7 @@
-# Admin API SDK
+# otel-arrow-dfe-admin-api
+
+This crate is currently pre-1.0. Its public API may evolve between minor
+releases.
 
 `otel-arrow-dfe-admin-api` is the public Rust integration crate for the OTAP Dataflow
 Engine admin surface. External applications should depend on this crate rather
@@ -37,9 +40,8 @@ endpoint scheme and TLS settings without changing the domain methods they use.
 
 Default SDK usage is usually enough:
 
-```toml
-[dependencies]
-otel-arrow-dfe-admin-api = "0.1.0"
+```sh
+cargo add otel-arrow-dfe-admin-api
 ```
 
 This enables:
@@ -50,9 +52,10 @@ This enables:
 If you need a different rustls crypto backend, disable default features and
 prefer enabling a single provider feature explicitly:
 
-```toml
-[dependencies]
-otel-arrow-dfe-admin-api = { version = "0.1.0", default-features = false, features = ["http-client", "crypto-aws-lc"] }
+```sh
+cargo add otel-arrow-dfe-admin-api \
+  --no-default-features \
+  --features http-client,crypto-aws-lc
 ```
 
 Available provider features:
@@ -67,9 +70,10 @@ Available provider features:
 
 For FIPS-oriented deployments, start with:
 
-```toml
-[dependencies]
-otel-arrow-dfe-admin-api = { version = "0.1.0", default-features = false, features = ["http-client", "crypto-openssl"] }
+```sh
+cargo add otel-arrow-dfe-admin-api \
+  --no-default-features \
+  --features http-client,crypto-openssl
 ```
 
 Important note:

--- a/rust/otap-dataflow/xtask/src/crates_publish.rs
+++ b/rust/otap-dataflow/xtask/src/crates_publish.rs
@@ -731,6 +731,9 @@ mod tests {
             .iter()
             .map(|name| {
                 let dependencies: &[&str] = match *name {
+                    "otel-arrow-dfe-admin-api" => {
+                        &["otel-arrow-dfe-admin-types", "otel-arrow-dfe-config"]
+                    }
                     "otel-arrow-dfe-admin" => &[
                         "otel-arrow-dfe-admin-types",
                         "otel-arrow-dfe-config",

--- a/rust/otap-dataflow/xtask/src/publish_policy.rs
+++ b/rust/otap-dataflow/xtask/src/publish_policy.rs
@@ -7,6 +7,7 @@ pub(crate) const INDEPENDENT_VERSION_PACKAGES: &[&str] = &["otel-arrow-dfe-pdata
 
 pub(crate) const PUBLISH_PACKAGES: &[&str] = &[
     "otel-arrow-dfe-admin",
+    "otel-arrow-dfe-admin-api",
     "otel-arrow-dfe-admin-types",
     "otel-arrow-dfe-channel",
     "otel-arrow-dfe-component-inventory-syntax",

--- a/rust/otap-dataflow/xtask/src/structure_check.rs
+++ b/rust/otap-dataflow/xtask/src/structure_check.rs
@@ -303,6 +303,28 @@ mod tests {
         );
     }
 
+    /// Scenario: the public admin SDK explicitly enables publication.
+    /// Guarantees: structure validation accepts admin-api as an approved package.
+    #[test]
+    fn publish_policy_accepts_admin_api() {
+        let manifest = package(
+            r#"
+            [package]
+            name = "otel-arrow-dfe-admin-api"
+            publish = true
+            "#,
+        );
+
+        assert!(
+            check_publish_policy(
+                Path::new("Cargo.toml"),
+                "otel-arrow-dfe-admin-api",
+                &manifest
+            )
+            .is_ok()
+        );
+    }
+
     /// Scenario: an unapproved package explicitly enables publication.
     /// Guarantees: structure validation requires every other crate to inherit workspace policy.
     #[test]

--- a/rust/otap-dataflow/xtask/src/structure_check.rs
+++ b/rust/otap-dataflow/xtask/src/structure_check.rs
@@ -303,28 +303,6 @@ mod tests {
         );
     }
 
-    /// Scenario: the public admin SDK explicitly enables publication.
-    /// Guarantees: structure validation accepts admin-api as an approved package.
-    #[test]
-    fn publish_policy_accepts_admin_api() {
-        let manifest = package(
-            r#"
-            [package]
-            name = "otel-arrow-dfe-admin-api"
-            publish = true
-            "#,
-        );
-
-        assert!(
-            check_publish_policy(
-                Path::new("Cargo.toml"),
-                "otel-arrow-dfe-admin-api",
-                &manifest
-            )
-            .is_ok()
-        );
-    }
-
     /// Scenario: an unapproved package explicitly enables publication.
     /// Guarantees: structure validation requires every other crate to inherit workspace policy.
     #[test]


### PR DESCRIPTION
## Chore summary

- add `otel-arrow-dfe-admin-api` to the crates.io publication policy
- version its workspace dependency and declare crates.io metadata
- validate its dependency order after `admin-types` and `config`
- update the public SDK README with pre-1.0 guidance and version-independent install examples

## Related issue

Closes #4038

## Validation

- `cargo xtask check`
- `cargo xtask crates-publish check`
- `cargo package --locked --allow-dirty -p otel-arrow-dfe-admin-api`
- `cargo check --locked -p otel-arrow-dfe-admin-api --no-default-features`
- `cargo test --locked -p otel-arrow-dfe-admin-api`
- `cargo doc --locked --no-deps -p otel-arrow-dfe-admin-api`
- `make chlog-validate`
- `python3 tools/sanitycheck.py`
- markdownlint on `crates/admin-api/README.md`