### PR TITLE
chore(perf): reject invalid benchmark results

### DIFF
--- a/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/hooks/reporting/sql_report.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/hooks/reporting/sql_report.py
@@ -479,6 +479,8 @@ hooks:
 
         self._run_sql_queries(logger)
 
+        results = self._build_result_dataframes()
+
         if self.config.report_config.write_tables:
             try:
                 self._write_tables(logger, report)
@@ -486,7 +488,6 @@ hooks:
                 logger.error("SQL Report failed to write tables %s", e)
                 raise
 
-        results = self._build_result_dataframes()
         report.set_results(results)
         return report
 

--- a/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/hooks/reporting/sql_report.py
+++ b/tools/pipeline_perf_test/orchestrator/lib/impl/strategies/hooks/reporting/sql_report.py
@@ -51,6 +51,7 @@ hooks:
                 console: {}
 """
 
+import math
 import os
 from typing import ClassVar, Optional, List, Dict, Any, Literal
 from pathlib import Path
@@ -118,6 +119,8 @@ class ResultTable(BaseModel):
     name: str
     description: Optional[str] = None
     display: bool = True
+    finite_columns: List[str] = Field(default_factory=list)
+    required_values: Dict[str, List[str]] = Field(default_factory=dict)
 
 
 class SQLReportDetails(BaseModel):
@@ -339,10 +342,50 @@ hooks:
         """Loop through the result_tables config and convert them to result dataframes"""
         results = {}
         for table in self.config.report_config.result_tables:
-            results[table.name] = self.conn.execute(
+            dataframe = self.conn.execute(
                 f"SELECT * FROM {table.name}"
             ).fetchdf()
+            self._assert_required_values(table, dataframe)
+            self._assert_finite_columns(table, dataframe)
+            results[table.name] = dataframe
         return results
+
+    @staticmethod
+    def _assert_required_values(table: ResultTable, dataframe: pd.DataFrame):
+        """Reject result tables that omit configured values from a column."""
+        for column, required_values in table.required_values.items():
+            if column not in dataframe.columns:
+                raise ValueError(
+                    f"Result table '{table.name}' is missing required column '{column}'"
+                )
+
+            observed_values = set(dataframe[column].dropna().astype(str))
+            missing_values = sorted(set(required_values) - observed_values)
+            if missing_values:
+                raise ValueError(
+                    f"Result table '{table.name}' column '{column}' is missing "
+                    f"required values {missing_values}"
+                )
+
+    @staticmethod
+    def _assert_finite_columns(table: ResultTable, dataframe: pd.DataFrame):
+        """Reject configured result columns containing null, NaN, or infinite values."""
+        for column in table.finite_columns:
+            if column not in dataframe.columns:
+                raise ValueError(
+                    f"Result table '{table.name}' is missing finite column '{column}'"
+                )
+
+            numeric_values = pd.to_numeric(dataframe[column], errors="coerce")
+            finite_values = numeric_values.map(
+                lambda value: pd.notna(value) and math.isfinite(value)
+            )
+            if not finite_values.all():
+                invalid_rows = dataframe.index[~finite_values].tolist()
+                raise ValueError(
+                    f"Result table '{table.name}' column '{column}' contains "
+                    f"non-finite values at rows {invalid_rows}"
+                )
 
     def _build_metadata_table(self, metadata):
         """Register duckdb tables containing context metadata."""

--- a/tools/pipeline_perf_test/orchestrator/tests/impl/strategies/hooks/reporting/test_sql_report.py
+++ b/tools/pipeline_perf_test/orchestrator/tests/impl/strategies/hooks/reporting/test_sql_report.py
@@ -1,4 +1,5 @@
 import pytest
+import pandas as pd
 from pathlib import Path
 from pydantic import ValidationError
 import tempfile
@@ -194,3 +195,52 @@ def test_write_table_config_rejects_invalid_format():
         WriteTableConfig(path="foo.out", format="invalid")
 
     assert "Input should be 'parquet', 'json' or 'csv'" in str(exc_info.value)
+
+
+# Scenario: A required benchmark value is NaN.
+# Guarantees: SQL reporting fails instead of publishing an invalid benchmark.
+def test_result_table_rejects_non_finite_values():
+    table = ResultTable(name="gh_actions_benchmark", finite_columns=["value"])
+
+    with pytest.raises(ValueError, match="contains non-finite values"):
+        SQLReportHook._assert_finite_columns(
+            table, pd.DataFrame({"name": ["loss"], "value": [float("nan")]})
+        )
+
+
+# Scenario: Every required benchmark value is finite.
+# Guarantees: SQL reporting accepts valid benchmark output without value thresholds.
+def test_result_table_accepts_finite_values():
+    table = ResultTable(name="gh_actions_benchmark", finite_columns=["value"])
+
+    SQLReportHook._assert_finite_columns(
+        table, pd.DataFrame({"name": ["loss", "throughput"], "value": [0.0, 1.0]})
+    )
+
+
+# Scenario: A benchmark table omits a configured KPI while all emitted values are finite.
+# Guarantees: SQL reporting fails rather than publishing an incomplete benchmark set.
+def test_result_table_rejects_missing_required_values():
+    table = ResultTable(
+        name="gh_actions_benchmark",
+        required_values={"name": ["loss", "produced_rate"]},
+    )
+
+    with pytest.raises(ValueError, match=r"required values \['produced_rate'\]"):
+        SQLReportHook._assert_required_values(
+            table, pd.DataFrame({"name": ["loss"], "value": [0.0]})
+        )
+
+
+# Scenario: A benchmark table contains every configured KPI.
+# Guarantees: Required-value validation accepts complete benchmark output.
+def test_result_table_accepts_required_values():
+    table = ResultTable(
+        name="gh_actions_benchmark",
+        required_values={"name": ["loss", "produced_rate"]},
+    )
+
+    SQLReportHook._assert_required_values(
+        table,
+        pd.DataFrame({"name": ["loss", "produced_rate"], "value": [0.0, 1.0]}),
+    )

--- a/tools/pipeline_perf_test/orchestrator/tests/impl/strategies/hooks/reporting/test_sql_report.py
+++ b/tools/pipeline_perf_test/orchestrator/tests/impl/strategies/hooks/reporting/test_sql_report.py
@@ -244,3 +244,30 @@ def test_result_table_accepts_required_values():
         table,
         pd.DataFrame({"name": ["loss", "produced_rate"], "value": [0.0, 1.0]}),
     )
+
+
+# Scenario: A configured SQL result table contains an invalid required KPI
+# value.
+# Guarantees: Building report results invokes configured validity checks.
+def test_build_result_dataframes_validates_configured_table():
+    table = ResultTable(
+        name="gh_actions_benchmark",
+        finite_columns=["value"],
+        required_values={"name": ["loss", "produced_rate"]},
+    )
+    hook = SQLReportHook(
+        SQLReportConfig(
+            name="validated_report",
+            report_config=SQLReportDetails(result_tables=[table]),
+        )
+    )
+    hook.conn = __import__("duckdb").connect()
+    hook.conn.execute(
+        """
+        CREATE TABLE gh_actions_benchmark AS
+        SELECT 'loss' AS name, CAST('NaN' AS DOUBLE) AS value
+        """
+    )
+
+    with pytest.raises(ValueError, match=r"required values \['produced_rate'\]"):
+        hook._build_result_dataframes()

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
@@ -498,7 +498,6 @@ result_tables:
         - network_tx_bytes_rate_avg
         - network_rx_bytes_rate_avg
         - egress_bytes_per_log
-        - uncompressed_bytes_per_log
     #display: False
   - name: dashboard_timeseries
     description: Per-metric time-series data points within the observation window for dashboard charts.

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
@@ -488,9 +488,17 @@ result_tables:
     required_values:
       name:
         - dropped_logs_percentage
+        - cpu_percentage_normalized_avg
+        - cpu_percentage_normalized_max
+        - ram_mib_avg
+        - ram_mib_max
         - logs_produced_rate
         - logs_received_rate
         - test_duration
+        - network_tx_bytes_rate_avg
+        - network_rx_bytes_rate_avg
+        - egress_bytes_per_log
+        - uncompressed_bytes_per_log
     #display: False
   - name: dashboard_timeseries
     description: Per-metric time-series data points within the observation window for dashboard charts.

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_logs.yaml
@@ -484,6 +484,13 @@ result_tables:
     description: Log throughput rates (logs/sec) calculated from total counts and observation window duration
   - name: gh_actions_benchmark
     description: The final metrics used with gh_actions_benchmark.
+    finite_columns: [value]
+    required_values:
+      name:
+        - dropped_logs_percentage
+        - logs_produced_rate
+        - logs_received_rate
+        - test_duration
     #display: False
   - name: dashboard_timeseries
     description: Per-metric time-series data points within the observation window for dashboard charts.

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_metrics.yaml
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_metrics.yaml
@@ -454,6 +454,13 @@ result_tables:
     description: Metric throughput rates (metrics/sec) calculated from total counts and observation window duration
   - name: gh_actions_benchmark
     description: The final metrics used with gh_actions_benchmark.
+    finite_columns: [value]
+    required_values:
+      name:
+        - dropped_metrics_percentage
+        - metrics_produced_rate
+        - metrics_received_rate
+        - test_duration
     #display: False
   - name: dashboard_timeseries
     description: Per-metric time-series data points within the observation window for dashboard charts.

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_metrics.yaml
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_metrics.yaml
@@ -458,9 +458,15 @@ result_tables:
     required_values:
       name:
         - dropped_metrics_percentage
+        - cpu_percentage_normalized_avg
+        - cpu_percentage_normalized_max
+        - ram_mib_avg
+        - ram_mib_max
         - metrics_produced_rate
         - metrics_received_rate
         - test_duration
+        - network_tx_bytes_rate_avg
+        - network_rx_bytes_rate_avg
     #display: False
   - name: dashboard_timeseries
     description: Per-metric time-series data points within the observation window for dashboard charts.

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_traces.yaml
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_traces.yaml
@@ -454,6 +454,13 @@ result_tables:
     description: Span throughput rates (spans/sec) calculated from total counts and observation window duration
   - name: gh_actions_benchmark
     description: The final metrics used with gh_actions_benchmark.
+    finite_columns: [value]
+    required_values:
+      name:
+        - dropped_spans_percentage
+        - spans_produced_rate
+        - spans_received_rate
+        - test_duration
     #display: False
   - name: dashboard_timeseries
     description: Per-metric time-series data points within the observation window for dashboard charts.

--- a/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_traces.yaml
+++ b/tools/pipeline_perf_test/test_suites/comparison_dashboard/reports/report_traces.yaml
@@ -458,9 +458,15 @@ result_tables:
     required_values:
       name:
         - dropped_spans_percentage
+        - cpu_percentage_normalized_avg
+        - cpu_percentage_normalized_max
+        - ram_mib_avg
+        - ram_mib_max
         - spans_produced_rate
         - spans_received_rate
         - test_duration
+        - network_tx_bytes_rate_avg
+        - network_rx_bytes_rate_avg
     #display: False
   - name: dashboard_timeseries
     description: Per-metric time-series data points within the observation window for dashboard charts.

--- a/tools/pipeline_perf_test/test_suites/integration/configs/clickhouse_report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/clickhouse_report_logs.yaml
@@ -225,4 +225,8 @@ result_tables:
       name:
         - logs_produced_rate
         - log_rows_written_rate
+        - df-engine_cpu_percentage_normalized_avg
+        - clickhouse_cpu_percentage_normalized_avg
+        - df-engine_ram_mib_max
+        - clickhouse_ram_mib_max
         - test_duration

--- a/tools/pipeline_perf_test/test_suites/integration/configs/clickhouse_report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/clickhouse_report_logs.yaml
@@ -220,3 +220,9 @@ result_tables:
     description: Terminal generated and final post-drain ClickHouse-persisted rows.
   - name: gh_actions_benchmark
     description: Metrics formatted for github-action-benchmark.
+    finite_columns: [value]
+    required_values:
+      name:
+        - logs_produced_rate
+        - log_rows_written_rate
+        - test_duration

--- a/tools/pipeline_perf_test/test_suites/integration/configs/idle_state_report.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/idle_state_report.yaml
@@ -168,3 +168,12 @@ result_tables:
   - name: gh_actions_benchmark
     description: The final metrics used with gh_actions_benchmark.
     finite_columns: [value]
+    required_values:
+      name:
+        - idle_cpu_percentage_avg
+        - idle_cpu_percentage_max
+        - idle_ram_mib_avg
+        - idle_ram_mib_max
+        - idle_test_duration
+        - idle_rss_mib_avg
+        - idle_rss_mib_max

--- a/tools/pipeline_perf_test/test_suites/integration/configs/idle_state_report.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/idle_state_report.yaml
@@ -167,3 +167,4 @@ result_tables:
     description: Summary of idle state performance metrics
   - name: gh_actions_benchmark
     description: The final metrics used with gh_actions_benchmark.
+    finite_columns: [value]

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
@@ -100,7 +100,7 @@ queries:
             COALESCE("metric_attributes.otel_scope_core_id", 'N/A') AS core_id,
             FROM metrics
             WHERE metric_name IN (
-              'logs_produced',
+              'logs_produced_ci_validation_probe',
               'logs_bytes_produced',
               'failed',
               'bytes_sent',

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
@@ -100,7 +100,7 @@ queries:
             COALESCE("metric_attributes.otel_scope_core_id", 'N/A') AS core_id,
             FROM metrics
             WHERE metric_name IN (
-              'logs_produced_ci_validation_probe',
+              'logs_produced',
               'logs_bytes_produced',
               'failed',
               'bytes_sent',

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
@@ -399,4 +399,11 @@ result_tables:
     description: Log throughput rates (logs/sec) calculated from total counts and observation window duration
   - name: gh_actions_benchmark
     description: The final metrics used with gh_actions_benchmark.
+    finite_columns: [value]
+    required_values:
+      name:
+        - dropped_logs_percentage
+        - logs_produced_rate
+        - logs_received_rate
+        - test_duration
     #display: False

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
@@ -403,7 +403,15 @@ result_tables:
     required_values:
       name:
         - dropped_logs_percentage
+        - cpu_percentage_normalized_avg
+        - cpu_percentage_normalized_max
+        - ram_mib_avg
+        - ram_mib_max
         - logs_produced_rate
         - logs_received_rate
         - test_duration
+        - network_tx_bytes_rate_avg
+        - network_rx_bytes_rate_avg
+        - egress_bytes_per_log
+        - uncompressed_bytes_per_log
     #display: False

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_logs.yaml
@@ -413,5 +413,4 @@ result_tables:
         - network_tx_bytes_rate_avg
         - network_rx_bytes_rate_avg
         - egress_bytes_per_log
-        - uncompressed_bytes_per_log
     #display: False

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_metrics.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_metrics.yaml
@@ -369,4 +369,11 @@ result_tables:
     description: Metric throughput rates (metrics/sec) calculated from total counts and observation window duration
   - name: gh_actions_benchmark
     description: The final metrics used with gh_actions_benchmark.
+    finite_columns: [value]
+    required_values:
+      name:
+        - dropped_signals_percentage
+        - metrics_produced_rate
+        - metrics_received_rate
+        - test_duration
     #display: False

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_metrics.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_metrics.yaml
@@ -373,7 +373,13 @@ result_tables:
     required_values:
       name:
         - dropped_signals_percentage
+        - cpu_percentage_normalized_avg
+        - cpu_percentage_normalized_max
+        - ram_mib_avg
+        - ram_mib_max
         - metrics_produced_rate
         - metrics_received_rate
         - test_duration
+        - network_tx_bytes_rate_avg
+        - network_rx_bytes_rate_avg
     #display: False

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_traces.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_traces.yaml
@@ -373,7 +373,13 @@ result_tables:
     required_values:
       name:
         - dropped_signals_percentage
+        - cpu_percentage_normalized_avg
+        - cpu_percentage_normalized_max
+        - ram_mib_avg
+        - ram_mib_max
         - spans_produced_rate
         - spans_received_rate
         - test_duration
+        - network_tx_bytes_rate_avg
+        - network_rx_bytes_rate_avg
     #display: False

--- a/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_traces.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/integration_report_traces.yaml
@@ -369,4 +369,11 @@ result_tables:
     description: Span throughput rates (spans/sec) calculated from total counts and observation window duration
   - name: gh_actions_benchmark
     description: The final metrics used with gh_actions_benchmark.
+    finite_columns: [value]
+    required_values:
+      name:
+        - dropped_signals_percentage
+        - spans_produced_rate
+        - spans_received_rate
+        - test_duration
     #display: False

--- a/tools/pipeline_perf_test/test_suites/integration/configs/otelcol_clickhouse_report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/otelcol_clickhouse_report_logs.yaml
@@ -145,3 +145,8 @@ result_tables:
     required_values:
       name:
         - log_rows_written_rate
+        - logs_produced_rate
+        - go-collector_cpu_percentage_normalized_avg
+        - clickhouse_cpu_percentage_normalized_avg
+        - go-collector_ram_mib_max
+        - clickhouse_ram_mib_max

--- a/tools/pipeline_perf_test/test_suites/integration/configs/otelcol_clickhouse_report_logs.yaml
+++ b/tools/pipeline_perf_test/test_suites/integration/configs/otelcol_clickhouse_report_logs.yaml
@@ -141,3 +141,7 @@ result_tables:
   - name: clickhouse_throughput
   - name: component_resources
   - name: gh_actions_benchmark
+    finite_columns: [value]
+    required_values:
+      name:
+        - log_rows_written_rate


### PR DESCRIPTION
## Change summary

- Add configurable validation for finite numeric values in SQL report result tables.
- Add configurable required-value validation so missing benchmark KPIs fail reporting.
- Apply these checks to GitHub benchmark outputs across the performance suites.

## Motivation

[PR #3888](https://github.com/open-telemetry/otel-arrow/pull/3888) removes traffic-generator producer metrics that the performance reports still consume. Its hosted performance CI completed successfully even though `dropped_logs_percentage` became `NaN` and `logs_produced_rate` disappeared.

This change turns those invalid or incomplete benchmark results into CI failures. It does not assert machine-dependent performance values; it only requires configured KPIs to be present and numeric results to be finite.

## Changelog

Not required: this changes CI and performance-report validation only.