### PR TITLE
fix: [quiver] prevent segment sequence number reuse after cleanup

### DIFF
--- a/rust/otap-dataflow/.chloggen/quiver-segment-seq-reuse.yaml
+++ b/rust/otap-dataflow/.chloggen/quiver-segment-seq-reuse.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: pipeline
+note: Fix Quiver silently skipping new telemetry after a restart reuses a segment sequence number cleaned up by a previous run.
+issues: [4024]
+subtext: |
+  Quiver now durably persists the next segment sequence number as segments are written, so restarts never reallocate a sequence number that stale subscriber progress could mistake for already-delivered data.

--- a/rust/otap-dataflow/crates/quiver/ARCHITECTURE.md
+++ b/rust/otap-dataflow/crates/quiver/ARCHITECTURE.md
@@ -869,6 +869,46 @@ The 16-digit zero-padding ensures lexicographic ordering matches numeric
 ordering, allowing simple directory listings to enumerate segments in order.
 The `SegmentSeq::to_filename_component()` method generates this format.
 
+`segment_seq` must never be reused, even if every segment file is later
+deleted (e.g. by retention cleanup) and the store restarts--reuse could be
+misread by a subscriber's persisted progress as data it already delivered.
+To guarantee this independent of what files or subscriber progress remain on
+disk, the next allocatable sequence number is persisted in a tiny sidecar
+(`segments/quiver.segment.seq`) each time a segment is finalized, via an
+atomic write-fsync-rename. On startup this value, not just the highest
+`.qseg` filename observed, forms the floor for `next_segment_seq`.
+
+```text
+SeqSidecar (v1, 24 bytes) {
+    [u8; 8] magic = b"QUIVER\0N";  // distinguishes from other Quiver files
+    u16 version = 1;                // bump if layout changes
+    u16 size = 24;                  // total encoded size (enables variable-width)
+    u64 next_seq;                   // lowest sequence a future segment may use
+    u32 crc32;                      // covers magic..next_seq (everything except CRC)
+}
+```
+
+As with the WAL cursor sidecar, the `size` field lets a future version append
+fields while remaining readable here. Writes are serialized and the stored
+value is monotonic, so concurrent finalizations completing out of order cannot
+regress the floor. The floor is persisted after the segment file is written but
+before the segment is registered, so a persist failure leaves the segment
+durable yet invisible to subscribers and to cleanup; the restart filename scan
+then raises the floor and the segment is delivered normally.
+
+At startup the floor is the maximum of three independent sources: the highest
+`.qseg` filename, this sidecar, and the highest segment tracked by restored
+subscriber progress. The last matters because progress files live outside the
+segments directory, so they still bound sequence reuse when the sidecar is
+absent -- on the first start after an upgrade, or if the segments directory is
+cleared wholesale.
+
+A sidecar that is missing or corrupt is treated as "no value", since the
+remaining sources still bound the floor and the next write restores it. A
+sidecar that exists but cannot be read is different: it may hold the highest
+floor, so both `persist_next_seq` and engine startup fail rather than proceed
+with a value that cannot be verified.
+
 #### Read-Only Enforcement
 
 Finalized segment files are immutable by design. After writing completes,

--- a/rust/otap-dataflow/crates/quiver/src/engine.rs
+++ b/rust/otap-dataflow/crates/quiver/src/engine.rs
@@ -314,6 +314,17 @@ impl std::fmt::Debug for QuiverEngine {
     }
 }
 
