### PR TITLE
feat(azure_monitor_exporter): adopt shared exporter attempt metrics

### DIFF
--- a/rust/otap-dataflow/.chloggen/azure-monitor-shared-attempt-metrics.yaml
+++ b/rust/otap-dataflow/.chloggen/azure-monitor-shared-attempt-metrics.yaml
@@ -1,0 +1,6 @@
+change_type: breaking
+component: observability
+note: Replace Azure Monitor export item, message, and byte metrics with shared exporter attempt metrics.
+issues: [3822]
+subtext: |
+  Migration: Update queries from `exporter.azure_monitor.exports.{items,messages,bytes}` to `exporter.attempted.{items,messages,payload.size}`. Internal HTTP retries now produce separate shared attempts.

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs
@@ -3,6 +3,7 @@
 
 use bytes::Bytes;
 
+use otel_arrow_dfe_config::SignalType;
 use otel_arrow_dfe_telemetry::common_attributes::HttpResponse;
 use rand::{RngExt, SeedableRng, rngs::SmallRng};
 use reqwest::{
@@ -19,6 +20,12 @@ const MAX_RETRIES: u32 = 5;
 const INITIAL_BACKOFF: Duration = Duration::from_secs(3);
 const MAX_BACKOFF: Duration = Duration::from_secs(30);
 const MAX_IDLE_CONNECTIONS_PER_HOST: usize = 2;
+
+/// Counts naturally available for every HTTP attempt of one compressed batch.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct ExportAttemptMetadata {
+    pub(super) items: u64,
+}
 
 /// HTTP header name for Azure Monitor source resource ID tracking.
 pub(super) const AZURE_MONITOR_SOURCE_RESOURCEID_HEADER: &str = "azure-monitor-source-resourceid";
