### PR TITLE
feat(otlp): Adopt shared receiver and exporter metrics in OTLP nodes

### DIFF
--- a/rust/otap-dataflow/.chloggen/otlp-shared-boundary-metrics.yaml
+++ b/rust/otap-dataflow/.chloggen/otlp-shared-boundary-metrics.yaml
@@ -1,6 +1,6 @@
 change_type: breaking
 component: observability
 note: Replace OTLP receiver and exporter telemetry with shared node-boundary metrics.
-issues: [3983]
+issues: [3822]
 subtext: |
   Migration: Update dashboards and alerts from `receiver.otlp.requests.started/completed/payload_size`, `receiver.otlp.rejections.requests`, and `exporter.exports.*` to `receiver.otlp.requests.accepted/rejected`, `receiver.received.*`, `receiver.processing.duration`, and `exporter.attempted.*`.

--- a/rust/otap-dataflow/.chloggen/otlp-shared-boundary-metrics.yaml
+++ b/rust/otap-dataflow/.chloggen/otlp-shared-boundary-metrics.yaml
@@ -1,0 +1,6 @@
+change_type: breaking
+component: observability
+note: Replace OTLP receiver and exporter telemetry with shared node-boundary metrics.
+issues: [3983]
+subtext: |
+  Migration: Update dashboards and alerts from `receiver.otlp.requests.started/completed/payload_size`, `receiver.otlp.rejections.requests`, and `exporter.exports.*` to `receiver.otlp.requests.accepted/rejected`, `receiver.received.*`, `receiver.processing.duration`, and `exporter.attempted.*`.

--- a/rust/otap-dataflow/configs/otlp-component-boundary-metrics.yaml
+++ b/rust/otap-dataflow/configs/otlp-component-boundary-metrics.yaml
@@ -1,0 +1,224 @@
+# Exercises shared OTLP receiver and exporter metrics for gRPC and HTTP in one
+# process. Each traffic generator exports to a loopback OTLP receiver, whose
+# output is discarded by a noop exporter.
+#
+# The observability pipeline prints the affected shared and OTLP-specific
+# instruments plus node output message and item counts. Successful traffic
+# populates the received, processing, accepted, attempted, and output metrics.
+# Rejection and failure instruments remain absent unless an error is introduced.
+#
+# Run with:
+#   cargo run -- --config configs/otlp-component-boundary-metrics.yaml
+
+version: otel_dataflow/v1
+policies:
+  resources:
+    core_allocation:
+      type: core_count
+      count: 1
+engine:
+  telemetry:
+    reporting_interval: 1s
+  observability:
+    pipeline:
+      policies:
+        telemetry:
+          pipeline_metrics: false
+          tokio_metrics: false
+          runtime_metrics: none
+      nodes:
+        telemetry:
+          type: receiver:internal_telemetry
+          config:
+            signals: [metrics]
+            metrics:
+              interval: 1s
+              views:
+                - selector:
+                    scope_name: receiver.received
+                    instrument_name: messages
+                  stream:
+                    name: receiver_received_messages
+                - selector:
+                    scope_name: receiver.received
+                    instrument_name: payload.size
+                  stream:
+                    name: receiver_received_payload_size
+                - selector:
+                    scope_name: receiver.processing
+                    instrument_name: duration
+                  stream:
+                    name: receiver_processing_duration
+                - selector:
+                    scope_name: receiver.otlp.requests
+                    instrument_name: accepted
+                  stream:
+                    name: receiver_otlp_requests_accepted
+                - selector:
+                    scope_name: receiver.otlp.requests
+                    instrument_name: rejected
+                  stream:
+                    name: receiver_otlp_requests_rejected
+                - selector:
+                    scope_name: node.output
+                    instrument_name: messages
+                  stream:
+                    name: node_output_messages
+                - selector:
+                    scope_name: node.output
+                    instrument_name: items
+                  stream:
+                    name: node_output_items
+                - selector:
+                    scope_name: exporter.attempted
+                    instrument_name: messages
+                  stream:
+                    name: exporter_attempted_messages
+                - selector:
+                    scope_name: exporter.attempted
+                    instrument_name: duration
+                  stream:
+                    name: exporter_attempted_duration
+                - selector:
+                    scope_name: exporter.attempted
+                    instrument_name: payload.size
+                  stream:
+                    name: exporter_attempted_payload_size
+                - selector:
+                    scope_name: exporter.attempted
+                    instrument_name: items
+                  stream:
+                    name: exporter_attempted_items
+                - selector:
+                    scope_name: exporter.otlp_http.failures
+                    instrument_name: messages
+                  stream:
+                    name: exporter_otlp_http_failures
+                - selector:
+                    scope_name: exporter.otlp_grpc.failures
+                    instrument_name: messages
+                  stream:
+                    name: exporter_otlp_grpc_failures
+        boundary_metrics:
+          type: processor:filter
+          config:
+            metrics:
+              include:
+                match_type: strict
+                metric_names:
+                  - receiver_received_messages
+                  - receiver_received_payload_size
+                  - receiver_processing_duration
+                  - receiver_otlp_requests_accepted
+                  - receiver_otlp_requests_rejected
+                  - node_output_messages
+                  - node_output_items
+                  - exporter_attempted_messages
+                  - exporter_attempted_duration
+                  - exporter_attempted_payload_size
+                  - exporter_attempted_items
+                  - exporter_otlp_http_failures
+                  - exporter_otlp_grpc_failures
+        metrics_debug:
+          type: processor:debug
+          config:
+            verbosity: normal
+            mode: batch
+            signals: [metrics]
+        noop:
+          type: exporter:noop
+          config: {}
+      connections:
+        - from: telemetry
+          to: boundary_metrics
+        - from: boundary_metrics
+          to: metrics_debug
+        - from: metrics_debug
+          to: noop
+
+groups:
+  default:
+    pipelines:
+      grpc_source:
+        policies:
+          telemetry:
+            runtime_metrics: detailed
+        nodes:
+          generator:
+            type: receiver:traffic_generator
+            config:
+              data_source: synthetic
+              traffic_config:
+                max_batch_size: 10
+                signals_per_second: 20
+                log_weight: 100
+                metric_weight: 0
+                trace_weight: 0
+          exporter:
+            type: exporter:otlp_grpc
+            config:
+              grpc_endpoint: "http://127.0.0.1:14317"
+        connections:
+          - from: generator
+            to: exporter
+
+      grpc_sink:
+        policies:
+          telemetry:
+            runtime_metrics: detailed
+        nodes:
+          receiver:
+            type: receiver:otlp
+            config:
+              protocols:
+                grpc:
+                  listening_addr: "127.0.0.1:14317"
+          noop:
+            type: exporter:noop
+            config: {}
+        connections:
+          - from: receiver
+            to: noop
+
+      http_source:
+        policies:
+          telemetry:
+            runtime_metrics: detailed
+        nodes:
+          generator:
+            type: receiver:traffic_generator
+            config:
+              data_source: synthetic
+              traffic_config:
+                max_batch_size: 10
+                signals_per_second: 20
+                log_weight: 100
+                metric_weight: 0
+                trace_weight: 0
+          exporter:
+            type: exporter:otlp_http
+            config:
+              endpoint: "http://127.0.0.1:14318"
+              http: {}
+              client_pool_size: 1
+        connections:
+          - from: generator
+            to: exporter
+
+      http_sink:
+        policies:
+          telemetry:
+            runtime_metrics: detailed
+        nodes:
+          receiver:
+            type: receiver:otlp
+            config:
+              protocols:
+                http:
+                  listening_addr: "127.0.0.1:14318"
+          noop:
+            type: exporter:noop
+            config: {}
+        connections:
+          - from: receiver
+            to: noop

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/README.md
@@ -167,12 +167,14 @@ Input PData message volume is reported by the engine through
 `channel.receiver.messages` with its `signal` attribute on the PData input
 channel and is not duplicated by the exporter.
 
-#### `exporter.exports`
+#### `exporter.attempted`
 
 | Metric | Unit | Attributes | Description |
 | --- | --- | --- | --- |
-| `exporter.exports.messages` | `{message}` | `signal`, `outcome` | Number of PData messages whose export reached a terminal outcome. |
-| `exporter.exports.duration` | `s` | `signal`, `outcome` | Time from dequeuing PData through the terminal gRPC export result, including encoding and in-flight queueing but excluding Ack/Nack notification. |
+| `exporter.attempted.messages` | `{message}` | `signal`, `outcome` | Number of component-local gRPC delivery attempts, including preparation failures. |
+| `exporter.attempted.duration` | `s` | `signal`, `outcome` | Attempt time through the terminal local or backend result, excluding Ack/Nack notification. Emitted when component duration is enabled. |
+| `exporter.attempted.payload.size` | `By` | `signal`, `outcome` | OTLP protobuf payload bytes submitted by the attempt. Emitted when size measurement is enabled. |
+| `exporter.attempted.items` | `{item}` | `signal`, `outcome` | Signal items handled by the attempt. Emitted when item counting is enabled. |
 
 #### `exporter.otlp_grpc.failures`
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/metrics.rs
@@ -5,14 +5,12 @@
 
 use otel_arrow_dfe_config::SignalType;
 use otel_arrow_dfe_engine::context::PipelineContext;
-use otel_arrow_dfe_otap::metrics::ExporterExportMetrics;
-use otel_arrow_dfe_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
+use otel_arrow_dfe_otap::metrics::ExporterMetrics;
 use otel_arrow_dfe_telemetry::error::Error as TelemetryError;
 use otel_arrow_dfe_telemetry::instrument::Counter;
 use otel_arrow_dfe_telemetry::metrics::{MeasurementMetricSet, MetricSetSnapshot};
 use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
 use otel_arrow_dfe_telemetry_macros::{AttributeEnum, attribute_set, metric_set};
-use std::time::Duration;
 use tonic::{Code, Status};
 
 /// Actionable category for a failed OTLP gRPC export.
@@ -61,6 +59,15 @@ impl OtlpGrpcExporterErrorType {
             Code::Ok => Self::Other,
         }
     }
+
+    /// Returns whether the destination refused the attempt without an exporter failure.
+    #[must_use]
+    pub(super) const fn is_refusal(self) -> bool {
+        matches!(
+            self,
+            Self::Authentication | Self::Authorization | Self::Throttled | Self::Rejected
+        )
+    }
 }
 
 /// Signal and error dimensions for failed OTLP gRPC exports.