+/// Converts a subscriber-layer error into a [`SegmentError`], preserving the
+/// path and [`std::io::ErrorKind`] when the source is a segment I/O failure.
+///
+/// Other variants carry no I/O source, so they are flattened to a message.
+fn segment_error_from_subscriber(e: SubscriberError) -> SegmentError {
+    match e {
+        SubscriberError::SegmentIo { path, source } => SegmentError::io(path, source),
+        other => SegmentError::io_no_path(std::io::Error::other(other.to_string())),
+    }
+}
+
 impl QuiverEngine {
     /// Creates a builder for constructing a `QuiverEngine`.
     ///
@@ -443,8 +454,34 @@ impl QuiverEngine {
         let startup_expired_items_by_shape = HashMap::new();
         match segment_store.scan_existing_with_max_age(config.retention.max_age) {
             Ok(scan_result) => {
+                // An unreadable sidecar may hold a higher floor than any other
+                // source. Continuing would risk reallocating a sequence number
+                // that is already in use, which silently suppresses new data
+                // (issue #4024), so refuse to open instead.
+                if scan_result.seq_sidecar_unreadable {
+                    let path = segment_store.seq_sidecar_path();
+                    otel_error!(
+                        "quiver.engine.init",
+                        path = %path.display(),
+                        error_type = "io",
+                        reason = "seq_sidecar_unreadable",
+                        message = "cannot verify the segment sequence floor, \
+                                   refusing to open",
+                    );
+                    return Err(SegmentError::io(
+                        path,
+                        std::io::Error::other("unreadable segment sequence sidecar"),
+                    )
+                    .into());
+                }
                 if let Some(highest) = scan_result.highest_seen {
                     next_segment_seq = highest.raw() + 1;
+                }
+                // The sidecar counter survives deletion of all segment files
+                // (e.g. after cleanup), so it must never be overridden by a
+                // lower filename-derived floor.
+                if let Some(persisted) = scan_result.persisted_next_seq {
+                    next_segment_seq = next_segment_seq.max(persisted);
                 }
 
                 if !scan_result.found.is_empty() {
@@ -496,6 +533,15 @@ impl QuiverEngine {
         // read from files that no longer exist.
         if !deleted_during_scan.is_empty() {
             registry.force_complete_segments(&deleted_during_scan);
+        }
+
+        // Restored subscriber progress is a third record of sequence numbers
+        // already in use. It matters when the sidecar is unavailable (notably
+        // on the first start after upgrading, or if the segments directory was
+        // cleared wholesale), since progress files live outside that directory
+        // and survive independently.
+        if let Some(highest) = registry.highest_tracked_segment_any() {
+            next_segment_seq = next_segment_seq.max(highest.raw() + 1);
         }
 
         // Start with empty open segment and default cursor
@@ -1326,7 +1372,6 @@ impl QuiverEngine {
             return Ok(());
         }
 
-        // Assign a segment sequence number
         let seq = SegmentSeq::new(self.next_segment_seq.fetch_add(1, Ordering::SeqCst));
 
         // Write the segment file (streaming serialization - no intermediate buffer)
@@ -1394,6 +1439,35 @@ impl QuiverEngine {
         // Record the segment's bytes in the budget.
         // This is safe: the soft_cap reserves headroom for exactly this.
         self.budget.add(bytes_written);
+
+        // Durably record the sequence floor now that the segment file exists.
+        // Failing closed is required for correctness: registering this segment
+        // without a persisted floor would let a later cleanup plus restart
+        // reallocate its sequence number, and stale subscriber progress would
+        // then suppress the new data (issue #4024).
+        //
+        // The segment file is deliberately left on disk. It is not registered,
+        // so no subscriber can observe it and cleanup cannot reclaim it before
+        // the floor is known. On restart the filename scan raises the floor
+        // past this sequence and the segment is delivered normally, so the
+        // bundles survive even under DurabilityMode::SegmentOnly.
+        self.segment_store
+            .persist_next_seq(seq.raw() + 1)
+            .await
+            .map_err(|e| {
+                self.metrics.record_flush_failure();
+                let sidecar_path = self.segment_store.seq_sidecar_path();
+                otel_error!(
+                    "quiver.segment.flush",
+                    segment = seq.raw(),
+                    path = %sidecar_path.display(),
+                    error = %e,
+                    error_type = "io",
+                    message = "failed to persist segment sequence floor, \
+                               segment withheld until restart",
+                );
+                segment_error_from_subscriber(e)
+            })?;
 
         // Step 5: Advance WAL cursor now that segment is durable
         {
@@ -5740,6 +5814,527 @@ mod tests {
                 segments_created
             );
         }
+    }
+
+    /// Scenario: reproduction of issue #4024. A subscriber acks all delivered
+    /// bundles, progress is persisted, and `cleanup_completed_segments` then
+    /// removes every segment file (the prior startup-deletion test only
+    /// covers files removed during *this* run's scan, not files already
+    /// deleted by a previous run). The store restarts with zero segment
+    /// files but the subscriber's persisted progress still references the
+    /// reused sequence number.
+    /// Guarantees: post-restart data written under the reused sequence
+    /// number is still delivered, i.e. segment sequence numbers are never
+    /// reused once allocated, regardless of file/progress cleanup.
+    #[tokio::test]
+    async fn reused_segment_seq_is_not_skipped_by_restored_progress() {
+        let dir = tempdir().expect("tempdir");
+        let sub_id = SubscriberId::new("s1").expect("id");
+
+        let config = QuiverConfig::builder()
+            .data_dir(dir.path())
+            .segment(SegmentConfig {
+                target_size_bytes: NonZeroU64::new(100).unwrap(),
+                ..Default::default()
+            })
+            .build()
+            .expect("config");
+
+        // First run: ingest, ack everything, persist progress, delete all segments.
+        {
+            let engine = QuiverEngine::open(config.clone(), test_budget())
+                .await
+                .expect("engine");
+            engine
+                .register_subscriber(sub_id.clone())
+                .expect("register");
+            engine.activate_subscriber(&sub_id).expect("activate");
+
+            engine
+                .ingest(&DummyBundle::with_rows(50))
+                .await
+                .expect("ingest");
+            engine.flush().await.expect("flush");
+
+            let mut acked = 0;
+            while let Some(h) = engine.poll_next_bundle(&sub_id).expect("poll") {
+                h.ack();
+                acked += 1;
+            }
+            assert!(acked > 0);
+            let _ = engine.flush_progress().await.expect("flush progress");
+
+            assert!(engine.cleanup_completed_segments().expect("cleanup") > 0);
+            assert_eq!(engine.segment_store().segment_count(), 0);
+        }
+
+        // Restart: no segment files remain, but subscriber progress does.
+        let engine = QuiverEngine::open(config, test_budget())
+            .await
+            .expect("engine");
+        engine.activate_subscriber(&sub_id).expect("activate");
+
+        engine
+            .ingest(&DummyBundle::with_rows(50))
+            .await
+            .expect("ingest");
+        engine.flush().await.expect("flush");
+
+        let mut delivered = 0;
+        while let Some(h) = engine.poll_next_bundle(&sub_id).expect("poll") {
+            h.ack();
+            delivered += 1;
+        }
+        assert!(delivered > 0, "post-restart data must be delivered");
+    }
+
+    /// Scenario: a sequence-sidecar I/O failure is converted into the
+    /// `SegmentError` returned by segment finalization.
+    /// Guarantees: the sidecar path and the underlying `io::ErrorKind` survive
+    /// the conversion, so operators can see which file failed and callers can
+    /// still match on the kind rather than parsing a flattened string.
+    #[test]
+    fn subscriber_segment_io_error_preserves_path_and_kind() {
+        let path = PathBuf::from("/tmp/quiver.segment.seq");
+        let source = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
+
+        let converted =
+            segment_error_from_subscriber(SubscriberError::segment_io(path.clone(), source));
+
+        match converted {
+            SegmentError::Io {
+                path: Some(actual),
+                source,
+            } => {
+                assert_eq!(actual, path);
+                assert_eq!(source.kind(), std::io::ErrorKind::PermissionDenied);
+            }
+            other => panic!("expected Io with a path, got {other:?}"),
+        }
+    }
+
+    /// Scenario: in `SegmentOnly` mode (no WAL), the sequence sidecar becomes
+    /// unwritable after the engine is open (a directory is placed at its
+    /// path), a segment finalizes, and the engine later restarts with the
+    /// sidecar path cleared.
+    /// Guarantees: finalization fails closed without discarding data -- the
+    /// segment file stays on disk and unregistered, so no subscriber can
+    /// observe it before its sequence floor is durable, and the restart
+    /// filename scan raises the floor and delivers the bundles. Persisting
+    /// before the segment write instead would drop them outright (#4024).
+    #[tokio::test]
+    async fn finalize_preserves_segment_when_seq_cannot_be_persisted() {
+        let dir = tempdir().expect("tempdir");
+        let sub_id = SubscriberId::new("s1").expect("id");
+        let config = QuiverConfig::builder()
+            .data_dir(dir.path())
+            .segment(SegmentConfig {
+                target_size_bytes: NonZeroU64::new(100).unwrap(),
+                ..Default::default()
+            })
+            .durability(DurabilityMode::SegmentOnly)
+            .build()
+            .expect("config");
+
+        let segment_dir = dir.path().join("segments");
+        let blocker = segment_dir.join(crate::segment_store::SEQ_SIDECAR_FILENAME);
+        {
+            let engine = QuiverEngine::open(config.clone(), test_budget())
+                .await
+                .expect("engine");
+            engine
+                .register_subscriber(sub_id.clone())
+                .expect("register subscriber");
+            engine.activate_subscriber(&sub_id).expect("activate");
+
+            // No sidecar exists yet, so open succeeded. Make the sidecar path
+            // unwritable now that the engine is running.
+            fs::create_dir(&blocker).expect("create dir at sidecar path");
+
+            // Finalization can be triggered by the size threshold during
+            // ingest or by the explicit flush; either way it must fail.
+            let ingest_result = engine.ingest(&DummyBundle::with_rows(50)).await;
+            let failed = if ingest_result.is_err() {
+                true
+            } else {
+                engine.flush().await.is_err()
+            };
+            assert!(
+                failed,
+                "finalization must fail when the sequence floor cannot be persisted"
+            );
+
+            // The segment file survives so the data is recoverable, but it was
+            // never registered, so this subscriber cannot see it yet.
+            let segment_files = fs::read_dir(&segment_dir)
+                .expect("read segments dir")
+                .filter_map(std::result::Result::ok)
+                .filter(|e| e.path().extension().is_some_and(|ext| ext == "qseg"))
+                .count();
+            assert_eq!(
+                segment_files, 1,
+                "the written segment must be kept so its bundles are not lost"
+            );
+            assert!(
+                engine.poll_next_bundle(&sub_id).expect("poll").is_none(),
+                "a segment without a durable sequence floor must not be visible"
+            );
+        }
+
+        fs::remove_dir(&blocker).expect("clear sidecar path");
+
+        let engine = QuiverEngine::open(config, test_budget())
+            .await
+            .expect("reopen");
+        // Subscribers are re-registered by the application on startup.
+        let _ = engine.register_subscriber(sub_id.clone());
+        engine.activate_subscriber(&sub_id).expect("activate");
+        let mut delivered = 0usize;
+        while let Some(handle) = engine.poll_next_bundle(&sub_id).expect("poll") {
+            handle.ack();
+            delivered += 1;
+        }
+        assert!(
+            delivered > 0,
+            "bundles written before the sidecar failure must be delivered after restart"
+        );
+    }
+
+    /// Scenario: the same sidecar-unwritable finalization failure occurs under
+    /// `DurabilityMode::Wal`, and the retained segment file is then lost
+    /// before restart, so the WAL is the only remaining copy of the data.
+    /// Guarantees: the WAL cursor is advanced only after the sequence floor is
+    /// persisted, so a failure to persist leaves the cursor covering the
+    /// affected bundles and replay still delivers them. Advancing the cursor
+    /// first would acknowledge data that was never durably sequenced.
+    #[tokio::test]
+    async fn wal_mode_replays_bundles_when_seq_cannot_be_persisted() {
+        let dir = tempdir().expect("tempdir");
+        let sub_id = SubscriberId::new("s1").expect("id");
+        let config = QuiverConfig::builder()
+            .data_dir(dir.path())
+            .segment(SegmentConfig {
+                target_size_bytes: NonZeroU64::new(100).unwrap(),
+                ..Default::default()
+            })
+            .durability(DurabilityMode::Wal)
+            .build()
+            .expect("config");
+
+        let segment_dir = dir.path().join("segments");
+        let blocker = segment_dir.join(crate::segment_store::SEQ_SIDECAR_FILENAME);
+        {
+            let engine = QuiverEngine::open(config.clone(), test_budget())
+                .await
+                .expect("engine");
+            engine
+                .register_subscriber(sub_id.clone())
+                .expect("register subscriber");
+            engine.activate_subscriber(&sub_id).expect("activate");
+
+            fs::create_dir(&blocker).expect("create dir at sidecar path");
+
+            let ingest_result = engine.ingest(&DummyBundle::with_rows(50)).await;
+            let failed = if ingest_result.is_err() {
+                true
+            } else {
+                engine.flush().await.is_err()
+            };
+            assert!(
+                failed,
+                "finalization must fail when the sequence floor cannot be persisted"
+            );
+            assert!(
+                engine.poll_next_bundle(&sub_id).expect("poll").is_none(),
+                "a segment without a durable sequence floor must not be visible"
+            );
+        }
+
+        fs::remove_dir(&blocker).expect("clear sidecar path");
+        // Discard the retained segment so the WAL is the only source left.
+        for entry in fs::read_dir(&segment_dir).expect("read segments dir") {
+            let path = entry.expect("dir entry").path();
+            if path.extension().is_some_and(|ext| ext == "qseg") {
+                fs::remove_file(&path).expect("remove segment");
+            }
+        }
+
+        let engine = QuiverEngine::open(config, test_budget())
+            .await
+            .expect("reopen");
+        let _ = engine.register_subscriber(sub_id.clone());
+        engine.activate_subscriber(&sub_id).expect("activate");
+        let mut delivered = 0usize;
+        while let Some(handle) = engine.poll_next_bundle(&sub_id).expect("poll") {
+            handle.ack();
+            delivered += 1;
+        }
+        assert!(
+            delivered > 0,
+            "WAL replay must still cover bundles whose sequence floor was never persisted"
+        );
+    }
+
+    /// Guarantees: `open` fails instead of falling back to a lower floor,
+    /// which could reallocate an in-use sequence number and silently suppress
+    /// newly ingested data (issue #4024).
+    #[tokio::test]
+    async fn open_fails_when_seq_sidecar_is_unreadable() {
+        let dir = tempdir().expect("tempdir");
+        let segment_dir = dir.path().join("segments");
+        fs::create_dir_all(&segment_dir).expect("create segments dir");
+        // A directory at the sidecar path fails `read` for every user,
+        // including root, so this is deterministic in CI.
+        fs::create_dir(segment_dir.join(crate::segment_store::SEQ_SIDECAR_FILENAME))
+            .expect("create dir at sidecar path");
+
+        let config = QuiverConfig::builder()
+            .data_dir(dir.path())
+            .build()
+            .expect("config");
+
+        let result = QuiverEngine::open(config, test_budget()).await;
+        assert!(
+            result.is_err(),
+            "open must fail closed when the sequence floor cannot be verified"
+        );
+    }
+
+    /// Scenario: the sequence sidecar is unavailable after all segments were
+    /// cleaned up, as on the first start after an upgrade or when the segments
+    /// directory is cleared wholesale. Subscriber progress files live outside
+    /// that directory and still record the reused sequence numbers.
+    /// Guarantees: the floor derived from restored subscriber progress alone
+    /// prevents sequence reuse, so post-restart data is still delivered
+    /// instead of being suppressed (issue #4024).
+    #[tokio::test]
+    async fn reused_segment_seq_is_not_skipped_without_sidecar() {
+        let dir = tempdir().expect("tempdir");
+        let sub_id = SubscriberId::new("s1").expect("id");
+
+        let config = QuiverConfig::builder()
+            .data_dir(dir.path())
+            .segment(SegmentConfig {
+                target_size_bytes: NonZeroU64::new(100).unwrap(),
+                ..Default::default()
+            })
+            .build()
+            .expect("config");
+
+        {
+            let engine = QuiverEngine::open(config.clone(), test_budget())
+                .await
+                .expect("engine");
+            engine
+                .register_subscriber(sub_id.clone())
+                .expect("register");
+            engine.activate_subscriber(&sub_id).expect("activate");
+
+            engine
+                .ingest(&DummyBundle::with_rows(50))
+                .await
+                .expect("ingest");
+            engine.flush().await.expect("flush");
+
+            while let Some(h) = engine.poll_next_bundle(&sub_id).expect("poll") {
+                h.ack();
+            }
+
+            let _ = engine.maintain().await.expect("maintain");
+            assert_eq!(engine.segment_store().segment_count(), 0);
+        }
+
+        // Remove the sidecar, leaving only the filename-derived floor (zero,
+        // with no segment files) and subscriber progress.
+        let sidecar = dir
+            .path()
+            .join("segments")
+            .join(crate::segment_store::SEQ_SIDECAR_FILENAME);
+        fs::remove_file(&sidecar).expect("remove sidecar");
+
+        let engine = QuiverEngine::open(config, test_budget())
+            .await
+            .expect("engine");
+        assert!(
+            engine.total_segments_written() > 0,
+            "subscriber progress must still supply a non-zero floor"
+        );
+        engine.activate_subscriber(&sub_id).expect("activate");
+
+        engine
+            .ingest(&DummyBundle::with_rows(50))
+            .await
+            .expect("ingest");
+        engine.flush().await.expect("flush");
+
+        let mut delivered = 0;
+        while let Some(h) = engine.poll_next_bundle(&sub_id).expect("poll") {
+            h.ack();
+            delivered += 1;
+        }
+        assert!(
+            delivered > 0,
+            "post-restart data must be delivered without the sidecar"
+        );
+    }
+
+    /// Scenario: the same cleanup-then-restart sequence as the previous test,
+    /// but driven through a full `maintain()` cycle (flush progress, clean up
+    /// completed segments, apply retention) rather than the individual calls,
+    /// covering the path an embedding layer actually runs periodically.
+    /// Guarantees: the durable sequence sidecar records a non-zero floor even
+    /// after every segment file is gone, and post-restart data is delivered
+    /// rather than being suppressed by restored progress.
+    #[tokio::test]
+    async fn reused_segment_seq_is_not_skipped_after_maintenance_cycle() {
+        let dir = tempdir().expect("tempdir");
+        let sub_id = SubscriberId::new("s1").expect("id");
+
+        let config = QuiverConfig::builder()
+            .data_dir(dir.path())
+            .segment(SegmentConfig {
+                target_size_bytes: NonZeroU64::new(100).unwrap(),
+                ..Default::default()
+            })
+            .build()
+            .expect("config");
+
+        {
+            let engine = QuiverEngine::open(config.clone(), test_budget())
+                .await
+                .expect("engine");
+            engine
+                .register_subscriber(sub_id.clone())
+                .expect("register");
+            engine.activate_subscriber(&sub_id).expect("activate");
+
+            engine
+                .ingest(&DummyBundle::with_rows(50))
+                .await
+                .expect("ingest");
+            engine.flush().await.expect("flush");
+
+            while let Some(h) = engine.poll_next_bundle(&sub_id).expect("poll") {
+                h.ack();
+            }
+
+            // A full maintenance cycle flushes progress, then deletes every
+            // completed segment file.
+            let _ = engine.maintain().await.expect("maintain");
+            assert_eq!(engine.segment_store().segment_count(), 0);
+
+            // With no segment files left, the sidecar is the only remaining
+            // record of which sequence numbers have been used.
+            assert!(
+                engine
+                    .segment_store()
+                    .read_persisted_next_seq()
+                    .is_some_and(|next| next > 0),
+                "sidecar must retain a non-zero floor after all segments are deleted"
+            );
+        }
+
+        let engine = QuiverEngine::open(config, test_budget())
+            .await
+            .expect("engine");
+        engine.activate_subscriber(&sub_id).expect("activate");
+
+        engine
+            .ingest(&DummyBundle::with_rows(50))
+            .await
+            .expect("ingest");
+        engine.flush().await.expect("flush");
+
+        let mut delivered = 0;
+        while let Some(h) = engine.poll_next_bundle(&sub_id).expect("poll") {
+            h.ack();
+            delivered += 1;
+        }
+        assert!(
+            delivered > 0,
+            "post-restart data must be delivered even with an empty progress file"
+        );
+    }
+
+    /// Scenario: the persisted sequence floor is ahead of every `.qseg` file
+    /// on disk -- e.g. cleanup removed the segments a finalization persisted
+    /// past. The store then restarts and ingests.
+    /// Guarantees: the gap is harmless; the skipped sequence number is never
+    /// reallocated, and post-restart data is still delivered to a subscriber
+    /// restored from progress written before the gap.
+    #[tokio::test]
+    async fn sequence_gap_above_segment_files_is_safe() {
+        let dir = tempdir().expect("tempdir");
+        let sub_id = SubscriberId::new("s1").expect("id");
+
+        let config = QuiverConfig::builder()
+            .data_dir(dir.path())
+            .segment(SegmentConfig {
+                target_size_bytes: NonZeroU64::new(100).unwrap(),
+                ..Default::default()
+            })
+            .build()
+            .expect("config");
+
+        {
+            let engine = QuiverEngine::open(config.clone(), test_budget())
+                .await
+                .expect("engine");
+            engine
+                .register_subscriber(sub_id.clone())
+                .expect("register");
+            engine.activate_subscriber(&sub_id).expect("activate");
+
+            engine
+                .ingest(&DummyBundle::with_rows(50))
+                .await
+                .expect("ingest");
+            engine.flush().await.expect("flush");
+
+            while let Some(h) = engine.poll_next_bundle(&sub_id).expect("poll") {
+                h.ack();
+            }
+            let _ = engine.flush_progress().await.expect("flush progress");
+            let _ = engine.cleanup_completed_segments().expect("cleanup");
+
+            // Simulate a crash after the floor was reserved but before the
+            // corresponding segment file was written: advance the persisted
+            // counter well past anything on disk.
+            engine
+                .segment_store()
+                .persist_next_seq(500)
+                .await
+                .expect("persist gap");
+        }
+
+        let engine = QuiverEngine::open(config, test_budget())
+            .await
+            .expect("engine");
+        engine.activate_subscriber(&sub_id).expect("activate");
+
+        engine
+            .ingest(&DummyBundle::with_rows(50))
+            .await
+            .expect("ingest");
+        engine.flush().await.expect("flush");
+
+        for seq in engine.segment_store().segment_sequences() {
+            assert!(
+                seq.raw() >= 500,
+                "new segment seq {} must respect the persisted floor",
+                seq.raw()
+            );
+        }
+
+        let mut delivered = 0;
+        while let Some(h) = engine.poll_next_bundle(&sub_id).expect("poll") {
+            h.ack();
+            delivered += 1;
+        }
+        assert!(
+            delivered > 0,
+            "data written after a sequence gap must still be delivered"
+        );
     }
 
     // -----------------------------------------------------------------------------

--- a/rust/otap-dataflow/crates/quiver/src/segment_store.rs
+++ b/rust/otap-dataflow/crates/quiver/src/segment_store.rs
@@ -13,6 +13,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 
 use parking_lot::{Mutex, RwLock};
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex as TokioMutex;
 
 use crate::budget::DiskBudget;
 use crate::logging::{otel_debug, otel_error, otel_warn};
@@ -36,6 +38,82 @@ const BASE_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 /// Upper bound on the exponential backoff interval so that retries do
 /// not stall for excessively long periods.
 const MAX_RETRY_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Filename for the durable segment sequence counter sidecar.
+///
+/// Persists the lowest sequence number that may be allocated to a future
+/// segment, independent of which segment files currently exist on disk.
+/// This prevents sequence reuse when all segments have been deleted (e.g.
+/// after cleanup) before a restart: without it, the startup floor would be
+/// derived solely from `.qseg` filenames, which can be empty.
+pub(crate) const SEQ_SIDECAR_FILENAME: &str = "quiver.segment.seq";
+
+/// Magic bytes identifying a segment sequence sidecar file.
+const SEQ_SIDECAR_MAGIC: &[u8; 8] = b"QUIVER\0N";
+
+/// Current sidecar format version.
+const SEQ_SIDECAR_VERSION: u16 = 1;
+
+/// Minimum prefix needed to read the size field: magic (8) + version (2) + size (2).
+const SEQ_SIDECAR_MIN_LEN: usize = 12;
+
+/// Sidecar layout (v1, 24 bytes):
+/// magic (8) + version (2) + size (2) + next_seq (8) + crc32 (4).
+///
+/// The `size` field records the total encoded length so a future version can
+/// append fields while remaining readable here: a v1 reader validates the
+/// v1-compatible prefix and ignores unknown trailing bytes.
+const SEQ_SIDECAR_V1_LEN: usize = 24;
+
+/// Encodes a `next_seq` value into the sidecar's on-disk representation.
+fn encode_seq_sidecar(next_seq: u64) -> [u8; SEQ_SIDECAR_V1_LEN] {
+    let mut buf = [0u8; SEQ_SIDECAR_V1_LEN];
+    buf[0..8].copy_from_slice(SEQ_SIDECAR_MAGIC);
+    buf[8..10].copy_from_slice(&SEQ_SIDECAR_VERSION.to_le_bytes());
+    buf[10..12].copy_from_slice(&(SEQ_SIDECAR_V1_LEN as u16).to_le_bytes());
+    buf[12..20].copy_from_slice(&next_seq.to_le_bytes());
+    let crc = crc32fast::hash(&buf[..20]);
+    buf[20..24].copy_from_slice(&crc.to_le_bytes());
+    buf
+}
+
+/// Decodes a sidecar buffer, returning `None` if it is truncated, declares an
+/// unusable size, or fails magic/version/CRC validation. Corruption is treated
+/// as "no persisted value" rather than a hard error, since the filename-derived
+/// floor still provides a (weaker) fallback.
+///
+/// Newer versions are accepted as long as they carry the v1 fields, so a
+/// forward-written sidecar still constrains this reader's sequence floor
+/// instead of being silently discarded.
+fn decode_seq_sidecar(buf: &[u8]) -> Option<u64> {
+    if buf.len() < SEQ_SIDECAR_MIN_LEN || buf[0..8] != *SEQ_SIDECAR_MAGIC {
+        return None;
+    }
+
+    let version = u16::from_le_bytes(buf[8..10].try_into().ok()?);
+    let size = u16::from_le_bytes(buf[10..12].try_into().ok()?) as usize;
+
+    // A v1 file must match exactly; a newer one must still contain the v1
+    // fields plus a trailing CRC.
+    if version == SEQ_SIDECAR_VERSION {
+        if size != SEQ_SIDECAR_V1_LEN {
+            return None;
+        }
+    } else if version < SEQ_SIDECAR_VERSION || size < SEQ_SIDECAR_V1_LEN {
+        return None;
+    }
+    if buf.len() < size {
+        return None;
+    }
+
+    let next_seq = u64::from_le_bytes(buf[12..20].try_into().ok()?);
+    let crc_offset = size - 4;
+    let stored_crc = u32::from_le_bytes(buf[crc_offset..size].try_into().ok()?);
+    if crc32fast::hash(&buf[..crc_offset]) != stored_crc {
+        return None;
+    }
+    Some(next_seq)
+}
 
 /// A segment whose file deletion was deferred for later retry.
 #[derive(Debug, Clone, Copy)]
@@ -70,6 +148,19 @@ pub struct ScanResult {
     pub deleted: Vec<(SegmentSeq, u64)>,
     /// Highest valid segment sequence observed, including retained corrupt files.
     pub highest_seen: Option<SegmentSeq>,
+    /// Durably persisted "next segment sequence" counter, if present.
+    ///
+    /// Read from the sequence sidecar rather than derived from filenames, so
+    /// it remains a valid floor even when no segment files exist on disk
+    /// (e.g. all segments were previously cleaned up).
+    pub persisted_next_seq: Option<u64>,
+    /// Set when the sidecar exists but could not be read.
+    ///
+    /// Distinct from `persisted_next_seq: None`, which means no sidecar is
+    /// present. An unreadable sidecar may hold a floor higher than any other
+    /// source, so callers must not treat it as absent and silently allocate a
+    /// sequence number that is already in use.
+    pub seq_sidecar_unreadable: bool,
 }
 
 #[derive(Debug, Default)]
@@ -228,6 +319,8 @@ pub struct SegmentStore {
     /// Entries are retried each maintenance cycle and evicted after
     /// [`MAX_DELETE_ATTEMPTS`] failures (releasing the budget with an error log).
     pending_deletes: Mutex<HashMap<SegmentSeq, PendingDelete>>,
+    /// Serializes sequence sidecar read-modify-write cycles.
+    seq_sidecar_lock: TokioMutex<()>,
 }
 
 impl std::fmt::Debug for SegmentStore {
@@ -258,6 +351,7 @@ impl SegmentStore {
             on_segment_registered: Mutex::new(None),
             budget: None,
             pending_deletes: Mutex::new(HashMap::new()),
+            seq_sidecar_lock: TokioMutex::new(()),
         }
     }
 
@@ -276,6 +370,7 @@ impl SegmentStore {
             on_segment_registered: Mutex::new(None),
             budget: Some(budget),
             pending_deletes: Mutex::new(HashMap::new()),
+            seq_sidecar_lock: TokioMutex::new(()),
         }
     }
 
@@ -645,6 +740,140 @@ impl SegmentStore {
             .join(format!("{}.qseg", seq.to_filename_component()))
     }
 
+    /// Returns the path to the segment sequence counter sidecar.
+    pub(crate) fn seq_sidecar_path(&self) -> PathBuf {
+        self.segment_dir.join(SEQ_SIDECAR_FILENAME)
+    }
+
+    /// Reads the durably persisted "next segment sequence" counter, if present.
+    ///
+    /// Returns `None` if the sidecar is missing or corrupt. An existing but
+    /// unreadable sidecar also yields `None` here; callers that must not
+    /// mistake it for "absent" should use [`Self::load_seq_sidecar`].
+    #[must_use]
+    pub fn read_persisted_next_seq(&self) -> Option<u64> {
+        self.load_seq_sidecar().ok().flatten()
+    }
+
+    /// Interprets the outcome of reading the sidecar, distinguishing "absent"
+    /// from "unreadable".
+    ///
+    /// `Ok(None)` means no usable value is on disk (missing, or present but
+    /// corrupt); `Err` means the file exists but could not be read, so its
+    /// contents are unknown and must not be assumed absent.
+    fn interpret_seq_sidecar(
+        path: &Path,
+        read_result: std::io::Result<Vec<u8>>,
+    ) -> std::io::Result<Option<u64>> {
+        match read_result {
+            Ok(buf) => {
+                let decoded = decode_seq_sidecar(&buf);
+                if decoded.is_none() {
+                    otel_warn!(
+                        "quiver.segment.seq",
+                        path = %path.display(),
+                        error_type = "invalid_metadata",
+                        message = "corrupt segment sequence sidecar, \
+                                   floor falls back to filenames and \
+                                   subscriber progress",
+                    );
+                }
+                Ok(decoded)
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => {
+                otel_warn!(
+                    "quiver.segment.seq",
+                    path = %path.display(),
+                    error = %e,
+                    error_type = "io",
+                    message = "unreadable segment sequence sidecar, \
+                               protection against sequence reuse is degraded",
+                );
+                Err(e)
+            }
+        }
+    }
+
+    /// Reads and decodes the sidecar synchronously.
+    ///
+    /// Used on the startup path, which is already synchronous and runs before
+    /// the pipeline is processing data.
+    pub(crate) fn load_seq_sidecar(&self) -> std::io::Result<Option<u64>> {
+        let path = self.seq_sidecar_path();
+        let read_result = std::fs::read(&path);
+        Self::interpret_seq_sidecar(&path, read_result)
+    }
+
+    /// Durably persists `next_seq` as the lowest sequence number that may be
+    /// allocated to a future segment.
+    ///
+    /// This value survives deletion of all segment files, preventing
+    /// sequence reuse across cleanup + restart cycles. Writes use an atomic
+    /// rename plus `fsync` of the file and parent directory so a crash never
+    /// leaves a partially written sidecar.
+    ///
+    /// Calls are serialized and the stored value is monotonic: concurrent
+    /// finalizations may persist out of order, and a lower value must never
+    /// overwrite a higher one or the floor would regress across a restart.
+    ///
+    /// All filesystem work is asynchronous: this runs on the pipeline's
+    /// single-threaded runtime, where a blocking `fsync` would stall
+    /// ingestion, backpressure, and shutdown.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the existing sidecar cannot be read (its value is
+    /// then unknown, so monotonicity cannot be guaranteed) or if the new
+    /// value cannot be written.
+    pub async fn persist_next_seq(&self, next_seq: u64) -> Result<()> {
+        let path = self.seq_sidecar_path();
+        // Serializes the read-modify-write below and keeps concurrent writers
+        // from sharing the temporary file.
+        let _guard = self.seq_sidecar_lock.lock().await;
+
+        // An unreadable sidecar must not be treated as absent: doing so would
+        // bypass the monotonic check and could overwrite a higher floor.
+        let read_result = tokio::fs::read(&path).await;
+        if Self::interpret_seq_sidecar(&path, read_result)
+            .map_err(|e| SubscriberError::segment_io(path.clone(), e))?
+            .is_some_and(|persisted| persisted >= next_seq)
+        {
+            return Ok(());
+        }
+
+        let mut tmp_path = path.clone().into_os_string();
+        tmp_path.push(".tmp");
+        let tmp_path = PathBuf::from(tmp_path);
+
+        let write_result = async {
+            let mut file = tokio::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&tmp_path)
+                .await?;
+            file.write_all(&encode_seq_sidecar(next_seq)).await?;
+            file.sync_data().await?;
+            drop(file);
+            tokio::fs::rename(&tmp_path, &path).await?;
+            // The rename is only durable once the parent directory is synced,
+            // so a failure here must not be reported as a successful persist.
+            #[cfg(unix)]
+            if let Some(dir) = path.parent() {
+                tokio::fs::File::open(dir).await?.sync_all().await?;
+            }
+            Ok::<(), std::io::Error>(())
+        }
+        .await;
+
+        if write_result.is_err() {
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+        }
+
+        write_result.map_err(|e| SubscriberError::segment_io(path, e))
+    }
+
     /// Scans the segment directory and loads existing segments.
     ///
     /// Called during startup to discover segments from a previous run.
@@ -746,10 +975,13 @@ impl SegmentStore {
         found.sort_by_key(|(seq, _)| *seq);
         deleted.sort_by_key(|(seq, _)| *seq);
 
+        let loaded_seq_sidecar = self.load_seq_sidecar();
         Ok(ScanResult {
             found,
             deleted,
             highest_seen,
+            persisted_next_seq: loaded_seq_sidecar.as_ref().ok().copied().flatten(),
+            seq_sidecar_unreadable: loaded_seq_sidecar.is_err(),
         })
     }
 
@@ -954,6 +1186,255 @@ mod tests {
             result,
             Err(SubscriberError::SegmentNotFound { .. })
         ));
+    }
+
+    /// Scenario: no sequence sidecar has ever been written for a fresh store.
+    /// Guarantees: `read_persisted_next_seq` returns `None` rather than an
+    /// error, so a missing sidecar is not mistaken for an I/O failure. The
+    /// startup floor then falls back to segment filenames and restored
+    /// subscriber progress, which is only safe for a genuinely fresh store.
+    #[test]
+    fn read_persisted_next_seq_missing_returns_none() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("segments")).unwrap();
+        let store = SegmentStore::new(dir.path().join("segments"));
+
+        assert_eq!(store.read_persisted_next_seq(), None);
+    }
+
+    /// Scenario: a value is persisted via `persist_next_seq` and then read
+    /// back, including after the store is recreated (simulating restart).
+    /// Guarantees: the sidecar survives independently of any in-memory
+    /// `SegmentStore` state and round-trips exactly.
+    #[tokio::test]
+    async fn persist_and_read_next_seq_roundtrip() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("segments")).unwrap();
+        let store = SegmentStore::new(dir.path().join("segments"));
+
+        store.persist_next_seq(42).await.expect("persist");
+        assert_eq!(store.read_persisted_next_seq(), Some(42));
+
+        // A fresh store instance (as at restart) must observe the same value.
+        let reopened = SegmentStore::new(dir.path().join("segments"));
+        assert_eq!(reopened.read_persisted_next_seq(), Some(42));
+
+        // Persisting a new value overwrites the old one.
+        store.persist_next_seq(100).await.expect("persist again");
+        assert_eq!(store.read_persisted_next_seq(), Some(100));
+    }
+
+    /// Scenario: the sidecar file exists but is corrupted (bad CRC).
+    /// Guarantees: corruption is treated as "no persisted value" instead of
+    /// propagating an error, so startup proceeds on the remaining floors and
+    /// the next write restores a valid sidecar.
+    #[tokio::test]
+    async fn read_persisted_next_seq_ignores_corrupt_sidecar() {
+        let dir = tempdir().unwrap();
+        let segment_dir = dir.path().join("segments");
+        std::fs::create_dir_all(&segment_dir).unwrap();
+        let store = SegmentStore::new(&segment_dir);
+
+        store.persist_next_seq(7).await.expect("persist");
+        let sidecar_path = segment_dir.join(SEQ_SIDECAR_FILENAME);
+        let mut bytes = std::fs::read(&sidecar_path).unwrap();
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0xFF;
+        std::fs::write(&sidecar_path, bytes).unwrap();
+
+        assert_eq!(store.read_persisted_next_seq(), None);
+    }
+
+    /// Scenario: the segment directory is empty (no `.qseg` files) but a
+    /// sequence sidecar was persisted by a previous run.
+    /// Guarantees: `scan_existing_with_max_age` surfaces the persisted value
+    /// via `ScanResult::persisted_next_seq` even though `highest_seen` is
+    /// `None`.
+    #[tokio::test]
+    async fn scan_existing_surfaces_persisted_next_seq_with_no_segment_files() {
+        let dir = tempdir().unwrap();
+        let segment_dir = dir.path().join("segments");
+        std::fs::create_dir_all(&segment_dir).unwrap();
+        let store = SegmentStore::new(&segment_dir);
+        store.persist_next_seq(9).await.expect("persist");
+
+        let scan_result = store.scan_existing().expect("scan");
+        assert_eq!(scan_result.highest_seen, None);
+        assert_eq!(scan_result.persisted_next_seq, Some(9));
+    }
+
+    /// Scenario: a lower `next_seq` is persisted after a higher one, as can
+    /// happen when concurrent segment finalizations complete out of order.
+    /// Guarantees: the stored floor is monotonic, so a late-arriving lower
+    /// value never regresses the floor and reintroduces sequence reuse
+    /// after a restart.
+    #[tokio::test]
+    async fn persist_next_seq_never_regresses() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("segments")).unwrap();
+        let store = SegmentStore::new(dir.path().join("segments"));
+
+        store.persist_next_seq(12).await.expect("persist higher");
+        store.persist_next_seq(11).await.expect("persist lower");
+
+        assert_eq!(
+            store.read_persisted_next_seq(),
+            Some(12),
+            "a lower value must not overwrite a higher persisted floor"
+        );
+    }
+
+    /// Scenario: a crash left a stale `.tmp` file from an interrupted
+    /// sidecar write.
+    /// Guarantees: the stale temporary file is overwritten rather than
+    /// causing the next persist to fail, and the committed value is correct.
+    #[tokio::test]
+    async fn persist_next_seq_overwrites_stale_tmp_file() {
+        let dir = tempdir().unwrap();
+        let segment_dir = dir.path().join("segments");
+        std::fs::create_dir_all(&segment_dir).unwrap();
+        let store = SegmentStore::new(&segment_dir);
+
+        let mut tmp_path = segment_dir.join(SEQ_SIDECAR_FILENAME).into_os_string();
+        tmp_path.push(".tmp");
+        std::fs::write(PathBuf::from(&tmp_path), b"garbage").unwrap();
+
+        store.persist_next_seq(5).await.expect("persist");
+        assert_eq!(store.read_persisted_next_seq(), Some(5));
+    }
+
+    /// Scenario: a sidecar written by a hypothetical future version carries
+    /// extra trailing fields after `next_seq` and a larger declared size.
+    /// Guarantees: this reader still extracts the v1 `next_seq`, so a
+    /// forward-written counter continues to constrain the sequence floor
+    /// instead of being discarded and silently allowing reuse.
+    #[test]
+    fn decode_seq_sidecar_reads_future_version() {
+        let next_seq: u64 = 0x1234_5678_9ABC_DEF0;
+        let future_size: u16 = 32; // 24 bytes of v1 + an 8-byte future field
+
+        let mut buf = vec![0u8; future_size as usize];
+        buf[0..8].copy_from_slice(SEQ_SIDECAR_MAGIC);
+        buf[8..10].copy_from_slice(&2u16.to_le_bytes());
+        buf[10..12].copy_from_slice(&future_size.to_le_bytes());
+        buf[12..20].copy_from_slice(&next_seq.to_le_bytes());
+        buf[20..28].copy_from_slice(&0xDEAD_BEEF_u64.to_le_bytes());
+        let crc_offset = future_size as usize - 4;
+        let crc = crc32fast::hash(&buf[..crc_offset]);
+        buf[crc_offset..].copy_from_slice(&crc.to_le_bytes());
+
+        assert_eq!(decode_seq_sidecar(&buf), Some(next_seq));
+    }
+
+    /// Scenario: malformed sidecars -- a v1 file with the wrong declared
+    /// size, a future version too small to hold the v1 fields, and a
+    /// truncated buffer.
+    /// Guarantees: each is rejected as `None` rather than yielding a bogus
+    /// sequence floor that could permit reuse or skip valid data.
+    #[test]
+    fn decode_seq_sidecar_rejects_malformed_sizes() {
+        // v1 declaring a non-v1 size.
+        let mut wrong_v1 = vec![0u8; 32];
+        wrong_v1[0..8].copy_from_slice(SEQ_SIDECAR_MAGIC);
+        wrong_v1[8..10].copy_from_slice(&1u16.to_le_bytes());
+        wrong_v1[10..12].copy_from_slice(&32u16.to_le_bytes());
+        assert_eq!(decode_seq_sidecar(&wrong_v1), None);
+
+        // Future version too small to contain the v1 fields.
+        let mut small_future = vec![0u8; 20];
+        small_future[0..8].copy_from_slice(SEQ_SIDECAR_MAGIC);
+        small_future[8..10].copy_from_slice(&2u16.to_le_bytes());
+        small_future[10..12].copy_from_slice(&16u16.to_le_bytes());
+        assert_eq!(decode_seq_sidecar(&small_future), None);
+
+        // Declared size exceeds the bytes actually present.
+        let mut truncated = encode_seq_sidecar(7).to_vec();
+        truncated.truncate(20);
+        assert_eq!(decode_seq_sidecar(&truncated), None);
+
+        // Shorter than the minimum readable prefix.
+        assert_eq!(decode_seq_sidecar(&[0u8; 4]), None);
+    }
+
+    /// Scenario: a sidecar exists but cannot be read. A directory at the
+    /// sidecar path yields a non-`NotFound` I/O error from `read` for every
+    /// user, including root, so the failure is deterministic in CI.
+    /// Guarantees: `persist_next_seq` fails closed rather than treating the
+    /// unknown value as absent; otherwise it would bypass the monotonic check
+    /// and could overwrite a higher floor with a lower one, reintroducing
+    /// issue #4024.
+    #[tokio::test]
+    async fn persist_next_seq_fails_when_existing_sidecar_is_unreadable() {
+        let dir = tempdir().unwrap();
+        let segment_dir = dir.path().join("segments");
+        std::fs::create_dir_all(&segment_dir).unwrap();
+        let store = SegmentStore::new(&segment_dir);
+
+        std::fs::create_dir(segment_dir.join(SEQ_SIDECAR_FILENAME)).unwrap();
+
+        let err = store
+            .persist_next_seq(5)
+            .await
+            .expect_err("an unreadable sidecar must not be treated as absent");
+        assert!(
+            matches!(err, SubscriberError::SegmentIo { .. }),
+            "expected a segment I/O error, got {err:?}"
+        );
+    }
+
+    /// Scenario: startup scans a segment directory whose sidecar exists but
+    /// cannot be read, so the floor it would contribute is unknown.
+    /// Guarantees: the scan reports `seq_sidecar_unreadable` instead of
+    /// silently yielding `persisted_next_seq: None`, which callers would
+    /// otherwise treat as "no sidecar" and proceed with a lower floor.
+    #[test]
+    fn scan_existing_flags_unreadable_sidecar() {
+        let dir = tempdir().unwrap();
+        let segment_dir = dir.path().join("segments");
+        std::fs::create_dir_all(&segment_dir).unwrap();
+        let store = SegmentStore::new(&segment_dir);
+
+        std::fs::create_dir(segment_dir.join(SEQ_SIDECAR_FILENAME)).unwrap();
+
+        let scan_result = store.scan_existing().expect("scan");
+        assert!(
+            scan_result.seq_sidecar_unreadable,
+            "an unreadable sidecar must be reported, not silently ignored"
+        );
+        assert_eq!(scan_result.persisted_next_seq, None);
+    }
+
+    /// Scenario: many tasks persist sequence floors concurrently and out of
+    /// order, as concurrent segment finalizations would.
+    /// Guarantees: serialization and the monotonic guard hold under real
+    /// contention -- the committed value is the maximum requested, and
+    /// interleaved temp-file writes never leave the sidecar corrupt.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn persist_next_seq_is_monotonic_under_concurrency() {
+        let dir = tempdir().unwrap();
+        let segment_dir = dir.path().join("segments");
+        std::fs::create_dir_all(&segment_dir).unwrap();
+        let store = Arc::new(SegmentStore::new(&segment_dir));
+
+        let highest = 64u64;
+        // Descending order maximizes the chance a lower value is written
+        // after a higher one.
+        let mut handles = Vec::new();
+        for value in (1..=highest).rev() {
+            let store = Arc::clone(&store);
+            handles.push(tokio::spawn(async move {
+                store.persist_next_seq(value).await.expect("persist");
+            }));
+        }
+        for handle in handles {
+            handle.await.expect("task");
+        }
+
+        assert_eq!(
+            store.read_persisted_next_seq(),
+            Some(highest),
+            "the committed floor must be the maximum value requested"
+        );
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/quiver/src/subscriber/registry.rs
+++ b/rust/otap-dataflow/crates/quiver/src/subscriber/registry.rs
@@ -756,6 +756,23 @@ impl<P: SegmentProvider> SubscriberRegistry<P> {
             .min()
     }
 
