### PR TITLE
feat(filter_processor): Align metrics with universal node telemetry

### DIFF
--- a/rust/otap-dataflow/.chloggen/filter-metric-alignment.yaml
+++ b/rust/otap-dataflow/.chloggen/filter-metric-alignment.yaml
@@ -1,0 +1,8 @@
+change_type: breaking
+component: observability
+note: Align filter processor metrics with universal node telemetry
+issues: [3053, 3649]
+subtext: |
+  Migration: Rename `processor.filter.pdata.dropped.items` to
+  `processor.filter.dropped.items`. Use `node.input.messages` for received
+  batches and `node.output.items` for kept items.

--- a/rust/otap-dataflow/AGENTS.md
+++ b/rust/otap-dataflow/AGENTS.md
@@ -89,7 +89,7 @@ Examples:
 receiver.journald
 receiver.host_metrics
 processor.transform
-processor.filter.pdata
+processor.filter
 exporter.topic
 exporter.azure_monitor
 ```

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/README.md
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/README.md
@@ -152,11 +152,16 @@ runtime metric sets may also be attached by the pipeline telemetry policy.
 
 ### Metric Sets
 
-#### `processor.filter.pdata`
+#### `processor.filter`
 
 | Metric | Unit | Description |
 | --- | --- | --- |
-| `processor.filter.pdata.dropped.items` | `{item}` | Number of signal items (log records, spans, or metric data points) a decision node chose to drop. |
+| `processor.filter.dropped.items` | `{item}` | Number of signal items (log records, spans, or metric data points) a decision node chose to drop. |
+
+Use the engine-managed `node.input.messages` metric for batches received by
+the processor and `node.output.items` for items kept and forwarded. The active
+include and exclude paths are available from the node configuration rather than
+repeated as per-batch telemetry.
 
 ### Events
 

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/metrics.rs
@@ -6,15 +6,53 @@ use otel_arrow_dfe_telemetry::common_attributes::SignalAttributes;
 use otel_arrow_dfe_telemetry::instrument::Counter;
 use otel_arrow_dfe_telemetry_macros::metric_set;
 
-/// Pdata-oriented metrics for the OTAP FilterProcessor
+/// Item-drop metrics for the filter processor.
 #[metric_set(
-    name = "processor.filter.pdata",
+    name = "processor.filter",
     measurement_attributes = SignalAttributes
 )]
 #[derive(Debug, Default, Clone)]
-pub struct FilterPdataMetrics {
+pub struct FilterDropMetrics {
     /// Number of signal items (log records, spans, or metric data points) a
     /// decision node chose to drop.
     #[metric(name = "dropped.items", unit = "{item}")]
     pub dropped_items: Counter<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use otel_arrow_dfe_config::SignalType;
+    use otel_arrow_dfe_engine::context::ControllerContext;
+    use otel_arrow_dfe_telemetry::metrics::MeasurementMetricSet;
+    use otel_arrow_dfe_telemetry::registry::TelemetryRegistryHandle;
+
+    fn new_test_metrics() -> MeasurementMetricSet<FilterDropMetrics> {
+        let registry = TelemetryRegistryHandle::new();
+        let controller = ControllerContext::new(registry);
+        let pipeline_ctx =
+            controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        FilterDropMetrics::register(&pipeline_ctx)
+    }
+
+    /// Scenario: A filter batch drops items for one telemetry signal.
+    /// Guarantees: The dropped-item counter retains the existing signal dimension and value.
+    #[test]
+    fn dropped_items_are_recorded_by_signal() {
+        let mut metrics = new_test_metrics();
+        metrics
+            .with(SignalAttributes {
+                signal: SignalType::Traces,
+            })
+            .dropped_items
+            .add(4);
+
+        let snapshots = metrics.terminal_snapshots();
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(
+            snapshots[0].measurement_attribute_value("signal"),
+            Some("traces")
+        );
+        assert_eq!(snapshots[0].get_metrics()[0].to_u64_lossy(), 4);
+    }
 }

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/filter_processor/mod.rs
@@ -14,7 +14,7 @@ otel_arrow_dfe_telemetry::otel_component_scope!(
 );
 
 use self::config::Config;
-use self::metrics::FilterPdataMetrics;
+use self::metrics::FilterDropMetrics;
 use async_trait::async_trait;
 use linkme::distributed_slice;
 use otel_arrow_dfe_config::SignalType;
@@ -51,7 +51,7 @@ pub const FILTER_PROCESSOR_URN: &str = "urn:otel:processor:filter";
 /// processor that outputs all data received to stdout
 pub struct FilterProcessor {
     config: Config,
-    metrics: MeasurementMetricSet<FilterPdataMetrics>,
+    metrics: MeasurementMetricSet<FilterDropMetrics>,
     compute_duration: ComputeDuration,
     /// Reusable paged-bitmap pool for filtering metric child batches across
     /// successive `Message::PData` calls. Storing the pool on the processor
@@ -101,7 +101,7 @@ impl FilterProcessor {
     #[must_use]
     #[allow(dead_code)]
     pub fn new(config: Config, pipeline_ctx: PipelineContext) -> Self {
-        let metrics = FilterPdataMetrics::register(&pipeline_ctx);
+        let metrics = FilterDropMetrics::register(&pipeline_ctx);
         let compute_duration = ComputeDuration::new(&pipeline_ctx);
         FilterProcessor {
             config,
@@ -113,7 +113,7 @@ impl FilterProcessor {
 
     /// Creates a new FilterProcessor from a configuration object
     pub fn from_config(pipeline_ctx: PipelineContext, config: &Value) -> Result<Self, ConfigError> {
-        let metrics = FilterPdataMetrics::register(&pipeline_ctx);
+        let metrics = FilterDropMetrics::register(&pipeline_ctx);
         let compute_duration = ComputeDuration::new(&pipeline_ctx);
         let config: Config =
             serde_json::from_value(config.clone()).map_err(|e| ConfigError::InvalidUserConfig {
@@ -216,8 +216,10 @@ impl local::Processor<OtapPdata> for FilterProcessor {
                         }
                     })?;
 
-                let metric = self.metrics.with(SignalAttributes { signal });
-                metric.dropped_items.add(dropped_items);
+                self.metrics
+                    .with(SignalAttributes { signal })
+                    .dropped_items
+                    .add(dropped_items);
 
                 // Record the drop flow-metric. A no-op unless this node is
                 // a decision node in a flow that enables `dropped.items`.

--- a/rust/otap-dataflow/crates/pdata/src/otap/filter/logs.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/filter/logs.rs
@@ -145,7 +145,7 @@ impl LogFilter {
         {
             include_config.create_filters(&logs_payload, false)?
         } else {
-            // both include and exclude is none
+            // Both include and exclude are absent, so every log record is kept.
             let num_rows = logs_payload
                 .get(ArrowPayloadType::Logs)
                 // Safety: We check at the top of this function whether the
@@ -153,7 +153,7 @@ impl LogFilter {
                 // root record batch is present.
                 .expect("Logs payload has a root record")
                 .num_rows() as u64;
-            return Ok((logs_payload, num_rows, num_rows));
+            return Ok((logs_payload, num_rows, 0));
         };
 
         let (log_record_filter, child_record_batch_filters) = self.sync_up_filters(
@@ -655,6 +655,41 @@ mod test {
             }],
         }));
 
+        assert_equivalent(&[otap_to_otlp(&result)], &[otap_to_otlp(&expected)]);
+    }
+
+    /// Scenario: A log filter has neither an include nor an exclude rule.
+    /// Guarantees: All records pass through and the reported filtered count is zero.
+    #[test]
+    fn test_filter_pass_through_reports_no_filtered_records() {
+        let filter = LogFilter::new(None, None, Vec::new());
+        let log_records = vec![
+            LogRecord::build().severity_text("WARN").finish(),
+            LogRecord::build().severity_text("INFO").finish(),
+        ];
+        let input = otlp_to_otap(&OtlpProtoMessage::Logs(LogsData {
+            resource_logs: vec![ResourceLogs {
+                scope_logs: vec![ScopeLogs {
+                    log_records: log_records.clone(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        }));
+
+        let (result, logs_consumed, logs_filtered) = filter.filter(input).unwrap();
+
+        assert_eq!(logs_consumed, 2);
+        assert_eq!(logs_filtered, 0);
+        let expected = otlp_to_otap(&OtlpProtoMessage::Logs(LogsData {
+            resource_logs: vec![ResourceLogs {
+                scope_logs: vec![ScopeLogs {
+                    log_records,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        }));
         assert_equivalent(&[otap_to_otlp(&result)], &[otap_to_otlp(&expected)]);
     }
 }

--- a/rust/otap-dataflow/crates/pdata/src/otap/filter/traces.rs
+++ b/rust/otap-dataflow/crates/pdata/src/otap/filter/traces.rs
@@ -160,7 +160,7 @@ impl TraceFilter {
         {
             include_config.create_filters(&traces_payload, false)?
         } else {
-            // both include and exclude is none
+            // Both include and exclude are absent, so every span is kept.
             let num_rows = traces_payload
                 .get(ArrowPayloadType::Spans)
                 // Safety: We check at the top of this function whether the
@@ -168,7 +168,7 @@ impl TraceFilter {
                 // root record batch is present.
                 .expect("Traces payload has a root record")
                 .num_rows() as u64;
-            return Ok((traces_payload, num_rows, num_rows));
+            return Ok((traces_payload, num_rows, 0));
         };
 
         let (span_filter, child_record_batch_filters) = self.sync_up_filters(
@@ -817,6 +817,41 @@ mod test {
             }],
         }));
 
+        assert_equivalent(&[otap_to_otlp(&result)], &[otap_to_otlp(&expected)]);
+    }
+
+    /// Scenario: A trace filter has neither an include nor an exclude rule.
+    /// Guarantees: All spans pass through and the reported filtered count is zero.
+    #[test]
+    fn test_filter_pass_through_reports_no_filtered_spans() {
+        let filter = TraceFilter::new(None, None);
+        let spans = vec![
+            Span::build().name("span_name_1").finish(),
+            Span::build().name("span_name_2").finish(),
+        ];
+        let input = otlp_to_otap(&OtlpProtoMessage::Traces(TracesData {
+            resource_spans: vec![ResourceSpans {
+                scope_spans: vec![ScopeSpans {
+                    spans: spans.clone(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        }));
+
+        let (result, spans_consumed, spans_filtered) = filter.filter(input).unwrap();
+
+        assert_eq!(spans_consumed, 2);
+        assert_eq!(spans_filtered, 0);
+        let expected = otlp_to_otap(&OtlpProtoMessage::Traces(TracesData {
+            resource_spans: vec![ResourceSpans {
+                scope_spans: vec![ScopeSpans {
+                    spans,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        }));
         assert_equivalent(&[otap_to_otlp(&result)], &[otap_to_otlp(&expected)]);
     }
 }


### PR DESCRIPTION
# Change summary

- Rename `processor.filter.pdata` to `processor.filter`
- Improve test coverage for dropped metric emission

[#3053](https://github.com/open-telemetry/otel-arrow/issues/3053) predates universal node input and output metrics. Its proposed filter-specific counters answered whether batches arrived and how many items survived, while configured-path counters indicated only that a batch arrived while an `include` or `exclude` rule was configured.

Those requirements are now covered without duplicating throughput instrumentation:

| Requirement | Metric or source |
| --- | --- |
| Batches and items received | `node.input.messages` and `node.input.items` |
| Items kept and forwarded | `node.output.items` |
| Items filtered | `processor.filter.dropped.items` |
| Include/exclude configuration | Node configuration |

A configured-path counter would be equivalent to repeating node input counts with a static configuration flag. It would not indicate that filtering completed or that any rule matched, so this change does not carry that counter forward from #3268.

## Related issue

<!--We highly recommend correlation of every PR to an issue-->

- Closes #3053
- Closes #3649

## Validation

Unit tests

## User-facing changes

Migration: Rename `processor.filter.pdata.dropped.items` to `processor.filter.dropped.items`.