@@ -88,7 +95,7 @@ struct OtlpGrpcExporterFailureMetrics {
 
 /// Terminal outcome and failure metrics emitted by an OTLP gRPC exporter.
 pub(super) struct OtlpGrpcExporterMetrics {
-    pub(super) exports: MeasurementMetricSet<ExporterExportMetrics>,
+    pub(super) boundary: ExporterMetrics,
     failures: MeasurementMetricSet<OtlpGrpcExporterFailureMetrics>,
 }
 
@@ -97,34 +104,17 @@ impl OtlpGrpcExporterMetrics {
     #[must_use]
     pub(super) fn register(pipeline_ctx: &PipelineContext) -> Self {
         Self {
-            exports: ExporterExportMetrics::register(pipeline_ctx),
+            boundary: ExporterMetrics::register(pipeline_ctx),
             failures: OtlpGrpcExporterFailureMetrics::register(pipeline_ctx),
         }
     }
 
-    /// Records one successful terminal export.
-    pub(super) fn record_success(&mut self, signal: SignalType, duration: Duration) {
-        self.exports
-            .with(SignalOutcomeAttributes {
-                signal,
-                outcome: Outcome::Success,
-            })
-            .record(duration);
-    }
-
-    /// Records one failed terminal export and exactly one diagnostic category.
+    /// Records one failed terminal export diagnostic category.
     pub(super) fn record_failure(
         &mut self,
         signal: SignalType,
         error_type: OtlpGrpcExporterErrorType,
-        duration: Duration,
     ) {
-        self.exports
-            .with(SignalOutcomeAttributes {
-                signal,
-                outcome: Outcome::Failure,
-            })
-            .record(duration);
         self.failures
             .with(OtlpGrpcFailureAttributes { signal, error_type })
             .messages
@@ -133,15 +123,14 @@ impl OtlpGrpcExporterMetrics {
 
     /// Reports all touched OTLP gRPC exporter metric buckets.
     pub(super) fn report(&mut self, reporter: &mut MetricsReporter) -> Result<(), TelemetryError> {
-        reporter
-            .report_measurement(&mut self.exports)
-            .and_then(|()| reporter.report_measurement(&mut self.failures))
+        self.boundary.report(reporter)?;
+        reporter.report_measurement(&mut self.failures)
     }
 
     /// Takes terminal snapshots of all touched metric buckets.
     #[must_use]
     pub(super) fn terminal_snapshots(&mut self) -> Vec<MetricSetSnapshot> {
-        let mut snapshots = self.exports.terminal_snapshots();
+        let mut snapshots = self.boundary.terminal_snapshots();
         snapshots.extend(self.failures.terminal_snapshots());
         snapshots
     }
@@ -151,6 +140,7 @@ impl OtlpGrpcExporterMetrics {
 mod tests {
     use super::*;
     use otel_arrow_dfe_engine::context::ControllerContext;
+    use otel_arrow_dfe_otap::metrics::ErrorWithOutcome;
     use otel_arrow_dfe_telemetry::registry::TelemetryRegistryHandle;
 
     fn new_metrics() -> OtlpGrpcExporterMetrics {
@@ -210,35 +200,36 @@ mod tests {
     #[test]
     fn failure_classification_is_paired_with_the_terminal_outcome() {
         let mut metrics = new_metrics();
-        metrics.record_success(SignalType::Logs, Duration::from_millis(10));
-        metrics.record_failure(
-            SignalType::Logs,
-            OtlpGrpcExporterErrorType::Unavailable,
-            Duration::from_millis(20),
+        let completed = futures::executor::block_on(
+            metrics
+                .boundary
+                .attempt(SignalType::Logs)
+                .run(async |_| Ok::<_, ErrorWithOutcome<OtlpGrpcExporterErrorType>>(())),
         );
+        metrics.boundary.record(completed).unwrap();
+        let completed =
+            futures::executor::block_on(metrics.boundary.attempt(SignalType::Logs).run(
+                async |attempt| {
+                    Err::<(), _>(attempt.failed(OtlpGrpcExporterErrorType::Unavailable))
+                },
+            ));
+        let error_type = metrics.boundary.record(completed).unwrap_err();
+        metrics.record_failure(SignalType::Logs, error_type);
 
-        assert_eq!(
-            metrics
-                .exports
-                .get(SignalOutcomeAttributes {
-                    signal: SignalType::Logs,
-                    outcome: Outcome::Success,
-                })
-                .messages
-                .get(),
-            1
-        );
-        assert_eq!(
-            metrics
-                .exports
-                .get(SignalOutcomeAttributes {
-                    signal: SignalType::Logs,
-                    outcome: Outcome::Failure,
-                })
-                .messages
-                .get(),
-            1
-        );
+        let snapshots = metrics.boundary.terminal_snapshots();
+        for outcome in ["success", "failure"] {
+            assert!(snapshots.iter().any(|snapshot| {
+                snapshot.descriptor().name == "exporter.attempted"
+                    && snapshot.measurement_attribute_value("signal") == Some("logs")
+                    && snapshot.measurement_attribute_value("outcome") == Some(outcome)
+                    && snapshot
+                        .descriptor()
+                        .metrics
+                        .iter()
+                        .position(|metric| metric.name == "messages")
+                        .is_some_and(|index| snapshot.get_metrics()[index].to_u64_lossy() == 1)
+            }));
+        }
         assert_eq!(
             metrics
                 .failures

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_grpc_exporter/mod.rs
@@ -35,6 +35,7 @@ use otel_arrow_dfe_engine::message::{ExporterInbox, Message};
 use otel_arrow_dfe_engine::node::NodeId;
 use otel_arrow_dfe_engine::terminal_state::TerminalState;
 use otel_arrow_dfe_otap::OTAP_EXPORTER_FACTORIES;
+use otel_arrow_dfe_otap::metrics::{CompletedExporterAttempt, ExporterAttempt};
 use otel_arrow_dfe_otap::otap_grpc::client_settings::GrpcClientSettings;
 use otel_arrow_dfe_otap::otap_grpc::otlp::client::{
     LogsServiceClient, MetricsServiceClient, TraceServiceClient,
@@ -264,7 +265,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
         grpc_clients.prepopulate_clients();
 
         let mut inflight_exports = InFlightExports::new();
-        let mut pending_msg: Option<(OtapPdata, Instant)> = None;
+        let mut pending_msg: Option<OtapPdata> = None;
 
         // Consumer-side bearer-token adapter, if a provider is bound. It owns
         // the token subscription, the cached `authorization` header, and token
@@ -346,9 +347,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
             };
 
             // Prefer token events, then completions, then the next message.
-            let mut parked_export_started_at = None;
-            let msg = if let Some((pdata, export_started_at)) = parked_msg {
-                parked_export_started_at = Some(export_started_at);
+            let msg = if let Some(pdata) = parked_msg {
                 Message::PData(pdata)
             } else {
                 tokio::select! {
@@ -425,7 +424,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
                     // refresh, so NACK it as retryable -- the same policy the
                     // force-drained batches get below. Without this the parked batch
                     // would be dropped silently.
-                    if let Some((pdata, export_started_at)) = pending_msg.take() {
+                    if let Some(pdata) = pending_msg.take() {
                         debug_assert!(
                             auth.as_ref().is_some_and(|a| !a.is_ready()),
                             "a batch stays parked only while a bound token is unusable"
@@ -436,7 +435,6 @@ impl Exporter<OtapPdata> for OTLPExporter {
                         nack_without_usable_token(
                             pdata,
                             reason,
-                            export_started_at,
                             &effect_handler,
                             &mut self.metrics,
                         )
@@ -466,8 +464,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
                 }) => {
                     _ = self.metrics.report(&mut metrics_reporter);
                 }
-                Message::PData(pdata) => {
-                    let export_started_at = parked_export_started_at.unwrap_or_else(Instant::now);
+                Message::PData(mut pdata) => {
                     if inflight_exports.len() >= max_in_flight {
                         // The guard at the top of the loop stops receiving while a
                         // batch is parked and the budget is full, so parking here
@@ -476,7 +473,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
                             pending_msg.is_none(),
                             "a parked batch must be dispatched before another is parked"
                         );
-                        pending_msg = Some((pdata, export_started_at));
+                        pending_msg = Some(pdata);
                         continue;
                     }
 
@@ -493,7 +490,6 @@ impl Exporter<OtapPdata> for OTLPExporter {
                         nack_without_usable_token(
                             pdata,
                             reason,
-                            export_started_at,
                             &effect_handler,
                             &mut self.metrics,
                         )
@@ -502,6 +498,8 @@ impl Exporter<OtapPdata> for OTLPExporter {
                     }
 
                     let signal_type = pdata.signal_type();
+                    let mut attempt = self.metrics.boundary.attempt(signal_type);
+                    attempt.set_item_count_with(|| pdata.num_items() as u64);
                     let (context, payload) = pdata.into_parts();
 
                     // The cached bearer header, together with the generation of the
@@ -537,7 +535,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
                                 context,
                                 metadata,
                                 SignalType::Logs,
-                                export_started_at,
+                                attempt,
                                 &exporter_id,
                                 &mut logs_proto_buffer,
                                 &mut logs_proto_encoder,
@@ -557,7 +555,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
                                 context,
                                 metadata,
                                 SignalType::Metrics,
-                                export_started_at,
+                                attempt,
                                 &exporter_id,
                                 &mut metrics_proto_buffer,
                                 &mut metrics_proto_encoder,
@@ -577,7 +575,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
                                 context,
                                 metadata,
                                 SignalType::Traces,
-                                export_started_at,
+                                attempt,
                                 &exporter_id,
                                 &mut traces_proto_buffer,
                                 &mut traces_proto_encoder,
@@ -598,7 +596,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
                                     context,
                                     metadata,
                                     SignalType::Logs,
-                                    export_started_at,
+                                    attempt,
                                     |b| OtlpProtoBytes::ExportLogsRequest(b).into(),
                                 ),
                                 OtlpProtoBytes::ExportMetricsRequest(bytes) => prepare_otlp_export(
@@ -606,7 +604,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
                                     context,
                                     metadata,
                                     SignalType::Metrics,
-                                    export_started_at,
+                                    attempt,
                                     |b| OtlpProtoBytes::ExportMetricsRequest(b).into(),
                                 ),
                                 OtlpProtoBytes::ExportTracesRequest(bytes) => prepare_otlp_export(
@@ -614,7 +612,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
                                     context,
                                     metadata,
                                     SignalType::Traces,
-                                    export_started_at,
+                                    attempt,
                                     |b| OtlpProtoBytes::ExportTracesRequest(b).into(),
                                 ),
                             };
@@ -651,7 +649,7 @@ impl Exporter<OtapPdata> for OTLPExporter {
 /// whether the request actually succeeded. E.g. it does not return `Err` for an
 /// unsuccessful request.
 async fn route_export_result<T>(
-    result: &Result<T, tonic::Status>,
+    result: &Result<T, GrpcAttemptError>,
     context: Context,
     saved_payload: OtapPayload,
     effect_handler: &EffectHandler<OtapPdata>,
@@ -663,16 +661,16 @@ async fn route_export_result<T>(
                 .notify_ack(AckMsg::new(OtapPdata::new(context, saved_payload)))
                 .await?;
         }
-        Err(e) => {
-            let retryable = is_retryable_grpc_status(e) || auth_failure;
-            let error_msg = e.to_string();
+        Err((_, status)) => {
+            let retryable = is_retryable_grpc_status(status) || auth_failure;
+            let error_msg = status.to_string();
 
             // TODO(https://github.com/open-telemetry/otel-arrow/issues/3404):
             // NackMsg has no structured retry-after field yet, so we fold the
             // server's advisory RetryInfo delay into the human-readable reason.
             // Replace this with a structured field once #3404 lands.
             let mut reason = error_msg.clone();
-            if let Some(delay) = retry_after(e) {
+            if let Some(delay) = retry_after(status) {
                 reason.push_str(&format!(" (retry after {})", format_retry_delay(&delay)));
             }
 
@@ -753,6 +751,8 @@ fn is_retryable_grpc_status(status: &tonic::Status) -> bool {
     }
 }
 
+type GrpcAttemptError = (OtlpGrpcExporterErrorType, tonic::Status);
+
 /// Extracts the server-suggested retry delay from a `google.rpc.RetryInfo`
 /// detail carried in the status `grpc-status-details-bin` trailer, if present.
 ///
@@ -793,7 +793,7 @@ struct EncodedExport {
     context: Context,
     saved_payload: OtapPayload,
     signal_type: SignalType,
-    export_started_at: Instant,
+    attempt: ExporterAttempt,
     /// Per-request metadata plus the bearer token generation it carries.
     metadata: RequestMetadata,
 }
@@ -824,8 +824,8 @@ fn prepare_otap_export<Enc: ProtoBytesEncoder>(
     encoder: &mut Enc,
     exporter: &NodeId,
     signal_type: SignalType,
-    export_started_at: Instant,
-) -> Result<EncodedExport, Box<EncodingFailure>> {
+    attempt: ExporterAttempt,
+) -> Result<EncodedExport, (Box<EncodingFailure>, ExporterAttempt)> {
     proto_buffer.clear();
     if let Err(e) = encoder.encode(&mut otap_batch, proto_buffer) {
         let error = Error::ExporterError {
@@ -840,11 +840,14 @@ fn prepare_otap_export<Enc: ProtoBytesEncoder>(
         }
         let saved_payload: OtapPayload = otap_batch.into();
 
-        return Err(Box::new(EncodingFailure {
-            error,
-            context,
-            saved_payload,
-        }));
+        return Err((
+            Box::new(EncodingFailure {
+                error,
+                context,
+                saved_payload,
+            }),
+            attempt,
+        ));
     }
 
     // Maintain the buffer's capacity across repeated calls.
@@ -862,7 +865,7 @@ fn prepare_otap_export<Enc: ProtoBytesEncoder>(
         context,
         saved_payload,
         signal_type,
-        export_started_at,
+        attempt,
         metadata,
     })
 }
@@ -872,7 +875,7 @@ fn prepare_otlp_export(
     context: Context,
     metadata: RequestMetadata,
     signal_type: SignalType,
-    export_started_at: Instant,
+    attempt: ExporterAttempt,
     save_payload_fn: impl FnOnce(Bytes) -> OtapPayload,
 ) -> EncodedExport {
     let saved_payload = if context.may_return_payload() {
@@ -886,7 +889,7 @@ fn prepare_otlp_export(
         context,
         saved_payload,
         signal_type,
-        export_started_at,
+        attempt,
         metadata,
     }
 }
@@ -898,7 +901,7 @@ async fn dispatch_otap_export<Enc, Fut, MakeFuture>(
     context: Context,
     metadata: RequestMetadata,
     signal_type: SignalType,
-    export_started_at: Instant,
+    attempt: ExporterAttempt,
     exporter_id: &NodeId,
     proto_buffer: &mut ProtoBuffer,
     encoder: &mut Enc,
@@ -919,17 +922,22 @@ async fn dispatch_otap_export<Enc, Fut, MakeFuture>(
         encoder,
         exporter_id,
         signal_type,
-        export_started_at,
+        attempt,
     ) {
         Ok(encoded) => {
             inflight.push(make_future(encoded));
         }
-        Err(error) => {
-            metrics.record_failure(
-                signal_type,
-                OtlpGrpcExporterErrorType::Encoding,
-                export_started_at.elapsed(),
-            );
+        Err((error, attempt)) => {
+            let completed = attempt
+                .run(async |attempt| {
+                    Err::<(), _>(attempt.failed(OtlpGrpcExporterErrorType::Encoding))
+                })
+                .await;
+            let error_type = metrics
+                .boundary
+                .record(completed)
+                .expect_err("encoding attempt must fail");
+            metrics.record_failure(signal_type, error_type);
             _ = notify_prepare_error(error, effect_handler).await;
         }
     }
@@ -969,16 +977,17 @@ async fn notify_prepare_error(
 /// is intentionally excluded: it signals a scope or permission problem that a
 /// refresh will not fix. Always false when no provider is bound, since a
 /// statically configured credential cannot be refreshed.
-fn is_auth_failure(result: &Result<(), tonic::Status>, auth_bound: bool) -> bool {
-    auth_bound && matches!(result, Err(status) if status.code() == Code::Unauthenticated)
+fn is_auth_failure(result: &Result<(), GrpcAttemptError>, auth_bound: bool) -> bool {
+    auth_bound
+        && matches!(
+            result,
+            Err((_, status)) if status.code() == Code::Unauthenticated
+        )
 }
 
-/// Returns the bounded diagnostic category for a failed backend RPC.
-fn export_error_type(result: &Result<(), tonic::Status>) -> Option<OtlpGrpcExporterErrorType> {
-    result
-        .as_ref()
-        .err()
-        .map(OtlpGrpcExporterErrorType::from_status)
+/// Returns the bounded diagnostic category for a failed backend export.
+fn export_error_type(result: &Result<(), GrpcAttemptError>) -> Option<OtlpGrpcExporterErrorType> {
+    result.as_ref().err().map(|(error_type, _)| *error_type)
 }
 
 /// NACKs `pdata` because no usable bearer token is available, and records the
@@ -991,22 +1000,27 @@ fn export_error_type(result: &Result<(), tonic::Status>) -> Option<OtlpGrpcExpor
 /// because a refreshed token may still arrive, so the batch is deferred rather
 /// than dropped.
 async fn nack_without_usable_token(
-    pdata: OtapPdata,
+    mut pdata: OtapPdata,
     reason: &'static str,
-    export_started_at: Instant,
     effect_handler: &EffectHandler<OtapPdata>,
     metrics: &mut OtlpGrpcExporterMetrics,
 ) {
     let signal_type = pdata.signal_type();
-    let export_duration = export_started_at.elapsed();
+    let mut attempt = metrics.boundary.attempt(signal_type);
+    attempt.set_item_count_with(|| pdata.num_items() as u64);
+    let completed = attempt
+        .run(async |attempt| {
+            Err::<(), _>(attempt.refused(OtlpGrpcExporterErrorType::Authentication))
+        })
+        .await;
+    let error_type = metrics
+        .boundary
+        .record(completed)
+        .expect_err("authentication attempt must fail");
+    metrics.record_failure(signal_type, error_type);
     _ = effect_handler
         .notify_nack(NackMsg::new(reason, pdata))
         .await;
-    metrics.record_failure(
-        signal_type,
-        OtlpGrpcExporterErrorType::Authentication,
-        export_duration,
-    );
 }
 
 /// Applies the Ack/Nack side effects for a completed gRPC export and returns the
@@ -1017,34 +1031,34 @@ async fn finalize_completed_export(
     metrics: &mut OtlpGrpcExporterMetrics,
 ) -> (SignalClient, Option<u64>) {
     let CompletedExport {
-        result,
+        attempt,
         context,
         saved_payload,
         signal_type,
-        export_started_at,
-        client,
         token_generation,
     } = completed;
-    let export_duration = export_started_at.elapsed();
+    let result = metrics.boundary.record(attempt);
+    let (export_result, client) = match result {
+        Ok(client) => (Ok(()), client),
+        Err((error, client)) => (Err(error), client),
+    };
 
     // Record the rejected generation so the caller invalidates exactly the token
     // that was used, before the batch is retried. A stamped generation is what
     // "a provider is bound" means for this request: the dispatch path only
     // reaches a send with a usable token cached, so the generation is `Some`
     // exactly when the request carried a refreshable credential.
-    let auth_failure = is_auth_failure(&result, token_generation.is_some());
+    let auth_failure = is_auth_failure(&export_result, token_generation.is_some());
     let rejected_generation = if auth_failure { token_generation } else { None };
 
     // The shared outcome describes the backend RPC, independently of whether
     // its Ack/Nack notification can be delivered to the upstream subscriber.
-    if let Some(error_type) = export_error_type(&result) {
-        metrics.record_failure(signal_type, error_type, export_duration);
-    } else {
-        metrics.record_success(signal_type, export_duration);
+    if let Some(error_type) = export_error_type(&export_result) {
+        metrics.record_failure(signal_type, error_type);
     }
 
     if let Err(e) = route_export_result(
-        &result,
+        &export_result,
         context,
         saved_payload,
         effect_handler,
@@ -1057,7 +1071,7 @@ async fn finalize_completed_export(
             message = "error routing export Ack/Nack",
             error = %e
         );
-    } else if let Err(status) = &result {
+    } else if let Err((_, status)) = &export_result {
         otel_warn!(
             "otlp.exporter.grpc.export_error",
             message = "service request error",
@@ -1198,7 +1212,7 @@ fn make_export_future(
         context,
         saved_payload,
         signal_type,
-        export_started_at,
+        attempt,
         metadata: RequestMetadata {
             metadata,
             token_generation,
@@ -1210,45 +1224,48 @@ fn make_export_future(
         Some(md) => tonic::Request::from_parts(md, tonic::Extensions::new(), bytes),
         None => tonic::Request::new(bytes),
     };
+    let payload_size = request.get_ref().len();
 
     async move {
-        match client {
-            SignalClient::Logs(mut client) => {
-                let result = client.export(request).await.map(|_| ());
-                CompletedExport {
-                    result,
-                    context,
-                    saved_payload,
-                    signal_type,
-                    export_started_at,
-                    client: SignalClient::Logs(client),
-                    token_generation,
+        let completed = attempt
+            .run(async |attempt| {
+                attempt.set_payload_size_with(|| payload_size);
+                let result = match client {
+                    SignalClient::Logs(mut client) => match client.export(request).await {
+                        Ok(_) => Ok(SignalClient::Logs(client)),
+                        Err(status) => Err((
+                            (OtlpGrpcExporterErrorType::from_status(&status), status),
+                            SignalClient::Logs(client),
+                        )),
+                    },
+                    SignalClient::Metrics(mut client) => match client.export(request).await {
+                        Ok(_) => Ok(SignalClient::Metrics(client)),
+                        Err(status) => Err((
+                            (OtlpGrpcExporterErrorType::from_status(&status), status),
+                            SignalClient::Metrics(client),
+                        )),
+                    },
+                    SignalClient::Traces(mut client) => match client.export(request).await {
+                        Ok(_) => Ok(SignalClient::Traces(client)),
+                        Err(status) => Err((
+                            (OtlpGrpcExporterErrorType::from_status(&status), status),
+                            SignalClient::Traces(client),
+                        )),
+                    },
+                };
+                match result {
+                    Ok(client) => Ok(client),
+                    Err(error) if (error.0).0.is_refusal() => Err(attempt.refused(error)),
+                    Err(error) => Err(attempt.failed(error)),
                 }
-            }
-            SignalClient::Metrics(mut client) => {
-                let result = client.export(request).await.map(|_| ());
-                CompletedExport {
-                    result,
-                    context,
-                    saved_payload,
-                    signal_type,
-                    export_started_at,
-                    client: SignalClient::Metrics(client),
-                    token_generation,
-                }
-            }
-            SignalClient::Traces(mut client) => {
-                let result = client.export(request).await.map(|_| ());
-                CompletedExport {
-                    result,
-                    context,
-                    saved_payload,
-                    signal_type,
-                    export_started_at,
-                    client: SignalClient::Traces(client),
-                    token_generation,
-                }
-            }
+            })
+            .await;
+        CompletedExport {
+            attempt: completed,
+            context,
+            saved_payload,
+            signal_type,
+            token_generation,
         }
     }
 }
@@ -1406,12 +1423,10 @@ enum SignalClient {
 
 /// Captures everything we need once a single export RPC has completed.
 struct CompletedExport {
-    result: Result<(), tonic::Status>,
+    attempt: CompletedExporterAttempt<SignalClient, (GrpcAttemptError, SignalClient)>,
     context: Context,
     saved_payload: OtapPayload,
     signal_type: SignalType,
-    export_started_at: Instant,
-    client: SignalClient,
     /// Generation of the bearer token this request carried, echoed back so an
     /// `UNAUTHENTICATED` response invalidates exactly that token and a stale
     /// rejection is ignored. `None` when no token provider is bound.
@@ -2371,7 +2386,7 @@ mod tests {
             let mut logs_failed_count = 0;
             for _ in 0..2 {
                 let metrics = metrics_receiver.recv_async().await.unwrap();
-                if metrics.descriptor().name == "exporter.exports"
+                if metrics.descriptor().name == "exporter.attempted"
                     && metrics.measurement_attribute_value("signal") == Some("logs")
                 {
                     match metrics.measurement_attribute_value("outcome") {
@@ -2494,8 +2509,12 @@ mod tests {
     #[test]
     fn export_error_type_is_derived_from_the_rpc_result() {
         assert_eq!(export_error_type(&Ok(())), None);
+        let status = status_with_code(Code::Unavailable);
         assert_eq!(
-            export_error_type(&Err(status_with_code(Code::Unavailable))),
+            export_error_type(&Err((
+                OtlpGrpcExporterErrorType::from_status(&status),
+                status,
+            ))),
             Some(OtlpGrpcExporterErrorType::Unavailable)
         );
     }
@@ -3485,7 +3504,8 @@ mod tests {
     /// lapsed or raced token costs a retry rather than dropping the batch.
     #[test]
     fn unauthenticated_is_an_auth_failure_when_a_provider_is_bound() {
-        let result = Err(tonic::Status::unauthenticated("token expired"));
+        let status = tonic::Status::unauthenticated("token expired");
+        let result = Err((OtlpGrpcExporterErrorType::from_status(&status), status));
 
         assert!(is_auth_failure(&result, true));
     }
@@ -3496,7 +3516,8 @@ mod tests {
     /// retrying would loop on the same rejected credential.
     #[test]
     fn unauthenticated_is_permanent_without_a_bound_provider() {
-        let result = Err(tonic::Status::unauthenticated("token expired"));
+        let status = tonic::Status::unauthenticated("token expired");
+        let result = Err((OtlpGrpcExporterErrorType::from_status(&status), status));
 
         assert!(!is_auth_failure(&result, false));
     }
@@ -3508,7 +3529,8 @@ mod tests {
     /// scope or permission problem a refresh cannot fix.
     #[test]
     fn permission_denied_is_not_an_auth_failure() {
-        let result = Err(tonic::Status::permission_denied("scope missing"));
+        let status = tonic::Status::permission_denied("scope missing");
+        let result = Err((OtlpGrpcExporterErrorType::from_status(&status), status));
 
         assert!(!is_auth_failure(&result, true));
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/README.md
@@ -223,12 +223,14 @@ Input PData message volume is reported by the engine through
 `channel.receiver.messages` with its `signal` attribute on the PData input
 channel and is not duplicated by the exporter.
 
-#### `exporter.exports`
+#### `exporter.attempted`
 
 | Metric | Unit | Attributes | Description |
 | --- | --- | --- | --- |
-| `exporter.exports.messages` | `{message}` | `signal`, `outcome` | Number of PData messages whose export reached a terminal outcome. |
-| `exporter.exports.duration` | `s` | `signal`, `outcome` | Time from dequeuing PData through the terminal HTTP export result, including encoding, compression, and in-flight queueing but excluding Ack/Nack notification. |
+| `exporter.attempted.messages` | `{message}` | `signal`, `outcome` | Number of component-local HTTP delivery attempts, including preparation failures. |
+| `exporter.attempted.duration` | `s` | `signal`, `outcome` | Attempt time through the terminal local or backend result, excluding Ack/Nack notification. Emitted when component duration is enabled. |
+| `exporter.attempted.payload.size` | `By` | `signal`, `outcome` | Uncompressed OTLP protobuf payload bytes produced or submitted by the attempt. Emitted when size measurement is enabled and bytes are available. |
+| `exporter.attempted.items` | `{item}` | `signal`, `outcome` | Signal items handled by the attempt. Emitted when item counting is enabled. |
 
 #### `exporter.otlp_http.failures`
 

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/metrics.rs
@@ -6,14 +6,12 @@
 use http::StatusCode;
 use otel_arrow_dfe_config::SignalType;
 use otel_arrow_dfe_engine::context::PipelineContext;
-use otel_arrow_dfe_otap::metrics::ExporterExportMetrics;
-use otel_arrow_dfe_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
+use otel_arrow_dfe_otap::metrics::ExporterMetrics;
 use otel_arrow_dfe_telemetry::error::Error as TelemetryError;
 use otel_arrow_dfe_telemetry::instrument::Counter;
 use otel_arrow_dfe_telemetry::metrics::{MeasurementMetricSet, MetricSetSnapshot};
 use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
 use otel_arrow_dfe_telemetry_macros::{AttributeEnum, attribute_set, metric_set};
-use std::time::Duration;
 
 use super::agent_fed_auth::AgentFedAuthErrorType;
 
@@ -65,6 +63,19 @@ impl OtlpHttpExporterErrorType {
             _ => Self::Other,
         }
     }
+
+    /// Returns whether the destination refused the attempt without an exporter failure.
+    #[must_use]
+    pub(super) const fn is_refusal(self) -> bool {
+        matches!(
+            self,
+            Self::Authentication
+                | Self::Authorization
+                | Self::Throttled
+                | Self::Rejected
+                | Self::PartialRejection
+        )
+    }
 }
 
 /// Signal and error dimensions for failed OTLP HTTP exports.
@@ -113,7 +124,7 @@ struct OtlpHttpExporterAuthMetrics {
 
 /// Terminal outcome and failure metrics emitted by an OTLP HTTP exporter.
 pub(super) struct OtlpHttpExporterMetrics {
-    pub(super) exports: MeasurementMetricSet<ExporterExportMetrics>,
+    pub(super) boundary: ExporterMetrics,
     failures: MeasurementMetricSet<OtlpHttpExporterFailureMetrics>,
     auth: MeasurementMetricSet<OtlpHttpExporterAuthMetrics>,
 }
@@ -123,7 +134,7 @@ impl OtlpHttpExporterMetrics {
     #[must_use]
     pub(super) fn register(pipeline_ctx: &PipelineContext) -> Self {
         Self {
-            exports: ExporterExportMetrics::register(pipeline_ctx),
+            boundary: ExporterMetrics::register(pipeline_ctx),
             failures: OtlpHttpExporterFailureMetrics::register(pipeline_ctx),
             auth: OtlpHttpExporterAuthMetrics::register(pipeline_ctx),
         }
@@ -137,29 +148,12 @@ impl OtlpHttpExporterMetrics {
             .inc();
     }
 
-    /// Records one successful terminal export.
-    pub(super) fn record_success(&mut self, signal: SignalType, duration: Duration) {
-        self.exports
-            .with(SignalOutcomeAttributes {
-                signal,
-                outcome: Outcome::Success,
-            })
-            .record(duration);
-    }
-
-    /// Records one failed terminal export and exactly one diagnostic category.
+    /// Records one failed terminal export diagnostic category.
     pub(super) fn record_failure(
         &mut self,
         signal: SignalType,
         error_type: OtlpHttpExporterErrorType,
-        duration: Duration,
     ) {
-        self.exports
-            .with(SignalOutcomeAttributes {
-                signal,
-                outcome: Outcome::Failure,
-            })
-            .record(duration);
         self.failures
             .with(OtlpHttpFailureAttributes { signal, error_type })
             .messages
@@ -168,16 +162,15 @@ impl OtlpHttpExporterMetrics {
 
     /// Reports all touched OTLP HTTP exporter metric buckets.
     pub(super) fn report(&mut self, reporter: &mut MetricsReporter) -> Result<(), TelemetryError> {
-        reporter
-            .report_measurement(&mut self.exports)
-            .and_then(|()| reporter.report_measurement(&mut self.failures))
-            .and_then(|()| reporter.report_measurement(&mut self.auth))
+        self.boundary.report(reporter)?;
+        reporter.report_measurement(&mut self.failures)?;
+        reporter.report_measurement(&mut self.auth)
     }
 
     /// Takes terminal snapshots of all touched metric buckets.
     #[must_use]
     pub(super) fn terminal_snapshots(&mut self) -> Vec<MetricSetSnapshot> {
-        let mut snapshots = self.exports.terminal_snapshots();
+        let mut snapshots = self.boundary.terminal_snapshots();
         snapshots.extend(self.failures.terminal_snapshots());
         snapshots.extend(self.auth.terminal_snapshots());
         snapshots
@@ -188,6 +181,7 @@ impl OtlpHttpExporterMetrics {
 mod tests {
     use super::*;
     use otel_arrow_dfe_engine::context::ControllerContext;
+    use otel_arrow_dfe_otap::metrics::ErrorWithOutcome;
     use otel_arrow_dfe_telemetry::registry::TelemetryRegistryHandle;
     use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
 
@@ -250,35 +244,34 @@ mod tests {
     #[test]
     fn failure_classification_is_paired_with_the_terminal_outcome() {
         let mut metrics = new_metrics();
-        metrics.record_success(SignalType::Metrics, Duration::from_millis(10));
-        metrics.record_failure(
-            SignalType::Metrics,
-            OtlpHttpExporterErrorType::Throttled,
-            Duration::from_millis(20),
+        let completed = futures::executor::block_on(
+            metrics
+                .boundary
+                .attempt(SignalType::Metrics)
+                .run(async |_| Ok::<_, ErrorWithOutcome<OtlpHttpExporterErrorType>>(())),
         );
+        metrics.boundary.record(completed).unwrap();
+        let completed =
+            futures::executor::block_on(metrics.boundary.attempt(SignalType::Metrics).run(
+                async |attempt| Err::<(), _>(attempt.refused(OtlpHttpExporterErrorType::Throttled)),
+            ));
+        let error_type = metrics.boundary.record(completed).unwrap_err();
+        metrics.record_failure(SignalType::Metrics, error_type);
 
-        assert_eq!(
-            metrics
-                .exports
-                .get(SignalOutcomeAttributes {
-                    signal: SignalType::Metrics,
-                    outcome: Outcome::Success,
-                })
-                .messages
-                .get(),
-            1
-        );
-        assert_eq!(
-            metrics
-                .exports
-                .get(SignalOutcomeAttributes {
-                    signal: SignalType::Metrics,
-                    outcome: Outcome::Failure,
-                })
-                .messages
-                .get(),
-            1
-        );
+        let snapshots = metrics.boundary.terminal_snapshots();
+        for outcome in ["success", "refused"] {
+            assert!(snapshots.iter().any(|snapshot| {
+                snapshot.descriptor().name == "exporter.attempted"
+                    && snapshot.measurement_attribute_value("signal") == Some("metrics")
+                    && snapshot.measurement_attribute_value("outcome") == Some(outcome)
+                    && snapshot
+                        .descriptor()
+                        .metrics
+                        .iter()
+                        .position(|metric| metric.name == "messages")
+                        .is_some_and(|index| snapshot.get_metrics()[index].to_u64_lossy() == 1)
+            }));
+        }
         assert_eq!(
             metrics
                 .failures

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
@@ -65,6 +65,7 @@ use self::config::Config;
 use crate::exporters::otlp_grpc_exporter::InFlightExports;
 use otel_arrow_dfe_otap::OTAP_EXPORTER_FACTORIES;
 use otel_arrow_dfe_otap::bearer_auth::{BearerAuth, BearerAuthEvents};
+use otel_arrow_dfe_otap::metrics::CompletedExporterAttempt;
 use otel_arrow_dfe_otap::otlp_http::client_settings::{HttpClientError, HttpClientSettings};
 use otel_arrow_dfe_otap::otlp_http::{
     LOGS_PATH, METRICS_PATH, PROTOBUF_CONTENT_TYPE, RpcStatus, TRACES_PATH,
@@ -385,11 +386,10 @@ impl OtlpHttpExporter {
 
 #[derive(Debug)]
 struct CompletedExport {
-    result: Result<ServiceResponse, ServiceRequestError>,
+    attempt: CompletedExporterAttempt<(), ServiceRequestError>,
     context: Context,
     saved_payload: OtapPayload,
     signal_type: SignalType,
-    export_started_at: Instant,
     /// Authentication mode used by this request. Bearer-provider requests retain
     /// the token generation so a 401 invalidates only the token that was sent;
     /// agent-fed and unauthenticated requests retain their mode for response
@@ -599,9 +599,10 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                 Message::Control(NodeControlMsg::CollectTelemetry {
                     mut metrics_reporter,
                 }) => _ = self.metrics.report(&mut metrics_reporter),
-                Message::PData(pdata) => {
-                    let export_started_at = Instant::now();
+                Message::PData(mut pdata) => {
                     let signal_type = pdata.signal_type();
+                    let mut attempt = self.metrics.boundary.attempt(signal_type);
+                    attempt.set_item_count_with(|| pdata.num_items() as u64);
                     let (context, payload) = pdata.into_parts();
 
                     // We normally only reach here with a usable token, since intake
@@ -610,16 +611,23 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                     // usable token we cannot send, so NACK it as retryable -- a token
                     // may yet arrive, so nothing is dropped.
                     if !auth.is_ready() {
-                        let export_duration = export_started_at.elapsed();
+                        let completed = attempt
+                            .run(async |attempt| {
+                                Err::<(), _>(
+                                    attempt.refused(OtlpHttpExporterErrorType::Authentication),
+                                )
+                            })
+                            .await;
+                        let error_type = self
+                            .metrics
+                            .boundary
+                            .record(completed)
+                            .expect_err("authentication attempt must fail");
+                        self.metrics.record_failure(signal_type, error_type);
                         // `NackMsg::new` is retryable by construction.
                         let nack =
                             NackMsg::new(auth.not_ready_reason(), OtapPdata::new(context, payload));
                         _ = effect_handler.notify_nack(nack).await;
-                        self.metrics.record_failure(
-                            signal_type,
-                            OtlpHttpExporterErrorType::Authentication,
-                            export_duration,
-                        );
                         continue;
                     }
 
@@ -644,22 +652,22 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                         InProtoBuffer,
                     }
 
-                    // proto encode the payload into the request body, while keeping a copy of the
+                    // Proto encode the payload into the request body, while keeping a copy of the
                     // original payload if the context allows it to be returned.
                     let (uncompressed, saved_payload) = match payload.into_data() {
                         PayloadData::OtlpBytes(mut otlp_bytes) => {
                             if context.may_return_payload() {
-                                // use cheap clone of bytes as the request body
+                                // Use a cheap clone of bytes as the request body.
                                 let body = otlp_bytes.clone_bytes();
                                 (Uncompressed::Bytes(body), otlp_bytes.into())
                             } else {
-                                // take the bytes and replace with empty bytes in original payload
+                                // Take the bytes and replace them with empty bytes in the payload.
                                 let body = otlp_bytes.replace_bytes(Bytes::new());
                                 (Uncompressed::Bytes(body), otlp_bytes.into())
                             }
                         }
                         PayloadData::OtapArrowRecords(mut otap_batch) => {
-                            // encode the OTAP batch as protobuf request body
+                            // Encode the OTAP batch as a protobuf request body.
                             proto_buffer.clear();
                             let encode_result =
                                 match signal_type {
@@ -672,25 +680,31 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                                 };
 
                             if !context.may_return_payload() {
-                                // drop the original OTAP batch if the context indicates it
-                                // does not wish it to be returned
+                                // Drop the original OTAP batch if it need not be returned.
                                 _ = otap_batch.take_payload();
                             }
 
-                            if let Err(e) = encode_result {
-                                let export_duration = export_started_at.elapsed();
-                                // encoding error, we must have received an invalid structured batch
+                            if let Err(error) = encode_result {
+                                let completed = attempt
+                                    .run(async |attempt| {
+                                        Err::<(), _>(
+                                            attempt.failed(OtlpHttpExporterErrorType::Encoding),
+                                        )
+                                    })
+                                    .await;
+                                let error_type = self
+                                    .metrics
+                                    .boundary
+                                    .record(completed)
+                                    .expect_err("encoding attempt must fail");
+                                self.metrics.record_failure(signal_type, error_type);
+                                // Encoding failed because the structured batch is invalid.
                                 let mut nack = NackMsg::new(
-                                    e.to_string(),
+                                    error.to_string(),
                                     OtapPdata::new(context, otap_batch.into()),
                                 );
                                 nack.permanent = true;
                                 _ = effect_handler.notify_nack(nack).await;
-                                self.metrics.record_failure(
-                                    signal_type,
-                                    OtlpHttpExporterErrorType::Encoding,
-                                    export_duration,
-                                );
                                 continue;
                             }
 
@@ -698,33 +712,43 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                         }
                     };
 
+                    let uncompressed_slice: &[u8] = match &uncompressed {
+                        Uncompressed::Bytes(bytes) => bytes.as_ref(),
+                        Uncompressed::InProtoBuffer => proto_buffer.as_ref(),
+                    };
+                    let payload_size = uncompressed_slice.len();
+
                     let body = match compression {
                         Some(method) => {
-                            let uncompressed_slice: &[u8] = match &uncompressed {
-                                Uncompressed::Bytes(b) => b.as_ref(),
-                                Uncompressed::InProtoBuffer => proto_buffer.as_ref(),
-                            };
-                            if let Err(e) =
+                            if let Err(error) =
                                 method.encode(uncompressed_slice, &mut compressed_buffer)
                             {
-                                let export_duration = export_started_at.elapsed();
+                                let completed = attempt
+                                    .run(async |attempt| {
+                                        attempt.set_payload_size_with(|| payload_size);
+                                        Err::<(), _>(
+                                            attempt.failed(OtlpHttpExporterErrorType::Compression),
+                                        )
+                                    })
+                                    .await;
+                                let error_type = self
+                                    .metrics
+                                    .boundary
+                                    .record(completed)
+                                    .expect_err("compression attempt must fail");
+                                self.metrics.record_failure(signal_type, error_type);
                                 let mut nack = NackMsg::new(
-                                    e.to_string(),
+                                    error.to_string(),
                                     OtapPdata::new(context, saved_payload),
                                 );
                                 nack.permanent = true;
                                 _ = effect_handler.notify_nack(nack).await;
-                                self.metrics.record_failure(
-                                    signal_type,
-                                    OtlpHttpExporterErrorType::Compression,
-                                    export_duration,
-                                );
                                 continue;
                             }
                             Bytes::copy_from_slice(&compressed_buffer)
                         }
                         None => match uncompressed {
-                            Uncompressed::Bytes(b) => b,
+                            Uncompressed::Bytes(bytes) => bytes,
                             Uncompressed::InProtoBuffer => {
                                 Bytes::copy_from_slice(proto_buffer.as_ref())
                             }
@@ -738,6 +762,7 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                     });
 
                     let max_response_body_len = self.config.max_response_body_length;
+                    let client = client_pool.get_client();
 
                     // Enforce the in-flight cap on the send path too. Normal
                     // intake is gated by `accepting_pdata`, but shutdown
@@ -760,35 +785,65 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                         }
                     }
 
-                    let client = client_pool.get_client();
                     inflight_exports.push(async move {
-                        let mut req = client.post(endpoint.as_str()).body(body);
-                        if let Some(auth) = auth_header {
-                            // A per-request header takes precedence over the
-                            // client's default headers, so the refreshed bearer
-                            // token overrides any statically configured
-                            // `authorization` credential.
-                            req = req.header(http::header::AUTHORIZATION, auth);
-                        }
-                        if let Some(method) = compression {
-                            req = req.header(
-                                http::header::CONTENT_ENCODING,
-                                method.as_http_content_encoding(),
-                            );
-                        }
-                        let result = req.send().await;
-
+                        let attempt = attempt
+                            .run(async |attempt| {
+                                attempt.set_payload_size_with(|| payload_size);
+                                let result = query_result_to_service_response(
+                                    &signal_type,
+                                    max_response_body_len,
+                                    {
+                                        let mut req = client.post(endpoint.as_str()).body(body);
+                                        if let Some(auth) = auth_header {
+                                            // A per-request header takes precedence over the
+                                            // client's default headers, so the refreshed bearer
+                                            // token overrides any statically configured
+                                            // `authorization` credential.
+                                            req = req.header(http::header::AUTHORIZATION, auth);
+                                        }
+                                        if let Some(method) = compression {
+                                            req = req.header(
+                                                http::header::CONTENT_ENCODING,
+                                                method.as_http_content_encoding(),
+                                            );
+                                        }
+                                        req.send().await
+                                    },
+                                )
+                                .await;
+                                match result {
+                                    Ok(service_response) => {
+                                        match service_response.partial_success {
+                                            Some(partial_success)
+                                                if partial_success.rejected == 0 =>
+                                            {
+                                                otel_debug!(
+                                                    "otlp.exporter.http.zero_partial_rejected",
+                                                    details = partial_success.error_message
+                                                );
+                                                Ok(())
+                                            }
+                                            Some(partial_success) => Err(attempt.refused(
+                                                ServiceRequestError::PartialRejection {
+                                                    rejected: partial_success.rejected,
+                                                    error_message: partial_success.error_message,
+                                                },
+                                            )),
+                                            None => Ok(()),
+                                        }
+                                    }
+                                    Err(error) if error.error_type().is_refusal() => {
+                                        Err(attempt.refused(error))
+                                    }
+                                    Err(error) => Err(attempt.failed(error)),
+                                }
+                            })
+                            .await;
                         CompletedExport {
-                            result: query_result_to_service_response(
-                                &signal_type,
-                                max_response_body_len,
-                                result,
-                            )
-                            .await,
+                            attempt,
                             context,
                             saved_payload,
                             signal_type,
-                            export_started_at,
                             request_auth,
                         }
                     })
@@ -877,6 +932,12 @@ enum ServiceRequestError {
 
     #[error("Response body size {body_size} exceeds maximum allowed size of {max_size} bytes")]
     BodyTooLarge { body_size: usize, max_size: usize },
+
+    #[error("{error_message} ({rejected} rejected)")]
+    PartialRejection {
+        rejected: i64,
+        error_message: String,
+    },
 }
 
 impl From<reqwest::Error> for ServiceRequestError {
@@ -903,6 +964,7 @@ impl ServiceRequestError {
             }
             Self::DecodeError(_) => OtlpHttpExporterErrorType::ResponseDecode,
             Self::BodyTooLarge { .. } => OtlpHttpExporterErrorType::ResponseTooLarge,
+            Self::PartialRejection { .. } => OtlpHttpExporterErrorType::PartialRejection,
         }
     }
 
@@ -935,7 +997,7 @@ impl ServiceRequestError {
                     )
             }
 
-            Self::BodyTooLarge { .. } | ServiceRequestError::DecodeError(_) => {
+            Self::BodyTooLarge { .. } | Self::DecodeError(_) | Self::PartialRejection { .. } => {
                 // these errors happen when we've received a 200 response, but for some reason
                 // were unable to deserialize the response body.
                 //
@@ -1096,69 +1158,37 @@ async fn finalize_completed_export(
     metrics: &mut OtlpHttpExporterMetrics,
 ) -> Option<RequestAuth> {
     let CompletedExport {
-        result,
+        attempt,
         context,
         saved_payload,
         signal_type,
-        export_started_at,
         request_auth,
     } = completed;
-    let export_duration = export_started_at.elapsed();
-
+    let result = metrics.boundary.record(attempt);
     let pdata = OtapPdata::new(context, saved_payload);
 
     // Set to the request identity when the server rejects its credential (401),
     // so the caller can invalidate exactly that generation before retry.
     let mut rejected_auth = None;
     let err = match result {
-        Ok(service_resp) => service_resp.partial_success.and_then(|partial_success| {
-            // As per OTLP HTTP spec, the server may use partial success to convey information
-            // even in the case where it fully accepts the request. In these cases, it MUST have
-            // set the rejected_<signal> field to 0. We'll treat this case as a success
-            if partial_success.rejected == 0 {
-                otel_debug!(
-                    "otlp.exporter.http.zero_partial_rejected",
-                    details = partial_success.error_message
-                );
-
-                None
-            } else {
-                // In the case we received a partial_success, the spec states that the request
-                // should not be retried.
-                // https://opentelemetry.io/docs/specs/otlp/#partial-success-1
-                let retryable = false;
-                Some((
-                    format!(
-                        "{} ({} rejected)",
-                        partial_success.error_message, partial_success.rejected
-                    ),
-                    retryable,
-                    OtlpHttpExporterErrorType::PartialRejection,
-                ))
-            }
-        }),
-        Err(e) => {
+        Ok(()) => None,
+        Err(error) => {
             // A 401 for either dynamic source is retryable and carries the exact
             // request generation back to the owning authentication variant.
-            let auth_failure = request_auth.is_dynamic() && e.is_auth_failure();
+            let auth_failure = request_auth.is_dynamic() && error.is_auth_failure();
             if auth_failure {
                 rejected_auth = Some(request_auth);
             }
-            let retryable = e.is_retryable() || auth_failure;
-            let error_type = e.error_type();
-            Some((e.to_string(), retryable, error_type))
+            Some((
+                error.to_string(),
+                error.is_retryable() || auth_failure,
+                error.error_type(),
+            ))
         }
     };
 
-    // Record the backend result before routing its Ack/Nack. Notification
-    // delivery is a separate pipeline concern and must not redefine or suppress
-    // the terminal HTTP export outcome.
-    if let Some((_, _, error_type)) = &err {
-        metrics.record_failure(signal_type, *error_type, export_duration);
-    } else {
-        metrics.record_success(signal_type, export_duration);
-    }
-
+    // The boundary result is recorded before Ack/Nack routing. Notification
+    // delivery is a separate pipeline concern and cannot redefine the attempt.
     match err {
         None => {
             if let Err(error) = effect_handler.notify_ack(AckMsg::new(pdata)).await {
@@ -1169,13 +1199,14 @@ async fn finalize_completed_export(
                 );
             }
         }
-        Some((err_msg, retryable, _)) => {
+        Some((message, retryable, error_type)) => {
+            metrics.record_failure(signal_type, error_type);
             otel_warn!(
                 "otlp.exporter.http.export_error",
-                message = err_msg,
+                message = message.as_str(),
                 retryable = retryable
             );
-            let mut nack = NackMsg::new(&err_msg, pdata);
+            let mut nack = NackMsg::new(&message, pdata);
             nack.permanent = !retryable;
             if let Err(error) = effect_handler.notify_nack(nack).await {
                 otel_warn!(
@@ -1311,6 +1342,7 @@ mod test {
     use otel_arrow_dfe_engine::shared::message::SharedSender;
     use otel_arrow_dfe_engine::testing::exporter::TestRuntime;
     use otel_arrow_dfe_engine::testing::node::test_node;
+    use otel_arrow_dfe_otap::metrics::ErrorWithOutcome;
     use otel_arrow_dfe_pdata::OtapArrowRecords;
     use otel_arrow_dfe_pdata::OtlpProtoBytes;
     use otel_arrow_dfe_pdata::otap::Logs;
@@ -1325,7 +1357,6 @@ mod test {
     use otel_arrow_dfe_pdata::proto::opentelemetry::trace::v1::{ResourceSpans, TracesData};
     use otel_arrow_dfe_pdata::testing::equiv::assert_equivalent;
     use otel_arrow_dfe_pdata::testing::round_trip::otlp_to_otap;
-    use otel_arrow_dfe_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
     use otel_arrow_dfe_telemetry::registry::TelemetryRegistryHandle;
     use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
 
@@ -3929,59 +3960,46 @@ mod test {
             metrics_reporter,
             otel_arrow_dfe_engine::testing::test_pipeline_runtime_services(),
         );
+        let runtime = Runtime::new().unwrap();
+        let attempt = runtime.block_on(metrics.boundary.attempt(SignalType::Logs).run(
+            async |attempt| {
+                Err(attempt.failed(ServiceRequestError::BodyTooLarge {
+                    body_size: 2,
+                    max_size: 1,
+                }))
+            },
+        ));
         let completed = CompletedExport {
-            result: Err(ServiceRequestError::BodyTooLarge {
-                body_size: 2,
-                max_size: 1,
-            }),
+            attempt,
             context: Context::default(),
             saved_payload: OtlpProtoBytes::ExportLogsRequest(Bytes::new()).into(),
             signal_type: SignalType::Logs,
-            export_started_at: Instant::now(),
             request_auth: RequestAuth::None,
         };
 
-        let _ = Runtime::new().unwrap().block_on(finalize_completed_export(
+        let _ = runtime.block_on(finalize_completed_export(
             completed,
             &effect_handler,
             &mut metrics,
         ));
 
-        assert_eq!(
-            metrics
-                .exports
-                .get(SignalOutcomeAttributes {
-                    signal: SignalType::Logs,
-                    outcome: Outcome::Failure,
-                })
-                .messages
-                .get(),
-            1
-        );
-        assert_eq!(
-            metrics
-                .exports
-                .get(SignalOutcomeAttributes {
-                    signal: SignalType::Logs,
-                    outcome: Outcome::Success,
-                })
-                .messages
-                .get(),
-            0
-        );
-        assert_eq!(
-            metrics
-                .exports
-                .get(SignalOutcomeAttributes {
-                    signal: SignalType::Logs,
-                    outcome: Outcome::Failure,
-                })
-                .duration_seconds
-                .get()
-                .count(),
-            1
-        );
         let snapshots = metrics.terminal_snapshots();
+        assert!(snapshots.iter().any(|snapshot| {
+            snapshot.descriptor().name == "exporter.attempted"
+                && snapshot.measurement_attribute_value("signal") == Some("logs")
+                && snapshot.measurement_attribute_value("outcome") == Some("failure")
+                && snapshot
+                    .descriptor()
+                    .metrics
+                    .iter()
+                    .position(|metric| metric.name == "messages")
+                    .is_some_and(|index| snapshot.get_metrics()[index].to_u64_lossy() == 1)
+        }));
+        assert!(!snapshots.iter().any(|snapshot| {
+            snapshot.descriptor().name == "exporter.attempted"
+                && snapshot.measurement_attribute_value("signal") == Some("logs")
+                && snapshot.measurement_attribute_value("outcome") == Some("success")
+        }));
         assert!(snapshots.iter().any(|snapshot| {
             snapshot.descriptor().name == "exporter.otlp_http.failures"
                 && snapshot.measurement_attribute_value("signal") == Some("logs")
@@ -3990,7 +4008,7 @@ mod test {
         }));
     }
 
-    /// Scenario: A zero-rejection partial success cannot deliver its upstream Ack notification.
+    /// Scenario: A successful backend export cannot deliver its upstream Ack notification.
     /// Guarantees: The backend success is recorded once without a failure classification.
     #[test]
     fn successful_export_is_recorded_when_ack_notification_fails() {
@@ -4013,51 +4031,46 @@ mod test {
         let pdata = OtapPdata::new_default(OtlpProtoBytes::ExportLogsRequest(Bytes::new()).into())
             .test_subscribe_to(Interests::ACKS, TestCallData::default().into(), 123);
         let (context, saved_payload) = pdata.into_parts();
+        let runtime = Runtime::new().unwrap();
+        let attempt = runtime.block_on(
+            metrics
+                .boundary
+                .attempt(SignalType::Logs)
+                .run(async |_| Ok::<_, ErrorWithOutcome<ServiceRequestError>>(())),
+        );
         let completed = CompletedExport {
-            result: Ok(ServiceResponse {
-                partial_success: Some(PartialSuccess {
-                    rejected: 0,
-                    error_message: "informational warning".to_owned(),
-                }),
-            }),
+            attempt,
             context,
             saved_payload,
             signal_type: SignalType::Logs,
-            export_started_at: Instant::now(),
             request_auth: RequestAuth::None,
         };
 
-        let _ = Runtime::new().unwrap().block_on(finalize_completed_export(
+        let _ = runtime.block_on(finalize_completed_export(
             completed,
             &effect_handler,
             &mut metrics,
         ));
 
-        assert_eq!(
-            metrics
-                .exports
-                .get(SignalOutcomeAttributes {
-                    signal: SignalType::Logs,
-                    outcome: Outcome::Success,
-                })
-                .messages
-                .get(),
-            1
-        );
-        assert_eq!(
-            metrics
-                .exports
-                .get(SignalOutcomeAttributes {
-                    signal: SignalType::Logs,
-                    outcome: Outcome::Failure,
-                })
-                .messages
-                .get(),
-            0
-        );
+        let snapshots = metrics.terminal_snapshots();
+        assert!(snapshots.iter().any(|snapshot| {
+            snapshot.descriptor().name == "exporter.attempted"
+                && snapshot.measurement_attribute_value("signal") == Some("logs")
+                && snapshot.measurement_attribute_value("outcome") == Some("success")
+                && snapshot
+                    .descriptor()
+                    .metrics
+                    .iter()
+                    .position(|metric| metric.name == "messages")
+                    .is_some_and(|index| snapshot.get_metrics()[index].to_u64_lossy() == 1)
+        }));
+        assert!(!snapshots.iter().any(|snapshot| {
+            snapshot.descriptor().name == "exporter.attempted"
+                && snapshot.measurement_attribute_value("signal") == Some("logs")
+                && snapshot.measurement_attribute_value("outcome") == Some("failure")
+        }));
         assert!(
-            metrics
-                .terminal_snapshots()
+            snapshots
                 .iter()
                 .all(|snapshot| snapshot.descriptor().name != "exporter.otlp_http.failures")
         );

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otlp_http_exporter/mod.rs
@@ -762,7 +762,6 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                     });
 
                     let max_response_body_len = self.config.max_response_body_length;
-                    let client = client_pool.get_client();
 
                     // Enforce the in-flight cap on the send path too. Normal
                     // intake is gated by `accepting_pdata`, but shutdown
@@ -785,6 +784,7 @@ impl Exporter<OtapPdata> for OtlpHttpExporter {
                         }
                     }
 
+                    let client = client_pool.get_client();
                     inflight_exports.push(async move {
                         let attempt = attempt
                             .run(async |attempt| {
@@ -997,12 +997,13 @@ impl ServiceRequestError {
                     )
             }
 
-            Self::BodyTooLarge { .. } | Self::DecodeError(_) | Self::PartialRejection { .. } => {
-                // these errors happen when we've received a 200 response, but for some reason
-                // were unable to deserialize the response body.
-                //
-                // this indicates either a full success, or partial success. In either case, we
-                // shouldn't retry. The spec explicitly states this for partial success
+            Self::BodyTooLarge { .. } | Self::DecodeError(_) => {
+                // The backend returned success, but the response could not be
+                // consumed safely. Retrying may duplicate data already accepted.
+                false
+            }
+            Self::PartialRejection { .. } => {
+                // OTLP explicitly forbids retrying partial-success responses.
                 // https://opentelemetry.io/docs/specs/otlp/#partial-success-1
                 false
             }
@@ -4004,6 +4005,89 @@ mod test {
             snapshot.descriptor().name == "exporter.otlp_http.failures"
                 && snapshot.measurement_attribute_value("signal") == Some("logs")
                 && snapshot.measurement_attribute_value("error.type") == Some("response_too_large")
+                && snapshot.get_metrics()[0].to_u64_lossy() == 1
+        }));
+    }
+
+    /// Scenario: A successful HTTP response rejects part of an OTLP logs request.
+    /// Guarantees: The existing permanent Nack is preserved while shared metrics record one refused attempt and the bounded partial-rejection diagnostic.
+    #[test]
+    fn partial_rejection_preserves_nack_and_records_refused_attempt() {
+        let registry = TelemetryRegistryHandle::new();
+        let controller = ControllerContext::new(registry);
+        let pipeline_ctx =
+            controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        let mut metrics = OtlpHttpExporterMetrics::register(&pipeline_ctx);
+
+        let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(1);
+        let mut effect_handler = EffectHandler::new(
+            test_node("test-exporter"),
+            metrics_reporter,
+            otel_arrow_dfe_engine::testing::test_pipeline_runtime_services(),
+        );
+        let (completion_tx, mut completion_rx) =
+            otel_arrow_dfe_engine::control::pipeline_completion_msg_channel(1);
+        effect_handler.set_pipeline_completion_msg_sender(completion_tx);
+        let pdata = OtapPdata::new_default(OtlpProtoBytes::ExportLogsRequest(Bytes::new()).into())
+            .test_subscribe_to(
+                Interests::ACKS | Interests::NACKS,
+                TestCallData::default().into(),
+                123,
+            );
+        let (context, saved_payload) = pdata.into_parts();
+        let runtime = Runtime::new().unwrap();
+        let attempt = runtime.block_on(metrics.boundary.attempt(SignalType::Logs).run(
+            async |attempt| {
+                Err(attempt.refused(ServiceRequestError::PartialRejection {
+                    rejected: 1,
+                    error_message: "partial success error".to_owned(),
+                }))
+            },
+        ));
+        let completed = CompletedExport {
+            attempt,
+            context,
+            saved_payload,
+            signal_type: SignalType::Logs,
+            request_auth: RequestAuth::None,
+        };
+
+        let rejected_auth = runtime.block_on(finalize_completed_export(
+            completed,
+            &effect_handler,
+            &mut metrics,
+        ));
+        assert!(rejected_auth.is_none());
+
+        let completion = runtime
+            .block_on(completion_rx.recv())
+            .expect("partial rejection must route a completion");
+        match completion {
+            PipelineCompletionMsg::DeliverNack { nack } => {
+                assert!(nack.permanent, "partial rejection must remain permanent");
+                assert!(nack.reason.contains("partial success error (1 rejected)"));
+            }
+            PipelineCompletionMsg::DeliverAck { .. } => {
+                panic!("partial rejection must not route an Ack")
+            }
+        }
+
+        let snapshots = metrics.terminal_snapshots();
+        assert!(snapshots.iter().any(|snapshot| {
+            snapshot.descriptor().name == "exporter.attempted"
+                && snapshot.measurement_attribute_value("signal") == Some("logs")
+                && snapshot.measurement_attribute_value("outcome") == Some("refused")
+                && snapshot
+                    .descriptor()
+                    .metrics
+                    .iter()
+                    .position(|metric| metric.name == "messages")
+                    .is_some_and(|index| snapshot.get_metrics()[index].to_u64_lossy() == 1)
+        }));
+        assert!(snapshots.iter().any(|snapshot| {
+            snapshot.descriptor().name == "exporter.otlp_http.failures"
+                && snapshot.measurement_attribute_value("signal") == Some("logs")
+                && snapshot.measurement_attribute_value("error.type") == Some("partial_rejection")
                 && snapshot.get_metrics()[0].to_u64_lossy() == 1
         }));
     }

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/README.md
@@ -143,38 +143,47 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 ### Metric Sets
 
+#### `receiver.received`
+
+| Metric | Unit | Attributes | Description |
+| --- | --- | --- | --- |
+| `receiver.received.messages` | `{message}` | `signal`, `outcome` | Number of classified OTLP messages whose receiver-local handling terminated. |
+| `receiver.received.payload.size` | `By` | `signal`, `outcome` | Encoded application payload bytes observed at the receiver boundary. |
+
+#### `receiver.processing`
+
+| Metric | Unit | Attributes | Description |
+| --- | --- | --- | --- |
+| `receiver.processing.duration` | `s` | `signal` | Receiver-local processing time before downstream handoff. Emitted when component duration is enabled. |
+
 #### `receiver.otlp.requests`
 
 | Metric | Unit | Attributes | Description |
 | --- | --- | --- | --- |
-| `receiver.otlp.requests.started` | `{request}` | `signal`, `protocol` | Number of requests admitted to the pipeline send path. |
-| `receiver.otlp.requests.completed` | `{request}` | `signal`, `protocol` | Number of admitted requests whose receiver work terminated. |
-| `receiver.otlp.requests.payload_size` | `By` | `signal`, `protocol` | Decompressed payload bytes for requests admitted to the pipeline send path. |
+| `receiver.otlp.requests.accepted` | `{request}` | `signal`, `protocol` | Number of OTLP requests admitted to the pipeline send path. |
+| `receiver.otlp.requests.rejected` | `{request}` | `protocol`, `error.type` | Number of requests rejected before pipeline admission. |
 
-#### `receiver.otlp.rejections`
-
-| Metric | Unit | Attributes | Description |
-| --- | --- | --- | --- |
-| `receiver.otlp.rejections.requests` | `{request}` | `protocol`, `error.type` | Number of requests rejected before pipeline admission. |
-
-Rate-admission outcomes are reported by the engine metric set
-`admission.rate_limiter`. Its `refusals` counter uses the bounded attributes
-`dimension=bytes` and `refusal=would_throttle|throttle|oversized`. The metric is
-scoped to the configured node entity, but tenant or request identities are
-never measurement attributes. Protocol-specific enforced rejections remain in
-`receiver.otlp.rejections`.
-
-#### `receiver.otlp.acknowledgements`
-
-| Metric | Unit | Attributes | Description |
-| --- | --- | --- | --- |
-| `receiver.otlp.acknowledgements.responses` | `{response}` | `signal`, `outcome` | Number of routed or invalid acknowledgement responses. |
+The shared `receiver.received` metrics report terminal outcome and payload size
+for classified requests.
 
 #### `receiver.otlp.transport`
 
 | Metric | Unit | Attributes | Description |
 | --- | --- | --- | --- |
 | `receiver.otlp.transport.errors` | `{error}` | `protocol` | Number of transport-level server errors. |
+
+Rate-admission outcomes are reported by the engine metric set
+`admission.rate_limiter`. Its `refusals` counter uses the bounded attributes
+`dimension=bytes` and `refusal=would_throttle|throttle|oversized`. The metric is
+scoped to the configured node entity, but tenant or request identities are
+never measurement attributes. Protocol-specific enforced rejections remain in
+`receiver.otlp.requests.rejected`.
+
+#### `receiver.otlp.acknowledgements`
+
+| Metric | Unit | Attributes | Description |
+| --- | --- | --- | --- |
+| `receiver.otlp.acknowledgements.responses` | `{response}` | `signal`, `outcome` | Number of routed or invalid acknowledgement responses. |
 
 Attribute values are bounded: `signal` is `traces`, `metrics`, or `logs`;
 `protocol` is `grpc` or `http`; `outcome` is `success`, `failure`, or

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/otlp_receiver/mod.rs
@@ -3536,7 +3536,7 @@ mod tests {
                     assert_eq!(
                         metrics
                             .requests_for(SignalType::Logs, OtlpProtocol::Grpc)
-                            .started
+                            .accepted
                             .get(),
                         0
                     );
@@ -3624,8 +3624,7 @@ mod tests {
                 {
                     let metrics = scenario_metrics.lock();
                     let requests = metrics.requests_for(SignalType::Logs, OtlpProtocol::Grpc);
-                    assert_eq!(requests.started.get(), 1);
-                    assert_eq!(requests.payload_size.get(), request_weight);
+                    assert_eq!(requests.accepted.get(), 1);
                     assert_eq!(
                         metrics
                             .rejections_for(
@@ -3769,8 +3768,7 @@ mod tests {
                 {
                     let metrics = scenario_metrics.lock();
                     let requests = metrics.requests_for(SignalType::Logs, OtlpProtocol::Http);
-                    assert_eq!(requests.started.get(), 1);
-                    assert_eq!(requests.payload_size.get(), request_weight);
+                    assert_eq!(requests.accepted.get(), 1);
                     assert_eq!(
                         metrics
                             .rejections_for(
@@ -3909,7 +3907,7 @@ mod tests {
                     assert_eq!(
                         metrics
                             .requests_for(SignalType::Logs, OtlpProtocol::Http)
-                            .started
+                            .accepted
                             .get(),
                         0
                     );

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server_new.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server_new.rs
@@ -363,20 +363,6 @@ impl OtapBatchService {
     }
 }
 
-/// Records request completion when the gRPC future returns or is cancelled.
-struct RequestCompletionGuard {
-    metrics: Arc<Mutex<OtlpReceiverMetrics>>,
-    signal: SignalType,
-}
-
-impl Drop for RequestCompletionGuard {
-    fn drop(&mut self) {
-        self.metrics
-            .lock()
-            .record_request_completed(self.signal, OtlpProtocol::Grpc);
-    }
-}
-
 /// Guard mechanism for cancelling a slot when Tonic timeout
 /// drops the future.
 pub(crate) struct SlotGuard {
@@ -444,85 +430,87 @@ impl UnaryService<OtapPdata> for OtapBatchService {
             }
         }
 
-        // Payload size is required only by byte admission. When admission is
-        // disabled, missing optional size telemetry must never reject traffic.
-        let payload_bytes = payload_size.and_then(|size| u64::try_from(size).ok());
-
-        // Propagate the receiver-observed peer address so downstream processors
-        // (e.g. k8sattributes) can correlate telemetry with the originating socket.
-        if let Some(addr) = peer_addr_from_extensions(&extensions) {
-            otap_batch.set_peer_addr(addr);
-        }
-
         let effect_handler = self
             .effect_handler
             .take()
             .expect("`OtapBatchService` is not reused for multiple calls");
 
-        // Capture transport headers synchronously before moving the effect handler
-        // into the async block, avoiding a clone of the capture policy.
-        if let Some(policy) = effect_handler.capture_policy() {
-            let mut transport_headers = TransportHeaders::new();
-
-            // Collect all metadata pairs, decoding binary values so we store
-            // raw bytes rather than the base64 wire encoding (which would be
-            // double-encoded on downstream gRPC propagation).
-            let pairs: Vec<(&str, Vec<u8>)> = metadata
-                .iter()
-                .filter_map(|kv| match kv {
-                    tonic::metadata::KeyAndValueRef::Ascii(key, value) => {
-                        Some((key.as_str(), value.as_bytes().to_vec()))
-                    }
-                    tonic::metadata::KeyAndValueRef::Binary(key, value) => value
-                        .to_bytes()
-                        .ok()
-                        .map(|decoded| (key.as_str(), decoded.to_vec())),
-                })
-                .collect();
-
-            let _stats = policy.capture_from_pairs(
-                pairs.iter().map(|(k, v)| (*k, v.as_slice())),
-                &mut transport_headers,
-            );
-            if !transport_headers.is_empty() {
-                otap_batch.set_transport_headers(transport_headers);
-            }
-        }
-
         let state = self.state.clone();
         let metrics = self.metrics.clone();
         let signal = self.signal;
         Box::pin(async move {
-            let cancel_rx = if let Some(state) = state {
-                let (key, rx) = match state.allocate_slot() {
-                    None => {
-                        metrics.lock().record_rejection(
-                            OtlpProtocol::Grpc,
-                            ReceiverRejectionErrorType::ConcurrencyLimit,
-                        );
-                        return Err(Status::resource_exhausted("Too many concurrent requests"));
+            let processing = metrics.lock().boundary.processing();
+            let completed = processing.run(|processing| {
+                if let Some(payload_size) = payload_size {
+                    processing.set_payload_size_with(|| payload_size);
+                }
+
+                // Propagate the receiver-observed peer address so downstream processors
+                // (e.g. k8sattributes) can correlate telemetry with the originating socket.
+                if let Some(addr) = peer_addr_from_extensions(&extensions) {
+                    otap_batch.set_peer_addr(addr);
+                }
+
+                // Capture transport headers synchronously before downstream handoff.
+                if let Some(policy) = effect_handler.capture_policy() {
+                    let mut transport_headers = TransportHeaders::new();
+
+                    // Decode binary values so downstream gRPC propagation does not
+                    // double-encode their base64 wire representation.
+                    let pairs: Vec<(&str, Vec<u8>)> = metadata
+                        .iter()
+                        .filter_map(|kv| match kv {
+                            tonic::metadata::KeyAndValueRef::Ascii(key, value) => {
+                                Some((key.as_str(), value.as_bytes().to_vec()))
+                            }
+                            tonic::metadata::KeyAndValueRef::Binary(key, value) => value
+                                .to_bytes()
+                                .ok()
+                                .map(|decoded| (key.as_str(), decoded.to_vec())),
+                        })
+                        .collect();
+
+                    let _stats = policy.capture_from_pairs(
+                        pairs.iter().map(|(k, v)| (*k, v.as_slice())),
+                        &mut transport_headers,
+                    );
+                    if !transport_headers.is_empty() {
+                        otap_batch.set_transport_headers(transport_headers);
                     }
-                    Some(pair) => pair,
+                }
+
+                let cancel_rx = if let Some(state) = state {
+                    let (key, rx) = match state.allocate_slot() {
+                        None => {
+                            metrics.lock().record_rejection(
+                                OtlpProtocol::Grpc,
+                                ReceiverRejectionErrorType::ConcurrencyLimit,
+                            );
+                            return Err(processing.refused(
+                                signal,
+                                Status::resource_exhausted("Too many concurrent requests"),
+                            ));
+                        }
+                        Some(pair) => pair,
+                    };
+
+                    // Enter the subscription. Slot key becomes calldata.
+                    effect_handler.subscribe_to(
+                        Interests::ACKS | Interests::NACKS,
+                        key.into(),
+                        &mut otap_batch,
+                    );
+                    Some((SlotGuard { key, state }, rx))
+                } else {
+                    None
                 };
 
-                // Enter the subscription. Slot key becomes calldata.
-                effect_handler.subscribe_to(
-                    Interests::ACKS | Interests::NACKS,
-                    key.into(),
-                    &mut otap_batch,
-                );
-                Some((SlotGuard { key, state }, rx))
-            } else {
-                None
-            };
-
+                Ok((signal, (otap_batch, cancel_rx)))
+            });
+            let (otap_batch, cancel_rx) = metrics.lock().boundary.record(completed)?;
             metrics
                 .lock()
-                .record_request_admitted(signal, OtlpProtocol::Grpc, payload_bytes);
-            let _completion_guard = RequestCompletionGuard {
-                metrics: metrics.clone(),
-                signal,
-            };
+                .record_request_admitted(signal, OtlpProtocol::Grpc);
 
             // Send and wait for Ack/Nack
             match effect_handler
@@ -919,8 +907,8 @@ mod tests {
     use otel_arrow_dfe_engine::control::runtime_ctrl_msg_channel;
     use otel_arrow_dfe_engine::shared::message::SharedSender;
     use otel_arrow_dfe_engine::testing::test_node;
+    use otel_arrow_dfe_engine::testing::test_pipeline_ctx_with_interests;
     use otel_arrow_dfe_pdata::OtlpProtoBytes;
-    use otel_arrow_dfe_telemetry::registry::TelemetryRegistryHandle;
     use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
     use std::collections::HashMap;
     use tokio::sync::mpsc as tokio_mpsc;
@@ -974,10 +962,8 @@ mod tests {
     }
 
     fn new_test_metrics() -> Arc<Mutex<OtlpReceiverMetrics>> {
-        let registry = TelemetryRegistryHandle::new();
-        let controller = otel_arrow_dfe_engine::context::ControllerContext::new(registry);
-        let pipeline_ctx =
-            controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        let (pipeline_ctx, _registry) =
+            test_pipeline_ctx_with_interests(Interests::PRODUCED_CONSUMED_SIZE);
         Arc::new(Mutex::new(OtlpReceiverMetrics::register(&pipeline_ctx)))
     }
 
@@ -1251,8 +1237,8 @@ mod tests {
         );
     }
 
-    /// Scenario: A non-empty gRPC request does not require an acknowledgement slot.
-    /// Guarantees: Successful admission records its started, completed, and payload-byte values.
+    /// Scenario: A non-empty gRPC request is admitted with receiver size telemetry enabled.
+    /// Guarantees: The OTLP accepted counter and shared payload metric each record the request.
     #[tokio::test]
     async fn admitted_grpc_request_records_payload_bytes() {
         let metrics = new_test_metrics();
@@ -1265,17 +1251,29 @@ mod tests {
 
         assert!(result.is_ok());
         let _ = msg_rx.recv().await.expect("request forwarded downstream");
-        let metrics = metrics.lock();
+        let mut metrics = metrics.lock();
         let requests = metrics.requests_for(SignalType::Logs, OtlpProtocol::Grpc);
-        assert_eq!(requests.started.get(), 1);
-        assert_eq!(requests.completed.get(), 1);
-        assert_eq!(requests.payload_size.get(), payload_bytes);
+        assert_eq!(requests.accepted.get(), 1);
+        let snapshots = metrics.boundary.terminal_snapshots();
+        assert!(snapshots.iter().any(|snapshot| {
+            snapshot.descriptor().name == "receiver.received"
+                && snapshot.measurement_attribute_value("signal") == Some("logs")
+                && snapshot.measurement_attribute_value("outcome") == Some("success")
+                && snapshot
+                    .descriptor()
+                    .metrics
+                    .iter()
+                    .position(|metric| metric.name == "payload.size")
+                    .is_some_and(|index| {
+                        snapshot.get_metrics()[index].to_u64_lossy() == payload_bytes
+                    })
+        }));
     }
 
     /// Scenario: A non-empty gRPC request cannot allocate its acknowledgement slot.
-    /// Guarantees: The request is rejected without recording admission, completion, or payload bytes.
+    /// Guarantees: The request is rejected without incrementing the OTLP accepted counter.
     #[tokio::test]
-    async fn rejected_grpc_request_does_not_record_payload_bytes() {
+    async fn rejected_grpc_request_is_not_accepted() {
         let metrics = new_test_metrics();
         let (mut service, mut msg_rx) = new_test_service(Some(AckSlot::new(0)), metrics.clone());
         let payload = Bytes::from_static(b"grpc-rejected-payload");
@@ -1290,9 +1288,7 @@ mod tests {
         assert!(msg_rx.try_recv().is_err());
         let metrics = metrics.lock();
         let requests = metrics.requests_for(SignalType::Logs, OtlpProtocol::Grpc);
-        assert_eq!(requests.started.get(), 0);
-        assert_eq!(requests.completed.get(), 0);
-        assert_eq!(requests.payload_size.get(), 0);
+        assert_eq!(requests.accepted.get(), 0);
         assert_eq!(
             metrics
                 .rejections_for(

--- a/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server_new.rs
+++ b/rust/otap-dataflow/crates/otap/src/otap_grpc/otlp/server_new.rs
@@ -430,10 +430,45 @@ impl UnaryService<OtapPdata> for OtapBatchService {
             }
         }
 
+        // Propagate the receiver-observed peer address so downstream processors
+        // (e.g. k8sattributes) can correlate telemetry with the originating socket.
+        if let Some(addr) = peer_addr_from_extensions(&extensions) {
+            otap_batch.set_peer_addr(addr);
+        }
+
         let effect_handler = self
             .effect_handler
             .take()
             .expect("`OtapBatchService` is not reused for multiple calls");
+
+        // Capture transport headers synchronously before moving the effect handler
+        // into the async block, avoiding a clone of the capture policy.
+        if let Some(policy) = effect_handler.capture_policy() {
+            let mut transport_headers = TransportHeaders::new();
+
+            // Decode binary values so downstream gRPC propagation does not
+            // double-encode their base64 wire representation.
+            let pairs: Vec<(&str, Vec<u8>)> = metadata
+                .iter()
+                .filter_map(|kv| match kv {
+                    tonic::metadata::KeyAndValueRef::Ascii(key, value) => {
+                        Some((key.as_str(), value.as_bytes().to_vec()))
+                    }
+                    tonic::metadata::KeyAndValueRef::Binary(key, value) => value
+                        .to_bytes()
+                        .ok()
+                        .map(|decoded| (key.as_str(), decoded.to_vec())),
+                })
+                .collect();
+
+            let _stats = policy.capture_from_pairs(
+                pairs.iter().map(|(k, v)| (*k, v.as_slice())),
+                &mut transport_headers,
+            );
+            if !transport_headers.is_empty() {
+                otap_batch.set_transport_headers(transport_headers);
+            }
+        }
 
         let state = self.state.clone();
         let metrics = self.metrics.clone();
@@ -443,40 +478,6 @@ impl UnaryService<OtapPdata> for OtapBatchService {
             let completed = processing.run(|processing| {
                 if let Some(payload_size) = payload_size {
                     processing.set_payload_size_with(|| payload_size);
-                }
-
-                // Propagate the receiver-observed peer address so downstream processors
-                // (e.g. k8sattributes) can correlate telemetry with the originating socket.
-                if let Some(addr) = peer_addr_from_extensions(&extensions) {
-                    otap_batch.set_peer_addr(addr);
-                }
-
-                // Capture transport headers synchronously before downstream handoff.
-                if let Some(policy) = effect_handler.capture_policy() {
-                    let mut transport_headers = TransportHeaders::new();
-
-                    // Decode binary values so downstream gRPC propagation does not
-                    // double-encode their base64 wire representation.
-                    let pairs: Vec<(&str, Vec<u8>)> = metadata
-                        .iter()
-                        .filter_map(|kv| match kv {
-                            tonic::metadata::KeyAndValueRef::Ascii(key, value) => {
-                                Some((key.as_str(), value.as_bytes().to_vec()))
-                            }
-                            tonic::metadata::KeyAndValueRef::Binary(key, value) => value
-                                .to_bytes()
-                                .ok()
-                                .map(|decoded| (key.as_str(), decoded.to_vec())),
-                        })
-                        .collect();
-
-                    let _stats = policy.capture_from_pairs(
-                        pairs.iter().map(|(k, v)| (*k, v.as_slice())),
-                        &mut transport_headers,
-                    );
-                    if !transport_headers.is_empty() {
-                        otap_batch.set_transport_headers(transport_headers);
-                    }
                 }
 
                 let cancel_rx = if let Some(state) = state {

--- a/rust/otap-dataflow/crates/otap/src/otlp_http.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_http.rs
@@ -819,74 +819,80 @@ impl HttpHandler {
                 }
             }
 
-            let context = if self.settings.wait_for_result {
-                Context::with_capacity(1)
-            } else {
-                Context::default()
-            };
+            let processing = self.metrics.lock().boundary.processing();
+            let completed = processing.run(|processing| {
+                processing.set_payload_size_with(|| body.len());
 
-            let payload = match signal {
-                SignalType::Logs => OtlpProtoBytes::ExportLogsRequest(body),
-                SignalType::Metrics => OtlpProtoBytes::ExportMetricsRequest(body),
-                SignalType::Traces => OtlpProtoBytes::ExportTracesRequest(body),
-            };
-
-            let mut pdata = OtapPdata::new(context, payload.into());
-            pdata.set_peer_addr(self.peer_addr);
-
-            // Capture transport headers from HTTP headers when a capture policy is configured.
-            if let Some(policy) = self.effect_handler.capture_policy() {
-                let mut transport_headers = TransportHeaders::new();
-                let pairs = headers
-                    .iter()
-                    .map(|(name, value)| (name.as_str(), value.as_bytes()));
-                let _stats = policy.capture_from_pairs(pairs, &mut transport_headers);
-                if !transport_headers.is_empty() {
-                    pdata.set_transport_headers(transport_headers);
-                }
-            }
-
-            let cancel_rx = if self.settings.wait_for_result {
-                let state = match signal {
-                    SignalType::Logs => self.ack_registry.logs.clone(),
-                    SignalType::Metrics => self.ack_registry.metrics.clone(),
-                    SignalType::Traces => self.ack_registry.traces.clone(),
+                let context = if self.settings.wait_for_result {
+                    Context::with_capacity(1)
+                } else {
+                    Context::default()
                 };
 
-                let Some(state) = state else {
-                    self.record_rejection(ReceiverRejectionErrorType::Internal);
-                    return Err(internal_error());
+                let payload = match signal {
+                    SignalType::Logs => OtlpProtoBytes::ExportLogsRequest(body),
+                    SignalType::Metrics => OtlpProtoBytes::ExportMetricsRequest(body),
+                    SignalType::Traces => OtlpProtoBytes::ExportTracesRequest(body),
                 };
 
-                let (key, rx) = match state.allocate_slot() {
-                    None => {
-                        self.record_rejection(ReceiverRejectionErrorType::ConcurrencyLimit);
-                        return Err(service_unavailable());
+                let mut pdata = OtapPdata::new(context, payload.into());
+                pdata.set_peer_addr(self.peer_addr);
+
+                // Capture transport headers from HTTP headers when a capture policy is configured.
+                if let Some(policy) = self.effect_handler.capture_policy() {
+                    let mut transport_headers = TransportHeaders::new();
+                    let pairs = headers
+                        .iter()
+                        .map(|(name, value)| (name.as_str(), value.as_bytes()));
+                    let _stats = policy.capture_from_pairs(pairs, &mut transport_headers);
+                    if !transport_headers.is_empty() {
+                        pdata.set_transport_headers(transport_headers);
                     }
-                    Some(pair) => pair,
+                }
+
+                let cancel_rx = if self.settings.wait_for_result {
+                    let state = match signal {
+                        SignalType::Logs => self.ack_registry.logs.clone(),
+                        SignalType::Metrics => self.ack_registry.metrics.clone(),
+                        SignalType::Traces => self.ack_registry.traces.clone(),
+                    };
+
+                    let Some(state) = state else {
+                        self.record_rejection(ReceiverRejectionErrorType::Internal);
+                        return Err(processing.failed(signal, Box::new(internal_error())));
+                    };
+
+                    let (key, rx) = match state.allocate_slot() {
+                        None => {
+                            self.record_rejection(ReceiverRejectionErrorType::ConcurrencyLimit);
+                            return Err(processing.refused(signal, Box::new(service_unavailable())));
+                        }
+                        Some(pair) => pair,
+                    };
+
+                    // Register calldata in the context.
+                    self.effect_handler.subscribe_to(
+                        Interests::ACKS | Interests::NACKS,
+                        key.into(),
+                        &mut pdata,
+                    );
+
+                    Some((SlotGuard { key, state }, rx))
+                } else {
+                    None
                 };
 
-                // Register calldata in the context.
-                self.effect_handler.subscribe_to(
-                    Interests::ACKS | Interests::NACKS,
-                    key.into(),
-                    &mut pdata,
-                );
-
-                Some((SlotGuard { key, state }, rx))
-            } else {
-                None
-            };
-
-            self.metrics.lock().record_request_admitted(
-                signal,
-                OtlpProtocol::Http,
-                Some(payload_bytes),
-            );
-            let _completion_guard = RequestCompletionGuard {
-                metrics: self.metrics.clone(),
-                signal,
-            };
+                Ok((signal, (pdata, cancel_rx)))
+            });
+            let (pdata, cancel_rx) = self
+                .metrics
+                .lock()
+                .boundary
+                .record(completed)
+                .map_err(|response| *response)?;
+            self.metrics
+                .lock()
+                .record_request_admitted(signal, OtlpProtocol::Http);
 
             if self
                 .effect_handler
@@ -954,19 +960,6 @@ impl HttpHandler {
 struct SlotGuard {
     key: crate::accessory::slots::Key,
     state: AckSlot,
-}
-
-struct RequestCompletionGuard {
-    metrics: Arc<Mutex<OtlpReceiverMetrics>>,
-    signal: SignalType,
-}
-
-impl Drop for RequestCompletionGuard {
-    fn drop(&mut self) {
-        self.metrics
-            .lock()
-            .record_request_completed(self.signal, OtlpProtocol::Http);
-    }
 }
 
 impl Drop for SlotGuard {
@@ -1584,7 +1577,7 @@ mod tests {
                 1
             );
             let requests = metrics.requests_for(SignalType::Logs, OtlpProtocol::Http);
-            assert_eq!(requests.started.get(), 0);
+            assert_eq!(requests.accepted.get(), 0);
         }
 
         shutdown.cancel();
@@ -1728,9 +1721,9 @@ mod tests {
     }
 
     /// Scenario: A non-empty HTTP request cannot allocate its acknowledgement slot.
-    /// Guarantees: The request is rejected without recording admission, completion, or payload bytes.
+    /// Guarantees: The request is rejected without incrementing the OTLP accepted counter.
     #[tokio::test]
-    async fn rejected_http_request_does_not_record_payload_bytes() {
+    async fn rejected_http_request_is_not_accepted() {
         use hyper::Method;
         use hyper::client::conn::http1;
         use hyper::header::{CONTENT_TYPE, HOST};
@@ -1828,9 +1821,7 @@ mod tests {
         {
             let metrics = metrics.lock();
             let requests = metrics.requests_for(SignalType::Logs, OtlpProtocol::Http);
-            assert_eq!(requests.started.get(), 0);
-            assert_eq!(requests.completed.get(), 0);
-            assert_eq!(requests.payload_size.get(), 0);
+            assert_eq!(requests.accepted.get(), 0);
             assert_eq!(
                 metrics
                     .rejections_for(
@@ -1986,8 +1977,7 @@ mod tests {
         {
             let metrics = metrics.lock();
             let requests = metrics.requests_for(SignalType::Logs, OtlpProtocol::Http);
-            assert_eq!(requests.started.get(), 0);
-            assert_eq!(requests.payload_size.get(), 0);
+            assert_eq!(requests.accepted.get(), 0);
             assert_eq!(
                 metrics
                     .rejections_for(
@@ -2143,8 +2133,7 @@ mod tests {
                 0
             );
             let requests = metrics.requests_for(SignalType::Logs, OtlpProtocol::Http);
-            assert_eq!(requests.started.get(), 1);
-            assert_eq!(requests.completed.get(), 1);
+            assert_eq!(requests.accepted.get(), 1);
         }
 
         let _ = msg_rx.recv().await.expect("request forwarded downstream");
@@ -2301,7 +2290,7 @@ mod tests {
             assert_eq!(
                 metrics
                     .requests_for(SignalType::Logs, OtlpProtocol::Http)
-                    .started
+                    .accepted
                     .get(),
                 0
             );
@@ -2463,7 +2452,7 @@ mod tests {
             assert_eq!(
                 metrics
                     .requests_for(SignalType::Logs, OtlpProtocol::Http)
-                    .started
+                    .accepted
                     .get(),
                 0
             );

--- a/rust/otap-dataflow/crates/otap/src/otlp_metrics.rs
+++ b/rust/otap-dataflow/crates/otap/src/otlp_metrics.rs
@@ -3,6 +3,7 @@
 
 //! Shared OTLP receiver metric definitions.
 
+use crate::metrics::ReceiverMetrics;
 use otel_arrow_dfe_config::SignalType;
 use otel_arrow_dfe_engine::context::PipelineContext;
 use otel_arrow_dfe_telemetry::common_attributes::{
@@ -23,16 +24,6 @@ pub enum OtlpProtocol {
     Http,
 }
 
-/// Signal and protocol dimensions for an accepted OTLP request.
-#[attribute_set(item, measurement)]
-#[derive(Debug, Clone, Copy)]
-pub struct OtlpRequestAttributes {
-    /// Signal carried by the request.
-    pub signal: SignalType,
-    /// OTLP transport used by the request.
-    pub protocol: OtlpProtocol,
-}
-
 /// Protocol and bounded error type dimensions for a rejected request.
 #[attribute_set(item, measurement)]
 #[derive(Debug, Clone, Copy)]
@@ -44,41 +35,45 @@ pub struct OtlpRejectionAttributes {
     pub error_type: ReceiverRejectionErrorType,
 }
 
-/// Protocol dimension for a transport-level receiver error.
+/// Signal and protocol dimensions for an accepted OTLP transport request.
 #[attribute_set(item, measurement)]
 #[derive(Debug, Clone, Copy)]
-pub struct OtlpTransportAttributes {
-    /// OTLP transport that surfaced the error.
+pub struct OtlpRequestAttributes {
+    /// Signal carried by the request.
+    pub signal: SignalType,
+    /// OTLP transport used by the request.
     pub protocol: OtlpProtocol,
 }
 
-/// Lifecycle and payload metrics for admitted OTLP requests.
+/// Protocol dimension for a transport-level receiver error.
+#[attribute_set(item, measurement)]
+#[derive(Debug, Clone, Copy)]
+pub struct OtlpTransportErrorAttributes {
+    /// OTLP transport that surfaced the server error.
+    pub protocol: OtlpProtocol,
+}
+
+/// Admitted OTLP requests.
 #[metric_set(
     name = "receiver.otlp.requests",
     measurement_attributes = OtlpRequestAttributes
 )]
 #[derive(Debug, Default, Clone)]
 pub struct OtlpRequestMetrics {
-    /// Number of requests admitted to the pipeline send path.
+    /// Number of OTLP requests admitted to the pipeline send path.
     #[metric(unit = "{request}")]
-    pub started: Counter<u64>,
-    /// Number of admitted requests whose receiver work terminated.
-    #[metric(unit = "{request}")]
-    pub completed: Counter<u64>,
-    /// Decompressed payload bytes for requests admitted to the pipeline send path.
-    #[metric(unit = "By")]
-    pub payload_size: Counter<u64>,
+    pub accepted: Counter<u64>,
 }
 
 /// Requests rejected before pipeline admission.
 #[metric_set(
-    name = "receiver.otlp.rejections",
+    name = "receiver.otlp.requests",
     measurement_attributes = OtlpRejectionAttributes
 )]
 #[derive(Debug, Default, Clone)]
 pub struct OtlpRejectionMetrics {
     /// Number of rejected requests.
-    #[metric(unit = "{request}")]
+    #[metric(name = "rejected", unit = "{request}")]
     pub requests: Counter<u64>,
 }
 
@@ -97,10 +92,10 @@ pub struct OtlpAcknowledgementMetrics {
 /// Transport-level OTLP receiver errors.
 #[metric_set(
     name = "receiver.otlp.transport",
-    measurement_attributes = OtlpTransportAttributes
+    measurement_attributes = OtlpTransportErrorAttributes
 )]
 #[derive(Debug, Default, Clone)]
-pub struct OtlpTransportMetrics {
+pub struct OtlpTransportErrorMetrics {
     /// Number of transport-level server errors.
     #[metric(unit = "{error}")]
     pub errors: Counter<u64>,
@@ -109,10 +104,12 @@ pub struct OtlpTransportMetrics {
 /// Shared bounded-cardinality OTLP receiver metrics tracker.
 #[derive(Debug)]
 pub struct OtlpReceiverMetrics {
+    /// Shared receiver boundary metrics.
+    pub boundary: ReceiverMetrics,
     requests: MeasurementMetricSet<OtlpRequestMetrics>,
     rejections: MeasurementMetricSet<OtlpRejectionMetrics>,
     acknowledgements: MeasurementMetricSet<OtlpAcknowledgementMetrics>,
-    transport: MeasurementMetricSet<OtlpTransportMetrics>,
+    transport_errors: MeasurementMetricSet<OtlpTransportErrorMetrics>,
 }
 
 impl OtlpReceiverMetrics {
@@ -120,34 +117,19 @@ impl OtlpReceiverMetrics {
     #[must_use]
     pub fn register(pipeline_ctx: &PipelineContext) -> Self {
         Self {
+            boundary: ReceiverMetrics::register(pipeline_ctx),
             requests: OtlpRequestMetrics::register(pipeline_ctx),
             rejections: OtlpRejectionMetrics::register(pipeline_ctx),
             acknowledgements: OtlpAcknowledgementMetrics::register(pipeline_ctx),
-            transport: OtlpTransportMetrics::register(pipeline_ctx),
+            transport_errors: OtlpTransportErrorMetrics::register(pipeline_ctx),
         }
     }
 
-    /// Records a request and its decompressed payload bytes after pipeline admission succeeds.
-    pub fn record_request_admitted(
-        &mut self,
-        signal: SignalType,
-        protocol: OtlpProtocol,
-        payload_bytes: Option<u64>,
-    ) {
-        let requests = self
-            .requests
-            .with(OtlpRequestAttributes { signal, protocol });
-        requests.started.inc();
-        if let Some(payload_bytes) = payload_bytes.filter(|bytes| *bytes > 0) {
-            requests.payload_size.add(payload_bytes);
-        }
-    }
-
-    /// Records termination of receiver work for an admitted request.
-    pub fn record_request_completed(&mut self, signal: SignalType, protocol: OtlpProtocol) {
+    /// Records an admitted OTLP request.
+    pub fn record_request_admitted(&mut self, signal: SignalType, protocol: OtlpProtocol) {
         self.requests
             .with(OtlpRequestAttributes { signal, protocol })
-            .completed
+            .accepted
             .inc();
     }
 
@@ -176,13 +158,13 @@ impl OtlpReceiverMetrics {
 
     /// Records a transport-level server error.
     pub fn record_transport_error(&mut self, protocol: OtlpProtocol) {
-        self.transport
-            .with(OtlpTransportAttributes { protocol })
+        self.transport_errors
+            .with(OtlpTransportErrorAttributes { protocol })
             .errors
             .inc();
     }
 
-    /// Returns a request bucket for inspection without marking it for export.
+    /// Returns a transport request bucket without marking it for export.
     #[must_use]
     pub fn requests_for(&self, signal: SignalType, protocol: OtlpProtocol) -> &OtlpRequestMetrics {
         self.requests
@@ -215,24 +197,27 @@ impl OtlpReceiverMetrics {
 
     /// Returns a transport bucket for inspection without marking it for export.
     #[must_use]
-    pub fn transport_for(&self, protocol: OtlpProtocol) -> &OtlpTransportMetrics {
-        self.transport.get(OtlpTransportAttributes { protocol })
+    pub fn transport_errors_for(&self, protocol: OtlpProtocol) -> &OtlpTransportErrorMetrics {
+        self.transport_errors
+            .get(OtlpTransportErrorAttributes { protocol })
     }
 
     /// Reports every touched OTLP receiver metric bucket.
     pub fn report(&mut self, reporter: &mut MetricsReporter) -> Result<(), TelemetryError> {
+        self.boundary.report(reporter)?;
         reporter.report_measurement(&mut self.requests)?;
         reporter.report_measurement(&mut self.rejections)?;
         reporter.report_measurement(&mut self.acknowledgements)?;
-        reporter.report_measurement(&mut self.transport)
+        reporter.report_measurement(&mut self.transport_errors)
     }
 
     /// Takes every touched OTLP receiver metric bucket for terminal handoff.
     pub fn terminal_snapshots(&mut self) -> Vec<MetricSetSnapshot> {
-        let mut snapshots = self.requests.terminal_snapshots();
+        let mut snapshots = self.boundary.terminal_snapshots();
+        snapshots.extend(self.requests.terminal_snapshots());
         snapshots.extend(self.rejections.terminal_snapshots());
         snapshots.extend(self.acknowledgements.terminal_snapshots());
-        snapshots.extend(self.transport.terminal_snapshots());
+        snapshots.extend(self.transport_errors.terminal_snapshots());
         snapshots
     }
 }
@@ -256,8 +241,12 @@ mod tests {
     #[test]
     fn receiver_metrics_are_partitioned_by_context() {
         let mut metrics = new_test_metrics();
-        metrics.record_request_admitted(SignalType::Logs, OtlpProtocol::Grpc, Some(42));
-        metrics.record_request_completed(SignalType::Logs, OtlpProtocol::Grpc);
+        let completed = metrics.boundary.processing().run(|processing| {
+            processing.set_payload_size_with(|| 42);
+            Ok::<_, crate::metrics::ErrorWithOutcome<()>>((SignalType::Logs, ()))
+        });
+        metrics.boundary.record(completed).unwrap();
+        metrics.record_request_admitted(SignalType::Logs, OtlpProtocol::Grpc);
         metrics.record_rejection(
             OtlpProtocol::Http,
             ReceiverRejectionErrorType::InvalidRequest,
@@ -265,17 +254,18 @@ mod tests {
         metrics.record_acknowledgement(SignalType::Logs, Outcome::Refused);
         metrics.record_transport_error(OtlpProtocol::Grpc);
 
-        let requests = metrics.requests_for(SignalType::Logs, OtlpProtocol::Grpc);
-        assert_eq!(requests.started.get(), 1);
-        assert_eq!(requests.completed.get(), 1);
-        assert_eq!(requests.payload_size.get(), 42);
-        assert_eq!(
-            metrics
-                .requests_for(SignalType::Logs, OtlpProtocol::Http)
-                .started
-                .get(),
-            0
-        );
+        let snapshots = metrics.boundary.terminal_snapshots();
+        assert!(snapshots.iter().any(|snapshot| {
+            snapshot.descriptor().name == "receiver.received"
+                && snapshot.measurement_attribute_value("signal") == Some("logs")
+                && snapshot.measurement_attribute_value("outcome") == Some("success")
+                && snapshot
+                    .descriptor()
+                    .metrics
+                    .iter()
+                    .position(|metric| metric.name == "messages")
+                    .is_some_and(|index| snapshot.get_metrics()[index].to_u64_lossy() == 1)
+        }));
         assert_eq!(
             metrics
                 .rejections_for(
@@ -293,19 +283,48 @@ mod tests {
                 .get(),
             1
         );
-        assert_eq!(metrics.transport_for(OtlpProtocol::Grpc).errors.get(), 1);
+        let requests = metrics.requests_for(SignalType::Logs, OtlpProtocol::Grpc);
+        assert_eq!(requests.accepted.get(), 1);
+        assert_eq!(
+            metrics
+                .transport_errors_for(OtlpProtocol::Grpc)
+                .errors
+                .get(),
+            1
+        );
     }
 
     /// Scenario: An admitted OTLP request has an empty decompressed payload.
-    /// Guarantees: Admission is counted even though the payload-size counter remains unchanged.
+    /// Guarantees: The shared receiver boundary still records the successful message.
     #[test]
-    fn admitted_empty_request_still_records_started() {
+    fn admitted_empty_request_still_records_received() {
         let mut metrics = new_test_metrics();
-        metrics.record_request_admitted(SignalType::Logs, OtlpProtocol::Http, Some(0));
+        let completed = metrics.boundary.processing().run(|processing| {
+            processing.set_payload_size_with(|| 0);
+            Ok::<_, crate::metrics::ErrorWithOutcome<()>>((SignalType::Logs, ()))
+        });
+        metrics.boundary.record(completed).unwrap();
+        metrics.record_request_admitted(SignalType::Logs, OtlpProtocol::Http);
 
-        let requests = metrics.requests_for(SignalType::Logs, OtlpProtocol::Http);
-        assert_eq!(requests.started.get(), 1);
-        assert_eq!(requests.payload_size.get(), 0);
+        let snapshots = metrics.boundary.terminal_snapshots();
+        assert!(snapshots.iter().any(|snapshot| {
+            snapshot.descriptor().name == "receiver.received"
+                && snapshot.measurement_attribute_value("signal") == Some("logs")
+                && snapshot.measurement_attribute_value("outcome") == Some("success")
+                && snapshot
+                    .descriptor()
+                    .metrics
+                    .iter()
+                    .position(|metric| metric.name == "messages")
+                    .is_some_and(|index| snapshot.get_metrics()[index].to_u64_lossy() == 1)
+        }));
+        assert_eq!(
+            metrics
+                .requests_for(SignalType::Logs, OtlpProtocol::Http)
+                .accepted
+                .get(),
+            1
+        );
     }
 
     /// Scenario: OTLP receiver metrics are transferred into terminal snapshots twice.
@@ -313,21 +332,31 @@ mod tests {
     #[test]
     fn terminal_snapshots_preserve_enum_attribute_values_once() {
         let mut metrics = new_test_metrics();
-        metrics.record_request_admitted(SignalType::Metrics, OtlpProtocol::Http, Some(0));
+        let completed = metrics
+            .boundary
+            .processing()
+            .run(|_| Ok::<_, crate::metrics::ErrorWithOutcome<()>>((SignalType::Metrics, ())));
+        metrics.boundary.record(completed).unwrap();
+        metrics.record_request_admitted(SignalType::Metrics, OtlpProtocol::Http);
         metrics.record_rejection(
             OtlpProtocol::Grpc,
             ReceiverRejectionErrorType::MemoryPressure,
         );
 
         let snapshots = metrics.terminal_snapshots();
-        assert_eq!(snapshots.len(), 2);
+        assert_eq!(snapshots.len(), 3);
+        assert!(snapshots.iter().any(|snapshot| {
+            snapshot.descriptor().name == "receiver.received"
+                && snapshot.measurement_attribute_value("signal") == Some("metrics")
+                && snapshot.measurement_attribute_value("outcome") == Some("success")
+        }));
         assert!(snapshots.iter().any(|snapshot| {
             snapshot.descriptor().name == "receiver.otlp.requests"
                 && snapshot.measurement_attribute_value("signal") == Some("metrics")
                 && snapshot.measurement_attribute_value("protocol") == Some("http")
         }));
         assert!(snapshots.iter().any(|snapshot| {
-            snapshot.descriptor().name == "receiver.otlp.rejections"
+            snapshot.descriptor().name == "receiver.otlp.requests"
                 && snapshot.measurement_attribute_value("protocol") == Some("grpc")
                 && snapshot.measurement_attribute_value("error.type") == Some("memory_pressure")
         }));

--- a/rust/otap-dataflow/docs/otlp-receiver.md
+++ b/rust/otap-dataflow/docs/otlp-receiver.md
@@ -291,9 +291,11 @@ Result:
 The receiver reports bounded, enum-based measurement attributes across both
 protocols:
 
-- `receiver.otlp.requests.started`, `completed`, and `payload_size` use
-  `signal` and `protocol`.
-- `receiver.otlp.rejections.requests` uses `protocol` and `error.type`.
+- `receiver.otlp.requests.accepted` uses `signal` and `protocol`.
+- `receiver.otlp.requests.rejected` uses `protocol` and `error.type`.
+- `receiver.received.messages` and `receiver.received.payload.size` use
+  `signal` and `outcome`.
+- `receiver.processing.duration` uses `signal`.
 - `receiver.otlp.acknowledgements.responses` uses `signal` and `outcome`.
 - `receiver.otlp.transport.errors` uses `protocol`.
 


### PR DESCRIPTION
# Change summary

- Adopt the shared `receiver.received`, `receiver.processing`, and `exporter.attempted` metrics in the OTLP receiver and OTLP HTTP and gRPC exporters.
- Preserve OTLP-specific bounded diagnostics and existing authentication, admission, retry, reconnect, partial-success, and Ack/Nack behavior.
- Record encoded application payload size consistently before HTTP or gRPC transport compression.

## Related issue

* Implementation of #3822 for OTLP nodes

## Validation

Ran `configs/otlp-component-boundary-metrics.yaml`, which sends generated logs through independent gRPC and HTTP loopback pipelines and prints only the affected metrics.

### gRPC loopback pipeline

| Prefix | Observed metrics |
| --- | --- |
| `exporter.*` | `attempted.messages{signal=logs,outcome=success}=2`<br>`attempted.duration{signal=logs,outcome=success}: count=2, sum=0.007409712s, min=0.002427904s, max=0.004981808s`<br>`attempted.payload.size{signal=logs,outcome=success}=4,896 By`<br>`attempted.items{signal=logs,outcome=success}=20`<br>`otlp_grpc.failures.messages`: not emitted |
| `receiver.*` | `received.messages{signal=logs,outcome=success}=2`<br>`received.payload.size{signal=logs,outcome=success}=4,896 By`<br>`processing.duration{signal=logs}: count=2, sum=0.0000168s, min=0.0000075s, max=0.0000093s`<br>`otlp.requests.accepted{signal=logs,protocol=grpc}=2`<br>`otlp.requests.rejected`: not emitted |
| `node.*` | Receiver `output.messages{signal=logs,outcome=success}=2`<br>Receiver `output.items{signal=logs,outcome=success}=20` |

### HTTP loopback pipeline

| Prefix | Observed metrics |
| --- | --- |
| `exporter.*` | `attempted.messages{signal=logs,outcome=success}=2`<br>`attempted.duration{signal=logs,outcome=success}: count=2, sum=0.004414406s, min=0.001932503s, max=0.002481903s`<br>`attempted.payload.size{signal=logs,outcome=success}=4,896 By`<br>`attempted.items{signal=logs,outcome=success}=20`<br>`otlp_http.failures.messages`: not emitted |
| `receiver.*` | `received.messages{signal=logs,outcome=success}=2`<br>`received.payload.size{signal=logs,outcome=success}=4,896 By`<br>`processing.duration{signal=logs}: count=2, sum=0.0000103s, min=0.0000051s, max=0.0000052s`<br>`otlp.requests.accepted{signal=logs,protocol=http}=2`<br>`otlp.requests.rejected`: not emitted |
| `node.*` | Receiver `output.messages{signal=logs,outcome=success}=2`<br>Receiver `output.items{signal=logs,outcome=success}=20` |

## User-facing changes

- Replace `receiver.otlp.requests.started`, `completed`, and `payload_size` with `receiver.otlp.requests.accepted`, `receiver.received.*`, and `receiver.processing.duration`.
- Replace `receiver.otlp.rejections.requests` with `receiver.otlp.requests.rejected`.
- Replace `exporter.exports.*` with `exporter.attempted.*`.
