### PR TITLE
chore(metrics): Remove legacy `PipelineContext::register_metrics::<T>()` in favor of `T::register()`

### DIFF
--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/clickhouse_exporter/mod.rs
@@ -120,7 +120,7 @@ impl ClickhouseExporter {
         pipeline_ctx: PipelineContext,
         config: &serde_json::Value,
     ) -> Result<Self, otel_arrow_dfe_config::error::Error> {
-        let ch_metrics = pipeline_ctx.register_metrics::<ClickhouseExporterMetrics>();
+        let ch_metrics = ClickhouseExporterMetrics::register(&pipeline_ctx);
         let pdata_metrics = ExporterExportMetrics::register(&pipeline_ctx);
 
         let patch: ConfigPatch = serde_json::from_value(config.clone()).map_err(|e| {

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/geneva_exporter/mod.rs
@@ -1219,7 +1219,7 @@ impl GenevaExporter {
     ) -> Result<Self, ConfigError> {
         let geneva_client = create_geneva_client(&config, node_config, capabilities)?;
         let pdata_metrics = ExporterExportMetrics::register(&pipeline_ctx);
-        let metrics = pipeline_ctx.register_metrics::<ExporterMetrics>();
+        let metrics = ExporterMetrics::register(&pipeline_ctx);
 
         Ok(Self {
             config,

--- a/rust/otap-dataflow/crates/contrib-nodes/src/processors/resource_validator_processor/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/processors/resource_validator_processor/mod.rs
@@ -196,7 +196,7 @@ pub static RESOURCE_VALIDATOR_PROCESSOR_FACTORY: otel_arrow_dfe_engine::Processo
 impl ResourceValidatorProcessor {
     /// Creates a new ResourceValidatorProcessor from configuration
     pub fn from_config(pipeline_ctx: PipelineContext, config: &Value) -> Result<Self, ConfigError> {
-        let metrics = pipeline_ctx.register_metrics::<ResourceValidatorMetrics>();
+        let metrics = ResourceValidatorMetrics::register(&pipeline_ctx);
         let config: Config =
             serde_json::from_value(config.clone()).map_err(|e| ConfigError::InvalidUserConfig {
                 error: e.to_string(),
@@ -221,7 +221,7 @@ impl ResourceValidatorProcessor {
         case_sensitive: bool,
         pipeline_ctx: PipelineContext,
     ) -> Self {
-        let metrics = pipeline_ctx.register_metrics::<ResourceValidatorMetrics>();
+        let metrics = ResourceValidatorMetrics::register(&pipeline_ctx);
         Self {
             required_attribute_key,
             allowed_values,

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/etw_receiver/mod.rs
@@ -443,7 +443,7 @@ impl EtwReceiver {
         cfg.validate()?;
 
         let num_cores = pipeline.num_cores();
-        let metrics = pipeline.register_metrics::<EtwReceiverMetrics>();
+        let metrics = EtwReceiverMetrics::register(&pipeline);
         let batching = cfg.batching.clone().unwrap_or_default();
 
         // Acquire this core's consumer channel from the per-session-name

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/metrics.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/kafka_receiver/metrics.rs
@@ -308,7 +308,7 @@ impl KafkaReceiverMetrics {
             acknowledgements: KafkaReceiverAcknowledgementMetrics::register(pipeline_ctx),
             rejections: KafkaReceiverRejectionMetrics::register(pipeline_ctx),
             offset_commits: KafkaReceiverOffsetCommitMetrics::register(pipeline_ctx),
-            consumer: pipeline_ctx.register_metrics::<KafkaReceiverConsumerMetrics>(),
+            consumer: KafkaReceiverConsumerMetrics::register(pipeline_ctx),
             transport: KafkaReceiverTransportMetrics::register(pipeline_ctx),
         }
     }

--- a/rust/otap-dataflow/crates/contrib-nodes/src/receivers/user_events_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/receivers/user_events_receiver/mod.rs
@@ -301,9 +301,7 @@ impl UserEventsReceiver {
             drain,
             batching,
             cpu_id: pipeline.core_id(),
-            metrics: Rc::new(RefCell::new(
-                pipeline.register_metrics::<UserEventsReceiverMetrics>(),
-            )),
+            metrics: Rc::new(RefCell::new(UserEventsReceiverMetrics::register(&pipeline))),
             admission_state: LocalReceiverAdmissionState::from_process_state(
                 &pipeline.memory_pressure_state(),
             ),
@@ -1149,9 +1147,9 @@ mod config_tests {
 
     fn test_metrics() -> Rc<RefCell<MetricSet<UserEventsReceiverMetrics>>> {
         let (pipeline_ctx, _) = test_pipeline_ctx();
-        Rc::new(RefCell::new(
-            pipeline_ctx.register_metrics::<UserEventsReceiverMetrics>(),
-        ))
+        Rc::new(RefCell::new(UserEventsReceiverMetrics::register(
+            &pipeline_ctx,
+        )))
     }
 
     fn test_effect_handler(

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/parquet_exporter/mod.rs
@@ -142,7 +142,7 @@ impl ParquetExporter {
         })?;
 
         let pdata_metrics = ExporterExportMetrics::register(&pipeline_ctx);
-        let io_metrics = pipeline_ctx.register_metrics::<metrics::ParquetExporterMetrics>();
+        let io_metrics = metrics::ParquetExporterMetrics::register(&pipeline_ctx);
 
         Ok(ParquetExporter {
             config,

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -1292,7 +1292,7 @@ pub fn create_otap_batch_processor(
     node_config: Arc<NodeUserConfig>,
     processor_config: &ProcessorConfig,
 ) -> Result<ProcessorWrapper<OtapPdata>, ConfigError> {
-    let metrics = BatchProcessorMetrics::register(pipeline_ctx);
+    let metrics = BatchProcessorMetrics::register(&pipeline_ctx);
     let proc = BatchProcessor::build_from_json(&node_config.config, metrics)?;
     Ok(ProcessorWrapper::local(
         proc,

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/batch_processor/mod.rs
@@ -1292,7 +1292,7 @@ pub fn create_otap_batch_processor(
     node_config: Arc<NodeUserConfig>,
     processor_config: &ProcessorConfig,
 ) -> Result<ProcessorWrapper<OtapPdata>, ConfigError> {
-    let metrics = pipeline_ctx.register_metrics::<BatchProcessorMetrics>();
+    let metrics = BatchProcessorMetrics::register(pipeline_ctx);
     let proc = BatchProcessor::build_from_json(&node_config.config, metrics)?;
     Ok(ProcessorWrapper::local(
         proc,

--- a/rust/otap-dataflow/crates/core-nodes/src/processors/fanout_processor/metrics.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/processors/fanout_processor/metrics.rs
@@ -61,7 +61,7 @@ impl FanoutMetrics {
         max_inflight: usize,
         destinations: impl IntoIterator<Item = String>,
     ) -> Self {
-        let mut operational = pipeline_ctx.register_metrics::<FanoutOperationalMetrics>();
+        let mut operational = FanoutOperationalMetrics::register(pipeline_ctx);
         operational.max_inflight_config.set(max_inflight as u64);
         let timeouts = destinations
             .into_iter()

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/host_metrics_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/host_metrics_receiver/mod.rs
@@ -168,7 +168,7 @@ fn create_host_metrics_receiver(
         });
     }
     let mut receiver = HostMetricsReceiver::from_config(&node_config.config)?;
-    receiver.metrics = Some(pipeline.register_metrics::<HostMetricsReceiverMetrics>());
+    receiver.metrics = Some(HostMetricsReceiverMetrics::register(&pipeline));
     Ok(ReceiverWrapper::local(
         receiver,
         node,

--- a/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/receivers/journald_receiver/mod.rs
@@ -178,7 +178,7 @@ fn create_journald_receiver(
         receiver_config.name.as_ref(),
         &receiver.config.source_id,
     );
-    receiver.metrics = Some(pipeline.register_metrics::<JournaldReceiverMetrics>());
+    receiver.metrics = Some(JournaldReceiverMetrics::register(&pipeline));
     Ok(ReceiverWrapper::local(
         receiver,
         node,

--- a/rust/otap-dataflow/crates/dev-nodes/src/receivers/traffic_generator/mod.rs
+++ b/rust/otap-dataflow/crates/dev-nodes/src/receivers/traffic_generator/mod.rs
@@ -146,7 +146,7 @@ impl TrafficGeneratorReceiver {
     /// creates a new TrafficGeneratorReceiver
     #[must_use]
     pub fn new(pipeline_ctx: PipelineContext, config: Config) -> Self {
-        let metrics = pipeline_ctx.register_metrics::<TrafficGeneratorReceiverMetrics>();
+        let metrics = TrafficGeneratorReceiverMetrics::register(&pipeline_ctx);
         Self {
             config,
             metrics,

--- a/rust/otap-dataflow/crates/engine/src/context.rs
+++ b/rust/otap-dataflow/crates/engine/src/context.rs
@@ -542,28 +542,6 @@ impl PipelineContext {
         }
     }
 
-    /// Compatibility registration for metric sets declared before `#[metric_set]`.
-    ///
-    /// New component metrics use their generated `MyMetrics::register(self)`
-    /// method, which chooses the correct registration shape automatically.
-    #[must_use]
-    #[doc(hidden)]
-    pub fn register_metrics<T: MetricSetHandler + Default + Debug + Send + Sync>(
-        &self,
-    ) -> MetricSet<T> {
-        self.register_scoped_metrics(
-            |handle, entity_key| handle.register_metric_set_for_entity::<T>(entity_key),
-            MetricSet::metric_set_key,
-            |ctx, handle| {
-                if ctx.node_telemetry_attrs.is_empty() {
-                    handle.register_metric_set::<T>(ctx.node_attribute_set())
-                } else {
-                    handle.register_metric_set::<T>(ctx.node_with_custom_attribute_set())
-                }
-            },
-        )
-    }
-
     /// Registers a metric set for the current node entity, scoped by an additional `topic` attribute.
     ///
     /// This is used by topic-aware nodes so their metric series can be filtered by `topic`.
@@ -836,7 +814,17 @@ impl MetricSetRegistrar for PipelineContext {
     fn register_metric_set<M: MetricSetHandler + Default + Debug + Send + Sync>(
         &self,
     ) -> MetricSet<M> {
-        self.register_metrics::<M>()
+        self.register_scoped_metrics(
+            |handle, entity_key| handle.register_metric_set_for_entity::<M>(entity_key),
+            MetricSet::metric_set_key,
+            |ctx, handle| {
+                if ctx.node_telemetry_attrs.is_empty() {
+                    handle.register_metric_set::<M>(ctx.node_attribute_set())
+                } else {
+                    handle.register_metric_set::<M>(ctx.node_with_custom_attribute_set())
+                }
+            },
+        )
     }
 
     fn register_registration_metric_set<M: RegistrationMetricSetHandler + Debug + Send + Sync>(

--- a/rust/otap-dataflow/crates/validation/src/fanout_processor.rs
+++ b/rust/otap-dataflow/crates/validation/src/fanout_processor.rs
@@ -47,7 +47,7 @@ pub static FANOUT_PROCESSOR_FACTORY: ProcessorFactory<OtapPdata> = ProcessorFact
          node_config: Arc<NodeUserConfig>,
          processor_config: &ProcessorConfig,
          _capabilities: &otel_arrow_dfe_engine::capability::registry::Capabilities| {
-            let metrics = pipeline_ctx.register_metrics::<FanoutMetrics>();
+            let metrics = FanoutMetrics::register(&pipeline_ctx);
             Ok(ProcessorWrapper::local(
                 FanoutProcessor { metrics },
                 node,

--- a/rust/otap-dataflow/crates/validation/src/validation_exporter.rs
+++ b/rust/otap-dataflow/crates/validation/src/validation_exporter.rs
@@ -153,7 +153,7 @@ impl ValidationExporter {
         pipeline_ctx: PipelineContext,
         config: &serde_json::Value,
     ) -> Result<Self, ConfigError> {
-        let metrics = pipeline_ctx.register_metrics::<ValidationExporterMetrics>();
+        let metrics = ValidationExporterMetrics::register(&pipeline_ctx);
         let config: ValidationExporterConfig =
             serde_json::from_value(config.clone()).map_err(|e| {
                 otel_arrow_dfe_config::error::Error::InvalidUserConfig {


### PR DESCRIPTION
# Chore summary

- Migrate plain metric sets to their generated `MetricType::register(...)` function
- Remove the legacy `PipelineContext::register_metrics` compatibility method

Every `#[metric_set]` now generates a type-owned `MetricType::register(...)` function that selects the correct registration shape for plain, registration-attribute, measurement-attribute, and combined metric sets.

Using that function consistently keeps registration details out of component code and gives metric authors one API regardless of attribute shape. If a metric set later gains attributes, its registration remains centered on the metric type instead of switching between unrelated context APIs.

## Related issue

* Closes #3496