+    /// Returns the highest segment sequence tracked by any subscriber,
+    /// including inactive ones.
+    ///
+    /// Restored progress is a record of segments that once existed, so this
+    /// acts as a floor for future sequence allocation: reusing one of these
+    /// sequence numbers would collide with stale progress and suppress the
+    /// new data (issue #4024). Inactive subscribers are included because
+    /// their state is retained and can be reactivated.
+    #[must_use]
+    pub fn highest_tracked_segment_any(&self) -> Option<SegmentSeq> {
+        self.subscribers
+            .read()
+            .values()
+            .filter_map(|state_lock| state_lock.read().highest_tracked_segment())
+            .max()
+    }
+
     /// Returns debug info about subscriber segment counts (for debugging).
     #[must_use]
     pub fn debug_subscriber_segment_counts(&self) -> Vec<(String, usize, bool)> {


### PR DESCRIPTION
# Change summary

Fixes Quiver silently skipping newly ingested telemetry after retention cleanup removes all segment files and the process restarts.

`next_segment_seq` was derived only from the highest `.qseg` filename seen during the startup scan, defaulting to `0` once every segment was cleaned up. The reallocated sequence number then collided with a stale, already-resolved entry in a subscriber's restored progress (`add_segment` uses `entry(seq).or_insert_with(...)`), so the new segment was treated as already delivered and never handed to the subscriber.

This adds a durable sidecar (`segments/quiver.segment.seq`) recording the next allocatable sequence number, written atomically (write, fsync, rename, fsync parent) as each segment finalizes. At startup the floor is the max of three independent sources: the highest `.qseg` filename, the sidecar, and the highest segment tracked by restored subscriber progress (covers the first start after upgrading, and a wholesale segments-dir clear, since progress files live outside that directory).

The floor is persisted after the segment file is written but before the segment is registered, so a persist failure leaves the segment durable but invisible to subscribers and cleanup; the next restart discovers it by filename and delivers it normally, rather than discarding it (which would lose data outright under `DurabilityMode::SegmentOnly`, with no WAL to fall back on).

## Related issue

* Closes #4024

## Validation

* Added regression tests reproducing the original bug (sequence reuse after cleanup, with and without maintenance cycles, and without a sidecar present) and confirmed they fail without the fix.
* Added tests for the sidecar format (roundtrip, corruption, missing file, forward-compatible future versions, malformed sizes), monotonic behavior under concurrent finalization, and fail-closed behavior when the sidecar exists but cannot be read (both at startup and during persistence).
* Added fault-injection tests for the new persist ordering under both `DurabilityMode::SegmentOnly` and `DurabilityMode::Wal`, confirming a sidecar-persist failure retains the segment/WAL data and delivers it after restart instead of dropping it.
* All new tests were mutation-tested (temporarily reverting the fix or reordering the persist/write/register steps) to confirm they fail for the right reason.
* `cargo test -p otel-arrow-dfe-quiver`: 467 passed, 0 failed.
* `cargo clippy -p otel-arrow-dfe-quiver --all-targets -- -D warnings`: clean.
* `cargo fmt --check`, `tools/sanitycheck.py`, `make chlog-validate`: all pass.

## User-facing changes

Quiver no longer silently drops newly ingested telemetry after a restart following retention cleanup of all segment files. See `.chloggen/quiver-segment-seq-reuse.yaml`.