@@ -178,17 +185,22 @@ impl LogsIngestionClient {
     /// recovery belongs to the caller, which invalidates the rejected token and
     /// re-dispatches once a fresh one is cached.
     ///
+    /// Every HTTP attempt (including internal retries) records a shared
+    /// `exporter.attempted.*` observation using `metadata`.
+    ///
     /// # Arguments
     /// * `body` - The gzip-compressed JSON data to send
     /// * `auth_header` - The authorization header for this request
+    /// * `metadata` - Counts naturally available for every HTTP attempt of this batch
     ///
     /// # Returns
     /// * `Ok(Duration)` - Total time spent (including retries) if successful
     /// * `Err(Error)` - Error if all retries are exhausted or a non-retryable error is returned
-    pub async fn export(
+    pub(super) async fn export(
         &mut self,
         body: Bytes,
         auth_header: &HeaderValue,
+        metadata: ExportAttemptMetadata,
     ) -> Result<Duration, Error> {
         let mut attempt = 0u32;
         let mut rng = SmallRng::seed_from_u64(
@@ -200,7 +212,7 @@ impl LogsIngestionClient {
         );
 
         loop {
-            match self.try_export(body.clone(), auth_header).await {
+            match self.try_export(body.clone(), auth_header, metadata).await {
                 Ok(duration) => return Ok(duration),
                 Err(e) if !e.is_retryable() => {
                     return Err(Error::ExportFailed {
@@ -242,8 +254,30 @@ impl LogsIngestionClient {
         }
     }
 
-    /// Single export attempt without retry logic.
+    /// Single export attempt without retry logic. Records one shared
+    /// `exporter.attempted.*` observation per invocation.
     async fn try_export(
+        &mut self,
+        body: Bytes,
+        auth_header: &HeaderValue,
+        metadata: ExportAttemptMetadata,
+    ) -> Result<Duration, Error> {
+        let attempt = self.metrics.borrow().boundary.attempt(SignalType::Logs);
+        let completed = attempt
+            .run(async |attempt| {
+                attempt.set_item_count_with(|| metadata.items);
+                attempt.set_payload_size_with(|| body.len());
+                match self.try_export_request(body, auth_header).await {
+                    Ok(duration) => Ok(duration),
+                    Err(error) if error.is_refusal() => Err(attempt.refused(error)),
+                    Err(error) => Err(attempt.failed(error)),
+                }
+            })
+            .await;
+        self.metrics.borrow_mut().boundary.record(completed)
+    }
+
+    async fn try_export_request(
         &mut self,
         body: Bytes,
         auth_header: &HeaderValue,
@@ -334,8 +368,10 @@ fn http_response_for_status(status: u16) -> HttpResponse {
 mod tests {
     use super::super::metrics::AzureMonitorExporterMetricsTracker;
     use super::*;
-    use otel_arrow_dfe_engine::context::{ControllerContext, PipelineContext};
-    use otel_arrow_dfe_telemetry::registry::TelemetryRegistryHandle;
+    use otel_arrow_dfe_engine::Interests;
+    use otel_arrow_dfe_engine::testing::test_pipeline_ctx_with_interests;
+    use otel_arrow_dfe_telemetry::common_attributes::Outcome;
+    use otel_arrow_dfe_telemetry::metrics::MetricSetSnapshot;
     use reqwest::header::HeaderValue;
     use std::cell::RefCell;
     use std::rc::Rc;
@@ -345,10 +381,14 @@ mod tests {
     // ==================== Test Helpers ====================
 
     fn create_test_metrics() -> AzureMonitorExporterMetricsRc {
-        let registry = TelemetryRegistryHandle::new();
-        let controller = ControllerContext::new(registry);
-        let pipeline_ctx: PipelineContext =
-            controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        // Enable every shared exporter attempt bucket (messages, duration,
+        // payload.size, items) so tests can observe them without depending on
+        // pipeline-wide MetricLevel defaults.
+        let interests = Interests::NODE_INPUT_METRICS
+            | Interests::NODE_LOCAL_DURATION
+            | Interests::NODE_ITEM_COUNTS
+            | Interests::NODE_SIZE;
+        let (pipeline_ctx, _registry) = test_pipeline_ctx_with_interests(interests);
         Rc::new(RefCell::new(AzureMonitorExporterMetricsTracker::register(
             &pipeline_ctx,
         )))
@@ -374,6 +414,29 @@ mod tests {
             .expect("failed to create HTTP client")
     }
 
+    fn attempted_messages(snapshots: &[MetricSetSnapshot], outcome: Outcome) -> u64 {
+        let outcome = match outcome {
+            Outcome::Success => "success",
+            Outcome::Failure => "failure",
+            Outcome::Refused => "refused",
+        };
+        let snapshot = snapshots
+            .iter()
+            .find(|snapshot| {
+                snapshot.descriptor().name == "exporter.attempted"
+                    && snapshot.measurement_attribute_value("signal") == Some("logs")
+                    && snapshot.measurement_attribute_value("outcome") == Some(outcome)
+            })
+            .expect("exporter attempt snapshot");
+        let messages = snapshot
+            .descriptor()
+            .metrics
+            .iter()
+            .position(|metric| metric.name == "messages")
+            .expect("messages metric");
+        snapshot.get_metrics()[messages].to_u64_lossy()
+    }
+
     /// Scenario: Azure Monitor returns classified client-error and unclassified HTTP statuses.
     /// Guarantees: 400 and 404 have dedicated metric buckets; other statuses use `Other`.
     #[test]
@@ -381,6 +444,134 @@ mod tests {
         assert_eq!(http_response_for_status(400), HttpResponse::Http400);
         assert_eq!(http_response_for_status(404), HttpResponse::Http404);
         assert_eq!(http_response_for_status(418), HttpResponse::Other);
+    }
+
+    /// Scenario: HTTP attempts terminate as accepted, backend-refused, and exporter/transport failures.
+    /// Guarantees: Every 4xx client-error status is a refusal; 5xx and transport errors remain failures.
+    #[test]
+    fn classifies_shared_export_attempt_outcomes() {
+        assert!(Error::unauthorized(String::new()).is_refusal());
+        assert!(Error::forbidden(String::new()).is_refusal());
+        assert!(Error::PayloadTooLarge.is_refusal());
+        assert!(
+            Error::RateLimited {
+                body: String::new(),
+                retry_after: None,
+            }
+            .is_refusal()
+        );
+        assert!(
+            Error::UnexpectedStatus {
+                status: reqwest::StatusCode::BAD_REQUEST,
+                body: String::new(),
+            }
+            .is_refusal()
+        );
+        // Uncommon 4xx statuses that Azure Monitor may return (e.g. 422 for
+        // schema rejection, 418 for anything unclassified) must not surface as
+        // exporter failures.
+        assert!(
+            Error::UnexpectedStatus {
+                status: reqwest::StatusCode::UNPROCESSABLE_ENTITY,
+                body: String::new(),
+            }
+            .is_refusal()
+        );
+        assert!(
+            Error::UnexpectedStatus {
+                status: reqwest::StatusCode::IM_A_TEAPOT,
+                body: String::new(),
+            }
+            .is_refusal()
+        );
+        assert!(
+            !Error::ServerError {
+                status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+                body: String::new(),
+                retry_after: None,
+            }
+            .is_refusal()
+        );
+    }
+
+    /// Scenario: Azure submissions succeed, are rate limited, and fail at the backend.
+    /// Guarantees: Each concrete HTTP submission records exactly one shared attempt outcome.
+    #[tokio::test]
+    async fn records_shared_metrics_for_each_http_attempt() {
+        let metrics = create_test_metrics();
+        for (status, expected_error) in [(204, false), (429, true), (500, true)] {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(ResponseTemplate::new(status))
+                .expect(1)
+                .mount(&mock_server)
+                .await;
+            let mut client = LogsIngestionClient::from_parts(
+                create_test_http_client(),
+                mock_server.uri(),
+                metrics.clone(),
+            );
+
+            let result = client
+                .try_export(
+                    Bytes::from_static(b"payload"),
+                    &HeaderValue::from_static("******"),
+                    ExportAttemptMetadata { items: 3 },
+                )
+                .await;
+            assert_eq!(result.is_err(), expected_error);
+        }
+
+        let snapshots = metrics.borrow_mut().boundary.terminal_snapshots();
+        assert_eq!(attempted_messages(&snapshots, Outcome::Success), 1);
+        assert_eq!(attempted_messages(&snapshots, Outcome::Refused), 1);
+        assert_eq!(attempted_messages(&snapshots, Outcome::Failure), 1);
+    }
+
+    /// Scenario: A retried batch first receives a 500 and then a 204 on the retry.
+    /// Guarantees: Each internal HTTP attempt records its own shared exporter attempt outcome.
+    //
+    // Note: uses real time (not `start_paused`) because `start_paused` interferes with reqwest's
+    // request timeout during real network I/O to the mock server. The test tolerates the client's
+    // real exponential-backoff wait (INITIAL_BACKOFF = 3s * ~0.85..1.15 jitter).
+    #[tokio::test]
+    async fn retries_record_each_shared_attempt() {
+        let metrics = create_test_metrics();
+        let mock_server = MockServer::start().await;
+        // First attempt: 500 (retryable failure). Subsequent attempts: 204 (success).
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(500))
+            .up_to_n_times(1)
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut client = LogsIngestionClient::from_parts(
+            create_test_http_client(),
+            mock_server.uri(),
+            metrics.clone(),
+        );
+
+        let result = client
+            .export(
+                Bytes::from_static(b"payload"),
+                &HeaderValue::from_static("******"),
+                ExportAttemptMetadata { items: 3 },
+            )
+            .await;
+        assert!(
+            result.is_ok(),
+            "expected retried export to succeed: {result:?}"
+        );
+
+        let snapshots = metrics.borrow_mut().boundary.terminal_snapshots();
+        assert_eq!(attempted_messages(&snapshots, Outcome::Success), 1);
+        assert_eq!(attempted_messages(&snapshots, Outcome::Failure), 1);
     }
 
     // ==================== Construction Tests ====================
@@ -465,6 +656,7 @@ mod tests {
             .export(
                 Bytes::from_static(b"payload"),
                 &HeaderValue::from_static("Bearer supplied-token"),
+                ExportAttemptMetadata { items: 0 },
             )
             .await;
 
@@ -502,6 +694,7 @@ mod tests {
                 .export(
                     Bytes::from_static(b"payload"),
                     &HeaderValue::from_str(token).unwrap(),
+                    ExportAttemptMetadata { items: 0 },
                 )
                 .await
                 .expect("export should succeed");
@@ -531,6 +724,7 @@ mod tests {
             .export(
                 Bytes::from_static(b"payload"),
                 &HeaderValue::from_static("Bearer stale"),
+                ExportAttemptMetadata { items: 0 },
             )
             .await
             .expect_err("401 should fail the export");
@@ -563,6 +757,7 @@ mod tests {
             .export(
                 Bytes::from_static(b"payload"),
                 &HeaderValue::from_static("Bearer scoped-out"),
+                ExportAttemptMetadata { items: 0 },
             )
             .await
             .expect_err("403 should fail the export");
@@ -599,6 +794,7 @@ mod tests {
             .export(
                 Bytes::from_static(b"payload"),
                 &HeaderValue::from_static("Bearer token"),
+                ExportAttemptMetadata { items: 0 },
             )
             .await
             .expect("export should succeed");

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/error.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/error.rs
@@ -195,6 +195,28 @@ impl Error {
         )
     }
 
+    /// Returns true if the backend explicitly refused this export attempt.
+    ///
+    /// Any 4xx client-error status is treated as a backend refusal: the request
+    /// reached the ingestion endpoint and was rejected, so it is not an exporter
+    /// failure and retrying the same payload will not help. Transport and 5xx
+    /// errors remain failures.
+    ///
+    /// Note: this classification is independent of [`Self::is_retryable`]. A
+    /// 429 is both a refusal (the backend rejected this attempt) and retryable
+    /// (a later attempt with the same payload may succeed after backoff), so
+    /// every retried attempt records `outcome=refused` on the shared
+    /// `exporter.attempted.*` metrics. See `telemetry.md` for the outcome
+    /// contract.
+    #[must_use]
+    pub fn is_refusal(&self) -> bool {
+        match self {
+            Error::Auth { .. } | Error::PayloadTooLarge | Error::RateLimited { .. } => true,
+            Error::UnexpectedStatus { status, .. } => status.is_client_error(),
+            _ => false,
+        }
+    }
+
     /// Returns true if this error was caused by an HTTP 401 response.
     #[must_use]
     pub fn is_unauthorized(&self) -> bool {

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs
@@ -148,7 +148,6 @@ impl AzureMonitorExporter {
             client,
             result,
             row_count,
-            body_size_bytes,
             token_generation,
         } = completed_export;
 
@@ -161,17 +160,11 @@ impl AzureMonitorExporter {
 
         match result {
             Ok(duration) => {
-                self.handle_export_success(
-                    effect_handler,
-                    batch_id,
-                    row_count,
-                    body_size_bytes,
-                    duration,
-                )
-                .await
+                self.handle_export_success(effect_handler, batch_id, row_count, duration)
+                    .await
             }
             Err(e) => {
-                self.handle_export_failure(effect_handler, batch_id, row_count, body_size_bytes, e)
+                self.handle_export_failure(effect_handler, batch_id, e)
                     .await
             }
         }
@@ -182,20 +175,13 @@ impl AzureMonitorExporter {
         effect_handler: &EffectHandler<OtapPdata>,
         batch_id: u64,
         row_count: u64,
-        body_size_bytes: u64,
         duration: std::time::Duration,
     ) -> Result<(), EngineError> {
         // Export succeeded - Ack only fully-completed messages
         let completed_messages = self.state.remove_batch_success(batch_id);
-        {
-            let mut m = self.metrics.borrow_mut();
-            m.record_export(
-                Outcome::Success,
-                row_count,
-                completed_messages.len() as u64,
-                body_size_bytes,
-            );
-        }
+        self.metrics
+            .borrow_mut()
+            .record_completed_batch(Outcome::Success);
 
         otel_debug!(
             "azure_monitor_exporter.export.success",
@@ -216,21 +202,13 @@ impl AzureMonitorExporter {
         &mut self,
         effect_handler: &EffectHandler<OtapPdata>,
         batch_id: u64,
-        row_count: u64,
-        body_size_bytes: u64,
         error: Error,
     ) -> Result<(), EngineError> {
         // Export failed - Nack ALL messages in this batch, remove entirely
         let failed_messages = self.state.remove_batch_failure(batch_id);
-        {
-            let mut m = self.metrics.borrow_mut();
-            m.record_export(
-                Outcome::Failure,
-                row_count,
-                failed_messages.len() as u64,
-                body_size_bytes,
-            );
-        }
+        self.metrics
+            .borrow_mut()
+            .record_completed_batch(Outcome::Failure);
 
         otel_warn!("azure_monitor_exporter.export.failed", batch_id = batch_id, error = %error);
 
@@ -275,13 +253,7 @@ impl AzureMonitorExporter {
                 reason: auth.not_ready_reason(),
             };
             return self
-                .handle_export_failure(
-                    effect_handler,
-                    pending_batch.batch_id,
-                    pending_batch.row_count,
-                    pending_batch.compressed_data.len() as u64,
-                    error,
-                )
+                .handle_export_failure(effect_handler, pending_batch.batch_id, error)
                 .await;
         };
 
@@ -630,12 +602,8 @@ impl Exporter<OtapPdata> for AzureMonitorExporter {
                                 let bs = m.batch_size();
                                 otel_debug!(
                                     "azure_monitor_exporter.metrics.collect",
-                                    successful_items = m.export_for(Outcome::Success).items.get(),
                                     successful_batches = m.export_for(Outcome::Success).batches.get(),
-                                    successful_messages = m.export_for(Outcome::Success).messages.get(),
-                                    failed_items = m.export_for(Outcome::Failure).items.get(),
                                     failed_batches = m.export_for(Outcome::Failure).batches.get(),
-                                    failed_messages = m.export_for(Outcome::Failure).messages.get(),
                                     client_success_latency_avg_ms = if cl.count > 0 { cl.sum / cl.count as f64 } else { 0.0 },
                                     client_success_latency_min_ms = if cl.count > 0 { cl.min } else { 0.0 },
                                     client_success_latency_max_ms = if cl.count > 0 { cl.max } else { 0.0 },
@@ -823,8 +791,8 @@ mod tests {
         auth
     }
 
-    /// Scenario: A completed export succeeds with a known compressed request-body size.
-    /// Guarantees: The successful outcome records the resolved request-body bytes.
+    /// Scenario: A completed export succeeds.
+    /// Guarantees: The successful outcome records one completed compressed batch.
     #[tokio::test]
     async fn test_handle_export_success() {
         let config = create_test_config();
@@ -855,16 +823,13 @@ mod tests {
 
         // This might fail due to missing sender in effect_handler, but state should be updated
         let _ = exporter
-            .handle_export_success(&effect_handler, batch_id, 10, 1_024, Duration::from_secs(1))
+            .handle_export_success(&effect_handler, batch_id, 10, Duration::from_secs(1))
             .await;
 
         // Verify stats
         let m = exporter.metrics.borrow();
         let success = m.export_for(Outcome::Success);
         assert_eq!(success.batches.get(), 1);
-        assert_eq!(success.messages.get(), 1);
-        assert_eq!(success.items.get(), 10);
-        assert_eq!(success.bytes.get(), 1_024);
         drop(m);
 
         // Verify state cleared
@@ -872,8 +837,8 @@ mod tests {
         assert!(exporter.state.msg_to_data.is_empty());
     }
 
-    /// Scenario: A completed export fails with a known compressed request-body size.
-    /// Guarantees: The failed outcome records the resolved request-body bytes.
+    /// Scenario: A completed export fails.
+    /// Guarantees: The failed outcome records one completed compressed batch.
     #[tokio::test]
     async fn test_handle_export_failure() {
         let config = create_test_config();
@@ -909,16 +874,13 @@ mod tests {
         };
 
         let _ = exporter
-            .handle_export_failure(&effect_handler, batch_id, 10, 512, error)
+            .handle_export_failure(&effect_handler, batch_id, error)
             .await;
 
         // Verify stats
         let m = exporter.metrics.borrow();
         let failure = m.export_for(Outcome::Failure);
         assert_eq!(failure.batches.get(), 1);
-        assert_eq!(failure.messages.get(), 1);
-        assert_eq!(failure.items.get(), 10);
-        assert_eq!(failure.bytes.get(), 512);
         drop(m);
 
         // Verify state cleared
@@ -962,7 +924,6 @@ mod tests {
             client,
             result: Err(Error::unauthorized("rejected".to_string())),
             row_count: 1,
-            body_size_bytes: 1,
             token_generation,
         };
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/in_flight_exports.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/in_flight_exports.rs
@@ -8,7 +8,7 @@ use futures::stream::FuturesUnordered;
 use http::HeaderValue;
 use tokio::time::Duration;
 
-use super::client::LogsIngestionClient;
+use super::client::{ExportAttemptMetadata, LogsIngestionClient};
 use super::error::Error;
 
 pub struct CompletedExport {
@@ -16,7 +16,6 @@ pub struct CompletedExport {
     pub client: LogsIngestionClient,
     pub result: Result<Duration, Error>,
     pub row_count: u64,
-    pub body_size_bytes: u64,
     pub token_generation: u64,
 }
 
@@ -121,14 +120,18 @@ impl InFlightExports {
         token_generation: u64,
     ) -> LocalBoxFuture<'static, CompletedExport> {
         Box::pin(async move {
-            let body_size_bytes = body.len() as u64;
-            let result = client.export(body, &auth_header).await;
+            let result = client
+                .export(
+                    body,
+                    &auth_header,
+                    ExportAttemptMetadata { items: row_count },
+                )
+                .await;
             CompletedExport {
                 batch_id,
                 client,
                 result,
                 row_count,
-                body_size_bytes,
                 token_generation,
             }
         })
@@ -206,7 +209,6 @@ mod tests {
                 client: create_test_client(),
                 result,
                 row_count,
-                body_size_bytes: 0,
                 token_generation: 1,
             }
         })
@@ -435,7 +437,6 @@ mod tests {
         assert_eq!(completed.batch_id, 7);
         assert_eq!(completed.token_generation, 42);
         assert_eq!(completed.row_count, 3);
-        assert_eq!(completed.body_size_bytes, 7);
         assert!(
             completed.result.is_ok(),
             "expected success, got {:?}",

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/metrics.rs
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/metrics.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 
 use otel_arrow_dfe_config::SignalType;
 use otel_arrow_dfe_engine::context::PipelineContext;
+use otel_arrow_dfe_otap::metrics::ExporterMetrics;
 use otel_arrow_dfe_telemetry::common_attributes::{
     HttpResponse, Outcome, OutcomeAttributes, SignalRegistrationAttributes,
 };
@@ -59,18 +60,9 @@ pub struct AzureMonitorExporterOperationalMetrics {
 )]
 #[derive(Debug, Default, Clone)]
 pub struct AzureMonitorExporterExportMetrics {
-    /// Number of items in completed export attempts.
-    #[metric(unit = "{item}")]
-    pub items: Counter<u64>,
     /// Number of completed export batches.
     #[metric(unit = "{batch}")]
     pub batches: Counter<u64>,
-    /// Number of messages in completed export attempts.
-    #[metric(unit = "{message}")]
-    pub messages: Counter<u64>,
-    /// Compressed request-body bytes in completed export attempts.
-    #[metric(unit = "By")]
-    pub bytes: Counter<u64>,
 }
 
 /// HTTP export attempts partitioned by response category.
@@ -127,6 +119,7 @@ pub struct AzureMonitorExporterHeartbeatMetrics {
 
 /// Full metrics tracker for the Azure Monitor exporter.
 pub struct AzureMonitorExporterMetricsTracker {
+    pub(super) boundary: ExporterMetrics,
     operational_metrics: MetricSet<AzureMonitorExporterOperationalMetrics>,
     export_metrics: MeasurementMetricSet<AzureMonitorExporterExportMetrics>,
     http_metrics: MeasurementMetricSet<AzureMonitorExporterHttpMetrics>,
@@ -146,6 +139,7 @@ impl AzureMonitorExporterMetricsTracker {
     #[must_use]
     pub(super) fn register(pipeline_ctx: &PipelineContext) -> Self {
         Self {
+            boundary: ExporterMetrics::register(pipeline_ctx),
             operational_metrics: AzureMonitorExporterOperationalMetrics::register(pipeline_ctx),
             export_metrics: AzureMonitorExporterExportMetrics::register(
                 pipeline_ctx,
@@ -161,12 +155,14 @@ impl AzureMonitorExporterMetricsTracker {
 
     /// Report metrics to the telemetry system.
     pub(super) fn report(&mut self, reporter: &mut MetricsReporter) -> Result<(), TelemetryError> {
-        reporter
-            .report(&mut self.operational_metrics)
-            .and_then(|()| reporter.report_measurement(&mut self.export_metrics))
-            .and_then(|()| reporter.report_measurement(&mut self.http_metrics))
-            .and_then(|()| reporter.report_measurement(&mut self.state_metrics))
-            .and_then(|()| reporter.report_measurement(&mut self.heartbeat_metrics))
+        self.boundary.report(reporter).and_then(|()| {
+            reporter
+                .report(&mut self.operational_metrics)
+                .and_then(|()| reporter.report_measurement(&mut self.export_metrics))
+                .and_then(|()| reporter.report_measurement(&mut self.http_metrics))
+                .and_then(|()| reporter.report_measurement(&mut self.state_metrics))
+                .and_then(|()| reporter.report_measurement(&mut self.heartbeat_metrics))
+        })
     }
 
     /// Take snapshots of every metric set for terminal state reporting.
@@ -174,7 +170,8 @@ impl AzureMonitorExporterMetricsTracker {
     pub(super) fn terminal_snapshots(
         &mut self,
     ) -> Vec<otel_arrow_dfe_telemetry::metrics::MetricSetSnapshot> {
-        let mut snapshots = self.operational_metrics.terminal_snapshots();
+        let mut snapshots = self.boundary.terminal_snapshots();
+        snapshots.extend(self.operational_metrics.terminal_snapshots());
         snapshots.extend(self.export_metrics.terminal_snapshots());
         snapshots.extend(self.http_metrics.terminal_snapshots());
         snapshots.extend(self.state_metrics.terminal_snapshots());
@@ -201,18 +198,11 @@ impl AzureMonitorExporterMetricsTracker {
     }
 
     #[inline]
-    pub(super) fn record_export(
-        &mut self,
-        outcome: Outcome,
-        items: u64,
-        messages: u64,
-        bytes: u64,
-    ) {
-        let metrics = self.export_metrics.with(OutcomeAttributes { outcome });
-        metrics.items.add(items);
-        metrics.batches.inc();
-        metrics.messages.add(messages);
-        metrics.bytes.add(bytes);
+    pub(super) fn record_completed_batch(&mut self, outcome: Outcome) {
+        self.export_metrics
+            .with(OutcomeAttributes { outcome })
+            .batches
+            .inc();
     }
 
     #[inline]
@@ -269,36 +259,34 @@ impl AzureMonitorExporterMetricsTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use otel_arrow_dfe_engine::context::ControllerContext;
-    use otel_arrow_dfe_telemetry::registry::TelemetryRegistryHandle;
+    use otel_arrow_dfe_engine::Interests;
+    use otel_arrow_dfe_engine::testing::test_pipeline_ctx_with_interests;
 
     fn new_test_tracker() -> AzureMonitorExporterMetricsTracker {
-        let registry = TelemetryRegistryHandle::new();
-        let controller = ControllerContext::new(registry);
-        let pipeline_ctx =
-            controller.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+        // Enable every shared exporter attempt bucket (messages, duration,
+        // payload.size, items) so tests can observe them without depending on
+        // pipeline-wide MetricLevel defaults.
+        let interests = Interests::NODE_INPUT_METRICS
+            | Interests::NODE_LOCAL_DURATION
+            | Interests::NODE_ITEM_COUNTS
+            | Interests::NODE_SIZE;
+        let (pipeline_ctx, _registry) = test_pipeline_ctx_with_interests(interests);
         AzureMonitorExporterMetricsTracker::register(&pipeline_ctx)
     }
 
-    /// Scenario: Export attempts complete with successful and failed outcomes.
-    /// Guarantees: Each outcome records items, batches, and messages in its own metric bucket.
+    /// Scenario: Compressed batches reach successful and failed terminal outcomes.
+    /// Guarantees: Each outcome records completed batches in its own metric bucket.
     #[test]
     fn export_metrics_are_partitioned_by_outcome() {
         let mut metrics = new_test_tracker();
-        metrics.record_export(Outcome::Success, 100, 50, 1_024);
-        metrics.record_export(Outcome::Failure, 10, 5, 512);
+        metrics.record_completed_batch(Outcome::Success);
+        metrics.record_completed_batch(Outcome::Failure);
 
         let success = metrics.export_for(Outcome::Success);
-        assert_eq!(success.items.get(), 100);
         assert_eq!(success.batches.get(), 1);
-        assert_eq!(success.messages.get(), 50);
-        assert_eq!(success.bytes.get(), 1_024);
 
         let failure = metrics.export_for(Outcome::Failure);
-        assert_eq!(failure.items.get(), 10);
         assert_eq!(failure.batches.get(), 1);
-        assert_eq!(failure.messages.get(), 5);
-        assert_eq!(failure.bytes.get(), 512);
     }
 
     /// Scenario: HTTP attempts receive successful, throttled, and network-error responses.
@@ -404,7 +392,7 @@ mod tests {
     #[test]
     fn terminal_snapshots_include_touched_measurement_metrics() {
         let mut metrics = new_test_tracker();
-        metrics.record_export(Outcome::Success, 10, 1, 100);
+        metrics.record_completed_batch(Outcome::Success);
 
         let snapshots = metrics.terminal_snapshots();
         let export_snapshot = snapshots
@@ -431,7 +419,7 @@ mod tests {
         let mut metrics = new_test_tracker();
         let (receiver, mut reporter) = MetricsReporter::create_new_and_receiver(16);
         metrics.add_batch_size(42.0);
-        metrics.record_export(Outcome::Success, 42, 1, 420);
+        metrics.record_completed_batch(Outcome::Success);
 
         metrics.report(&mut reporter).unwrap();
 

--- a/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/telemetry.md
+++ b/rust/otap-dataflow/crates/contrib-nodes/src/exporters/azure_monitor_exporter/telemetry.md
@@ -8,10 +8,11 @@ by the crate and log events emitted via `otel_*` log macros.
 
 | Metric name | Description | Produced in file |
 | --- | --- | --- |
-| `exporter.azure_monitor.exports.items` | Number of log items (Azure Monitor rows) in completed export attempts. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `exporter.azure_monitor.exports.batches` | Number of completed log export batches. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `exporter.azure_monitor.exports.messages` | Number of log messages in completed export attempts. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
-| `exporter.azure_monitor.exports.bytes` | Compressed request-body bytes in completed export attempts. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+| `exporter.attempted.messages` | Number of compressed JSON payloads submitted to the Logs Ingestion API, partitioned by `signal` and `outcome`. Internal retries produce additional attempts. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
+| `exporter.attempted.duration` | Duration in seconds of each Logs Ingestion API attempt when component duration is enabled, partitioned by `signal` and `outcome`. Retry backoff is excluded. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
+| `exporter.attempted.payload.size` | Gzip-compressed JSON request-body bytes submitted by each HTTP attempt when payload size is enabled, partitioned by `signal` and `outcome`. HTTP and TLS overhead are excluded. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
+| `exporter.attempted.items` | Number of Azure Monitor rows represented by each HTTP attempt when item counts are enabled, partitioned by `signal` and `outcome`. Internal retries produce additional observations. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
+| `exporter.azure_monitor.exports.batches` | Number of compressed batches reaching a terminal result after internal retries. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `exporter.azure_monitor.http.responses` | Number of HTTP export attempts by `response` (`http_2xx`, `http_400`, `http_401`, `http_403`, `http_404`, `http_413`, `http_429`, `http_5xx`, `network_error`, or `other`). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
 | `exporter.azure_monitor.http.latency` | HTTP export attempt latency in milliseconds (min/max/sum/count), partitioned by `response`. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
 | `exporter.azure_monitor.batch_size` | Compressed batch size in bytes (min/max/sum/count). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/client.rs` |
@@ -21,6 +22,12 @@ by the crate and log events emitted via `otel_*` log macros.
 | `exporter.azure_monitor.state.mappings` | Current number of exporter state-map entries, partitioned by `mapping` (`batch_to_message`, `message_to_batch`, or `message_to_data`). | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `exporter.azure_monitor.log_entries_too_large` | Number of log entries rejected for exceeding batch size limit. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
 | `exporter.azure_monitor.heartbeats.sends` | Number of completed heartbeat send attempts. | `crates/contrib-nodes/src/exporters/azure_monitor_exporter/exporter.rs` |
+
+Shared attempt outcomes use `success` for HTTP 2xx responses, `refused` for
+explicit Azure rejections (including HTTP 429), and `failure` for transport or
+backend failures. Enable optional component duration, item counts, and payload
+size with `runtime_metrics: detailed` or the corresponding per-node telemetry
+policy.
 
 ## Logs
 


### PR DESCRIPTION
Emit  ``exporter.attempted.{messages,duration,payload.size,items}``  for every HTTP attempt to the Logs Ingestion API, partitioned by  signal  and  outcome . Each internal retry produces its own shared attempt observation. Refused outcomes cover any 4xx client-error status, including 429; 5xx and transport errors remain failures.

Replace  ``exporter.azure_monitor.exports.{items,messages,bytes}``  with shared attempt metrics. Rename  exporter.azure_monitor.exports.batches  to  exporter.azure_monitor.batches , and report compressed and uncompressed batch sizes in the same terminal metric set, partitioned by  signal  and  outcome .

## Change summary

- Adopt the shared `exporter.attempted` metric set in the Azure Monitor exporter, recording one observation per HTTP submission to the Logs Ingestion API, partitioned by `signal` and `outcome`.
- Replace `exporter.azure_monitor.exports.{items,messages,bytes}` with shared per-attempt metrics. Internal HTTP retries produce separate observations.
- Rename `exporter.azure_monitor.exports.batches` to `exporter.azure_monitor.batches`.
- Record terminal batch count, compressed size, and uncompressed size by `signal` and `outcome`.
- Record terminal batch metrics once at Ack/Nack so internal HTTP retries do not produce additional batch observations.
- Derive the terminal batch `outcome` from the export result: classify every 4xx client-error status, including 429, as `refused` on both the per-attempt (`exporter.attempted.*`) and terminal batch (`exporter.azure_monitor.batches`, `batch_size`, `batch_uncompressed_size`) metrics; keep 5xx and transport errors as `failure`.
- Preserve existing HTTP retry, 401 authentication invalidation and re-dispatch, batch pipelining, heartbeat, and gzip-compressed batching behavior.


## Related issue

• Implementation of #3822 for the Azure Monitor exporter.
## Validation

- `cargo test -p otel-arrow-dfe-contrib-nodes --features azure-monitor-exporter --lib` — all tests pass, including four tests that lock in the shared-attempt and terminal-batch contract:
  - `classifies_shared_export_attempt_outcomes` — every 4xx status, including 400, 401, 403, 413, 418, 422, and 429, is `refused`; 5xx and transport errors remain `failure`.
  - `records_shared_metrics_for_each_http_attempt` — each HTTP submission records one attempt observation in its outcome bucket, and asserts the optional `items`, `payload.size`, and `duration` instruments in that bucket.
  - `retries_record_each_shared_attempt` — retries produce independent attempt observations, with a separate `success` observation for the terminal attempt.
  - `refused_export_records_terminal_batch_as_refused` — a 4xx rejection records `exporter.azure_monitor.batches`, `batch_size`, and `batch_uncompressed_size` under `outcome=refused` (not `failure`); the 401 slot-freeing test is updated to match.

### End-to-end validation (sample config)

Ran a local fan-out config that sends generated logs to two `azure_monitor` exporters sharing one DCE/DCR (dev auth) and differing only by `stream_name`, then prints only the affected metrics. `ame-good` targets a valid stream; `ame-bad` targets a non-existing stream to force a 4xx (`InvalidStream`) rejection.

**Workload (per run):** traffic generator at `signals_per_second=10`, `max_signal_count=100`, `max_batch_size=10`, logs only → **100 log records in 10 messages × 10 items**. The fan-out (`mode=parallel`, `await_ack=none`) clones every message to both exporters, so **each exporter receives all 10 messages / 100 items**; the only difference is the backend response. Each exporter re-batches its 100 items into its own gzip export batches (`ame-good` → 3, `ame-bad` → 4; timing-dependent, item totals identical).

#### Valid stream (`ame-good`) — `outcome=success`

|  |  |
|--|--|
| exporter.attempted.* | attempted.messages{signal=logs,outcome=success}=3 attempted.duration{signal=logs,outcome=success}: count=3, sum=0.910365326s attempted.payload.size{signal=logs,outcome=success}=3,946 By attempted.items{signal=logs,outcome=success}=100 |
| exporter.azure_monitor.* | batches{outcome=success}=3 batch_size{outcome=success}: count=3, sum=3,946 By batch_uncompressed_size{outcome=success}: count=3, sum=26,113 By in_flight_exports=0 log_entries_too_large=0 |
| exporter.azure_monitor.http.* | responses{response=http_2xx}=3 latency: count=3, sum=908 ms |
| node.* | input.messages{signal=logs,outcome=success}=10 input.items{signal=logs,outcome=success}=100 input.size{signal=logs,outcome=success}=24,480 By completion.duration{outcome=success}: count=10 notify_ack.routed=10 notify_nack.routed=0 |

#### Non-existing stream (`ame-bad`) — `outcome=refused`

|  |  |
|--|--|
| exporter.attempted.* | attempted.messages{signal=logs,outcome=refused}=4 attempted.duration{signal=logs,outcome=refused}: count=4, sum=0.636602001s attempted.payload.size{signal=logs,outcome=refused}=4,963 By attempted.items{signal=logs,outcome=refused}=100 |
| exporter.azure_monitor.* | batches{outcome=refused}=4 batch_size{outcome=refused}: count=4, sum=4,963 By batch_uncompressed_size{outcome=refused}: count=4, sum=26,114 By in_flight_log_records=0 log_entries_too_large=0 |
| exporter.azure_monitor.http.* | responses{response=http_400}=4 latency: count=4, sum=633 ms |
| node.* | input.messages{signal=logs,outcome=failure}=10 input.items{signal=logs,outcome=failure}=100 input.size{signal=logs,outcome=failure}=24,480 By completion.duration{outcome=failure}: count=10 notify_ack.routed=0 notify_nack.routed=10 |

**Message accounting:** 10 messages / 100 items in per exporter → re-batched to 3 (good) / 4 (bad) attempts → 3× HTTP 2xx (`success`) vs 4× HTTP 400 (`refused`). No items lost on either path (`attempted.items=100` both). The refused batches now expose `outcome=refused` on `batches`, `batch_size`, and `batch.uncompressed_size` (the fix from the review), while the node boundary still nacks all 10 messages (`notify_nack.routed=10`), reflecting the N:M mapping.

## User-facing changes

- Replace `exporter.azure_monitor.exports.{items,messages,bytes}` with `exporter.attempted.{messages,duration,payload.size,items}`, partitioned by `signal` and `outcome`. Internal HTTP retries produce separate observations.
- Rename `exporter.azure_monitor.exports.batches` to `exporter.azure_monitor.batches`.
- Partition `exporter.azure_monitor.{batch_size,batch_uncompressed_size}` by `signal` and `outcome` and record them once at terminal Ack/Nack.
- Terminal batch metrics (`batches`, `batch_size`, `batch_uncompressed_size`) now carry `outcome=refused` for 4xx rejections (401/403/413/429) instead of `failure`; 5xx and transport errors remain `failure`.
- Optional `duration`, `payload.size`, and `items` metrics follow standard interest gating through `runtime_metrics: detailed` or the corresponding per-node telemetry policy.
