### PR TITLE
feat(engine): add engine and pipeline-group extension declarations

### DIFF
--- a/rust/otap-dataflow/.chloggen/extension-declaration-scopes.yaml
+++ b/rust/otap-dataflow/.chloggen/extension-declaration-scopes.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: engine
+note: Add engine- and group-scoped extension declarations with lexical capability resolution, shared state propagation, readiness barriers, and ordered shutdown.
+issues: [1966]
+subtext: Higher scopes require a shared variant. Hosted engine/group declaration or runtime-policy changes require restart; pipeline-scoped updates remain supported. Shutdown preserves per-phase grace and terminal telemetry when providers finish at different times.

--- a/rust/otap-dataflow/crates/config/src/engine.rs
+++ b/rust/otap-dataflow/crates/config/src/engine.rs
@@ -14,7 +14,7 @@ use crate::extension::ExtensionUserConfig;
 use crate::health::HealthPolicy;
 use crate::observed_state::ObservedStateSettings;
 use crate::pipeline::telemetry::TelemetryConfig;
-use crate::pipeline::{PipelineConfig, PipelineConnection, PipelineNodes};
+use crate::pipeline::{PipelineConfig, PipelineConnection, PipelineExtensions, PipelineNodes};
 use crate::pipeline_group::PipelineGroupConfig;
 use crate::policy::{ChannelCapacityPolicy, Policies, TelemetryPolicy};
 use crate::topic::{TopicImplSelectionPolicy, TopicSpec};
@@ -51,6 +51,10 @@ pub struct OtelDataflowSpec {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub topics: HashMap<TopicName, TopicSpec>,
 
+    /// Engine-scoped extension declarations visible to every regular pipeline.
+    #[serde(default, skip_serializing_if = "PipelineExtensions::is_empty")]
+    pub extensions: PipelineExtensions,
+
     /// Engine-wide runtime declarations.
     #[serde(default)]
     pub engine: EngineConfig,
@@ -72,6 +76,7 @@ impl OtelDataflowSpec {
     #[must_use]
     pub fn redacted_for_snapshot(&self) -> OtelDataflowSpec {
         let mut redacted = self.clone();
+        redacted.extensions = redacted.extensions.redacted_for_snapshot();
         redacted.engine = redacted.engine.redacted_for_snapshot();
         for group in redacted.groups.values_mut() {
             *group = group.redacted_for_snapshot();
@@ -542,6 +547,117 @@ groups:
         assert!(
             original_json.contains("Bearer super-secret-token"),
             "original spec must retain the cleartext credential"
+        );
+    }
+
+    /// Scenario: root and group extension configurations contain authentication headers.
+    /// Guarantees: snapshot redaction masks both declaration scopes without changing stored config.
+    #[test]
+    fn redacted_for_snapshot_masks_extension_headers_across_scopes() {
+        let yaml = r#"
+version: otel_dataflow/v1
+extensions:
+  root_auth:
+    type: "urn:test:extension:auth"
+    config:
+      headers:
+        authorization: "root-secret-value"
+groups:
+  default:
+    extensions:
+      group_auth:
+        type: "urn:test:extension:auth"
+        config:
+          headers:
+            authorization: "group-secret-value"
+"#;
+        let spec: OtelDataflowSpec = serde_yaml::from_str(yaml).expect("spec should deserialize");
+        let redacted = spec.redacted_for_snapshot();
+
+        let redacted_json = serde_json::to_string(&redacted).expect("redacted spec serializes");
+        assert!(!redacted_json.contains("root-secret-value"));
+        assert!(!redacted_json.contains("group-secret-value"));
+        assert!(redacted_json.contains(crate::node::REDACTED_HEADER_VALUE));
+
+        let original_json = serde_json::to_string(&spec).expect("spec serializes");
+        assert!(original_json.contains("root-secret-value"));
+        assert!(original_json.contains("group-secret-value"));
+    }
+
+    /// Scenario: a pipeline binds capabilities to engine and containing-group extensions.
+    /// Guarantees: both lexical ancestors are accepted as visible providers.
+    #[test]
+    fn from_yaml_accepts_capability_bindings_to_ancestor_extensions() {
+        let yaml = r#"
+version: otel_dataflow/v1
+extensions:
+  root_auth:
+    type: "urn:test:extension:auth"
+groups:
+  default:
+    extensions:
+      group_store:
+        type: "urn:test:extension:kv"
+    pipelines:
+      main:
+        nodes:
+          receiver:
+            type: "urn:test:receiver:example"
+          exporter:
+            type: "urn:test:exporter:example"
+            capabilities:
+              bearer_token_provider: root_auth
+              key_value_store: group_store
+        connections:
+          - from: receiver
+            to: exporter
+"#;
+        let spec = OtelDataflowSpec::from_yaml(yaml)
+            .expect("ancestor capability bindings should validate");
+
+        assert!(spec.extensions.contains_key("root_auth"));
+        assert!(
+            spec.groups["default"]
+                .extensions
+                .contains_key("group_store")
+        );
+    }
+
+    /// Scenario: a pipeline binds to an extension declared only by a sibling group.
+    /// Guarantees: sibling group declarations remain outside the pipeline's lexical scope.
+    #[test]
+    fn from_yaml_rejects_capability_binding_to_sibling_group_extension() {
+        let yaml = r#"
+version: otel_dataflow/v1
+groups:
+  owner:
+    extensions:
+      private_auth:
+        type: "urn:test:extension:auth"
+  consumer:
+    pipelines:
+      main:
+        nodes:
+          receiver:
+            type: "urn:test:receiver:example"
+          exporter:
+            type: "urn:test:exporter:example"
+            capabilities:
+              bearer_token_provider: private_auth
+        connections:
+          - from: receiver
+            to: exporter
+"#;
+        let error = OtelDataflowSpec::from_yaml(yaml)
+            .expect_err("sibling group extension binding should fail validation");
+        let message = error.to_string();
+        assert!(
+            message.contains("private_auth"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            message.contains("visible from the pipeline scope"),
+            "unexpected error: {message}"
         );
     }
 

--- a/rust/otap-dataflow/crates/config/src/engine/io.rs
+++ b/rust/otap-dataflow/crates/config/src/engine/io.rs
@@ -100,6 +100,7 @@ impl OtelDataflowSpec {
             version: ENGINE_CONFIG_VERSION_V1.to_string(),
             policies: Policies::default(),
             topics: HashMap::new(),
+            extensions: Default::default(),
             engine,
             groups,
         };

--- a/rust/otap-dataflow/crates/config/src/engine/validate.rs
+++ b/rust/otap-dataflow/crates/config/src/engine/validate.rs
@@ -107,9 +107,10 @@ impl OtelDataflowSpec {
             });
         } else {
             let pipeline_cfg = observability_pipeline.clone().into_pipeline_config();
-            if let Err(e) = pipeline_cfg.validate(
+            if let Err(e) = pipeline_cfg.validate_with_visible_extensions(
                 &SYSTEM_PIPELINE_GROUP_ID.into(),
                 &SYSTEM_OBSERVABILITY_PIPELINE_ID.into(),
+                |_| false,
             ) {
                 errors.push(e);
             }
@@ -156,7 +157,9 @@ impl OtelDataflowSpec {
                 });
                 continue;
             }
-            if let Err(e) = pipeline_group.validate(pipeline_group_id) {
+            if let Err(e) =
+                pipeline_group.validate_with_engine_extensions(pipeline_group_id, &self.extensions)
+            {
                 errors.push(e);
             }
             if pipeline_group

--- a/rust/otap-dataflow/crates/config/src/extension.rs
+++ b/rust/otap-dataflow/crates/config/src/extension.rs
@@ -7,9 +7,37 @@
 //! have no output ports, no wiring contracts, and no header policies.
 
 pub use crate::extension_urn::ExtensionUrn;
+use crate::{PipelineGroupId, PipelineId};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::fmt;
+
+/// Configuration scope containing an extension declaration.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ExtensionDeclarationScope {
+    /// Top-level engine scope.
+    Engine,
+    /// Pipeline-group scope.
+    PipelineGroup(PipelineGroupId),
+    /// Individual pipeline scope.
+    Pipeline(PipelineGroupId, PipelineId),
+}
+
+impl fmt::Display for ExtensionDeclarationScope {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Engine => formatter.write_str("engine scope"),
+            Self::PipelineGroup(pipeline_group_id) => {
+                write!(formatter, "pipeline-group `{pipeline_group_id}` scope")
+            }
+            Self::Pipeline(pipeline_group_id, pipeline_id) => write!(
+                formatter,
+                "pipeline `{pipeline_group_id}/{pipeline_id}` scope"
+            ),
+        }
+    }
+}
 
 /// User configuration for an extension instance.
 ///

--- a/rust/otap-dataflow/crates/config/src/pipeline.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline.rs
@@ -451,11 +451,12 @@ impl IntoIterator for PipelineNodes {
     }
 }
 
-/// A collection of pipeline extensions, keyed by extension ID.
+/// A collection of extension declarations, keyed by extension ID.
 ///
 /// Mirrors [`PipelineNodes`] but uses [`ExtensionUserConfig`] instead of
 /// [`NodeUserConfig`], reflecting that extensions have a simpler configuration
-/// model (no output ports, wiring, or header policies).
+/// model (no output ports, wiring, or header policies). The collection is
+/// reused at engine, pipeline-group, and pipeline scope.
 ///
 /// Deserialization rejects duplicate extension IDs (see
 /// [`Self::deserialize`]) so a config that accidentally repeats an
@@ -542,6 +543,16 @@ impl PipelineExtensions {
     pub fn keys(&self) -> impl Iterator<Item = &ExtensionId> {
         self.0.keys()
     }
+
+    /// Returns a clone with every extension's credential header values redacted.
+    #[must_use]
+    pub fn redacted_for_snapshot(&self) -> PipelineExtensions {
+        let mut redacted = self.clone();
+        for extension in redacted.0.values_mut() {
+            *extension = Arc::new(extension.redacted_for_snapshot());
+        }
+        redacted
+    }
 }
 
 impl IntoIterator for PipelineExtensions {
@@ -612,6 +623,28 @@ impl PipelineConfig {
         Ok(cfg)
     }
 
+    /// Creates a pipeline from JSON when extension bindings may resolve from
+    /// an enclosing engine or pipeline-group scope.
+    ///
+    /// Structural validation still runs here. The owning engine configuration
+    /// must later validate capability bindings against the full lexical scope.
+    pub fn from_json_allowing_inherited_extensions(
+        pipeline_group_id: PipelineGroupId,
+        pipeline_id: PipelineId,
+        json_str: &str,
+    ) -> Result<Self, Error> {
+        let mut cfg: PipelineConfig =
+            serde_json::from_str(json_str).map_err(|e| Error::DeserializationError {
+                context: Context::new(pipeline_group_id.clone(), pipeline_id.clone()),
+                format: "JSON".to_string(),
+                details: e.to_string(),
+            })?;
+
+        cfg.canonicalize_plugin_urns(&pipeline_group_id, &pipeline_id)?;
+        cfg.validate_with_visible_extensions(&pipeline_group_id, &pipeline_id, |_| true)?;
+        Ok(cfg)
+    }
+
     /// Create a new [`PipelineConfig`] from a YAML string.
     pub fn from_yaml(
         pipeline_group_id: PipelineGroupId,
@@ -627,6 +660,28 @@ impl PipelineConfig {
 
         spec.canonicalize_plugin_urns(&pipeline_group_id, &pipeline_id)?;
         spec.validate(&pipeline_group_id, &pipeline_id)?;
+        Ok(spec)
+    }
+
+    /// Creates a pipeline from YAML when extension bindings may resolve from
+    /// an enclosing engine or pipeline-group scope.
+    ///
+    /// Structural validation still runs here. The owning engine configuration
+    /// must later validate capability bindings against the full lexical scope.
+    pub fn from_yaml_allowing_inherited_extensions(
+        pipeline_group_id: PipelineGroupId,
+        pipeline_id: PipelineId,
+        yaml_str: &str,
+    ) -> Result<Self, Error> {
+        let mut spec: PipelineConfig =
+            serde_yaml::from_str(yaml_str).map_err(|e| Error::DeserializationError {
+                context: Context::new(pipeline_group_id.clone(), pipeline_id.clone()),
+                format: "YAML".to_string(),
+                details: e.to_string(),
+            })?;
+
+        spec.canonicalize_plugin_urns(&pipeline_group_id, &pipeline_id)?;
+        spec.validate_with_visible_extensions(&pipeline_group_id, &pipeline_id, |_| true)?;
         Ok(spec)
     }
 
@@ -654,9 +709,7 @@ impl PipelineConfig {
         for node in redacted.nodes.0.values_mut() {
             *node = Arc::new(node.redacted_for_snapshot());
         }
-        for extension in redacted.extensions.0.values_mut() {
-            *extension = Arc::new(extension.redacted_for_snapshot());
-        }
+        redacted.extensions = redacted.extensions.redacted_for_snapshot();
         redacted
     }
 
@@ -818,6 +871,19 @@ impl PipelineConfig {
         pipeline_group_id: &PipelineGroupId,
         pipeline_id: &PipelineId,
     ) -> Result<(), Error> {
+        self.validate_with_visible_extensions(pipeline_group_id, pipeline_id, |extension_id| {
+            self.extensions.contains_key(extension_id)
+        })
+    }
+
+    /// Validates this pipeline using extension declarations visible from its
+    /// declaration scope.
+    pub(crate) fn validate_with_visible_extensions(
+        &self,
+        pipeline_group_id: &PipelineGroupId,
+        pipeline_id: &PipelineId,
+        extension_exists: impl Fn(&str) -> bool,
+    ) -> Result<(), Error> {
         let mut errors = Vec::new();
 
         // Validate node-level transport header policy fields.
@@ -833,7 +899,7 @@ impl PipelineConfig {
             &mut errors,
         );
 
-        self.validate_capability_bindings(&mut errors);
+        self.validate_capability_bindings(&extension_exists, &mut errors);
 
         if !errors.is_empty() {
             Err(Error::InvalidConfiguration { errors })
@@ -842,19 +908,21 @@ impl PipelineConfig {
         }
     }
 
-    /// Validates that every capability binding references an extension that
-    /// exists in the `extensions:` section, and that extensions themselves
-    /// do not declare capability bindings (they provide capabilities, not
-    /// consume them).
-    fn validate_capability_bindings(&self, errors: &mut Vec<Error>) {
+    /// Validates that every capability binding references an extension visible
+    /// from this pipeline's lexical configuration scope.
+    fn validate_capability_bindings(
+        &self,
+        extension_exists: &impl Fn(&str) -> bool,
+        errors: &mut Vec<Error>,
+    ) {
         // Check that capability bindings on nodes reference valid extensions
         for (node_id, node_config) in self.nodes.iter() {
             for (capability_name, extension_name) in &node_config.capabilities {
-                if !self.extensions.contains_key(extension_name.as_ref()) {
+                if !extension_exists(extension_name.as_ref()) {
                     errors.push(Error::InvalidUserConfig {
                         error: format!(
                             "Node '{}' binds capability '{}' to extension '{}', \
-                             but no extension with that name exists in the `extensions` section.",
+                             but no extension with that name is visible from the pipeline scope.",
                             node_id.as_ref(),
                             capability_name,
                             extension_name,
@@ -3069,6 +3137,42 @@ connections:
         }
     }
 
+    /// Scenario: an isolated pipeline document binds a capability supplied by
+    /// an enclosing engine or pipeline-group extension declaration.
+    /// Guarantees: reconfiguration parsing can preserve the inherited binding
+    /// while strict standalone validation still rejects an unresolved ID.
+    #[test]
+    fn allowing_inherited_extensions_defers_binding_resolution() {
+        let yaml = r#"
+nodes:
+  receiver:
+    type: "urn:test:receiver:example"
+  exporter:
+    type: "urn:test:exporter:example"
+    capabilities:
+      bearer_token_provider: "ancestor_auth"
+
+connections:
+  - from: receiver
+    to: exporter
+"#;
+
+        assert!(
+            super::PipelineConfig::from_yaml("g".into(), "p".into(), yaml).is_err(),
+            "strict standalone parsing must reject an unresolved extension"
+        );
+        let parsed = super::PipelineConfig::from_yaml_allowing_inherited_extensions(
+            "g".into(),
+            "p".into(),
+            yaml,
+        )
+        .expect("inherited extension bindings should parse for full-spec validation");
+        assert!(
+            parsed.validate(&"g".into(), &"p".into()).is_err(),
+            "the full lexical owner must still validate the inherited binding"
+        );
+    }
+
     #[test]
     fn test_capability_binding_to_existing_extension_passes() {
         let yaml = r#"
@@ -3132,10 +3236,11 @@ connections:
         );
     }
 
+    /// Scenario: A pipeline group declares a shared extension beside its pipelines.
+    /// Guarantees: Group-level extensions deserialize into the pipeline-group
+    /// declaration scope.
     #[test]
-    fn test_extensions_at_group_level_rejected_by_serde() {
-        // PipelineGroupConfig uses #[serde(deny_unknown_fields)],
-        // so `extensions:` at the group level is rejected by deserialization.
+    fn test_extensions_at_group_level_accepted_by_serde() {
         let yaml = r#"
 pipelines:
   main:
@@ -3151,12 +3256,9 @@ extensions:
   auth:
     type: "urn:test:extension:auth"
 "#;
-        let result: Result<crate::pipeline_group::PipelineGroupConfig, _> =
-            serde_yaml::from_str(yaml);
-        assert!(
-            result.is_err(),
-            "extensions at group level should be rejected by serde"
-        );
+        let group: crate::pipeline_group::PipelineGroupConfig =
+            serde_yaml::from_str(yaml).expect("group-level extensions should deserialize");
+        assert!(group.extensions.contains_key("auth"));
     }
 
     #[test]

--- a/rust/otap-dataflow/crates/config/src/pipeline_group.rs
+++ b/rust/otap-dataflow/crates/config/src/pipeline_group.rs
@@ -4,7 +4,7 @@
 //! The configuration for a pipeline group.
 
 use crate::error::Error;
-use crate::pipeline::PipelineConfig;
+use crate::pipeline::{PipelineConfig, PipelineExtensions};
 use crate::policy::Policies;
 use crate::topic::TopicSpec;
 use crate::{PipelineGroupId, PipelineId, TopicName};
@@ -25,6 +25,10 @@ pub struct PipelineGroupConfig {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub topics: HashMap<TopicName, TopicSpec>,
 
+    /// Group-scoped extension declarations visible to every pipeline in this group.
+    #[serde(default, skip_serializing_if = "PipelineExtensions::is_empty")]
+    pub extensions: PipelineExtensions,
+
     /// All pipelines belonging to this pipeline group, keyed by pipeline ID.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub pipelines: HashMap<PipelineId, PipelineConfig>,
@@ -37,6 +41,7 @@ impl PipelineGroupConfig {
         Self {
             policies: None,
             topics: HashMap::new(),
+            extensions: PipelineExtensions::default(),
             pipelines: HashMap::new(),
         }
     }
@@ -49,6 +54,7 @@ impl PipelineGroupConfig {
     #[must_use]
     pub fn redacted_for_snapshot(&self) -> PipelineGroupConfig {
         let mut redacted = self.clone();
+        redacted.extensions = redacted.extensions.redacted_for_snapshot();
         for pipeline in redacted.pipelines.values_mut() {
             *pipeline = pipeline.redacted_for_snapshot();
         }
@@ -70,6 +76,15 @@ impl PipelineGroupConfig {
 
     /// Validates the pipeline group configuration.
     pub fn validate(&self, pipeline_group_id: &PipelineGroupId) -> Result<(), Error> {
+        self.validate_with_engine_extensions(pipeline_group_id, &PipelineExtensions::default())
+    }
+
+    /// Validates this group with engine-scoped extensions available to its pipelines.
+    pub(crate) fn validate_with_engine_extensions(
+        &self,
+        pipeline_group_id: &PipelineGroupId,
+        engine_extensions: &PipelineExtensions,
+    ) -> Result<(), Error> {
         let mut errors = Vec::new();
 
         if let Some(policies) = &self.policies {
@@ -102,7 +117,15 @@ impl PipelineGroupConfig {
                         .map(|error| Error::InvalidUserConfig { error }),
                 );
             }
-            if let Err(e) = pipeline.validate(pipeline_group_id, pipeline_id) {
+            if let Err(e) = pipeline.validate_with_visible_extensions(
+                pipeline_group_id,
+                pipeline_id,
+                |extension_id| {
+                    pipeline.extensions().contains_key(extension_id)
+                        || self.extensions.contains_key(extension_id)
+                        || engine_extensions.contains_key(extension_id)
+                },
+            ) {
                 errors.push(e);
             }
         }

--- a/rust/otap-dataflow/crates/controller/Cargo.toml
+++ b/rust/otap-dataflow/crates/controller/Cargo.toml
@@ -52,5 +52,6 @@ url = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
 otel-arrow-dfe-test-net = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["registry"] }

--- a/rust/otap-dataflow/crates/controller/src/error.rs
+++ b/rust/otap-dataflow/crates/controller/src/error.rs
@@ -147,6 +147,13 @@ pub enum Error {
         source: std::io::Error,
     },
 
+    /// A controller-owned thread did not stop before its teardown deadline.
+    #[error("Timed out waiting for thread '{thread_name}' to stop")]
+    ThreadJoinTimeout {
+        /// Name of the thread that remained active.
+        thread_name: String,
+    },
+
     /// Failed to enumerate available CPU cores on this platform.
     #[error("Failed to get available CPU cores (core detection unavailable on this platform)")]
     CoreDetectionUnavailable,

--- a/rust/otap-dataflow/crates/controller/src/extension/opamp/test/util.rs
+++ b/rust/otap-dataflow/crates/controller/src/extension/opamp/test/util.rs
@@ -162,6 +162,7 @@ pub fn test_config() -> OtelDataflowSpec {
         version: "otel_dataflow/v1".into(),
         policies: Policies::default(),
         topics: HashMap::new(),
+        extensions: Default::default(),
         engine: EngineConfig::default(),
         groups: HashMap::from_iter([(Cow::Borrowed("test_pipeline"), PipelineGroupConfig::new())]),
     }

--- a/rust/otap-dataflow/crates/controller/src/lib.rs
+++ b/rust/otap-dataflow/crates/controller/src/lib.rs
@@ -42,7 +42,9 @@
 //! - TODO: Better resource control
 
 use crate::error::Error;
-use crate::thread_task::{ThreadLocalTaskHandle, spawn_thread_local_task};
+use crate::thread_task::{
+    ThreadLocalTaskHandle, spawn_thread_local_task, spawn_thread_local_task_with_cleanup,
+};
 use core_affinity::CoreId;
 use otel_arrow_dfe_admin::ControlPlane;
 use otel_arrow_dfe_config::engine::{
@@ -80,6 +82,9 @@ use otel_arrow_dfe_engine::entity_context::{
     node_entity_key, pipeline_entity_key, set_pipeline_entity_key,
 };
 use otel_arrow_dfe_engine::error::Error as EngineError;
+use otel_arrow_dfe_engine::extension::scope::{
+    ExtensionScopeRegistry, InheritedExtensionRegistrations, RunningExtensionScopeSupervisor,
+};
 use otel_arrow_dfe_engine::listener_group::ListenerGroupSnapshot;
 use otel_arrow_dfe_engine::memory_limiter::{
     EffectiveMemoryLimiter, MemoryLimiterTick, MemoryPressureBehaviorConfig, MemoryPressureChanged,
@@ -108,7 +113,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::mpsc as std_mpsc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
 pub use linkme::distributed_slice;
@@ -142,10 +147,7 @@ pub use controller_monitor::{
     register_builtin_controller_extensions,
 };
 
-use live_control::{
-    ControllerRuntime, LaunchedPipelineThread, PanicReport, RuntimeInstanceError,
-    RuntimeInstanceExit,
-};
+use live_control::{ControllerRuntime, PanicReport, RuntimeInstanceError, RuntimeInstanceExit};
 use placement::{CorePlacement, PipelinePlacement, PlacementPlanner, PlacementSnapshot};
 
 use otel_arrow_dfe_engine::component_inventory;
@@ -170,6 +172,205 @@ pub struct Controller<PData: 'static + Clone + Send + Sync + std::fmt::Debug> {
 enum RunMode {
     ParkMainThread,
     ShutdownWhenDone,
+}
+
+fn shutdown_telemetry_task<T, E>(
+    name: &str,
+    handle: Arc<ThreadLocalTaskHandle<T, E>>,
+) -> Result<T, Error>
+where
+    E: Into<Error>,
+{
+    let handle = Arc::try_unwrap(handle).map_err(|_| Error::PipelineRuntimeError {
+        source: Box::new(std::io::Error::other(format!(
+            "{name} shutdown deferred: scope or pipeline teardown still owns telemetry support"
+        ))),
+    })?;
+    handle.shutdown_and_join()
+}
+
+/// Keeps engine and pipeline-group extension scope hosts alive until pipelines stop.
+struct ExtensionScopeSupervisorGuard<
+    PData: 'static + Clone + Send + Sync + std::fmt::Debug + ReceivedAtNode + Unwindable + FlowMetricHook,
+> {
+    handle: Option<ThreadLocalTaskHandle<(), Error>>,
+    runtime: Arc<ControllerRuntime<PData>>,
+    descendant_drain_timeout: Duration,
+    supervisor_shutdown_timeout: Duration,
+}
+
+impl<
+    PData: 'static + Clone + Send + Sync + std::fmt::Debug + ReceivedAtNode + Unwindable + FlowMetricHook,
+> ExtensionScopeSupervisorGuard<PData>
+{
+    const DESCENDANT_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+    const SUPERVISOR_SHUTDOWN_TIMEOUT: Duration = RunningExtensionScopeSupervisor::SHUTDOWN_TIMEOUT
+        .saturating_add(ControllerRuntime::<PData>::OBSERVABILITY_SHUTDOWN_TIMEOUT)
+        .saturating_add(Duration::from_secs(1));
+
+    fn new(
+        handle: ThreadLocalTaskHandle<(), Error>,
+        runtime: Arc<ControllerRuntime<PData>>,
+    ) -> Self {
+        Self {
+            handle: Some(handle),
+            runtime,
+            descendant_drain_timeout: Self::DESCENDANT_DRAIN_TIMEOUT,
+            supervisor_shutdown_timeout: Self::SUPERVISOR_SHUTDOWN_TIMEOUT,
+        }
+    }
+
+    #[cfg(test)]
+    fn new_with_timeouts(
+        handle: ThreadLocalTaskHandle<(), Error>,
+        runtime: Arc<ControllerRuntime<PData>>,
+        descendant_drain_timeout: Duration,
+        supervisor_shutdown_timeout: Duration,
+    ) -> Self {
+        Self {
+            handle: Some(handle),
+            runtime,
+            descendant_drain_timeout,
+            supervisor_shutdown_timeout,
+        }
+    }
+
+    fn timeout_error(&self, phase: &str) -> Error {
+        Error::PipelineRuntimeError {
+            source: Box::new(std::io::Error::other(format!(
+                "global shutdown deadline elapsed while waiting for {phase}"
+            ))),
+        }
+    }
+
+    fn drain_descendants_until(&self, deadline: Instant) -> Option<Error> {
+        let mut shutdown_error = None;
+
+        loop {
+            if let Err(error) = self.runtime.request_shutdown_all_until(deadline)
+                && shutdown_error.is_none()
+            {
+                shutdown_error = Some(Error::PipelineRuntimeError {
+                    source: Box::new(std::io::Error::other(format!(
+                        "failed to stop descendant pipelines before extension scope hosts: {error:?}"
+                    ))),
+                });
+            }
+            if self.runtime.all_producer_instances_exited() {
+                break;
+            }
+
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                return Some(self.timeout_error("descendant pipelines to stop"));
+            };
+            if !self
+                .runtime
+                .wait_for_global_shutdown_completion_for(remaining)
+            {
+                continue;
+            }
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .unwrap_or(Duration::ZERO);
+            _ = self.runtime.wait_until_all_producer_instances_exit_for(
+                remaining.min(Duration::from_millis(100)),
+            );
+        }
+
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .unwrap_or(Duration::ZERO);
+        if !self
+            .runtime
+            .wait_for_global_shutdown_completion_for(remaining)
+        {
+            return Some(self.timeout_error("descendant shutdown coordination"));
+        }
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .unwrap_or(Duration::ZERO);
+        if !self.runtime.wait_for_runtime_recoveries_for(remaining) {
+            return Some(self.timeout_error("runtime recovery workers to stop"));
+        }
+
+        shutdown_error
+    }
+
+    fn drain_observability_until(&self, deadline: Instant) -> Option<Error> {
+        let shutdown_error = self
+            .runtime
+            .request_shutdown_all_until(deadline)
+            .err()
+            .map(|error| Error::PipelineRuntimeError {
+                source: Box::new(std::io::Error::other(format!(
+                    "failed to stop system observability after extension scope hosts: {error:?}"
+                ))),
+            });
+
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .unwrap_or(Duration::ZERO);
+        if !self
+            .runtime
+            .wait_for_global_shutdown_completion_for(remaining)
+        {
+            return Some(self.timeout_error("system observability shutdown coordination"));
+        }
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .unwrap_or(Duration::ZERO);
+        if !self.runtime.wait_until_all_instances_exit_for(remaining) {
+            return Some(self.timeout_error("system observability to stop"));
+        }
+
+        shutdown_error
+    }
+
+    fn shutdown_after_descendants(&mut self) -> Option<Error> {
+        let deadline = self
+            .runtime
+            .global_shutdown_deadline_or_insert(self.descendant_drain_timeout);
+        let descendant_error = self.drain_descendants_until(deadline);
+        // Provider and observability grace starts after descendant draining.
+        // The supervisor's completion callback owns final telemetry teardown.
+        let supervisor_deadline = Instant::now() + self.supervisor_shutdown_timeout;
+        let extension_scope_error = self
+            .handle
+            .take()
+            .and_then(|handle| handle.shutdown_and_join_until(supervisor_deadline).err());
+        let extension_scope_timed_out = extension_scope_error
+            .as_ref()
+            .is_some_and(|error| matches!(error, Error::ThreadJoinTimeout { .. }));
+        let observability_error = if extension_scope_timed_out
+            || !self.runtime.all_producer_instances_exited()
+            || !self.runtime.wait_for_runtime_recoveries_for(Duration::ZERO)
+        {
+            None
+        } else {
+            self.runtime.mark_extension_scope_hosts_stopped();
+            self.drain_observability_until(self.runtime.observability_shutdown_deadline_or_insert())
+        };
+        descendant_error
+            .or(extension_scope_error)
+            .or(observability_error)
+    }
+}
+
+impl<
+    PData: 'static + Clone + Send + Sync + std::fmt::Debug + ReceivedAtNode + Unwindable + FlowMetricHook,
+> Drop for ExtensionScopeSupervisorGuard<PData>
+{
+    fn drop(&mut self) {
+        if self.handle.is_none() {
+            return;
+        }
+        if let Some(error) = self.shutdown_after_descendants() {
+            otel_warn!(
+                "controller.extension_scope_cleanup_failed",
+                error = error.to_string()
+            );
+        }
+    }
 }
 
 /// Error type returned by controller extension startup and runtime tasks.
@@ -1521,6 +1722,7 @@ impl<
         let placement_snapshot =
             Self::preflight_pipeline_placement(&pipelines, &all_cores, &topology)?;
 
+        let extension_scope_registry = ExtensionScopeRegistry::default();
         let runtime = Arc::new(ControllerRuntime::new(
             self.pipeline_factory,
             controller_ctx.clone(),
@@ -1528,6 +1730,7 @@ impl<
             obs_state_handle.clone(),
             engine_evt_reporter.clone(),
             metrics_reporter.clone(),
+            extension_scope_registry.clone(),
             declared_topics,
             all_cores.clone(),
             topology,
@@ -1557,7 +1760,9 @@ impl<
         // available when that pipeline begins processing control messages or ticks.
         let internal_collector = telemetry_system.collector();
         let (collector_ready_tx, collector_ready_rx) = std::sync::mpsc::sync_channel(1);
-        let metrics_agg_handle = spawn_thread_local_task(
+        // These leases protect telemetry support across OS-thread teardown.
+        // A detached scope supervisor retains them until the final producers exit.
+        let metrics_agg_handle = Arc::new(spawn_thread_local_task(
             "metrics-aggregator",
             admin_tracing_setup.clone(),
             move |cancellation_token| {
@@ -1565,16 +1770,154 @@ impl<
                 let _ = collector_ready_tx.send(());
                 task
             },
-        )?;
+        )?);
         collector_ready_rx.recv().map_err(|_| {
             Error::from(otel_arrow_dfe_telemetry::error::Error::MetricsCollectorNotRunning)
         })?;
 
-        // Pipeline threads receive only a Weak handle back to the controller runtime. That lets
-        // them report their terminal exit without becoming owners that keep the runtime alive
-        // during shutdown.
-        let observability_pipeline_handle = Self::spawn_observability_pipeline(
-            Arc::downgrade(&runtime),
+        let obs_state_store_runtime = obs_state_store.clone();
+        let obs_state_join_handle = Arc::new(spawn_thread_local_task(
+            "observed-state-store",
+            admin_tracing_setup.clone(),
+            move |cancellation_token| obs_state_store_runtime.run(cancellation_token),
+        )?);
+
+        // Engine and group extensions run once on a controller-owned LocalSet.
+        // Their immutable shared capability catalog is published only after
+        // every scope passes its startup and readiness barriers.
+        let extension_scope_config = engine_config.clone();
+        let extension_scope_controller_ctx = controller_ctx.clone();
+        let extension_scope_metrics_reporter = metrics_reporter.clone();
+        let extension_scope_registry_for_host = extension_scope_registry.clone();
+        let extension_scope_pipeline_factory = self.pipeline_factory;
+        // Keep controller shutdown state alive until the scope-host thread can
+        // open the observability phase after its final scope actually exits.
+        let extension_scope_runtime = Arc::clone(&runtime);
+        let extension_scope_completion_runtime = Arc::clone(&runtime);
+        let extension_scope_metrics_lease = Arc::clone(&metrics_agg_handle);
+        let extension_scope_state_lease = Arc::clone(&obs_state_join_handle);
+        let (extension_scope_ready_tx, extension_scope_ready_rx) =
+            std_mpsc::sync_channel::<Result<(), String>>(1);
+        let extension_scope_supervisor_handle = spawn_thread_local_task_with_cleanup(
+            "extension-scope-supervisor",
+            telemetry_system.engine_tracing_setup(),
+            move |cancellation_token| async move {
+                let prepared = match extension_scope_pipeline_factory.prepare_extension_scope_hosts(
+                    &extension_scope_config,
+                    &extension_scope_controller_ctx,
+                    extension_scope_metrics_reporter,
+                    extension_scope_registry_for_host,
+                ) {
+                    Ok(prepared) => prepared,
+                    Err(error) => {
+                        let message = error.to_string();
+                        let _ = extension_scope_ready_tx.send(Err(message));
+                        return Err(Error::PipelineRuntimeError {
+                            source: Box::new(error),
+                        });
+                    }
+                };
+                let running = match prepared
+                    .start_with_shutdown(cancellation_token.clone().cancelled_owned())
+                    .await
+                {
+                    Ok(Some(running)) => running,
+                    Ok(None) => {
+                        let _ = extension_scope_ready_tx
+                            .send(Err("extension scope startup was cancelled".to_owned()));
+                        return Ok(());
+                    }
+                    Err(error) => {
+                        let message = error.to_string();
+                        let _ = extension_scope_ready_tx.send(Err(message));
+                        return Err(Error::PipelineRuntimeError {
+                            source: Box::new(error),
+                        });
+                    }
+                };
+                if extension_scope_ready_tx.send(Ok(())).is_err() {
+                    return running
+                        .shutdown()
+                        .await
+                        .map_err(|error| Error::PipelineRuntimeError {
+                            source: Box::new(error),
+                        });
+                }
+
+                let failure_runtime = Arc::clone(&extension_scope_runtime);
+                running
+                    .run(cancellation_token.cancelled_owned(), move |message| {
+                        otel_error!(
+                            "controller.extension_scope_runtime_failed",
+                            error = message.as_str(),
+                            message = "An engine or pipeline-group extension failed; requesting engine shutdown"
+                        );
+                        failure_runtime.record_fatal_runtime_error(message);
+                        if let Err(shutdown_error) =
+                            failure_runtime.control_plane().shutdown_all(10)
+                        {
+                            otel_warn!(
+                                "controller.extension_scope_shutdown_failed",
+                                error = format!("{shutdown_error:?}")
+                            );
+                        }
+                    })
+                    .await
+                    .map_err(|error| Error::PipelineRuntimeError {
+                        source: Box::new(error),
+                    })
+            },
+            move |cancellation_token| {
+                extension_scope_completion_runtime
+                    .finish_shutdown_after_extension_scopes(&cancellation_token);
+                drop(extension_scope_metrics_lease);
+                drop(extension_scope_state_lease);
+            },
+        )?;
+        match extension_scope_ready_rx.recv() {
+            Ok(Ok(())) => {}
+            Ok(Err(message)) => {
+                let host_error = extension_scope_supervisor_handle
+                    .shutdown_and_join()
+                    .err()
+                    .unwrap_or_else(|| Error::PipelineRuntimeError {
+                        source: Box::new(std::io::Error::other(message)),
+                    });
+                if let Err(error) =
+                    shutdown_telemetry_task("metrics-aggregator", metrics_agg_handle)
+                {
+                    otel_warn!(
+                        "controller.extension_scope_startup_metrics_shutdown_failed",
+                        error = error.to_string()
+                    );
+                }
+                return Err(host_error);
+            }
+            Err(error) => {
+                let host_error = extension_scope_supervisor_handle
+                    .shutdown_and_join()
+                    .err()
+                    .unwrap_or_else(|| Error::PipelineRuntimeError {
+                        source: Box::new(error),
+                    });
+                if let Err(error) =
+                    shutdown_telemetry_task("metrics-aggregator", metrics_agg_handle)
+                {
+                    otel_warn!(
+                        "controller.extension_scope_startup_metrics_shutdown_failed",
+                        error = error.to_string()
+                    );
+                }
+                return Err(host_error);
+            }
+        }
+        let mut extension_scope_supervisor = ExtensionScopeSupervisorGuard::new(
+            extension_scope_supervisor_handle,
+            Arc::clone(&runtime),
+        );
+
+        Self::spawn_observability_pipeline(
+            &runtime,
             observability_key.clone(),
             observability_core,
             observability_pipeline,
@@ -1595,14 +1938,6 @@ impl<
         // before we start sending logs.
         telemetry_system.init_global_subscriber();
         Self::emit_topic_mode_reports(&runtime.declared_topics().inferred_mode_reports);
-
-        // Start the observed state store background task
-        let obs_state_store_runtime = obs_state_store.clone();
-        let obs_state_join_handle = spawn_thread_local_task(
-            "observed-state-store",
-            admin_tracing_setup.clone(),
-            move |cancellation_token| obs_state_store_runtime.run(cancellation_token),
-        )?;
 
         // Start the engine-wide metrics collection task.
         // This samples engine-level metrics (e.g. RSS) on a fixed interval and
@@ -1658,13 +1993,16 @@ impl<
             },
         )?;
 
-        runtime.register_launched_instance(observability_pipeline_handle);
-
         for (pipeline_entry, pipeline_placement) in
             pipelines.iter().zip(placement_snapshot.pipelines.iter())
         {
-            runtime.register_committed_pipeline(
+            let inherited_extensions = runtime.inherited_extensions_for_pipeline(
+                &pipeline_entry.pipeline_group_id,
+                &pipeline_entry.pipeline,
+            );
+            runtime.register_committed_pipeline_with_inherited(
                 pipeline_entry.clone(),
+                inherited_extensions.clone(),
                 pipeline_placement.clone(),
                 0,
             );
@@ -1706,10 +2044,7 @@ impl<
             );
 
             for placement in &pipeline_placement.cores {
-                // Pass a Weak runtime handle into each pipeline thread. The thread upgrades it
-                // only when it needs to report Success/Error/Panic on exit, and silently skips
-                // that late report if shutdown has already dropped the runtime.
-                let launched = Self::launch_pipeline_thread(
+                Self::launch_pipeline_thread(
                     self.pipeline_factory,
                     DeployedPipelineKey {
                         pipeline_group_id: pipeline_entry.pipeline_group_id.clone(),
@@ -1727,6 +2062,7 @@ impl<
                     pipeline_entry.policies.transport_headers.clone(),
                     pipeline_entry.policies.rate_limiters.clone(),
                     pipeline_entry.policies.rate_limiter_scope.clone(),
+                    inherited_extensions.clone(),
                     controller_ctx.clone(),
                     metrics_reporter.clone(),
                     engine_evt_reporter.clone(),
@@ -1735,12 +2071,23 @@ impl<
                     memory_pressure_tx.clone(),
                     &engine_config,
                     runtime.declared_topics(),
-                    Arc::downgrade(&runtime),
+                    &runtime,
                     runtime.next_thread_id(),
                     None,
                 )?;
-                runtime.register_launched_instance(launched);
             }
+        }
+
+        // An extension scope failure can race with a pipeline launch that was already
+        // admitted. Repeat the idempotent shutdown request after bootstrap has
+        // finished its launch attempts.
+        if runtime.has_fatal_runtime_error()
+            && let Err(error) = control_plane.shutdown_all(10)
+        {
+            otel_warn!(
+                "controller.extension_scope_late_shutdown_failed",
+                error = format!("{error:?}")
+            );
         }
 
         drop(metrics_reporter);
@@ -1783,10 +2130,10 @@ impl<
                     );
                 }
                 let _ = runtime.wait_for_global_shutdown_completion();
-                if !runtime.all_instances_exited() {
+                if !runtime.all_producer_instances_exited() {
                     otel_warn!(
                         "controller.extension_startup_pipeline_shutdown_timeout",
-                        message = "Timed out waiting for pipelines and system observability to stop after controller extension startup failed"
+                        message = "Timed out waiting for producer pipelines to stop after controller extension startup failed"
                     );
                 }
                 return Err(err);
@@ -1853,34 +2200,39 @@ impl<
             if let Err(error) = control_plane.shutdown_all(10) {
                 return Err(Error::PipelineRuntimeError {
                     source: Box::new(std::io::Error::other(format!(
-                        "failed to stop system observability after producers exited: {error:?}"
+                        "failed to initiate global shutdown after producers exited: {error:?}"
                     ))),
                 });
             }
             let _ = runtime.wait_for_global_shutdown_completion();
-            runtime.wait_until_all_instances_exit();
+            runtime.wait_until_all_producer_instances_exit();
         }
 
         if run_mode == RunMode::ParkMainThread {
             let global_shutdown_requested = runtime.wait_for_global_shutdown_completion();
-            let all_instances_exited = if global_shutdown_requested {
-                runtime.all_instances_exited()
+            let all_producers_exited = if global_shutdown_requested {
+                runtime.all_producer_instances_exited()
             } else {
-                runtime.wait_until_all_instances_exit_for(Duration::from_secs(12))
+                runtime.wait_until_all_producer_instances_exit_for(Duration::from_secs(12))
             };
-            if !all_instances_exited {
+            if !all_producers_exited {
                 otel_warn!(
                     "controller.pipeline_shutdown_timeout",
-                    message = "Timed out waiting for pipelines and system observability to stop before telemetry collector shutdown"
+                    message = "Timed out waiting for producer pipelines to stop before extension scope shutdown"
                 );
             }
         }
 
-        // All telemetry producers and pipelines have finished; shut down the
-        // remaining support tasks and the metric aggregator gracefully.
+        // Pipeline instances stop before engine and pipeline-group scope hosts.
+        let extension_scope_error = extension_scope_supervisor.shutdown_after_descendants();
+
+        // A timed-out scope thread keeps its telemetry leases until all actual
+        // producers exit. Never cancel the collector underneath that deferred cleanup.
         admin_server_handle.shutdown_and_join()?;
-        metrics_agg_handle.shutdown_and_join()?;
-        obs_state_join_handle.shutdown_and_join()?;
+        let metrics_shutdown_error =
+            shutdown_telemetry_task("metrics-aggregator", metrics_agg_handle).err();
+        let state_shutdown_error =
+            shutdown_telemetry_task("observed-state-store", obs_state_join_handle).err();
         drop(telemetry_system);
         if let Some(listener) = shutdown_signal_listener {
             listener.shutdown_and_join()?;
@@ -1891,6 +2243,14 @@ impl<
         }
 
         if let Some(err) = runtime.take_runtime_error() {
+            return Err(err);
+        }
+
+        if let Some(err) = extension_scope_error {
+            return Err(err);
+        }
+
+        if let Some(err) = metrics_shutdown_error.or(state_shutdown_error) {
             return Err(err);
         }
 
@@ -2539,10 +2899,8 @@ impl<
 
     /// Launches one pipeline OS thread and wires its terminal exit back into the controller.
     ///
-    /// The spawned thread owns the actual pipeline execution and maps success, runtime error, or
-    /// panic into RuntimeInstanceExit. `runtime` is a Weak handle on purpose: the pipeline thread
-    /// should be able to report its exit, but it must not become an owner that prolongs the
-    /// controller runtime during shutdown.
+    /// Launch reservation closes the gap between admission and runtime-thread
+    /// registration so scope-host teardown cannot miss an in-flight launch.
     #[allow(clippy::too_many_arguments)]
     fn launch_pipeline_thread(
         pipeline_factory: &'static PipelineFactory<PData>,
@@ -2557,6 +2915,7 @@ impl<
         transport_headers_policy: Option<TransportHeadersPolicy>,
         rate_limiter_policies: BTreeMap<String, RateLimiterPolicy>,
         rate_limiter_scope: Option<otel_arrow_dfe_config::policy::RateLimiterDeclarationScope>,
+        inherited_extensions: InheritedExtensionRegistrations,
         controller_ctx: ControllerContext,
         metrics_reporter: MetricsReporter,
         engine_evt_reporter: ObservedEventReporter,
@@ -2565,13 +2924,13 @@ impl<
         memory_pressure_tx: tokio::sync::watch::Sender<MemoryPressureChanged>,
         config: &OtelDataflowSpec,
         declared_topics: &DeclaredTopics<PData>,
-        runtime: std::sync::Weak<ControllerRuntime<PData>>,
+        runtime: &Arc<ControllerRuntime<PData>>,
         thread_id: usize,
         internal_telemetry: Option<(
             InternalTelemetrySettings,
             std_mpsc::SyncSender<Result<(), EngineError>>,
         )>,
-    ) -> Result<LaunchedPipelineThread<PData>, Error> {
+    ) -> Result<(), Error> {
         let mut pipeline_ctx = controller_ctx.pipeline_context_with_placement(
             pipeline_key.pipeline_group_id.clone(),
             pipeline_key.pipeline_id.clone(),
@@ -2606,7 +2965,9 @@ impl<
         let run_key = pipeline_key.clone();
         let runtime_key = pipeline_key.clone();
         let runtime_thread_name = thread_name.clone();
-        let _handle = thread::Builder::new()
+        runtime.reserve_instance_launch(&pipeline_key)?;
+        let runtime_weak = Arc::downgrade(runtime);
+        let spawn_result = thread::Builder::new()
             .name(thread_name.clone())
             .spawn(move || {
                 let exit = match catch_unwind(AssertUnwindSafe(|| {
@@ -2619,6 +2980,7 @@ impl<
                         transport_headers_policy,
                         rate_limiter_policies,
                         rate_limiter_scope,
+                        inherited_extensions,
                         telemetry_reporting_interval,
                         pipeline_factory,
                         pipeline_ctx,
@@ -2647,28 +3009,28 @@ impl<
                         ),
                     )),
                 };
-                if let Some(runtime) = runtime.upgrade() {
+                if let Some(runtime) = runtime_weak.upgrade() {
                     runtime.note_instance_exit(runtime_key, exit);
                 }
                 // The controller runtime may already be gone during teardown. In that case there
                 // is nothing left to update, so late exit reporting is intentionally best-effort.
-            })
-            .map_err(|e| Error::ThreadSpawnError {
+            });
+        if let Err(source) = spawn_result {
+            runtime.abort_instance_launch(&pipeline_key);
+            return Err(Error::ThreadSpawnError {
                 thread_name: thread_name.clone(),
-                source: e,
-            })?;
+                source,
+            });
+        }
+        runtime.complete_instance_launch(pipeline_key, control_sender);
 
-        Ok(LaunchedPipelineThread {
-            pipeline_key,
-            control_sender,
-            _marker: std::marker::PhantomData,
-        })
+        Ok(())
     }
 
     /// Spawns the engine's mandatory observability pipeline and waits for startup.
     #[allow(clippy::too_many_arguments)]
     fn spawn_observability_pipeline(
-        runtime: std::sync::Weak<ControllerRuntime<PData>>,
+        runtime: &Arc<ControllerRuntime<PData>>,
         observability_key: DeployedPipelineKey,
         observability_core: CoreId,
         observability_pipeline: ResolvedPipelineConfig,
@@ -2682,7 +3044,7 @@ impl<
         memory_pressure_tx: &tokio::sync::watch::Sender<MemoryPressureChanged>,
         tracing_setup: TracingSetup,
         observability_numa_node_id: usize,
-    ) -> Result<LaunchedPipelineThread<PData>, Error> {
+    ) -> Result<(), Error> {
         debug_assert_eq!(
             observability_pipeline.role,
             ResolvedPipelineRole::ObservabilityInternal
@@ -2695,7 +3057,7 @@ impl<
 
         // Create a channel to signal startup success/failure
         let (startup_tx, startup_rx) = std_mpsc::sync_channel::<Result<(), EngineError>>(1);
-        let launched = Self::launch_pipeline_thread(
+        Self::launch_pipeline_thread(
             pipeline_factory,
             observability_key,
             observability_core,
@@ -2708,6 +3070,7 @@ impl<
             None,
             BTreeMap::new(),
             None,
+            InheritedExtensionRegistrations::default(),
             controller_ctx.clone(),
             metrics_reporter.clone(),
             engine_evt_reporter.clone(),
@@ -2715,10 +3078,7 @@ impl<
             telemetry_reporting_interval,
             memory_pressure_tx.clone(),
             config,
-            runtime
-                .upgrade()
-                .expect("controller runtime should exist while spawning observability pipeline")
-                .declared_topics(),
+            runtime.declared_topics(),
             runtime,
             0,
             Some((internal_telemetry_settings, startup_tx)),
@@ -2746,7 +3106,7 @@ impl<
             }
         }
 
-        Ok(launched)
+        Ok(())
     }
 
     /// Runs a single pipeline in the current thread.
@@ -2759,6 +3119,7 @@ impl<
         transport_headers_policy: Option<TransportHeadersPolicy>,
         rate_limiter_policies: BTreeMap<String, RateLimiterPolicy>,
         rate_limiter_scope: Option<otel_arrow_dfe_config::policy::RateLimiterDeclarationScope>,
+        inherited_extensions: InheritedExtensionRegistrations,
         telemetry_reporting_interval: Duration,
         pipeline_factory: &'static PipelineFactory<PData>,
         pipeline_context: PipelineContext,
@@ -2811,7 +3172,7 @@ impl<
                 .map(|(settings, _)| settings)
                 .cloned();
             let runtime_pipeline = pipeline_factory
-                .build(
+                .build_with_inherited_extensions(
                     pipeline_context.clone(),
                     pipeline_config.clone(),
                     channel_capacity_policy,
@@ -2820,6 +3181,7 @@ impl<
                     rate_limiter_policies,
                     rate_limiter_scope,
                     internal_telemetry_settings,
+                    inherited_extensions,
                 )
                 .map_err(|e| {
                     if let Some((_, startup_tx)) = internal_telemetry.as_ref() {

--- a/rust/otap-dataflow/crates/controller/src/live_control/README.md
+++ b/rust/otap-dataflow/crates/controller/src/live_control/README.md
@@ -85,9 +85,16 @@ all active instances.
 - Terminal rollout and shutdown records are retained in memory with both a
   per-logical-pipeline cap and a TTL. This keeps recent admin lookups useful
   without unbounded history growth.
-- Runtime exit reporting is race-tolerant. A pipeline thread can exit before
-  `register_launched_instance()` publishes it as active; such exits are parked
-  in `pending_instance_exits` and reconciled during registration.
+- Runtime exit reporting is race-tolerant. Production launches reserve
+  liveness before OS-thread creation, then transition that reservation to an
+  active record after spawn. Synthetic test exits without a reservation are
+  parked in `pending_instance_exits` and reconciled during test registration.
+- Global shutdown retains its finite terminal instance set until teardown
+  completes, so an exit racing with shutdown dispatch cannot be mistaken for a
+  control-channel failure. The first accepted deadline bounds producer draining.
+  Group hosts, engine hosts, and observability receive separate ordered grace
+  periods; requests cannot reset an active phase's deadline. Scope-thread cleanup
+  retains telemetry support after a join timeout until all producers actually exit.
 - Unexpected runtime errors are recovered per logical core. A ready replacement
   uses a newer generation and becomes the serving generation only for that
   core, so healthy siblings do not restart.

--- a/rust/otap-dataflow/crates/controller/src/live_control/execution.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/execution.rs
@@ -323,6 +323,7 @@ impl<
             );
             let deployed_key = match self.launch_regular_pipeline_instance(
                 &plan.resolved_pipeline,
+                &plan.target_inherited_extensions,
                 &plan.target_placement,
                 *core_id,
                 plan.target_generation,
@@ -391,6 +392,7 @@ impl<
 
             let new_key = match self.launch_regular_pipeline_instance(
                 &plan.resolved_pipeline,
+                &plan.target_inherited_extensions,
                 &plan.target_placement,
                 *core_id,
                 active_generation,
@@ -509,6 +511,7 @@ impl<
 
             let new_key = match self.launch_regular_pipeline_instance(
                 &plan.resolved_pipeline,
+                &plan.target_inherited_extensions,
                 &plan.target_placement,
                 *core_id,
                 plan.target_generation,
@@ -570,6 +573,7 @@ impl<
 
             let new_key = match self.launch_regular_pipeline_instance(
                 &plan.resolved_pipeline,
+                &plan.target_inherited_extensions,
                 &plan.target_placement,
                 *core_id,
                 plan.target_generation,
@@ -754,6 +758,7 @@ impl<
             let old_key = self
                 .launch_regular_pipeline_instance(
                     &previous.resolved,
+                    &previous.inherited_extensions,
                     current_placement,
                     *core_id,
                     previous_generation,
@@ -889,6 +894,7 @@ impl<
             let old_key = self
                 .launch_regular_pipeline_instance(
                     &previous.resolved,
+                    &previous.inherited_extensions,
                     current_placement,
                     *core_id,
                     previous_generation,
@@ -937,6 +943,7 @@ impl<
             let old_key = self
                 .launch_regular_pipeline_instance(
                     &previous.resolved,
+                    &previous.inherited_extensions,
                     current_placement,
                     *core_id,
                     previous_generation,

--- a/rust/otap-dataflow/crates/controller/src/live_control/mod.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/mod.rs
@@ -75,6 +75,8 @@ pub(super) struct ControllerRuntime<PData: 'static + Clone + Send + Sync + std::
     engine_event_reporter: ObservedEventReporter,
     /// Metrics reporter cloned into launched runtime instances.
     metrics_reporter: MetricsReporter,
+    /// Immutable capability catalogs for engine and pipeline-group extensions.
+    extension_scope_registry: ExtensionScopeRegistry,
     /// Topic registry shared by all runtime instances.
     declared_topics: DeclaredTopics<PData>,
     /// Controller-wide core ids available for policy-based allocation.
@@ -105,6 +107,7 @@ struct ControllerControlPlane<PData: 'static + Clone + Send + Sync + std::fmt::D
 /// The controller stores the `control_sender` while the instance is active and
 /// drops it after shutdown is requested so the pipeline can observe control
 /// channel closure once node tasks finish.
+#[cfg(test)]
 pub(super) struct LaunchedPipelineThread<PData> {
     /// Concrete deployed instance key for the launched runtime thread.
     pub(super) pipeline_key: DeployedPipelineKey,
@@ -127,6 +130,7 @@ impl<
         observed_state_handle: ObservedStateHandle,
         engine_event_reporter: ObservedEventReporter,
         metrics_reporter: MetricsReporter,
+        extension_scope_registry: ExtensionScopeRegistry,
         declared_topics: DeclaredTopics<PData>,
         available_core_ids: Vec<CoreId>,
         topology: NumaTopology,
@@ -144,6 +148,7 @@ impl<
             observed_state_handle,
             engine_event_reporter,
             metrics_reporter,
+            extension_scope_registry,
             declared_topics,
             available_core_ids,
             topology,
@@ -156,6 +161,7 @@ impl<
                 config_revision: 0,
                 logical_pipelines: HashMap::new(),
                 runtime_instances: HashMap::new(),
+                launching_instances: HashSet::new(),
                 runtime_recoveries: HashMap::new(),
                 deferred_runtime_recoveries: HashMap::new(),
                 pipeline_operation_reservations: HashMap::new(),
@@ -178,7 +184,11 @@ impl<
                 next_pipeline_operation_reservation_id: 0,
                 first_error: None,
                 instance_wait_released: false,
+                launches_closed: false,
                 global_shutdown_requested: false,
+                global_shutdown_deadline: None,
+                observability_shutdown_deadline: None,
+                extension_scope_hosts_stopped: false,
                 global_shutdown_coordinators: 0,
             }),
             state_changed: Condvar::new(),
@@ -186,9 +196,29 @@ impl<
     }
 
     /// Seeds the runtime registry with a pipeline already committed at startup.
+    #[cfg(test)]
     pub(super) fn register_committed_pipeline(
         &self,
         resolved: ResolvedPipelineConfig,
+        placement: PipelinePlacement,
+        generation: u64,
+    ) {
+        let inherited_extensions =
+            self.inherited_extensions_for_pipeline(&resolved.pipeline_group_id, &resolved.pipeline);
+        self.register_committed_pipeline_with_inherited(
+            resolved,
+            inherited_extensions,
+            placement,
+            generation,
+        );
+    }
+
+    /// Seeds one committed pipeline with the exact inherited-provider snapshot
+    /// used to launch its runtime generation.
+    pub(super) fn register_committed_pipeline_with_inherited(
+        &self,
+        resolved: ResolvedPipelineConfig,
+        inherited_extensions: InheritedExtensionRegistrations,
         placement: PipelinePlacement,
         generation: u64,
     ) {
@@ -214,6 +244,7 @@ impl<
             pipeline_key,
             LogicalPipelineRecord {
                 resolved,
+                inherited_extensions,
                 active_generation: generation,
                 placement,
                 placement_generation: 0,
@@ -237,6 +268,16 @@ impl<
         &self.declared_topics
     }
 
+    /// Resolves the shared providers inherited by one pipeline.
+    pub(super) fn inherited_extensions_for_pipeline(
+        &self,
+        pipeline_group_id: &PipelineGroupId,
+        pipeline: &PipelineConfig,
+    ) -> InheritedExtensionRegistrations {
+        self.extension_scope_registry
+            .registrations_for_pipeline(pipeline_group_id, pipeline.extensions())
+    }
+
     /// Exposes the runtime as the admin control-plane trait object.
     pub(super) fn control_plane(self: &Arc<Self>) -> Arc<dyn ControlPlane> {
         Arc::new(ControllerControlPlane {
@@ -249,7 +290,11 @@ impl<
         state: &ControllerRuntimeState,
         pipeline_key: &PipelineKey,
     ) -> bool {
-        state.active_rollouts.contains_key(pipeline_key)
+        // Global shutdown is terminal for this runtime, so retaining its finite
+        // deployed-instance set cannot grow across later generations. The
+        // records close snapshot/send races until every coordinator finishes.
+        state.global_shutdown_requested
+            || state.active_rollouts.contains_key(pipeline_key)
             || state.active_shutdowns.contains_key(pipeline_key)
             || state
                 .pipeline_operation_reservations

--- a/rust/otap-dataflow/crates/controller/src/live_control/planning.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/planning.rs
@@ -9,6 +9,8 @@
 //! to conflict detection and bounded history retention.
 
 use super::*;
+use otel_arrow_dfe_config::policy::{Policies, ResolvedPolicies};
+use otel_arrow_dfe_engine::extension::scope::ExtensionHostRuntimePolicy;
 
 pub(super) struct EngineOperationGuard<
     PData: 'static + Clone + Send + Sync + std::fmt::Debug + ReceivedAtNode + Unwindable + FlowMetricHook,
@@ -603,6 +605,135 @@ impl<
         Ok(())
     }
 
+    fn validate_live_extension_scope_declarations_unchanged(
+        current_config: &OtelDataflowSpec,
+        desired_config: &OtelDataflowSpec,
+        delete_missing: bool,
+    ) -> Result<(), ControlPlaneError> {
+        if current_config.extensions != desired_config.extensions {
+            return Err(ControlPlaneError::InvalidRequest {
+                message:
+                    "request would require runtime engine extension mutation; restart the engine to change top-level extensions"
+                        .to_owned(),
+            });
+        }
+
+        let group_ids: HashSet<_> = current_config
+            .groups
+            .keys()
+            .chain(desired_config.groups.keys())
+            .cloned()
+            .collect();
+        for pipeline_group_id in group_ids {
+            let current = current_config.groups.get(&pipeline_group_id);
+            let desired = desired_config.groups.get(&pipeline_group_id);
+            match (current, desired) {
+                (Some(current), Some(desired)) if current.extensions != desired.extensions => {
+                    return Err(ControlPlaneError::InvalidRequest {
+                        message: format!(
+                            "request would require runtime extension mutation for pipeline group `{}`; restart the engine to change group extensions",
+                            pipeline_group_id.as_ref()
+                        ),
+                    });
+                }
+                (None, Some(desired)) if !desired.extensions.is_empty() => {
+                    return Err(ControlPlaneError::InvalidRequest {
+                        message: format!(
+                            "creating pipeline group `{}` with extensions requires an engine restart",
+                            pipeline_group_id.as_ref()
+                        ),
+                    });
+                }
+                (Some(current), None) if delete_missing && !current.extensions.is_empty() => {
+                    return Err(ControlPlaneError::InvalidRequest {
+                        message: format!(
+                            "deleting pipeline group `{}` with hosted extensions requires an engine restart",
+                            pipeline_group_id.as_ref()
+                        ),
+                    });
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn retain_extension_scope_declarations(
+        current_config: &OtelDataflowSpec,
+        desired_config: &mut OtelDataflowSpec,
+    ) {
+        for (extension_id, extension) in current_config.extensions.iter() {
+            if !desired_config
+                .extensions
+                .contains_key(extension_id.as_ref())
+            {
+                desired_config
+                    .extensions
+                    .insert(extension_id.clone(), extension.as_ref().clone());
+            }
+        }
+        for (pipeline_group_id, desired_group) in &mut desired_config.groups {
+            if let Some(current_group) = current_config.groups.get(pipeline_group_id) {
+                for (extension_id, extension) in current_group.extensions.iter() {
+                    if !desired_group.extensions.contains_key(extension_id.as_ref()) {
+                        desired_group
+                            .extensions
+                            .insert(extension_id.clone(), extension.as_ref().clone());
+                    }
+                }
+            }
+        }
+    }
+
+    fn validate_live_extension_host_policies_unchanged(
+        current_config: &OtelDataflowSpec,
+        desired_config: &OtelDataflowSpec,
+        delete_missing: bool,
+    ) -> Result<(), ControlPlaneError> {
+        let runtime_policy_changed = |current: &ResolvedPolicies, desired: &ResolvedPolicies| {
+            ExtensionHostRuntimePolicy::from_resolved(current)
+                != ExtensionHostRuntimePolicy::from_resolved(desired)
+        };
+
+        if !current_config.extensions.is_empty() {
+            let current = Policies::resolve([&current_config.policies]);
+            let desired = Policies::resolve([&desired_config.policies]);
+            if runtime_policy_changed(&current, &desired) {
+                return Err(ControlPlaneError::InvalidRequest {
+                    message: "request would change runtime policies used by hosted engine extensions; restart the engine to change their channel capacity or telemetry policy".to_owned(),
+                });
+            }
+        }
+
+        for (pipeline_group_id, current_group) in &current_config.groups {
+            if current_group.extensions.is_empty() {
+                continue;
+            }
+            let desired_group = match desired_config.groups.get(pipeline_group_id) {
+                Some(group) => group,
+                None if !delete_missing => current_group,
+                None => continue,
+            };
+            let current = current_group.policies.as_ref().map_or_else(
+                || Policies::resolve([&current_config.policies]),
+                |group_policies| Policies::resolve([group_policies, &current_config.policies]),
+            );
+            let desired = desired_group.policies.as_ref().map_or_else(
+                || Policies::resolve([&desired_config.policies]),
+                |group_policies| Policies::resolve([group_policies, &desired_config.policies]),
+            );
+            if runtime_policy_changed(&current, &desired) {
+                return Err(ControlPlaneError::InvalidRequest {
+                    message: format!(
+                        "request would change runtime policies used by hosted extensions in pipeline group `{}`; restart the engine to change their channel capacity or telemetry policy",
+                        pipeline_group_id.as_ref()
+                    ),
+                });
+            }
+        }
+        Ok(())
+    }
+
     /// Reserves, plans, and starts one explicit per-pipeline rollout.
     pub(super) fn request_reconfigure_pipeline(
         self: &Arc<Self>,
@@ -686,11 +817,6 @@ impl<
         };
 
         let candidate_pipeline = request.pipeline.clone();
-        candidate_pipeline
-            .validate(&pipeline_group_id, &pipeline_id)
-            .map_err(|err| ControlPlaneError::InvalidRequest {
-                message: err.to_string(),
-            })?;
 
         let mut candidate_config = planning_config
             .cloned()
@@ -727,6 +853,11 @@ impl<
             });
         }
         Self::validate_live_memory_limiter_unchanged(&live_config, &candidate_config)?;
+        Self::validate_live_extension_host_policies_unchanged(
+            &live_config,
+            &candidate_config,
+            true,
+        )?;
 
         let resolved_pipeline = candidate_config
             .resolve()
@@ -740,6 +871,10 @@ impl<
             .ok_or_else(|| ControlPlaneError::Internal {
                 message: "candidate pipeline disappeared during resolution".to_owned(),
             })?;
+        let target_inherited_extensions = self.inherited_extensions_for_pipeline(
+            &resolved_pipeline.pipeline_group_id,
+            &resolved_pipeline.pipeline,
+        );
         let current_pipeline_placement = current_record
             .as_ref()
             .map(|record| record.placement.clone());
@@ -976,6 +1111,7 @@ impl<
             pipeline_id,
             action,
             resolved_pipeline,
+            target_inherited_extensions,
             base_config_revision,
             current_record,
             current_placement,
@@ -1181,6 +1317,7 @@ impl<
                 plan.pipeline_key.clone(),
                 LogicalPipelineRecord {
                     resolved: plan.resolved_pipeline.clone(),
+                    inherited_extensions: plan.target_inherited_extensions.clone(),
                     active_generation,
                     placement: plan.target_placement.placement.clone(),
                     placement_generation: plan.target_placement.listener_group_snapshot.generation,
@@ -1478,6 +1615,12 @@ impl<
                     .to_owned(),
             });
         }
+        if !group.extensions.is_empty() {
+            return Err(ControlPlaneError::InvalidRequest {
+                message: "pipeline group creation with extensions requires an engine restart"
+                    .to_owned(),
+            });
+        }
         group
             .validate(&pipeline_group_id)
             .map_err(|err| ControlPlaneError::InvalidRequest {
@@ -1534,6 +1677,7 @@ impl<
         state.live_config.version = desired_config.version.clone();
         state.live_config.policies = desired_config.policies.clone();
         state.live_config.topics = desired_config.topics.clone();
+        state.live_config.extensions = desired_config.extensions.clone();
         state.live_config.engine = desired_config.engine.clone();
         for (pipeline_group_id, desired_group) in &desired_config.groups {
             let group = state
@@ -1543,6 +1687,7 @@ impl<
                 .or_default();
             group.policies = desired_group.policies.clone();
             group.topics = desired_group.topics.clone();
+            group.extensions = desired_group.extensions.clone();
             for (pipeline_id, pipeline) in &desired_group.pipelines {
                 _ = group
                     .pipelines
@@ -1866,6 +2011,14 @@ impl<
             let Some(group) = state.live_config.groups.get(&pipeline_group_id) else {
                 return Err(ControlPlaneError::GroupNotFound);
             };
+            if !group.extensions.is_empty() {
+                return Err(ControlPlaneError::InvalidRequest {
+                    message: format!(
+                        "deleting pipeline group `{}` with hosted extensions requires an engine restart",
+                        pipeline_group_id.as_ref()
+                    ),
+                });
+            }
             let mut ids: Vec<_> = group.pipelines.keys().cloned().collect();
             for pipeline_key in state.logical_pipelines.keys() {
                 if pipeline_key.pipeline_group_id() == &pipeline_group_id
@@ -1952,7 +2105,15 @@ impl<
         );
 
         let live_config = self.engine_config_snapshot();
-        let desired_config = request.config;
+        let mut desired_config = request.config;
+        if !request.delete_missing {
+            Self::retain_extension_scope_declarations(&live_config, &mut desired_config);
+        }
+        Self::validate_live_extension_scope_declarations_unchanged(
+            &live_config,
+            &desired_config,
+            request.delete_missing,
+        )?;
         desired_config
             .validate()
             .map_err(|err| ControlPlaneError::InvalidRequest {
@@ -1972,6 +2133,11 @@ impl<
             });
         }
         Self::validate_live_memory_limiter_unchanged(&live_config, &desired_config)?;
+        Self::validate_live_extension_host_policies_unchanged(
+            &live_config,
+            &desired_config,
+            request.delete_missing,
+        )?;
 
         let mut desired_keys = Vec::new();
         for (pipeline_group_id, group) in &desired_config.groups {

--- a/rust/otap-dataflow/crates/controller/src/live_control/runtime.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/runtime.rs
@@ -22,6 +22,7 @@ struct RuntimeRecoveryAttempt {
     attempt: usize,
     target_key: DeployedPipelineKey,
     resolved: ResolvedPipelineConfig,
+    inherited_extensions: InheritedExtensionRegistrations,
     placement: LivePipelinePlacement,
     backoff: Duration,
 }
@@ -41,6 +42,11 @@ fn deployed_instance_label(deployed_key: &DeployedPipelineKey) -> String {
         deployed_key.core_id,
         deployed_key.deployment_generation
     )
+}
+
+fn is_observability_instance(deployed_key: &DeployedPipelineKey) -> bool {
+    deployed_key.pipeline_group_id.as_ref() == SYSTEM_PIPELINE_GROUP_ID
+        && deployed_key.pipeline_id.as_ref() == SYSTEM_OBSERVABILITY_PIPELINE_ID
 }
 
 /// Computes capped exponential backoff for a one-based restart attempt.
@@ -73,10 +79,14 @@ impl<
     PData: 'static + Clone + Send + Sync + std::fmt::Debug + ReceivedAtNode + Unwindable + FlowMetricHook,
 > ControllerRuntime<PData>
 {
+    /// Final drain window, independent of producer and extension-scope shutdown.
+    pub(crate) const OBSERVABILITY_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
     /// Launches one regular pipeline instance on a specific core and generation.
     pub(super) fn launch_regular_pipeline_instance(
         self: &Arc<Self>,
         resolved_pipeline: &ResolvedPipelineConfig,
+        inherited_extensions: &InheritedExtensionRegistrations,
         placement: &LivePipelinePlacement,
         core_id: usize,
         deployment_generation: u64,
@@ -100,7 +110,7 @@ impl<
             core_id,
             deployment_generation,
         };
-        let launched = Controller::<PData>::launch_pipeline_thread(
+        Controller::<PData>::launch_pipeline_thread(
             self.pipeline_factory,
             deployed_key.clone(),
             CoreId { id: core_id },
@@ -113,6 +123,7 @@ impl<
             resolved_pipeline.policies.transport_headers.clone(),
             resolved_pipeline.policies.rate_limiters.clone(),
             resolved_pipeline.policies.rate_limiter_scope.clone(),
+            inherited_extensions.clone(),
             self.controller_context.clone(),
             self.metrics_reporter.clone(),
             self.engine_event_reporter.clone(),
@@ -121,64 +132,292 @@ impl<
             self.memory_pressure_tx.clone(),
             &live_config,
             &self.declared_topics,
-            Arc::downgrade(self),
+            self,
             thread_id,
             None,
         )?;
-        self.register_launched_instance(launched);
         Ok(deployed_key)
     }
 
-    /// Registers a launched instance and reconciles the race where the thread exited first.
+    /// Reserves one deployed key before its pipeline OS thread is spawned.
+    pub(crate) fn reserve_instance_launch(
+        &self,
+        pipeline_key: &DeployedPipelineKey,
+    ) -> Result<(), Error> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.launches_closed || state.global_shutdown_requested {
+            let message = state.first_error.as_ref().map_or_else(
+                || {
+                    format!(
+                        "pipeline launch admission is closed for {}",
+                        deployed_instance_label(pipeline_key)
+                    )
+                },
+                |error| {
+                    format!(
+                        "pipeline launch admission is closed for {} after fatal runtime failure: {error}",
+                        deployed_instance_label(pipeline_key)
+                    )
+                },
+            );
+            return Err(Error::PipelineRuntimeError {
+                source: Box::new(io::Error::other(message)),
+            });
+        }
+        let already_live = state.launching_instances.contains(pipeline_key)
+            || state
+                .runtime_instances
+                .get(pipeline_key)
+                .is_some_and(|instance| {
+                    matches!(instance.lifecycle, RuntimeInstanceLifecycle::Active)
+                });
+        if already_live {
+            return Err(Error::PipelineRuntimeError {
+                source: Box::new(io::Error::other(format!(
+                    "pipeline instance is already launching or active: {}",
+                    deployed_instance_label(pipeline_key)
+                ))),
+            });
+        }
+        let _ = state.launching_instances.insert(pipeline_key.clone());
+        state.active_instances += 1;
+        self.state_changed.notify_all();
+        Ok(())
+    }
+
+    /// Rolls back a launch reservation when OS-thread creation fails.
+    pub(crate) fn abort_instance_launch(&self, pipeline_key: &DeployedPipelineKey) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.launching_instances.remove(pipeline_key) {
+            state.active_instances = state.active_instances.saturating_sub(1);
+            self.state_changed.notify_all();
+        }
+    }
+
+    /// Publishes the control sender for a successfully spawned pipeline thread.
     ///
-    /// The launch path inserts the instance as Active here, while the runtime thread reports its
-    /// terminal exit independently through note_instance_exit(). If that exit arrived first, it
-    /// was parked in pending_instance_exits and is applied immediately during registration.
+    /// Returns a deadline when shutdown raced with the spawn and must be sent
+    /// to the newly active instance.
+    pub(crate) fn activate_instance_launch(
+        &self,
+        pipeline_key: DeployedPipelineKey,
+        control_sender: Arc<dyn PipelineAdminSender>,
+    ) -> Option<Instant> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !state.launching_instances.remove(&pipeline_key) {
+            return None;
+        }
+        let is_observability = is_observability_instance(&pipeline_key);
+        let _ = state.runtime_instances.insert(
+            pipeline_key,
+            RuntimeInstanceRecord {
+                control_sender: Some(control_sender),
+                lifecycle: RuntimeInstanceLifecycle::Active,
+            },
+        );
+        let shutdown_deadline = if state.launches_closed || state.global_shutdown_requested {
+            if is_observability {
+                if state.extension_scope_hosts_stopped
+                    && !Self::has_live_producer_instances_locked(&state)
+                {
+                    Some(
+                        *state
+                            .observability_shutdown_deadline
+                            .get_or_insert_with(|| {
+                                Instant::now() + Self::OBSERVABILITY_SHUTDOWN_TIMEOUT
+                            }),
+                    )
+                } else {
+                    None
+                }
+            } else {
+                Some(state.global_shutdown_deadline.unwrap_or_else(Instant::now))
+            }
+        } else {
+            None
+        };
+        self.state_changed.notify_all();
+        shutdown_deadline
+    }
+
+    /// Publishes a spawned instance and immediately stops it when shutdown won the race.
+    pub(crate) fn complete_instance_launch(
+        &self,
+        pipeline_key: DeployedPipelineKey,
+        control_sender: Arc<dyn PipelineAdminSender>,
+    ) {
+        if let Some(deadline) =
+            self.activate_instance_launch(pipeline_key.clone(), control_sender.clone())
+        {
+            if let Err(error) =
+                control_sender.try_send_shutdown(deadline, "global shutdown".to_owned())
+            {
+                match self.instance_exit(&pipeline_key) {
+                    Some(_) => self.release_instance_control_sender(&pipeline_key),
+                    None => {
+                        self.record_fatal_runtime_error(format!(
+                            "failed to stop pipeline launched during global shutdown ({}): {error}",
+                            deployed_instance_label(&pipeline_key)
+                        ));
+                    }
+                }
+            } else {
+                self.release_instance_control_sender(&pipeline_key);
+            }
+        }
+    }
+
+    /// Registers a synthetic launched instance used by controller state tests.
+    #[cfg(test)]
     pub(crate) fn register_launched_instance(
         self: &Arc<Self>,
         launched: LaunchedPipelineThread<PData>,
     ) {
-        let (should_compact, pending_exit) = {
+        let pending_exit = {
             let mut state = self
                 .state
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            _ = state.runtime_instances.insert(
-                launched.pipeline_key.clone(),
-                RuntimeInstanceRecord {
-                    control_sender: Some(launched.control_sender.clone()),
-                    lifecycle: RuntimeInstanceLifecycle::Active,
-                },
-            );
-            state.active_instances += 1;
-            let pending_exit = state.pending_instance_exits.remove(&launched.pipeline_key);
-            let should_compact = if let Some(exit) = pending_exit.as_ref() {
-                Self::apply_instance_exit_locked(&mut state, &launched.pipeline_key, exit)
-            } else {
-                false
-            };
-            self.state_changed.notify_all();
-            (should_compact, pending_exit)
+            state.pending_instance_exits.remove(&launched.pipeline_key)
         };
-
-        if should_compact {
-            let logical_pipeline_key = PipelineKey::new(
-                launched.pipeline_key.pipeline_group_id.clone(),
-                launched.pipeline_key.pipeline_id.clone(),
-            );
-            self.observed_state_store
-                .compact_pipeline_instances(&logical_pipeline_key);
+        if let Some(exit) = pending_exit {
+            let should_compact = {
+                let mut state = self
+                    .state
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                let _ = state.runtime_instances.insert(
+                    launched.pipeline_key.clone(),
+                    RuntimeInstanceRecord {
+                        control_sender: None,
+                        lifecycle: RuntimeInstanceLifecycle::Exited(exit.clone()),
+                    },
+                );
+                let logical_pipeline_key = PipelineKey::new(
+                    launched.pipeline_key.pipeline_group_id.clone(),
+                    launched.pipeline_key.pipeline_id.clone(),
+                );
+                Self::prune_exited_runtime_instances_for_pipeline_locked(
+                    &mut state,
+                    &logical_pipeline_key,
+                )
+            };
+            if should_compact {
+                let logical_pipeline_key = PipelineKey::new(
+                    launched.pipeline_key.pipeline_group_id.clone(),
+                    launched.pipeline_key.pipeline_id.clone(),
+                );
+                self.observed_state_store
+                    .compact_pipeline_instances(&logical_pipeline_key);
+            }
+            self.state_changed.notify_all();
+            if let RuntimeInstanceExit::Error(error) = exit {
+                self.schedule_runtime_recovery(launched.pipeline_key, error);
+            }
+            return;
         }
-        if let Some(RuntimeInstanceExit::Error(error)) = pending_exit {
-            self.schedule_runtime_recovery(launched.pipeline_key, error);
+
+        self.reserve_instance_launch(&launched.pipeline_key)
+            .expect("synthetic runtime instance should reserve");
+        let _ = self.activate_instance_launch(launched.pipeline_key, launched.control_sender);
+    }
+
+    /// Closes pipeline launch admission for the remainder of this controller run.
+    #[cfg(test)]
+    pub(crate) fn close_pipeline_launches(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.launches_closed = true;
+        self.state_changed.notify_all();
+    }
+
+    /// Opens the final shutdown phase for the system observability pipeline.
+    pub(crate) fn mark_extension_scope_hosts_stopped(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.extension_scope_hosts_stopped = true;
+        self.state_changed.notify_all();
+    }
+
+    /// Completes teardown on the scope-host thread after its LocalSet is gone.
+    ///
+    /// The controller's join remains bounded. If it times out, this thread
+    /// retains telemetry support while waiting for actual descendant and
+    /// observability exits, not merely the fatal-shutdown release latch.
+    pub(crate) fn finish_shutdown_after_extension_scopes(
+        self: &Arc<Self>,
+        shutdown_requested: &CancellationToken,
+    ) {
+        let deadline = self.global_shutdown_deadline_or_insert(Duration::from_secs(30));
+        if let Err(error) = self.request_shutdown_all_until(deadline) {
+            self.record_async_global_shutdown_failure(format!(
+                "failed to drain pipelines after extension scope shutdown: {error:?}"
+            ));
+        }
+
+        {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            while Self::has_live_producer_instances_locked(&state)
+                || state
+                    .runtime_recoveries
+                    .values()
+                    .any(|recovery| recovery.worker_id.is_some())
+            {
+                state = self
+                    .state_changed
+                    .wait(state)
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+            }
+        }
+
+        // An early return or panic can reach cleanup before controller-owned
+        // metric producers stop. The guard cancels only after those producers
+        // are gone; keep observability open until that handoff occurs.
+        while !shutdown_requested.is_cancelled() {
+            thread::sleep(Duration::from_millis(10));
+        }
+        self.mark_extension_scope_hosts_stopped();
+        // A producer-only coordinator may have owned dispatch when the hosts
+        // stopped. Wait for it before opening observability with its own budget.
+        _ = self.wait_for_global_shutdown_completion();
+        if let Err(error) = self.request_shutdown_all_until(deadline) {
+            self.record_async_global_shutdown_failure(format!(
+                "failed to stop system observability after extension scopes: {error:?}"
+            ));
+        }
+
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        while state.active_instances > 0 || state.global_shutdown_coordinators > 0 {
+            state = self
+                .state_changed
+                .wait(state)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
         }
     }
 
     /// Records a pipeline instance exit and closes the registration-before/after-exit race.
     ///
-    /// If the instance is already visible in runtime_instances, the exit is applied immediately.
-    /// Otherwise we store it in pending_instance_exits so register_launched_instance() can
-    /// reconcile it as soon as registration becomes visible.
+    /// A reserved or active instance is completed immediately. Synthetic test
+    /// exits without a reservation remain pending until test registration.
     pub(crate) fn note_instance_exit(
         self: &Arc<Self>,
         pipeline_key: DeployedPipelineKey,
@@ -204,10 +443,37 @@ impl<
                 .state
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            if state.runtime_instances.contains_key(&pipeline_key) {
+            if state.launching_instances.remove(&pipeline_key) {
+                let _ = state.runtime_instances.insert(
+                    pipeline_key.clone(),
+                    RuntimeInstanceRecord {
+                        control_sender: None,
+                        lifecycle: RuntimeInstanceLifecycle::Exited(exit.clone()),
+                    },
+                );
+                state.active_instances = state.active_instances.saturating_sub(1);
+                let logical_pipeline_key = PipelineKey::new(
+                    pipeline_key.pipeline_group_id.clone(),
+                    pipeline_key.pipeline_id.clone(),
+                );
+                (
+                    Self::prune_exited_runtime_instances_for_pipeline_locked(
+                        &mut state,
+                        &logical_pipeline_key,
+                    ),
+                    true,
+                )
+            } else if state.runtime_instances.contains_key(&pipeline_key) {
+                let exit_was_applied =
+                    state
+                        .runtime_instances
+                        .get(&pipeline_key)
+                        .is_some_and(|instance| {
+                            matches!(instance.lifecycle, RuntimeInstanceLifecycle::Active)
+                        });
                 (
                     Self::apply_instance_exit_locked(&mut state, &pipeline_key, &exit),
-                    true,
+                    exit_was_applied,
                 )
             } else {
                 _ = state
@@ -606,6 +872,7 @@ impl<
 
             let target_key = match self.launch_regular_pipeline_instance(
                 &attempt.resolved,
+                &attempt.inherited_extensions,
                 &attempt.placement,
                 core_id,
                 attempt.target_key.deployment_generation,
@@ -784,10 +1051,11 @@ impl<
             return RuntimeRecoveryAttemptDecision::Exhausted;
         }
 
-        let Some((resolved, placement, placement_generation)) =
+        let Some((resolved, inherited_extensions, placement, placement_generation)) =
             state.logical_pipelines.get(pipeline_key).map(|record| {
                 (
                     record.resolved.clone(),
+                    record.inherited_extensions.clone(),
                     record.placement.clone(),
                     record.placement_generation,
                 )
@@ -825,6 +1093,7 @@ impl<
                 deployment_generation: target_generation,
             },
             resolved,
+            inherited_extensions,
             placement,
             backoff: runtime_recovery_backoff(policy, attempt),
         }))
@@ -1003,10 +1272,11 @@ impl<
         }
     }
 
-    /// Cancels and joins every active runtime recovery worker.
+    /// Requests cancellation for every active runtime recovery worker.
     ///
-    /// Global shutdown uses this barrier before collecting instances so no new
-    /// recovery candidate can appear after the shutdown snapshot.
+    /// Global shutdown closes launch admission before calling this method, so
+    /// workers can be allowed to release their fencing tokens asynchronously
+    /// without creating a candidate after the shutdown snapshot.
     fn cancel_all_runtime_recoveries(&self) {
         let mut state = self
             .state
@@ -1018,16 +1288,6 @@ impl<
             }
         }
         self.state_changed.notify_all();
-        while state
-            .runtime_recoveries
-            .values()
-            .any(|recovery| recovery.worker_id.is_some())
-        {
-            state = self
-                .state_changed
-                .wait(state)
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-        }
     }
 
     /// Clears one worker's candidate generation while preserving its streak.
@@ -1245,7 +1505,7 @@ impl<
     }
 
     /// Returns the terminal exit result for one deployed instance, if any.
-    pub(super) fn instance_exit(
+    pub(crate) fn instance_exit(
         &self,
         deployed_key: &DeployedPipelineKey,
     ) -> Option<RuntimeInstanceExit> {
@@ -1374,6 +1634,20 @@ impl<
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         loop {
+            if state.launching_instances.contains(deployed_key) {
+                let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                    return Err(format!(
+                        "timed out waiting for pipeline {} to finish launching and drain before system observability shutdown",
+                        deployed_instance_label(deployed_key)
+                    ));
+                };
+                let (next_state, _) = self
+                    .state_changed
+                    .wait_timeout(state, remaining)
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                state = next_state;
+                continue;
+            }
             match state.runtime_instances.get(deployed_key) {
                 None
                 | Some(RuntimeInstanceRecord {
@@ -1424,7 +1698,7 @@ impl<
     /// an active instance. Releasing it makes shutdown dispatch idempotent for
     /// that instance and lets the pipeline control loop observe channel closure
     /// once node tasks have exited.
-    pub(super) fn release_instance_control_sender(&self, deployed_key: &DeployedPipelineKey) {
+    pub(crate) fn release_instance_control_sender(&self, deployed_key: &DeployedPipelineKey) {
         let mut state = self
             .state
             .lock()
@@ -1441,15 +1715,58 @@ impl<
     /// dispatch boundary: instances that already accepted shutdown have released
     /// their retained control sender and are skipped by later calls. When the
     /// system observability pipeline is active, producer pipelines are signaled
-    /// and awaited first so their final telemetry reaches the internal receiver
-    /// before that receiver is shut down.
+    /// and awaited first. Observability remains active until the controller marks
+    /// extension scope hosts stopped, then a later call starts its final phase.
+    /// Repeated requests retain the first producer deadline. Observability gets
+    /// its own fixed window when its dependencies have stopped.
     pub(super) fn request_shutdown_all(
         self: &Arc<Self>,
         timeout_secs: u64,
     ) -> Result<(), ControlPlaneError> {
+        self.request_shutdown_all_until(Instant::now() + Duration::from_secs(timeout_secs.max(1)))
+    }
+
+    /// Returns the established producer deadline, creating it only once.
+    pub(crate) fn global_shutdown_deadline_or_insert(&self, timeout: Duration) -> Instant {
+        let candidate = Instant::now() + timeout;
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *state.global_shutdown_deadline.get_or_insert(candidate)
+    }
+
+    /// Returns the fixed deadline for the final observability phase.
+    ///
+    /// Call only after producer pipelines and extension scope hosts stop.
+    pub(crate) fn observability_shutdown_deadline_or_insert(&self) -> Instant {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *state
+            .observability_shutdown_deadline
+            .get_or_insert_with(|| Instant::now() + Self::OBSERVABILITY_SHUTDOWN_TIMEOUT)
+    }
+
+    /// Requests global shutdown with an absolute deadline for producer draining.
+    pub(crate) fn request_shutdown_all_until(
+        self: &Arc<Self>,
+        requested_deadline: Instant,
+    ) -> Result<(), ControlPlaneError> {
+        let deadline = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let deadline = state.global_shutdown_deadline.unwrap_or(requested_deadline);
+            state.launches_closed = true;
+            state.global_shutdown_requested = true;
+            state.global_shutdown_deadline = Some(deadline);
+            self.state_changed.notify_all();
+            deadline
+        };
         self.cancel_all_runtime_recoveries();
-        let shutdown_timeout = Duration::from_secs(timeout_secs.max(1));
-        let deadline = Instant::now() + shutdown_timeout;
 
         // Snapshot under the state lock, then send outside the lock so runtime
         // callbacks can report exits while shutdown dispatch is in progress.
@@ -1467,6 +1784,7 @@ impl<
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             let coordinator_active = state.global_shutdown_coordinators > 0;
+            let extension_scope_hosts_stopped = state.extension_scope_hosts_stopped;
             let mut producer_keys = Vec::new();
             let mut producer_senders = Vec::new();
             let mut observability_senders = Vec::new();
@@ -1476,11 +1794,12 @@ impl<
                     continue;
                 }
 
-                let is_observability = deployed_key.pipeline_group_id.as_ref()
-                    == SYSTEM_PIPELINE_GROUP_ID
-                    && deployed_key.pipeline_id.as_ref() == SYSTEM_OBSERVABILITY_PIPELINE_ID;
+                let is_observability = is_observability_instance(deployed_key);
                 if is_observability {
-                    if !coordinator_active && let Some(sender) = instance.control_sender.take() {
+                    if extension_scope_hosts_stopped
+                        && !coordinator_active
+                        && let Some(sender) = instance.control_sender.take()
+                    {
                         // Taking the sender is the idempotence marker for the
                         // asynchronous observability-shutdown coordinator.
                         observability_senders.push((deployed_key.clone(), sender));
@@ -1492,10 +1811,16 @@ impl<
                     }
                 }
             }
+            producer_keys.extend(
+                state
+                    .launching_instances
+                    .iter()
+                    .filter(|deployed_key| !is_observability_instance(deployed_key))
+                    .cloned(),
+            );
 
             let coordinator_reserved = !coordinator_active
                 && (!producer_keys.is_empty() || !observability_senders.is_empty());
-            state.global_shutdown_requested = true;
             if coordinator_reserved {
                 state.global_shutdown_coordinators += 1;
             }
@@ -1565,7 +1890,6 @@ impl<
                             producer_keys,
                             observability_senders,
                             deadline,
-                            shutdown_timeout,
                         );
                     }));
                     runtime.finish_global_shutdown_coordinator();
@@ -1613,12 +1937,11 @@ impl<
         &self,
         producer_keys: Vec<DeployedPipelineKey>,
         observability_senders: Vec<(DeployedPipelineKey, Arc<dyn PipelineAdminSender>)>,
-        producer_deadline: Instant,
-        shutdown_timeout: Duration,
+        shutdown_deadline: Instant,
     ) {
         let mut wait_failures = Vec::new();
         for deployed_key in &producer_keys {
-            if let Err(error) = self.wait_for_global_shutdown_exit(deployed_key, producer_deadline)
+            if let Err(error) = self.wait_for_global_shutdown_exit(deployed_key, shutdown_deadline)
             {
                 wait_failures.push(error);
             }
@@ -1638,13 +1961,14 @@ impl<
             producer_keys
                 .iter()
                 .filter(|deployed_key| {
-                    matches!(
-                        state.runtime_instances.get(*deployed_key),
-                        Some(RuntimeInstanceRecord {
-                            lifecycle: RuntimeInstanceLifecycle::Active,
-                            ..
-                        })
-                    )
+                    state.launching_instances.contains(*deployed_key)
+                        || matches!(
+                            state.runtime_instances.get(*deployed_key),
+                            Some(RuntimeInstanceRecord {
+                                lifecycle: RuntimeInstanceLifecycle::Active,
+                                ..
+                            })
+                        )
                 })
                 .map(deployed_instance_label)
                 .collect::<Vec<_>>()
@@ -1658,20 +1982,19 @@ impl<
             return;
         }
 
-        // Observability is a distinct shutdown phase. Give it the same budget
-        // selected by the caller instead of collapsing that phase to one second
-        // after producers have consumed their own drain budget.
-        let observability_deadline = Instant::now() + shutdown_timeout;
+        if observability_senders.is_empty() {
+            return;
+        }
+        let shutdown_deadline = self.observability_shutdown_deadline_or_insert();
         let mut observability_keys = Vec::new();
         for (deployed_key, sender) in observability_senders {
             let final_error = loop {
-                match sender.try_send_shutdown(observability_deadline, "global shutdown".to_owned())
-                {
+                match sender.try_send_shutdown(shutdown_deadline, "global shutdown".to_owned()) {
                     Ok(()) => break None,
                     Err(error) => match self.instance_exit(&deployed_key) {
                         Some(RuntimeInstanceExit::Success) => break None,
                         Some(RuntimeInstanceExit::Error(exit)) => break Some(exit.message),
-                        None if Instant::now() < observability_deadline => {
+                        None if Instant::now() < shutdown_deadline => {
                             thread::sleep(Duration::from_millis(10));
                         }
                         None => break Some(error.to_string()),
@@ -1707,8 +2030,7 @@ impl<
         }
 
         for deployed_key in observability_keys {
-            if let Err(error) =
-                self.wait_for_global_shutdown_exit(&deployed_key, observability_deadline)
+            if let Err(error) = self.wait_for_global_shutdown_exit(&deployed_key, shutdown_deadline)
             {
                 self.record_async_global_shutdown_failure(format!(
                     "system observability shutdown did not complete: {error}"
@@ -1745,13 +2067,59 @@ impl<
         state.global_shutdown_requested
     }
 
+    /// Waits up to `timeout` for every phased global-shutdown coordinator.
+    pub(crate) fn wait_for_global_shutdown_completion_for(&self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        while state.global_shutdown_coordinators > 0 {
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                return false;
+            };
+            let (next_state, wait_result) = self
+                .state_changed
+                .wait_timeout(state, remaining)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state = next_state;
+            if wait_result.timed_out() && state.global_shutdown_coordinators > 0 {
+                return false;
+            }
+        }
+        true
+    }
+
     /// Returns whether every registered runtime instance has exited.
+    #[cfg(test)]
     pub(crate) fn all_instances_exited(&self) -> bool {
         self.state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .active_instances
             == 0
+    }
+
+    /// Records a fatal controller-owned runtime error for final teardown.
+    pub(crate) fn record_fatal_runtime_error(&self, message: String) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.first_error.is_none() {
+            state.first_error = Some(message);
+        }
+        state.instance_wait_released = true;
+        self.state_changed.notify_all();
+    }
+
+    /// Returns whether teardown has a fatal runtime error to surface.
+    pub(crate) fn has_fatal_runtime_error(&self) -> bool {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .first_error
+            .is_some()
     }
 
     /// Restores system observability senders if the coordinator could not start.
@@ -1786,6 +2154,8 @@ impl<
         if state.first_error.is_none() {
             state.first_error = Some(message);
         }
+        state.instance_wait_released = true;
+        self.state_changed.notify_all();
     }
 
     /// Starts a tracked shutdown operation for one logical pipeline.
@@ -1870,6 +2240,7 @@ impl<
 
     /// Blocks until all active runtime instances have exited, or until the wait
     /// is released via [`release_instance_wait`](Self::release_instance_wait).
+    #[cfg(test)]
     pub(crate) fn wait_until_all_instances_exit(&self) {
         let mut state = self
             .state
@@ -1897,7 +2268,8 @@ impl<
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         while !state.instance_wait_released
-            && (!state.global_shutdown_requested || state.active_instances > 0)
+            && (!state.global_shutdown_requested
+                || Self::has_live_producer_instances_locked(&state))
         {
             state = self
                 .state_changed
@@ -1906,8 +2278,7 @@ impl<
         }
     }
 
-    /// Releases [`wait_until_all_instances_exit`](Self::wait_until_all_instances_exit)
-    /// unconditionally, even if runtime instances are still active.
+    /// Releases controller lifecycle waits even if runtime instances are still active.
     ///
     /// This is a fatal-shutdown escape hatch: when a controller extension fails
     /// or runtime recovery is exhausted, the engine tears down regardless of
@@ -1933,16 +2304,87 @@ impl<
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        while state.runtime_instances.iter().any(|(key, instance)| {
-            matches!(instance.lifecycle, RuntimeInstanceLifecycle::Active)
-                && !(key.pipeline_group_id.as_ref() == SYSTEM_PIPELINE_GROUP_ID
-                    && key.pipeline_id.as_ref() == SYSTEM_OBSERVABILITY_PIPELINE_ID)
-        }) {
+        while !state.instance_wait_released && Self::has_live_producer_instances_locked(&state) {
             state = self
                 .state_changed
                 .wait(state)
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
         }
+    }
+
+    /// Returns whether every non-observability runtime instance has exited.
+    pub(crate) fn all_producer_instances_exited(&self) -> bool {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        !Self::has_live_producer_instances_locked(&state)
+    }
+
+    /// Waits for non-observability runtime instances without honoring the fatal-release latch.
+    pub(crate) fn wait_until_all_producer_instances_exit_for(&self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        while Self::has_live_producer_instances_locked(&state) {
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                return false;
+            };
+            let (next_state, wait_result) = self
+                .state_changed
+                .wait_timeout(state, remaining)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state = next_state;
+            if wait_result.timed_out() && Self::has_live_producer_instances_locked(&state) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Waits for every recovery worker to release its launch fencing token.
+    pub(crate) fn wait_for_runtime_recoveries_for(&self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        while state
+            .runtime_recoveries
+            .values()
+            .any(|recovery| recovery.worker_id.is_some())
+        {
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                return false;
+            };
+            let (next_state, wait_result) = self
+                .state_changed
+                .wait_timeout(state, remaining)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state = next_state;
+            if wait_result.timed_out()
+                && state
+                    .runtime_recoveries
+                    .values()
+                    .any(|recovery| recovery.worker_id.is_some())
+            {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn has_live_producer_instances_locked(state: &ControllerRuntimeState) -> bool {
+        state
+            .launching_instances
+            .iter()
+            .any(|key| !is_observability_instance(key))
+            || state.runtime_instances.iter().any(|(key, instance)| {
+                matches!(instance.lifecycle, RuntimeInstanceLifecycle::Active)
+                    && !is_observability_instance(key)
+            })
     }
 
     /// Blocks until every runtime instance exits or the timeout elapses.

--- a/rust/otap-dataflow/crates/controller/src/live_control/state.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control/state.rs
@@ -479,6 +479,8 @@ pub(super) struct RuntimeRecoveryState {
 /// Committed logical pipeline config plus the active deployment generation.
 pub(super) struct LogicalPipelineRecord {
     pub(super) resolved: ResolvedPipelineConfig,
+    /// Inherited provider snapshot captured when this logical config was committed.
+    pub(super) inherited_extensions: InheritedExtensionRegistrations,
     /// Pipeline-wide config generation; recovered cores may serve newer generations.
     pub(super) active_generation: u64,
     pub(super) placement: PipelinePlacement,
@@ -526,6 +528,8 @@ pub(super) struct ControllerRuntimeState {
     pub(super) logical_pipelines: HashMap<PipelineKey, LogicalPipelineRecord>,
     /// Deployed runtime instances keyed by group/pipeline/core/generation.
     pub(super) runtime_instances: HashMap<DeployedPipelineKey, RuntimeInstanceRecord>,
+    /// Pipeline threads reserved before OS-thread spawn and not yet activated.
+    pub(super) launching_instances: HashSet<DeployedPipelineKey>,
     /// Per-core restart streak and active recovery-worker state.
     pub(super) runtime_recoveries: HashMap<(PipelineKey, usize), RuntimeRecoveryState>,
     /// Runtime failures held while an explicit operation owns their lifecycle.
@@ -533,9 +537,8 @@ pub(super) struct ControllerRuntimeState {
     /// Planning-stage lifecycle reservations keyed by logical pipeline.
     pub(super) pipeline_operation_reservations:
         HashMap<PipelineKey, PipelineOperationReservationState>,
-    // A pipeline thread can finish before register_launched_instance() publishes it as Active.
-    // We park that exit here and reconcile it during registration instead of leaving stale
-    // liveness behind.
+    // Synthetic tests can report an exit before creating a launch reservation.
+    // Park those exits until test registration instead of leaving stale liveness behind.
     pub(super) pending_instance_exits: HashMap<DeployedPipelineKey, RuntimeInstanceExit>,
     /// Rollout snapshots retained for active and recent terminal lookups.
     pub(super) rollouts: HashMap<String, RolloutRecord>,
@@ -551,10 +554,21 @@ pub(super) struct ControllerRuntimeState {
     pub(super) terminal_shutdowns: HashMap<PipelineKey, VecDeque<String>>,
     /// Next deployment generation to assign for each logical pipeline.
     pub(super) generation_counters: HashMap<PipelineKey, u64>,
-    /// Count of runtime instances still considered active by the controller.
+    /// Count of pipeline threads still launching or active.
     pub(super) active_instances: usize,
+    /// Monotonic latch preventing any new pipeline thread from being spawned.
+    pub(super) launches_closed: bool,
     /// Whether at least one engine-wide shutdown request has been accepted.
     pub(super) global_shutdown_requested: bool,
+    /// First accepted producer shutdown deadline, also inherited by producer
+    /// threads that finish spawning after shutdown begins.
+    pub(super) global_shutdown_deadline: Option<Instant>,
+    /// Fixed deadline for the final observability phase, established only after
+    /// producer pipelines and extension scope hosts have stopped.
+    pub(super) observability_shutdown_deadline: Option<Instant>,
+    /// Whether engine and pipeline-group extension scope hosts have stopped, allowing the
+    /// system observability pipeline to enter its final shutdown phase.
+    pub(super) extension_scope_hosts_stopped: bool,
     /// Number of phased global-shutdown coordinators still running.
     pub(super) global_shutdown_coordinators: usize,
     /// Active engine-scoped live operation, if any.
@@ -621,6 +635,8 @@ pub(super) struct CandidateRolloutPlan {
     pub(super) action: RolloutAction,
     /// Resolved target pipeline config after applying the request.
     pub(super) resolved_pipeline: ResolvedPipelineConfig,
+    /// Inherited provider snapshot captured while this rollout was planned.
+    pub(super) target_inherited_extensions: InheritedExtensionRegistrations,
     /// Runtime config revision used to build this plan.
     pub(super) base_config_revision: u64,
     /// Current committed record, absent for create rollouts.

--- a/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
+++ b/rust/otap-dataflow/crates/controller/src/live_control_tests.rs
@@ -4,29 +4,47 @@
 use super::*;
 use async_trait::async_trait;
 use otel_arrow_dfe_config::engine::ResolvedPipelineRole;
+use otel_arrow_dfe_config::extension::ExtensionUserConfig;
 use otel_arrow_dfe_config::observed_state::ObservedStateSettings;
 use otel_arrow_dfe_config::settings::telemetry::logs::LogLevel;
-use otel_arrow_dfe_engine::config::{ExporterConfig, ProcessorConfig, ReceiverConfig};
+use otel_arrow_dfe_engine::capability::ExtensionCapabilities;
+use otel_arrow_dfe_engine::capability::registry::Capabilities;
+use otel_arrow_dfe_engine::config::{
+    ExporterConfig, ExtensionConfig, ProcessorConfig, ReceiverConfig,
+};
+use otel_arrow_dfe_engine::context::ExtensionContext;
 use otel_arrow_dfe_engine::control::{
-    NodeControlMsg, RuntimeControlMsg, RuntimeCtrlMsgReceiver, runtime_ctrl_msg_channel,
+    ExtensionControlMsg, NodeControlMsg, RuntimeControlMsg, RuntimeCtrlMsgReceiver,
+    runtime_ctrl_msg_channel,
 };
 use otel_arrow_dfe_engine::error::Error as EngineError;
 use otel_arrow_dfe_engine::exporter::ExporterWrapper;
+use otel_arrow_dfe_engine::extension::wrapper::ExtensionVariant;
+use otel_arrow_dfe_engine::extension::{EffectHandler, ExtensionBundle, ExtensionWrapper};
 use otel_arrow_dfe_engine::listener_group::ListenerProtocol;
 use otel_arrow_dfe_engine::local::{exporter, receiver};
 use otel_arrow_dfe_engine::message::{ExporterInbox, Message};
 use otel_arrow_dfe_engine::processor::ProcessorWrapper;
 use otel_arrow_dfe_engine::receiver::ReceiverWrapper;
 use otel_arrow_dfe_engine::terminal_state::TerminalState;
+use otel_arrow_dfe_engine::testing::capability::no_op_stateless::{
+    LocalNoOpStateless, NoOpStateless, SharedNoOpStateless,
+};
 use otel_arrow_dfe_engine::topology::NumaTopology;
 use otel_arrow_dfe_engine::wiring_contract::WiringContract;
-use otel_arrow_dfe_engine::{ExporterFactory, ProcessorFactory, ReceiverFactory};
+use otel_arrow_dfe_engine::{
+    ExporterFactory, ExtensionFactory, ProcessorFactory, ReceiverFactory, extension_capabilities,
+};
 use otel_arrow_dfe_state::pipeline_status::PipelineStatus;
-use otel_arrow_dfe_telemetry::TracingSetup;
+use otel_arrow_dfe_telemetry::attributes::AttributeSetHandler;
 use otel_arrow_dfe_telemetry::event::EngineEvent;
 use otel_arrow_dfe_telemetry::log_filter::{RuntimeLogFilter, RuntimeLogFilterHandle};
-use otel_arrow_dfe_telemetry::metrics::MetricSetSnapshot;
+use otel_arrow_dfe_telemetry::metrics::{
+    MetricExportBatch, MetricSet, MetricSetSnapshot, MetricValue,
+};
 use otel_arrow_dfe_telemetry::tracing_init::ProviderSetup;
+use otel_arrow_dfe_telemetry::{InternalTelemetrySystem, TracingSetup};
+use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio_util::sync::CancellationToken;
 use tracing::{Event, Subscriber};
@@ -65,7 +83,7 @@ fn test_receiver_create(
     _node: otel_arrow_dfe_engine::node::NodeId,
     _node_config: Arc<NodeUserConfig>,
     _receiver_config: &ReceiverConfig,
-    _capabilities: &otel_arrow_dfe_engine::capability::registry::Capabilities,
+    _capabilities: &Capabilities,
 ) -> Result<ReceiverWrapper<()>, otel_arrow_dfe_config::error::Error> {
     panic!("test receiver factory should not be constructed")
 }
@@ -75,7 +93,7 @@ fn test_exporter_create(
     _node: otel_arrow_dfe_engine::node::NodeId,
     _node_config: Arc<NodeUserConfig>,
     _exporter_config: &ExporterConfig,
-    _capabilities: &otel_arrow_dfe_engine::capability::registry::Capabilities,
+    _capabilities: &Capabilities,
 ) -> Result<ExporterWrapper<()>, otel_arrow_dfe_config::error::Error> {
     panic!("test exporter factory should not be constructed")
 }
@@ -85,7 +103,7 @@ fn test_processor_create(
     _node: otel_arrow_dfe_engine::node::NodeId,
     _node_config: Arc<NodeUserConfig>,
     _processor_config: &ProcessorConfig,
-    _capabilities: &otel_arrow_dfe_engine::capability::registry::Capabilities,
+    _capabilities: &Capabilities,
 ) -> Result<ProcessorWrapper<()>, otel_arrow_dfe_config::error::Error> {
     panic!("test processor factory should not be constructed")
 }
@@ -138,7 +156,7 @@ fn recovery_test_receiver_create(
     node: otel_arrow_dfe_engine::node::NodeId,
     node_config: Arc<NodeUserConfig>,
     receiver_config: &ReceiverConfig,
-    _capabilities: &otel_arrow_dfe_engine::capability::registry::Capabilities,
+    _capabilities: &Capabilities,
 ) -> Result<ReceiverWrapper<()>, otel_arrow_dfe_config::error::Error> {
     Ok(ReceiverWrapper::local(
         RecoveryTestReceiver,
@@ -153,7 +171,7 @@ fn recovery_test_exporter_create(
     node: otel_arrow_dfe_engine::node::NodeId,
     node_config: Arc<NodeUserConfig>,
     exporter_config: &ExporterConfig,
-    _capabilities: &otel_arrow_dfe_engine::capability::registry::Capabilities,
+    _capabilities: &Capabilities,
 ) -> Result<ExporterWrapper<()>, otel_arrow_dfe_config::error::Error> {
     Ok(ExporterWrapper::local(
         RecoveryTestExporter,
@@ -163,6 +181,487 @@ fn recovery_test_exporter_create(
     ))
 }
 
+#[derive(Default)]
+struct VariantReloadLifecycleCounts {
+    created: AtomicUsize,
+    started: AtomicUsize,
+    stopped: AtomicUsize,
+    dropped: AtomicUsize,
+}
+
+#[derive(Clone, Default)]
+struct VariantReloadProbe {
+    local: Arc<VariantReloadLifecycleCounts>,
+    shared: Arc<VariantReloadLifecycleCounts>,
+}
+
+// Factory callbacks are static function pointers and pipeline generations run on
+// separate OS threads. This registry only routes per-test counters by unique
+// config key; pipeline data paths never access it.
+static VARIANT_RELOAD_PROBES: std::sync::OnceLock<Mutex<HashMap<String, VariantReloadProbe>>> =
+    std::sync::OnceLock::new();
+
+fn variant_reload_probes() -> &'static Mutex<HashMap<String, VariantReloadProbe>> {
+    VARIANT_RELOAD_PROBES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn register_variant_reload_probe(key: &str) -> VariantReloadProbe {
+    let probe = VariantReloadProbe::default();
+    _ = variant_reload_probes()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(key.to_owned(), probe.clone());
+    probe
+}
+
+fn lookup_variant_reload_probe(key: &str) -> VariantReloadProbe {
+    variant_reload_probes()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(key)
+        .cloned()
+        .unwrap_or_else(|| panic!("variant reload probe `{key}` is not registered"))
+}
+
+struct VariantReloadLocalExtension {
+    counts: Arc<VariantReloadLifecycleCounts>,
+    counts_lifecycle_drop: bool,
+}
+
+impl Clone for VariantReloadLocalExtension {
+    fn clone(&self) -> Self {
+        Self {
+            counts: Arc::clone(&self.counts),
+            counts_lifecycle_drop: false,
+        }
+    }
+}
+
+impl Drop for VariantReloadLocalExtension {
+    fn drop(&mut self) {
+        if self.counts_lifecycle_drop {
+            _ = self.counts.dropped.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl LocalNoOpStateless for VariantReloadLocalExtension {
+    fn name(&self) -> &str {
+        "variant-reload-local"
+    }
+
+    fn echo(&self, value: u64) -> u64 {
+        value
+    }
+
+    async fn ping(&self) -> u64 {
+        0
+    }
+
+    async fn echo_async(&self, value: String) -> String {
+        value
+    }
+}
+
+#[async_trait(?Send)]
+impl otel_arrow_dfe_engine::local::extension::Extension for VariantReloadLocalExtension {
+    async fn start(
+        self: Rc<Self>,
+        mut ctrl: otel_arrow_dfe_engine::local::extension::ControlChannel,
+        _effect_handler: EffectHandler,
+    ) -> Result<TerminalState, EngineError> {
+        _ = self.counts.started.fetch_add(1, Ordering::SeqCst);
+        loop {
+            match ctrl.recv().await {
+                Ok(ExtensionControlMsg::Shutdown { .. }) | Err(_) => {
+                    _ = self.counts.stopped.fetch_add(1, Ordering::SeqCst);
+                    return Ok(TerminalState::default());
+                }
+                Ok(_) => {}
+            }
+        }
+    }
+}
+
+struct VariantReloadSharedExtension {
+    counts: Arc<VariantReloadLifecycleCounts>,
+    counts_lifecycle_drop: bool,
+}
+
+impl Clone for VariantReloadSharedExtension {
+    fn clone(&self) -> Self {
+        Self {
+            counts: Arc::clone(&self.counts),
+            counts_lifecycle_drop: false,
+        }
+    }
+}
+
+impl Drop for VariantReloadSharedExtension {
+    fn drop(&mut self) {
+        if self.counts_lifecycle_drop {
+            _ = self.counts.dropped.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+}
+
+#[async_trait]
+impl SharedNoOpStateless for VariantReloadSharedExtension {
+    fn name(&self) -> &str {
+        "variant-reload-shared"
+    }
+
+    fn echo(&self, value: u64) -> u64 {
+        value
+    }
+
+    async fn ping(&self) -> u64 {
+        0
+    }
+
+    async fn echo_async(&self, value: String) -> String {
+        value
+    }
+}
+
+#[async_trait]
+impl otel_arrow_dfe_engine::shared::extension::Extension for VariantReloadSharedExtension {
+    async fn start(
+        self: Box<Self>,
+        mut ctrl: otel_arrow_dfe_engine::shared::extension::ControlChannel,
+        _effect_handler: EffectHandler,
+    ) -> Result<TerminalState, EngineError> {
+        _ = self.counts.started.fetch_add(1, Ordering::SeqCst);
+        loop {
+            match ctrl.recv().await {
+                Ok(ExtensionControlMsg::Shutdown { .. }) | Err(_) => {
+                    _ = self.counts.stopped.fetch_add(1, Ordering::SeqCst);
+                    return Ok(TerminalState::default());
+                }
+                Ok(_) => {}
+            }
+        }
+    }
+}
+
+const VARIANT_RELOAD_EXTENSION_URN: &str = "urn:test:extension:variant-reload";
+
+fn variant_reload_extension_create(
+    _context: &ExtensionContext,
+    name: ExtensionId,
+    user_config: Arc<ExtensionUserConfig>,
+    runtime_config: &ExtensionConfig,
+) -> Result<ExtensionBundle, otel_arrow_dfe_config::error::Error> {
+    let probe_key = user_config
+        .config
+        .get("probe_key")
+        .and_then(|value| value.as_str())
+        .expect("variant reload extension config should contain probe_key");
+    let probe = lookup_variant_reload_probe(probe_key);
+    _ = probe.local.created.fetch_add(1, Ordering::SeqCst);
+    _ = probe.shared.created.fetch_add(1, Ordering::SeqCst);
+
+    let bundle = ExtensionWrapper::builder(name, user_config, runtime_config)
+        .active()
+        .shared(VariantReloadSharedExtension {
+            counts: probe.shared,
+            counts_lifecycle_drop: true,
+        })
+        .local(Rc::new(VariantReloadLocalExtension {
+            counts: probe.local,
+            counts_lifecycle_drop: true,
+        }))
+        .build()
+        .expect("variant reload extension bundle should build");
+    Ok(bundle)
+}
+
+const VARIANT_RELOAD_EXTENSION_FACTORY: ExtensionFactory = ExtensionFactory {
+    name: VARIANT_RELOAD_EXTENSION_URN,
+    description: "dual active extension for live-reload variant lifecycle tests",
+    documentation_url: "",
+    capabilities: Some(extension_capabilities!(
+        (
+            shared: VariantReloadSharedExtension,
+            local: VariantReloadLocalExtension
+        ) => [NoOpStateless]
+    )),
+    create: variant_reload_extension_create,
+    validate_config: test_validate_config,
+};
+
+const VARIANT_RELOAD_RECEIVER_URN: &str = "urn:test:receiver:variant-reload";
+
+fn variant_reload_receiver_create(
+    _pipeline_ctx: PipelineContext,
+    node: otel_arrow_dfe_engine::node::NodeId,
+    node_config: Arc<NodeUserConfig>,
+    receiver_config: &ReceiverConfig,
+    capabilities: &Capabilities,
+) -> Result<ReceiverWrapper<()>, otel_arrow_dfe_config::error::Error> {
+    match node_config
+        .config
+        .get("variant")
+        .and_then(|value| value.as_str())
+        .expect("variant reload receiver config should contain variant")
+    {
+        "local" => {
+            let capability = capabilities
+                .require_local::<NoOpStateless>()
+                .expect("local variant binding should resolve");
+            assert_eq!(capability.name(), "variant-reload-local");
+        }
+        "shared" => {
+            let capability = capabilities
+                .require_shared::<NoOpStateless>()
+                .expect("shared variant binding should resolve");
+            assert_eq!(capability.name(), "variant-reload-shared");
+        }
+        variant => panic!("unsupported variant reload receiver mode `{variant}`"),
+    }
+
+    Ok(ReceiverWrapper::local(
+        RecoveryTestReceiver,
+        node,
+        node_config,
+        receiver_config,
+    ))
+}
+
+const VARIANT_RELOAD_RECEIVER_FACTORY: ReceiverFactory<()> = ReceiverFactory {
+    name: VARIANT_RELOAD_RECEIVER_URN,
+    create: variant_reload_receiver_create,
+    wiring_contract: WiringContract::UNRESTRICTED,
+    validate_config: test_validate_config,
+};
+
+#[otel_arrow_dfe_telemetry_macros::metric_set(name = "test.extension.outer_scope_live_reconfig")]
+#[derive(Debug, Default, Clone)]
+struct OuterScopeLiveReconfigMetrics {
+    #[metric(name = "reported", unit = "{item}")]
+    reported: otel_arrow_dfe_telemetry::instrument::Counter<u64>,
+}
+
+struct OuterScopeLiveReconfigProbe {
+    created: AtomicUsize,
+    started: AtomicUsize,
+    stopped: AtomicUsize,
+    dropped: AtomicUsize,
+    bindings: AtomicUsize,
+    collections: AtomicUsize,
+    // Delivers deterministic collection barriers from the scope-host task to the test driver.
+    collection_events: tokio::sync::mpsc::UnboundedSender<usize>,
+}
+
+// Scope hosts and pipeline generations run on different threads. This registry shares only
+// per-test lifecycle counters and collection barriers, keyed by immutable test configuration.
+static OUTER_SCOPE_LIVE_RECONFIG_PROBES: std::sync::OnceLock<
+    Mutex<HashMap<String, Arc<OuterScopeLiveReconfigProbe>>>,
+> = std::sync::OnceLock::new();
+
+fn outer_scope_live_reconfig_probes()
+-> &'static Mutex<HashMap<String, Arc<OuterScopeLiveReconfigProbe>>> {
+    OUTER_SCOPE_LIVE_RECONFIG_PROBES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn register_outer_scope_live_reconfig_probe(
+    key: &str,
+) -> (
+    Arc<OuterScopeLiveReconfigProbe>,
+    tokio::sync::mpsc::UnboundedReceiver<usize>,
+) {
+    let (collection_events, collection_events_rx) = tokio::sync::mpsc::unbounded_channel();
+    let probe = Arc::new(OuterScopeLiveReconfigProbe {
+        created: AtomicUsize::new(0),
+        started: AtomicUsize::new(0),
+        stopped: AtomicUsize::new(0),
+        dropped: AtomicUsize::new(0),
+        bindings: AtomicUsize::new(0),
+        collections: AtomicUsize::new(0),
+        collection_events,
+    });
+    _ = outer_scope_live_reconfig_probes()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(key.to_owned(), Arc::clone(&probe));
+    (probe, collection_events_rx)
+}
+
+fn lookup_outer_scope_live_reconfig_probe(key: &str) -> Arc<OuterScopeLiveReconfigProbe> {
+    outer_scope_live_reconfig_probes()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(key)
+        .cloned()
+        .unwrap_or_else(|| panic!("outer-scope live-reconfig probe `{key}` is not registered"))
+}
+
+struct OuterScopeLiveReconfigExtension {
+    metrics: MetricSet<OuterScopeLiveReconfigMetrics>,
+    report_value: u64,
+    probe: Arc<OuterScopeLiveReconfigProbe>,
+    counts_lifecycle_drop: bool,
+}
+
+impl Clone for OuterScopeLiveReconfigExtension {
+    fn clone(&self) -> Self {
+        Self {
+            metrics: self.metrics.clone(),
+            report_value: self.report_value,
+            probe: Arc::clone(&self.probe),
+            counts_lifecycle_drop: false,
+        }
+    }
+}
+
+impl Drop for OuterScopeLiveReconfigExtension {
+    fn drop(&mut self) {
+        if self.counts_lifecycle_drop {
+            _ = self.probe.dropped.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+}
+
+#[async_trait]
+impl SharedNoOpStateless for OuterScopeLiveReconfigExtension {
+    fn name(&self) -> &str {
+        "outer-scope-live-reconfig"
+    }
+
+    fn echo(&self, value: u64) -> u64 {
+        value
+    }
+
+    async fn ping(&self) -> u64 {
+        0
+    }
+
+    async fn echo_async(&self, value: String) -> String {
+        value
+    }
+}
+
+#[async_trait]
+impl otel_arrow_dfe_engine::shared::extension::Extension for OuterScopeLiveReconfigExtension {
+    async fn start(
+        mut self: Box<Self>,
+        mut ctrl: otel_arrow_dfe_engine::shared::extension::ControlChannel,
+        _effect_handler: EffectHandler,
+    ) -> Result<TerminalState, EngineError> {
+        _ = self.probe.started.fetch_add(1, Ordering::SeqCst);
+        loop {
+            match ctrl.recv().await {
+                Ok(ExtensionControlMsg::CollectTelemetry {
+                    mut metrics_reporter,
+                }) => {
+                    self.metrics.reported.add(self.report_value);
+                    metrics_reporter
+                        .report(&mut self.metrics)
+                        .map_err(|error| EngineError::InternalError {
+                            message: format!(
+                                "outer-scope live-reconfig metric reporting failed: {error}"
+                            ),
+                        })?;
+                    let collection = self.probe.collections.fetch_add(1, Ordering::SeqCst) + 1;
+                    _ = self.probe.collection_events.send(collection);
+                }
+                Ok(ExtensionControlMsg::Shutdown { .. }) | Err(_) => {
+                    _ = self.probe.stopped.fetch_add(1, Ordering::SeqCst);
+                    return Ok(TerminalState::default());
+                }
+                Ok(ExtensionControlMsg::Config { .. }) => {}
+            }
+        }
+    }
+}
+
+const OUTER_SCOPE_LIVE_RECONFIG_EXTENSION_URN: &str =
+    "urn:test:extension:outer-scope-live-reconfig";
+
+fn outer_scope_live_reconfig_extension_create(
+    context: &ExtensionContext,
+    name: ExtensionId,
+    user_config: Arc<ExtensionUserConfig>,
+    runtime_config: &ExtensionConfig,
+) -> Result<ExtensionBundle, otel_arrow_dfe_config::error::Error> {
+    let probe_key = user_config
+        .config
+        .get("probe_key")
+        .and_then(|value| value.as_str())
+        .expect("outer-scope extension config should contain probe_key");
+    let report_value = user_config
+        .config
+        .get("report_value")
+        .and_then(serde_json::Value::as_u64)
+        .expect("outer-scope extension config should contain report_value");
+    let probe = lookup_outer_scope_live_reconfig_probe(probe_key);
+    _ = probe.created.fetch_add(1, Ordering::SeqCst);
+
+    let entity_key = context.register_extension_entity(name.clone(), ExtensionVariant::Shared);
+    let metrics =
+        context.register_metric_set_for_entity::<OuterScopeLiveReconfigMetrics>(entity_key);
+    let bundle = ExtensionWrapper::builder(name, user_config, runtime_config)
+        .active()
+        .shared(OuterScopeLiveReconfigExtension {
+            metrics,
+            report_value,
+            probe,
+            counts_lifecycle_drop: true,
+        })
+        .build()
+        .expect("outer-scope live-reconfig extension should build");
+    Ok(bundle)
+}
+
+const OUTER_SCOPE_LIVE_RECONFIG_EXTENSION_FACTORY: ExtensionFactory = ExtensionFactory {
+    name: OUTER_SCOPE_LIVE_RECONFIG_EXTENSION_URN,
+    description: "active shared extension for outer-scope live-reconfiguration tests",
+    documentation_url: "",
+    capabilities: Some(extension_capabilities!(
+        shared: OuterScopeLiveReconfigExtension => [NoOpStateless]
+    )),
+    create: outer_scope_live_reconfig_extension_create,
+    validate_config: test_validate_config,
+};
+
+const OUTER_SCOPE_LIVE_RECONFIG_RECEIVER_URN: &str = "urn:test:receiver:outer-scope-live-reconfig";
+
+fn outer_scope_live_reconfig_receiver_create(
+    _pipeline_ctx: PipelineContext,
+    node: otel_arrow_dfe_engine::node::NodeId,
+    node_config: Arc<NodeUserConfig>,
+    receiver_config: &ReceiverConfig,
+    capabilities: &Capabilities,
+) -> Result<ReceiverWrapper<()>, otel_arrow_dfe_config::error::Error> {
+    let probe_key = node_config
+        .config
+        .get("probe_key")
+        .and_then(|value| value.as_str())
+        .expect("outer-scope receiver config should contain probe_key");
+    let capability = capabilities
+        .require_shared::<NoOpStateless>()
+        .expect("outer-scope shared capability should resolve");
+    assert_eq!(capability.name(), "outer-scope-live-reconfig");
+    assert_eq!(capability.echo(37), 37);
+    let probe = lookup_outer_scope_live_reconfig_probe(probe_key);
+    _ = probe.bindings.fetch_add(1, Ordering::SeqCst);
+
+    Ok(ReceiverWrapper::local(
+        RecoveryTestReceiver,
+        node,
+        node_config,
+        receiver_config,
+    ))
+}
+
+const OUTER_SCOPE_LIVE_RECONFIG_RECEIVER_FACTORY: ReceiverFactory<()> = ReceiverFactory {
+    name: OUTER_SCOPE_LIVE_RECONFIG_RECEIVER_URN,
+    create: outer_scope_live_reconfig_receiver_create,
+    wiring_contract: WiringContract::UNRESTRICTED,
+    validate_config: test_validate_config,
+};
+
 static TEST_RECEIVER_FACTORIES: &[ReceiverFactory<()>] = &[
     ReceiverFactory {
         name: "urn:test:receiver:example",
@@ -170,6 +669,7 @@ static TEST_RECEIVER_FACTORIES: &[ReceiverFactory<()>] = &[
         wiring_contract: WiringContract::UNRESTRICTED,
         validate_config: test_validate_config,
     },
+    VARIANT_RELOAD_RECEIVER_FACTORY,
     ReceiverFactory {
         name: "urn:otel:receiver:topic",
         create: test_receiver_create,
@@ -224,11 +724,42 @@ static TEST_EXPORTER_FACTORIES: &[ExporterFactory<()>] = &[
     },
 ];
 
+fn test_scope_extension_create(
+    _context: &ExtensionContext,
+    name: ExtensionId,
+    user_config: Arc<ExtensionUserConfig>,
+    runtime_config: &ExtensionConfig,
+) -> Result<ExtensionBundle, otel_arrow_dfe_config::error::Error> {
+    Ok(ExtensionWrapper::builder(name, user_config, runtime_config)
+        .passive()
+        .cloned()
+        .shared(())
+        .build()
+        .expect("test scope-hosted extension should build"))
+}
+
+static TEST_EXTENSION_FACTORIES: &[ExtensionFactory] = &[
+    ExtensionFactory {
+        name: "urn:test:extension:scope-shared",
+        description: "shared extension for declaration-scope live-control tests",
+        documentation_url: "",
+        capabilities: Some(ExtensionCapabilities {
+            shared: &["bearer_token_provider"],
+            local: &[],
+            register_shared: |_, _, _| Ok(()),
+            register_local: |_, _, _| Ok(()),
+        }),
+        create: test_scope_extension_create,
+        validate_config: test_validate_config,
+    },
+    VARIANT_RELOAD_EXTENSION_FACTORY,
+];
+
 static TEST_PIPELINE_FACTORY: PipelineFactory<()> = PipelineFactory::new(
     TEST_RECEIVER_FACTORIES,
     TEST_PROCESSOR_FACTORIES,
     TEST_EXPORTER_FACTORIES,
-    &[],
+    TEST_EXTENSION_FACTORIES,
 );
 
 static RECOVERY_TEST_RECEIVER_FACTORIES: &[ReceiverFactory<()>] = &[
@@ -274,6 +805,46 @@ static RECOVERY_TEST_PIPELINE_FACTORY: PipelineFactory<()> = PipelineFactory::ne
     &[],
 );
 
+static VARIANT_RELOAD_TEST_RECEIVER_FACTORIES: &[ReceiverFactory<()>] = &[
+    VARIANT_RELOAD_RECEIVER_FACTORY,
+    ReceiverFactory {
+        name: "urn:otel:receiver:internal_telemetry",
+        create: recovery_test_receiver_create,
+        wiring_contract: WiringContract::UNRESTRICTED,
+        validate_config: test_validate_config,
+    },
+];
+
+static VARIANT_RELOAD_TEST_EXTENSION_FACTORIES: &[ExtensionFactory] =
+    &[VARIANT_RELOAD_EXTENSION_FACTORY];
+
+static VARIANT_RELOAD_TEST_PIPELINE_FACTORY: PipelineFactory<()> = PipelineFactory::new(
+    VARIANT_RELOAD_TEST_RECEIVER_FACTORIES,
+    TEST_PROCESSOR_FACTORIES,
+    RECOVERY_TEST_EXPORTER_FACTORIES,
+    VARIANT_RELOAD_TEST_EXTENSION_FACTORIES,
+);
+
+static OUTER_SCOPE_LIVE_RECONFIG_TEST_RECEIVER_FACTORIES: &[ReceiverFactory<()>] = &[
+    OUTER_SCOPE_LIVE_RECONFIG_RECEIVER_FACTORY,
+    ReceiverFactory {
+        name: "urn:otel:receiver:internal_telemetry",
+        create: recovery_test_receiver_create,
+        wiring_contract: WiringContract::UNRESTRICTED,
+        validate_config: test_validate_config,
+    },
+];
+
+static OUTER_SCOPE_LIVE_RECONFIG_TEST_EXTENSION_FACTORIES: &[ExtensionFactory] =
+    &[OUTER_SCOPE_LIVE_RECONFIG_EXTENSION_FACTORY];
+
+static OUTER_SCOPE_LIVE_RECONFIG_TEST_PIPELINE_FACTORY: PipelineFactory<()> = PipelineFactory::new(
+    OUTER_SCOPE_LIVE_RECONFIG_TEST_RECEIVER_FACTORIES,
+    TEST_PROCESSOR_FACTORIES,
+    RECOVERY_TEST_EXPORTER_FACTORIES,
+    OUTER_SCOPE_LIVE_RECONFIG_TEST_EXTENSION_FACTORIES,
+);
+
 fn test_runtime(config: &OtelDataflowSpec) -> Arc<ControllerRuntime<()>> {
     test_runtime_with_factory_and_topology(config, &TEST_PIPELINE_FACTORY, NumaTopology::unknown())
 }
@@ -298,6 +869,35 @@ fn test_runtime_with_factory_and_topology(
     topology: NumaTopology,
 ) -> Arc<ControllerRuntime<()>> {
     test_runtime_with_log_filter_and_topology(config, pipeline_factory, topology).0
+}
+
+fn test_runtime_with_extension_scope_registry(
+    config: &OtelDataflowSpec,
+    extension_scope_registry: ExtensionScopeRegistry,
+) -> Arc<ControllerRuntime<()>> {
+    test_runtime_with_factory_and_extension_scope_registry(
+        config,
+        &TEST_PIPELINE_FACTORY,
+        extension_scope_registry,
+    )
+}
+
+fn test_runtime_with_factory_and_extension_scope_registry(
+    config: &OtelDataflowSpec,
+    pipeline_factory: &'static PipelineFactory<()>,
+    extension_scope_registry: ExtensionScopeRegistry,
+) -> Arc<ControllerRuntime<()>> {
+    let (log_filter, log_filter_handle) =
+        RuntimeLogFilter::new(config.engine.telemetry.logs.level.as_ref());
+    test_runtime_with_supplied_log_filter_topology_and_extension_scope_registry(
+        config,
+        pipeline_factory,
+        NumaTopology::unknown(),
+        log_filter,
+        log_filter_handle,
+        extension_scope_registry,
+    )
+    .0
 }
 
 fn test_runtime_with_log_filter(
@@ -342,6 +942,28 @@ fn test_runtime_with_supplied_log_filter_and_topology(
     RuntimeLogFilterHandle,
     RuntimeLogFilter,
 ) {
+    test_runtime_with_supplied_log_filter_topology_and_extension_scope_registry(
+        config,
+        pipeline_factory,
+        topology,
+        log_filter,
+        log_filter_handle,
+        ExtensionScopeRegistry::default(),
+    )
+}
+
+fn test_runtime_with_supplied_log_filter_topology_and_extension_scope_registry(
+    config: &OtelDataflowSpec,
+    pipeline_factory: &'static PipelineFactory<()>,
+    topology: NumaTopology,
+    log_filter: RuntimeLogFilter,
+    log_filter_handle: RuntimeLogFilterHandle,
+    extension_scope_registry: ExtensionScopeRegistry,
+) -> (
+    Arc<ControllerRuntime<()>>,
+    RuntimeLogFilterHandle,
+    RuntimeLogFilter,
+) {
     let registry = TelemetryRegistryHandle::new();
     let observed_state_store =
         ObservedStateStore::new(&ObservedStateSettings::default(), registry.clone());
@@ -360,6 +982,7 @@ fn test_runtime_with_supplied_log_filter_and_topology(
             observed_state_handle,
             engine_event_reporter,
             metrics_reporter,
+            extension_scope_registry,
             declared_topics,
             available_core_ids(),
             topology,
@@ -471,6 +1094,475 @@ where
             pipeline_key.pipeline_id()
         );
         thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn wait_for_atomic_count(counter: &AtomicUsize, expected: usize, label: &str) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let actual = counter.load(Ordering::SeqCst);
+        if actual == expected {
+            return;
+        }
+        assert!(
+            actual < expected,
+            "{label} exceeded expected count {expected}: {actual}"
+        );
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {label} to reach {expected}; current count: {actual}"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn wait_for_terminal_rollout(runtime: &ControllerRuntime<()>, rollout_id: &str) -> RolloutStatus {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let status = runtime
+            .rollout_status_snapshot(rollout_id)
+            .expect("rollout should remain queryable");
+        if matches!(
+            status.state,
+            ApiPipelineRolloutState::Succeeded
+                | ApiPipelineRolloutState::Failed
+                | ApiPipelineRolloutState::RollbackFailed
+        ) {
+            return status;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for rollout {rollout_id}; current state: {:?}",
+            status.state
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn launch_committed_test_pipeline(
+    runtime: &Arc<ControllerRuntime<()>>,
+    config: &OtelDataflowSpec,
+) -> DeployedPipelineKey {
+    let resolved = config
+        .resolve()
+        .pipelines
+        .into_iter()
+        .find(|pipeline| {
+            pipeline.role == ResolvedPipelineRole::Regular
+                && pipeline.pipeline_group_id.as_ref() == "g1"
+                && pipeline.pipeline_id.as_ref() == "p1"
+        })
+        .expect("resolved test pipeline should exist");
+    let placement = runtime
+        .pipeline_placement_for_resolved(&resolved)
+        .expect("test pipeline placement should resolve");
+    let live_placement = runtime.live_pipeline_placement_from(&resolved, placement.clone(), 0);
+    let inherited_extensions =
+        runtime.inherited_extensions_for_pipeline(&resolved.pipeline_group_id, &resolved.pipeline);
+    runtime.register_committed_pipeline_with_inherited(
+        resolved.clone(),
+        inherited_extensions.clone(),
+        placement,
+        0,
+    );
+    let deployed_key = runtime
+        .launch_regular_pipeline_instance(&resolved, &inherited_extensions, &live_placement, 0, 0)
+        .expect("initial test pipeline should launch");
+    runtime
+        .wait_for_pipeline_ready(&deployed_key, Instant::now() + Duration::from_secs(5))
+        .expect("initial test pipeline should become ready");
+    deployed_key
+}
+
+fn variant_reload_pipeline_yaml(probe_key: &str, include_local_consumer: bool) -> String {
+    let local_node = include_local_consumer.then(|| {
+        format!(
+            r#"
+  local_receiver:
+    type: "{VARIANT_RELOAD_RECEIVER_URN}"
+    config:
+      variant: local
+    capabilities:
+      no_op_stateless: variant_extension"#
+        )
+    });
+    let local_connection = include_local_consumer.then_some(
+        r#"
+  - from: local_receiver
+    to: exporter"#,
+    );
+
+    format!(
+        r#"
+policies:
+  resources:
+    core_allocation:
+      type: core_count
+      count: 1
+extensions:
+  variant_extension:
+    type: "{VARIANT_RELOAD_EXTENSION_URN}"
+    config:
+      probe_key: "{probe_key}"
+nodes:
+  shared_receiver:
+    type: "{VARIANT_RELOAD_RECEIVER_URN}"
+    config:
+      variant: shared
+    capabilities:
+      no_op_stateless: variant_extension
+{local_node}
+  exporter:
+    type: "urn:test:exporter:example"
+connections:
+  - from: shared_receiver
+    to: exporter
+{local_connection}
+"#,
+        local_node = local_node.as_deref().unwrap_or(""),
+        local_connection = local_connection.unwrap_or(""),
+    )
+}
+
+fn variant_reload_engine_config(probe_key: &str, include_local_consumer: bool) -> OtelDataflowSpec {
+    let pipeline_yaml = variant_reload_pipeline_yaml(probe_key, include_local_consumer);
+    let indented_pipeline = pipeline_yaml
+        .lines()
+        .map(|line| format!("        {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    OtelDataflowSpec::from_yaml(&format!(
+        "version: otel_dataflow/v1\ngroups:\n  g1:\n    pipelines:\n      p1:\n{indented_pipeline}\n"
+    ))
+    .expect("variant reload engine config should parse")
+}
+
+fn variant_reload_pipeline_config(probe_key: &str, include_local_consumer: bool) -> PipelineConfig {
+    PipelineConfig::from_yaml(
+        "g1".into(),
+        "p1".into(),
+        &variant_reload_pipeline_yaml(probe_key, include_local_consumer),
+    )
+    .expect("variant reload pipeline config should parse")
+}
+
+#[derive(Clone, Copy)]
+enum OuterScopeLiveReconfigDeclarationScope {
+    Engine,
+    PipelineGroup,
+}
+
+impl OuterScopeLiveReconfigDeclarationScope {
+    const fn probe_key(self) -> &'static str {
+        match self {
+            Self::Engine => "engine-outer-scope-live-reconfig",
+            Self::PipelineGroup => "group-outer-scope-live-reconfig",
+        }
+    }
+
+    const fn report_value(self) -> u64 {
+        match self {
+            Self::Engine => 17,
+            Self::PipelineGroup => 29,
+        }
+    }
+
+    const fn scope_kind(self) -> &'static str {
+        match self {
+            Self::Engine => "engine",
+            Self::PipelineGroup => "group",
+        }
+    }
+
+    const fn pipeline_group_id(self) -> Option<&'static str> {
+        match self {
+            Self::Engine => None,
+            Self::PipelineGroup => Some("g1"),
+        }
+    }
+}
+
+fn outer_scope_live_reconfig_pipeline_yaml(probe_key: &str, revision: u64) -> String {
+    format!(
+        r#"
+policies:
+  resources:
+    core_allocation:
+      type: core_count
+      count: 1
+nodes:
+  receiver:
+    type: "{OUTER_SCOPE_LIVE_RECONFIG_RECEIVER_URN}"
+    config:
+      probe_key: "{probe_key}"
+      revision: {revision}
+    capabilities:
+      no_op_stateless: outer_scope_extension
+  exporter:
+    type: "urn:test:exporter:example"
+connections:
+  - from: receiver
+    to: exporter
+"#
+    )
+}
+
+fn outer_scope_live_reconfig_engine_config(
+    declaration_scope: OuterScopeLiveReconfigDeclarationScope,
+) -> OtelDataflowSpec {
+    outer_scope_live_reconfig_engine_config_with_revision(declaration_scope, 0)
+}
+
+fn outer_scope_live_reconfig_engine_config_with_revision(
+    declaration_scope: OuterScopeLiveReconfigDeclarationScope,
+    revision: u64,
+) -> OtelDataflowSpec {
+    let probe_key = declaration_scope.probe_key();
+    let report_value = declaration_scope.report_value();
+    let pipeline_yaml = outer_scope_live_reconfig_pipeline_yaml(probe_key, revision);
+    let indented_pipeline = pipeline_yaml
+        .lines()
+        .map(|line| format!("        {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let yaml = match declaration_scope {
+        OuterScopeLiveReconfigDeclarationScope::Engine => format!(
+            r#"
+version: otel_dataflow/v1
+extensions:
+  outer_scope_extension:
+    type: "{OUTER_SCOPE_LIVE_RECONFIG_EXTENSION_URN}"
+    config:
+      probe_key: "{probe_key}"
+      report_value: {report_value}
+groups:
+  g1:
+    pipelines:
+      p1:
+{indented_pipeline}
+"#
+        ),
+        OuterScopeLiveReconfigDeclarationScope::PipelineGroup => format!(
+            r#"
+version: otel_dataflow/v1
+groups:
+  g1:
+    extensions:
+      outer_scope_extension:
+        type: "{OUTER_SCOPE_LIVE_RECONFIG_EXTENSION_URN}"
+        config:
+          probe_key: "{probe_key}"
+          report_value: {report_value}
+    pipelines:
+      p1:
+{indented_pipeline}
+"#
+        ),
+    };
+    OtelDataflowSpec::from_yaml(&yaml).expect("outer-scope live-reconfig config should parse")
+}
+
+fn outer_scope_live_reconfig_replacement(
+    declaration_scope: OuterScopeLiveReconfigDeclarationScope,
+) -> PipelineConfig {
+    outer_scope_live_reconfig_engine_config_with_revision(declaration_scope, 1)
+        .groups
+        .get(&PipelineGroupId::from("g1"))
+        .and_then(|group| group.pipelines.get(&PipelineId::from("p1")))
+        .cloned()
+        .expect("outer-scope live-reconfig replacement pipeline should exist")
+}
+
+async fn wait_for_outer_scope_collection(
+    collection_events: &mut tokio::sync::mpsc::UnboundedReceiver<usize>,
+    expected: usize,
+) {
+    for _ in 0..64 {
+        match collection_events.try_recv() {
+            Ok(received) => {
+                assert_eq!(
+                    received, expected,
+                    "outer-scope telemetry collection sequence must be monotonic"
+                );
+                return;
+            }
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
+                tokio::task::yield_now().await;
+            }
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                panic!("outer-scope telemetry collection channel closed");
+            }
+        }
+    }
+    panic!("timed out waiting for outer-scope telemetry collection {expected}");
+}
+
+fn assert_outer_scope_live_reconfig_metric_batch(
+    batch: MetricExportBatch,
+    declaration_scope: OuterScopeLiveReconfigDeclarationScope,
+) -> BTreeMap<String, String> {
+    let mut matching = batch.metric_sets.into_iter().filter(|metric_set| {
+        metric_set.descriptor.name == "test.extension.outer_scope_live_reconfig"
+    });
+    let metric_set = matching
+        .next()
+        .expect("outer-scope custom metric set must reach the collector");
+    assert!(
+        matching.next().is_none(),
+        "one hosted outer-scope extension must produce one custom metric set per collection"
+    );
+    assert_eq!(
+        metric_set.values,
+        vec![MetricValue::from(declaration_scope.report_value())]
+    );
+
+    let attributes = metric_set
+        .attributes
+        .iter_attributes()
+        .map(|(key, value)| (key.to_owned(), value.to_string_value()))
+        .collect::<BTreeMap<_, _>>();
+    assert_eq!(
+        attributes.get("extension.id").map(String::as_str),
+        Some("outer_scope_extension")
+    );
+    assert_eq!(
+        attributes.get("extension.variant").map(String::as_str),
+        Some("shared")
+    );
+    assert_eq!(
+        attributes.get("scope.kind").map(String::as_str),
+        Some(declaration_scope.scope_kind())
+    );
+    match declaration_scope.pipeline_group_id() {
+        Some(pipeline_group_id) => assert_eq!(
+            attributes.get("pipeline.group.id").map(String::as_str),
+            Some(pipeline_group_id)
+        ),
+        None => assert!(
+            attributes
+                .get("pipeline.group.id")
+                .map(String::as_str)
+                .unwrap_or_default()
+                .is_empty(),
+            "engine-scoped metrics must not carry a pipeline group identity"
+        ),
+    }
+    attributes
+}
+
+async fn exercise_outer_scope_extension_live_reconfig(
+    declaration_scope: OuterScopeLiveReconfigDeclarationScope,
+) {
+    let (probe, mut collection_events) =
+        register_outer_scope_live_reconfig_probe(declaration_scope.probe_key());
+    let config = outer_scope_live_reconfig_engine_config(declaration_scope);
+    let telemetry_system = InternalTelemetrySystem::default();
+    let collector = telemetry_system.collector();
+    let extension_scope_registry = ExtensionScopeRegistry::default();
+    let controller_context = ControllerContext::new(telemetry_system.registry());
+    let prepared = OUTER_SCOPE_LIVE_RECONFIG_TEST_PIPELINE_FACTORY
+        .prepare_extension_scope_hosts(
+            &config,
+            &controller_context,
+            telemetry_system.reporter(),
+            extension_scope_registry.clone(),
+        )
+        .expect("outer-scope extension hosts should prepare");
+    let running = prepared
+        .start()
+        .await
+        .expect("outer-scope extension hosts should start");
+    tokio::task::yield_now().await;
+    assert_eq!(probe.created.load(Ordering::SeqCst), 1);
+    assert_eq!(probe.started.load(Ordering::SeqCst), 1);
+
+    let runtime = test_runtime_with_factory_and_extension_scope_registry(
+        &config,
+        &OUTER_SCOPE_LIVE_RECONFIG_TEST_PIPELINE_FACTORY,
+        extension_scope_registry,
+    );
+    let _observed_state_runner = ObservedStateRunner::start(&runtime);
+    let _initial_key = launch_committed_test_pipeline(&runtime, &config);
+    wait_for_atomic_count(&probe.bindings, 1, "initial outer-scope capability binding");
+
+    let plan = runtime
+        .prepare_rollout_plan(
+            "g1",
+            "p1",
+            &ReconfigureRequest {
+                pipeline: outer_scope_live_reconfig_replacement(declaration_scope),
+                step_timeout_secs: 5,
+                drain_timeout_secs: 5,
+            },
+        )
+        .expect("outer-scope pipeline replacement should plan");
+    assert_eq!(plan.action, RolloutAction::Replace);
+    let accepted = runtime
+        .spawn_rollout(plan)
+        .expect("outer-scope pipeline replacement should start");
+    let status = wait_for_terminal_rollout(&runtime, &accepted.rollout_id);
+    assert_eq!(
+        status.state,
+        ApiPipelineRolloutState::Succeeded,
+        "outer-scope pipeline replacement failed: {:?}",
+        status.failure_reason
+    );
+    wait_for_atomic_count(
+        &probe.bindings,
+        2,
+        "replacement outer-scope capability binding",
+    );
+    assert_eq!(probe.created.load(Ordering::SeqCst), 1);
+    assert_eq!(probe.started.load(Ordering::SeqCst), 1);
+    assert_eq!(probe.stopped.load(Ordering::SeqCst), 0);
+    assert_eq!(probe.dropped.load(Ordering::SeqCst), 0);
+
+    tokio::time::advance(Duration::from_secs(1)).await;
+    wait_for_outer_scope_collection(&mut collection_events, 1).await;
+    collector.collect_pending();
+    _ = assert_outer_scope_live_reconfig_metric_batch(
+        telemetry_system.registry().drain_metric_export_batch(),
+        declaration_scope,
+    );
+    assert_eq!(probe.collections.load(Ordering::SeqCst), 1);
+
+    let target_key = deployed_key("g1", "p1", 0, status.target_generation);
+    shutdown_test_pipeline(&runtime, &target_key);
+    assert_eq!(probe.stopped.load(Ordering::SeqCst), 0);
+    assert_eq!(probe.dropped.load(Ordering::SeqCst), 0);
+
+    tokio::time::resume();
+    running
+        .shutdown()
+        .await
+        .expect("outer-scope extension hosts should stop cleanly");
+    assert_eq!(probe.stopped.load(Ordering::SeqCst), 1);
+    assert_eq!(probe.dropped.load(Ordering::SeqCst), 1);
+    collector.collect_pending();
+}
+
+fn shutdown_test_pipeline(
+    runtime: &Arc<ControllerRuntime<()>>,
+    deployed_key: &DeployedPipelineKey,
+) {
+    runtime
+        .request_instance_shutdown(deployed_key, 5, "variant reload test cleanup")
+        .expect("test pipeline should accept shutdown");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let active_instances = runtime
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .active_instances;
+        if active_instances == 0 {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for test pipeline shutdown; active instances: {active_instances}"
+        );
+        thread::sleep(Duration::from_millis(10));
     }
 }
 
@@ -712,6 +1804,22 @@ fn deadline_notifying_admin_sender() -> (
         Arc::new(DeadlineNotifyingPipelineAdminSender { notification }),
         receiver,
     )
+}
+
+struct ExitThenFailPipelineAdminSender {
+    runtime: std::sync::Weak<ControllerRuntime<()>>,
+    deployed_key: DeployedPipelineKey,
+}
+
+impl PipelineAdminSender for ExitThenFailPipelineAdminSender {
+    fn try_send_shutdown(&self, _deadline: Instant, _reason: String) -> Result<(), EngineError> {
+        if let Some(runtime) = self.runtime.upgrade() {
+            runtime.note_instance_exit(self.deployed_key.clone(), RuntimeInstanceExit::Success);
+        }
+        Err(EngineError::RuntimeMsgError {
+            error: "sender closed after clean exit".to_owned(),
+        })
+    }
 }
 
 fn launched_runtime_instance(
@@ -3689,6 +4797,298 @@ fn create_group_rejects_payload_with_pipelines() {
     assert!(runtime.group_details_snapshot(&group_id).is_none());
 }
 
+/// Scenario: generation 0 prunes an unconsumed local extension variant, then
+/// live reload adds a node that consumes the local capability.
+/// Guarantees: the replacement generation constructs and starts a fresh local
+/// variant while the disposed generation-0 local variant remains stopped.
+#[test]
+fn live_reload_recreates_previously_pruned_local_extension_variant() {
+    let initial_probe = register_variant_reload_probe("variant-reload-unused-to-needed-initial");
+    let target_probe = register_variant_reload_probe("variant-reload-unused-to-needed-target");
+    let config = variant_reload_engine_config("variant-reload-unused-to-needed-initial", false);
+    let runtime = test_runtime_with_factory(&config, &VARIANT_RELOAD_TEST_PIPELINE_FACTORY);
+    let _observed_state_runner = ObservedStateRunner::start(&runtime);
+    let _initial_key = launch_committed_test_pipeline(&runtime, &config);
+
+    wait_for_atomic_count(&initial_probe.local.created, 1, "initial local creation");
+    wait_for_atomic_count(&initial_probe.shared.created, 1, "initial shared creation");
+    wait_for_atomic_count(&initial_probe.local.dropped, 1, "initial local drop");
+    wait_for_atomic_count(&initial_probe.shared.started, 1, "initial shared start");
+    assert_eq!(initial_probe.local.started.load(Ordering::SeqCst), 0);
+    assert_eq!(initial_probe.local.stopped.load(Ordering::SeqCst), 0);
+    assert_eq!(initial_probe.shared.stopped.load(Ordering::SeqCst), 0);
+    assert_eq!(initial_probe.shared.dropped.load(Ordering::SeqCst), 0);
+
+    let plan = runtime
+        .prepare_rollout_plan(
+            "g1",
+            "p1",
+            &ReconfigureRequest {
+                pipeline: variant_reload_pipeline_config(
+                    "variant-reload-unused-to-needed-target",
+                    true,
+                ),
+                step_timeout_secs: 5,
+                drain_timeout_secs: 5,
+            },
+        )
+        .expect("variant-enabling replacement should plan");
+    assert_eq!(plan.action, RolloutAction::Replace);
+    let accepted = runtime
+        .spawn_rollout(plan)
+        .expect("variant-enabling replacement should start");
+    let status = wait_for_terminal_rollout(&runtime, &accepted.rollout_id);
+    assert_eq!(
+        status.state,
+        ApiPipelineRolloutState::Succeeded,
+        "variant-enabling rollout failed: {:?}",
+        status.failure_reason
+    );
+
+    wait_for_atomic_count(&target_probe.local.created, 1, "target local creation");
+    wait_for_atomic_count(&target_probe.shared.created, 1, "target shared creation");
+    wait_for_atomic_count(&target_probe.local.started, 1, "target local start");
+    wait_for_atomic_count(&target_probe.shared.started, 1, "target shared start");
+    wait_for_atomic_count(&initial_probe.shared.stopped, 1, "initial shared stop");
+    wait_for_atomic_count(&initial_probe.shared.dropped, 1, "initial shared drop");
+    assert_eq!(initial_probe.local.started.load(Ordering::SeqCst), 0);
+    assert_eq!(initial_probe.local.stopped.load(Ordering::SeqCst), 0);
+    assert_eq!(target_probe.local.stopped.load(Ordering::SeqCst), 0);
+    assert_eq!(target_probe.local.dropped.load(Ordering::SeqCst), 0);
+    assert_eq!(target_probe.shared.stopped.load(Ordering::SeqCst), 0);
+    assert_eq!(target_probe.shared.dropped.load(Ordering::SeqCst), 0);
+
+    let target_key = deployed_key("g1", "p1", 0, status.target_generation);
+    shutdown_test_pipeline(&runtime, &target_key);
+    wait_for_atomic_count(&target_probe.local.stopped, 1, "target local stop");
+    wait_for_atomic_count(&target_probe.local.dropped, 1, "target local drop");
+    wait_for_atomic_count(&target_probe.shared.stopped, 1, "target shared stop");
+    wait_for_atomic_count(&target_probe.shared.dropped, 1, "target shared drop");
+}
+
+/// Scenario: generation 0 uses both extension variants, then live reload
+/// removes the only node that consumes the local capability.
+/// Guarantees: the replacement generation drops its newly constructed local
+/// variant before startup while retaining and starting the shared variant.
+#[test]
+fn live_reload_prunes_local_extension_variant_after_last_consumer_is_removed() {
+    let initial_probe = register_variant_reload_probe("variant-reload-needed-to-unused-initial");
+    let target_probe = register_variant_reload_probe("variant-reload-needed-to-unused-target");
+    let config = variant_reload_engine_config("variant-reload-needed-to-unused-initial", true);
+    let runtime = test_runtime_with_factory(&config, &VARIANT_RELOAD_TEST_PIPELINE_FACTORY);
+    let _observed_state_runner = ObservedStateRunner::start(&runtime);
+    let _initial_key = launch_committed_test_pipeline(&runtime, &config);
+
+    wait_for_atomic_count(&initial_probe.local.created, 1, "initial local creation");
+    wait_for_atomic_count(&initial_probe.shared.created, 1, "initial shared creation");
+    wait_for_atomic_count(&initial_probe.local.started, 1, "initial local start");
+    wait_for_atomic_count(&initial_probe.shared.started, 1, "initial shared start");
+    assert_eq!(initial_probe.local.stopped.load(Ordering::SeqCst), 0);
+    assert_eq!(initial_probe.local.dropped.load(Ordering::SeqCst), 0);
+    assert_eq!(initial_probe.shared.stopped.load(Ordering::SeqCst), 0);
+    assert_eq!(initial_probe.shared.dropped.load(Ordering::SeqCst), 0);
+
+    let plan = runtime
+        .prepare_rollout_plan(
+            "g1",
+            "p1",
+            &ReconfigureRequest {
+                pipeline: variant_reload_pipeline_config(
+                    "variant-reload-needed-to-unused-target",
+                    false,
+                ),
+                step_timeout_secs: 5,
+                drain_timeout_secs: 5,
+            },
+        )
+        .expect("variant-pruning replacement should plan");
+    assert_eq!(plan.action, RolloutAction::Replace);
+    let accepted = runtime
+        .spawn_rollout(plan)
+        .expect("variant-pruning replacement should start");
+    let status = wait_for_terminal_rollout(&runtime, &accepted.rollout_id);
+    assert_eq!(
+        status.state,
+        ApiPipelineRolloutState::Succeeded,
+        "variant-pruning rollout failed: {:?}",
+        status.failure_reason
+    );
+
+    wait_for_atomic_count(&target_probe.local.created, 1, "target local creation");
+    wait_for_atomic_count(&target_probe.shared.created, 1, "target shared creation");
+    wait_for_atomic_count(&target_probe.local.dropped, 1, "target local drop");
+    wait_for_atomic_count(&target_probe.shared.started, 1, "target shared start");
+    wait_for_atomic_count(&initial_probe.local.stopped, 1, "initial local stop");
+    wait_for_atomic_count(&initial_probe.local.dropped, 1, "initial local drop");
+    wait_for_atomic_count(&initial_probe.shared.stopped, 1, "initial shared stop");
+    wait_for_atomic_count(&initial_probe.shared.dropped, 1, "initial shared drop");
+    assert_eq!(target_probe.local.started.load(Ordering::SeqCst), 0);
+    assert_eq!(target_probe.local.stopped.load(Ordering::SeqCst), 0);
+    assert_eq!(target_probe.shared.stopped.load(Ordering::SeqCst), 0);
+    assert_eq!(target_probe.shared.dropped.load(Ordering::SeqCst), 0);
+
+    let target_key = deployed_key("g1", "p1", 0, status.target_generation);
+    shutdown_test_pipeline(&runtime, &target_key);
+    assert_eq!(target_probe.local.started.load(Ordering::SeqCst), 0);
+    assert_eq!(target_probe.local.stopped.load(Ordering::SeqCst), 0);
+    wait_for_atomic_count(&target_probe.shared.stopped, 1, "target shared stop");
+    wait_for_atomic_count(&target_probe.shared.dropped, 1, "target shared drop");
+}
+
+/// Scenario: A pipeline using an engine-scoped extension is replaced while its provider host runs.
+/// Guarantees: Both generations bind one retained host, which reports scoped metrics after cutover.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn live_reload_retains_engine_extension_host_and_metric_collection() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(exercise_outer_scope_extension_live_reconfig(
+            OuterScopeLiveReconfigDeclarationScope::Engine,
+        ))
+        .await;
+}
+
+/// Scenario: A pipeline using a group-scoped extension is replaced inside that pipeline group.
+/// Guarantees: Both generations bind one retained group host, which reports metrics after cutover.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn live_reload_retains_pipeline_group_extension_host_and_metric_collection() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(exercise_outer_scope_extension_live_reconfig(
+            OuterScopeLiveReconfigDeclarationScope::PipelineGroup,
+        ))
+        .await;
+}
+
+/// Scenario: a committed pipeline inherits an engine provider, then a replacement
+/// shadows the same extension ID with a pipeline-local declaration.
+/// Guarantees: rollout planning and commit retain exact, generation-specific
+/// inherited snapshots instead of consulting mutable scope-registry state.
+#[test]
+fn rollout_generation_records_exact_inherited_extension_snapshot() {
+    let config = OtelDataflowSpec::from_yaml(
+        r#"
+version: otel_dataflow/v1
+extensions:
+  root_auth:
+    type: urn:test:extension:scope-shared
+groups:
+  g1:
+    pipelines:
+      p1:
+        policies:
+          resources:
+            core_allocation:
+              type: core_count
+              count: 1
+        nodes:
+          receiver:
+            type: urn:test:receiver:example
+          exporter:
+            type: urn:test:exporter:example
+        connections:
+          - from: receiver
+            to: exporter
+"#,
+    )
+    .expect("config should parse");
+
+    let async_runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("test runtime should build");
+    let local = tokio::task::LocalSet::new();
+    async_runtime.block_on(local.run_until(async {
+        let extension_scope_registry = ExtensionScopeRegistry::default();
+        let controller_context = ControllerContext::new(TelemetryRegistryHandle::new());
+        let (_metrics_rx, metrics_reporter) = MetricsReporter::create_new_and_receiver(8);
+        let prepared = TEST_PIPELINE_FACTORY
+            .prepare_extension_scope_hosts(
+                &config,
+                &controller_context,
+                metrics_reporter,
+                extension_scope_registry.clone(),
+            )
+            .expect("extension scope hosts should prepare");
+        let running = prepared
+            .start()
+            .await
+            .expect("extension scope hosts should start");
+
+        let runtime = test_runtime_with_extension_scope_registry(&config, extension_scope_registry);
+        register_existing_pipeline(&runtime, &config);
+        let _control =
+            register_runtime_instance(&runtime, "g1", "p1", 0, 0, RuntimeInstanceLifecycle::Active);
+        let replacement = PipelineConfig::from_yaml(
+            "g1".into(),
+            "p1".into(),
+            r#"
+extensions:
+  root_auth:
+    type: urn:test:extension:scope-shared
+policies:
+  resources:
+    core_allocation:
+      type: core_count
+      count: 1
+nodes:
+  receiver:
+    type: urn:test:receiver:example
+  exporter:
+    type: urn:test:exporter:example
+connections:
+  - from: receiver
+    to: exporter
+"#,
+        )
+        .expect("replacement should parse");
+
+        let plan = runtime
+            .prepare_rollout_plan(
+                "g1",
+                "p1",
+                &ReconfigureRequest {
+                    pipeline: replacement,
+                    step_timeout_secs: 5,
+                    drain_timeout_secs: 5,
+                },
+            )
+            .expect("shadowing replacement should plan");
+
+        assert_eq!(plan.action, RolloutAction::Replace);
+        assert!(
+            !plan
+                .current_record
+                .as_ref()
+                .expect("replacement should retain its previous record")
+                .inherited_extensions
+                .is_empty()
+        );
+        assert!(
+            plan.target_inherited_extensions.is_empty(),
+            "pipeline-local shadowing must be frozen into the target generation"
+        );
+
+        runtime.commit_pipeline_record(&plan, plan.target_generation);
+        assert!(
+            runtime
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .logical_pipelines
+                .get(&plan.pipeline_key)
+                .expect("target generation should be committed")
+                .inherited_extensions
+                .is_empty()
+        );
+
+        runtime.note_instance_exit(deployed_key("g1", "p1", 0, 0), RuntimeInstanceExit::Success);
+        running
+            .shutdown()
+            .await
+            .expect("extension scope hosts should stop cleanly");
+    }));
+}
+
 /// Scenario: a control-plane caller deletes a stopped logical pipeline.
 /// Guarantees: the pipeline is removed from committed live config and the
 /// containing group remains available as an empty group.
@@ -4050,6 +5450,230 @@ fn initial_config_activation_applies_log_level_before_noop_reconciliation() {
         otel_info!("test.controller.reconciled_runtime_filter");
     });
     assert_eq!(event_count.load(Ordering::SeqCst), 1);
+}
+
+/// Scenario: full-config reconciliation changes a running engine-scoped
+/// extension declaration.
+/// Guarantees: the request is rejected before committed configuration changes.
+#[test]
+fn reconcile_rejects_engine_extension_declaration_mutation() {
+    let config = OtelDataflowSpec::from_yaml(
+        r#"
+version: otel_dataflow/v1
+extensions:
+  root_auth:
+    type: urn:test:extension:scope-shared
+    config:
+      audience: current
+"#,
+    )
+    .expect("config should parse");
+    let desired = OtelDataflowSpec::from_yaml(
+        r#"
+version: otel_dataflow/v1
+extensions:
+  root_auth:
+    type: urn:test:extension:scope-shared
+    config:
+      audience: desired
+"#,
+    )
+    .expect("desired config should parse");
+    let runtime = test_runtime(&config);
+
+    let err = runtime
+        .reconcile_engine_config(reconcile_request(desired, true))
+        .expect_err("engine extension mutation should require restart");
+
+    assert!(matches!(
+        err,
+        ControlPlaneError::InvalidRequest { ref message }
+            if message.contains("runtime engine extension mutation")
+    ));
+    assert_eq!(runtime.engine_config_snapshot(), config);
+}
+
+/// Scenario: full-config reconciliation changes a running group-scoped
+/// extension declaration.
+/// Guarantees: the request is rejected before committed configuration changes.
+#[test]
+fn reconcile_rejects_pipeline_group_extension_declaration_mutation() {
+    let config = OtelDataflowSpec::from_yaml(
+        r#"
+version: otel_dataflow/v1
+groups:
+  g1:
+    extensions:
+      group_auth:
+        type: urn:test:extension:scope-shared
+        config:
+          audience: current
+"#,
+    )
+    .expect("config should parse");
+    let desired = OtelDataflowSpec::from_yaml(
+        r#"
+version: otel_dataflow/v1
+groups:
+  g1:
+    extensions:
+      group_auth:
+        type: urn:test:extension:scope-shared
+        config:
+          audience: desired
+"#,
+    )
+    .expect("desired config should parse");
+    let runtime = test_runtime(&config);
+
+    let err = runtime
+        .reconcile_engine_config(reconcile_request(desired, true))
+        .expect_err("group extension mutation should require restart");
+
+    assert!(matches!(
+        err,
+        ControlPlaneError::InvalidRequest { ref message }
+            if message.contains("pipeline group `g1`")
+    ));
+    assert_eq!(runtime.engine_config_snapshot(), config);
+}
+
+/// Scenario: partial reconciliation omits immutable engine and group extension
+/// declarations while retaining their declaration scopes.
+/// Guarantees: `delete_missing: false` preserves engine and pipeline-group
+/// extension declarations.
+#[test]
+fn reconcile_preserves_omitted_extension_scope_declarations() {
+    let config = OtelDataflowSpec::from_yaml(
+        r#"
+version: otel_dataflow/v1
+extensions:
+  root_auth:
+    type: urn:test:extension:scope-shared
+  root_store:
+    type: urn:test:extension:scope-shared
+groups:
+  g1:
+    extensions:
+      group_auth:
+        type: urn:test:extension:scope-shared
+      group_store:
+        type: urn:test:extension:scope-shared
+"#,
+    )
+    .expect("config should parse");
+    let desired = OtelDataflowSpec::from_yaml(
+        r#"
+version: otel_dataflow/v1
+extensions:
+  root_auth:
+    type: urn:test:extension:scope-shared
+groups:
+  g1:
+    extensions:
+      group_auth:
+        type: urn:test:extension:scope-shared
+"#,
+    )
+    .expect("desired config should parse");
+    let runtime = test_runtime(&config);
+
+    let status = runtime
+        .reconcile_engine_config(reconcile_request(desired, false))
+        .expect("omitted immutable declarations should be retained");
+
+    assert_eq!(status.state, EngineConfigReconcileState::Succeeded);
+    let snapshot = runtime.engine_config_snapshot();
+    assert_eq!(snapshot.extensions, config.extensions);
+    assert_eq!(
+        snapshot.groups[&PipelineGroupId::from("g1")].extensions,
+        config.groups[&PipelineGroupId::from("g1")].extensions
+    );
+}
+
+/// Scenario: full-config reconciliation changes channel capacity consumed by
+/// a running engine-scoped extension host.
+/// Guarantees: policies that would require rebuilding the host are rejected.
+#[test]
+fn reconcile_rejects_extension_host_policy_mutation() {
+    let config = OtelDataflowSpec::from_yaml(
+        r#"
+version: otel_dataflow/v1
+extensions:
+  root_auth:
+    type: urn:test:extension:scope-shared
+"#,
+    )
+    .expect("config should parse");
+    let desired = OtelDataflowSpec::from_yaml(
+        r#"
+version: otel_dataflow/v1
+policies:
+  channel_capacity:
+    control:
+      node: 200
+      pipeline: 201
+      completion: 203
+    pdata: 202
+extensions:
+  root_auth:
+    type: urn:test:extension:scope-shared
+"#,
+    )
+    .expect("desired config should parse");
+    let runtime = test_runtime(&config);
+
+    let err = runtime
+        .reconcile_engine_config(reconcile_request(desired, true))
+        .expect_err("host runtime policy mutation should require restart");
+
+    assert!(matches!(
+        err,
+        ControlPlaneError::InvalidRequest { ref message }
+            if message.contains("policies used by hosted engine extensions")
+    ));
+    assert_eq!(runtime.engine_config_snapshot(), config);
+}
+
+/// Scenario: full-config reconciliation changes telemetry settings that a
+/// running engine extension host does not consume.
+/// Guarantees: unrelated live telemetry behavior remains reloadable.
+#[test]
+fn reconcile_accepts_irrelevant_extension_host_policy_changes() {
+    let config = OtelDataflowSpec::from_yaml(
+        r#"
+version: otel_dataflow/v1
+policies:
+  telemetry:
+    tokio_metrics: true
+    runtime_metrics: basic
+extensions:
+  root_auth:
+    type: urn:test:extension:scope-shared
+"#,
+    )
+    .expect("config should parse");
+    let desired = OtelDataflowSpec::from_yaml(
+        r#"
+version: otel_dataflow/v1
+policies:
+  telemetry:
+    tokio_metrics: false
+    runtime_metrics: detailed
+extensions:
+  root_auth:
+    type: urn:test:extension:scope-shared
+"#,
+    )
+    .expect("desired config should parse");
+    let runtime = test_runtime(&config);
+
+    let status = runtime
+        .reconcile_engine_config(reconcile_request(desired.clone(), true))
+        .expect("unused hosted-extension telemetry changes should reconcile");
+
+    assert_eq!(status.state, EngineConfigReconcileState::Succeeded);
+    assert_eq!(runtime.engine_config_snapshot(), desired);
 }
 
 /// Scenario: a full-config reconciliation request omits live stopped
@@ -5000,13 +6624,137 @@ fn request_shutdown_all_attempts_all_active_instances_before_returning_error() {
     );
 }
 
+/// Scenario: an active pipeline exits cleanly after global shutdown snapshots
+/// its sender but before that sender reports a closed-channel failure.
+/// Guarantees: the retained terminal result wins the race, so clean completion
+/// is not misreported as a fatal shutdown-send failure.
+#[test]
+fn request_shutdown_all_recognizes_exit_racing_with_send_failure() {
+    let runtime = test_runtime(&empty_engine_config());
+    let deployed_key = deployed_key("g1", "p1", 0, 0);
+    let sender: Arc<dyn PipelineAdminSender> = Arc::new(ExitThenFailPipelineAdminSender {
+        runtime: Arc::downgrade(&runtime),
+        deployed_key: deployed_key.clone(),
+    });
+    register_runtime_instance_with_sender(
+        &runtime,
+        deployed_key.clone(),
+        sender,
+        RuntimeInstanceLifecycle::Active,
+    );
+
+    runtime
+        .request_shutdown_all(1)
+        .expect("a clean racing exit should satisfy global shutdown");
+    assert!(runtime.wait_for_global_shutdown_completion_for(Duration::from_secs(1)));
+    assert!(
+        matches!(
+            runtime.instance_exit(&deployed_key),
+            Some(RuntimeInstanceExit::Success)
+        ),
+        "the clean terminal result should remain available during global shutdown"
+    );
+    assert!(!runtime.has_fatal_runtime_error());
+}
+
+/// Scenario: callers repeat global shutdown with different timeout requests
+/// while teardown is already active.
+/// Guarantees: producer instances retain the first accepted absolute deadline;
+/// later calls cannot reset, shorten, or extend that phase's budget.
+#[test]
+fn request_shutdown_all_preserves_first_absolute_deadline() {
+    let runtime = test_runtime(&empty_engine_config());
+    runtime
+        .request_shutdown_all(30)
+        .expect("initial global shutdown should succeed");
+    let first_deadline = runtime
+        .state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .global_shutdown_deadline
+        .expect("initial shutdown should establish a deadline");
+
+    runtime
+        .request_shutdown_all(1)
+        .expect("shorter repeated global shutdown should succeed");
+    let retained_deadline = runtime
+        .state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .global_shutdown_deadline
+        .expect("repeated shutdown should retain a deadline");
+    assert_eq!(retained_deadline, first_deadline);
+
+    runtime
+        .request_shutdown_all(60)
+        .expect("longer repeated global shutdown should succeed");
+    assert_eq!(
+        runtime
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .global_shutdown_deadline,
+        Some(first_deadline)
+    );
+}
+
+/// Scenario: global shutdown begins while a runtime recovery worker still owns
+/// its fencing token and may take a long time to unwind.
+/// Guarantees: launch admission closes and recovery cancellation is requested
+/// without blocking shutdown dispatch on the worker's release.
+#[test]
+fn request_shutdown_all_does_not_wait_for_recovery_worker_release() {
+    let runtime = test_runtime(&empty_engine_config());
+    let pipeline_key = PipelineKey::new("g1".into(), "p1".into());
+    {
+        let mut state = runtime
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        _ = state.runtime_recoveries.insert(
+            (pipeline_key, 0),
+            RuntimeRecoveryState {
+                serving_generation: 0,
+                restart_count: 0,
+                ready_since: None,
+                worker_id: Some(42),
+                candidate_generation: None,
+                cancel_requested: false,
+            },
+        );
+    }
+
+    let started = Instant::now();
+    runtime
+        .request_shutdown_all(1)
+        .expect("shutdown dispatch should not wait for recovery release");
+    assert!(
+        started.elapsed() < Duration::from_millis(250),
+        "global shutdown must not block on recovery cleanup"
+    );
+
+    let state = runtime
+        .state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let recovery = state
+        .runtime_recoveries
+        .values()
+        .next()
+        .expect("synthetic recovery should remain present");
+    assert!(recovery.cancel_requested);
+    assert!(state.launches_closed);
+    drop(state);
+    assert!(!runtime.wait_for_runtime_recoveries_for(Duration::from_millis(20)));
+}
+
 /// Scenario: global shutdown includes regular producer instances and the
 /// engine's system observability instance.
 /// Guarantees: all regular instances receive shutdown first, and the system
-/// observability sender is not called until every regular instance reports its
-/// terminal exit, preserving their final internal telemetry.
+/// observability sender is not called until both regular instances and the
+/// extension scope hosts have stopped, with a fresh, fixed observability deadline.
 #[test]
-fn request_shutdown_all_stops_observability_after_regular_instances_exit() {
+fn request_shutdown_all_defers_observability_until_extension_scope_hosts_stop() {
     let runtime = test_runtime(&engine_config_with_pipeline(simple_pipeline_yaml()));
     let regular_key0 = deployed_key("g1", "p1", 0, 0);
     let regular_key1 = deployed_key("g1", "p1", 1, 0);
@@ -5065,6 +6813,24 @@ fn request_shutdown_all_stops_observability_after_regular_instances_exit() {
     shutdown_thread
         .join()
         .expect("global shutdown dispatch thread should join");
+    let original_deadline = runtime
+        .state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .global_shutdown_deadline
+        .expect("global shutdown should establish one deadline");
+    runtime
+        .request_shutdown_all(30)
+        .expect("a longer repeated request should remain idempotent");
+    assert_eq!(
+        runtime
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .global_shutdown_deadline,
+        Some(original_deadline),
+        "a repeated request must not extend the original deadline"
+    );
     assert!(
         observability_notifications.try_recv().is_err(),
         "observability must remain active while regular instances drain"
@@ -5076,14 +6842,36 @@ fn request_shutdown_all_stops_observability_after_regular_instances_exit() {
         "one remaining regular instance must keep observability active"
     );
     runtime.note_instance_exit(regular_key1, RuntimeInstanceExit::Success);
+    assert!(runtime.wait_for_global_shutdown_completion());
+    assert!(
+        observability_notifications.try_recv().is_err(),
+        "extension scope hosts must stop before observability is stopped"
+    );
+
+    let observability_started = Instant::now();
+    runtime.mark_extension_scope_hosts_stopped();
+    runtime
+        .request_shutdown_all(5)
+        .expect("observability shutdown dispatch should succeed");
 
     let (reason, deadline) = observability_notifications
         .recv_timeout(Duration::from_secs(1))
         .expect("observability should receive shutdown after producers exit");
     assert_eq!(reason, "global shutdown");
     assert!(
-        deadline.saturating_duration_since(Instant::now()) > Duration::from_secs(4),
-        "observability should receive the caller's five-second shutdown budget"
+        deadline >= observability_started + ControllerRuntime::<()>::OBSERVABILITY_SHUTDOWN_TIMEOUT
+    );
+    assert!(deadline > original_deadline);
+    runtime
+        .request_shutdown_all(60)
+        .expect("a repeated request must retain the active observability deadline");
+    assert_eq!(
+        runtime
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .observability_shutdown_deadline,
+        Some(deadline)
     );
     runtime.note_instance_exit(observability_key, RuntimeInstanceExit::Success);
     assert!(
@@ -5139,8 +6927,18 @@ fn request_shutdown_all_keeps_observability_active_when_producer_times_out() {
             .is_err(),
         "observability must remain active when a producer misses its deadline"
     );
+    assert!(runtime.wait_for_global_shutdown_completion());
+    assert!(
+        runtime
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .instance_wait_released,
+        "a timed-out global shutdown must release the main lifecycle wait"
+    );
 
     runtime.note_instance_exit(regular_key, RuntimeInstanceExit::Success);
+    runtime.mark_extension_scope_hosts_stopped();
     runtime
         .request_shutdown_all(1)
         .expect("a later request should retry the restored observability sender");
@@ -5150,6 +6948,107 @@ fn request_shutdown_all_keeps_observability_active_when_producer_times_out() {
     runtime.note_instance_exit(observability_key, RuntimeInstanceExit::Success);
     assert!(runtime.wait_for_global_shutdown_completion());
     assert!(runtime.all_instances_exited());
+}
+
+/// Scenario: observability finishes launching before or after scope hosts stop, after producer grace expires.
+/// Guarantees: late activation waits for providers and uses the fixed, fresh observability deadline.
+#[test]
+fn global_shutdown_late_observability_launch_gets_its_own_deadline() {
+    for activate_before_hosts_stop in [true, false] {
+        let runtime = test_runtime(&empty_engine_config());
+        let key = deployed_key(
+            SYSTEM_PIPELINE_GROUP_ID,
+            SYSTEM_OBSERVABILITY_PIPELINE_ID,
+            0,
+            0,
+        );
+        runtime
+            .reserve_instance_launch(&key)
+            .expect("observability launch should reserve");
+        let producer_deadline = Instant::now() - Duration::from_secs(1);
+        runtime
+            .request_shutdown_all_until(producer_deadline)
+            .expect("producer shutdown should start");
+        let (sender, notifications) = deadline_notifying_admin_sender();
+        let phase_started = Instant::now();
+        if activate_before_hosts_stop {
+            runtime.complete_instance_launch(key.clone(), sender);
+            assert!(notifications.try_recv().is_err());
+            assert!(
+                runtime
+                    .state
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .observability_shutdown_deadline
+                    .is_none(),
+                "launching observability must not start its drain clock before providers stop"
+            );
+            runtime.mark_extension_scope_hosts_stopped();
+        } else {
+            runtime.mark_extension_scope_hosts_stopped();
+            runtime.complete_instance_launch(key.clone(), sender);
+        }
+        runtime
+            .request_shutdown_all(60)
+            .expect("observability shutdown should dispatch");
+        let (_, deadline) = notifications
+            .recv_timeout(Duration::from_secs(1))
+            .expect("late observability instance should receive shutdown");
+        assert!(
+            deadline >= phase_started + ControllerRuntime::<()>::OBSERVABILITY_SHUTDOWN_TIMEOUT
+        );
+        assert_eq!(
+            runtime.observability_shutdown_deadline_or_insert(),
+            deadline,
+            "repeated shutdown must not replenish observability grace"
+        );
+        assert_eq!(
+            runtime.global_shutdown_deadline_or_insert(Duration::from_secs(60)),
+            producer_deadline
+        );
+        runtime.note_instance_exit(key, RuntimeInstanceExit::Success);
+        assert!(runtime.wait_for_global_shutdown_completion_for(Duration::from_secs(1)));
+    }
+}
+
+/// Scenario: an observability launch completes after providers stop but a reserved producer is still live.
+/// Guarantees: activation does not shut down observability until that final producer actually exits.
+#[test]
+fn global_shutdown_late_observability_launch_waits_for_remaining_producer() {
+    let runtime = test_runtime(&empty_engine_config());
+    let producer_key = deployed_key("g1", "p1", 0, 0);
+    let observability_key = deployed_key(
+        SYSTEM_PIPELINE_GROUP_ID,
+        SYSTEM_OBSERVABILITY_PIPELINE_ID,
+        1,
+        0,
+    );
+    runtime
+        .reserve_instance_launch(&producer_key)
+        .expect("producer launch should reserve");
+    runtime
+        .reserve_instance_launch(&observability_key)
+        .expect("observability launch should reserve");
+    runtime
+        .request_shutdown_all(5)
+        .expect("producer shutdown should start");
+    runtime.mark_extension_scope_hosts_stopped();
+    let (sender, notifications) = deadline_notifying_admin_sender();
+    runtime.complete_instance_launch(observability_key.clone(), sender);
+    assert!(
+        notifications.try_recv().is_err(),
+        "a late observability launch must still wait for live producers"
+    );
+    runtime.note_instance_exit(producer_key, RuntimeInstanceExit::Success);
+    assert!(runtime.wait_for_global_shutdown_completion_for(Duration::from_secs(1)));
+    runtime
+        .request_shutdown_all(5)
+        .expect("observability shutdown should dispatch after producer exit");
+    _ = notifications
+        .recv_timeout(Duration::from_secs(1))
+        .expect("observability should receive its final shutdown");
+    runtime.note_instance_exit(observability_key, RuntimeInstanceExit::Success);
+    assert!(runtime.wait_for_global_shutdown_completion_for(Duration::from_secs(1)));
 }
 
 /// Scenario: all targeted runtime instances exit cleanly after a pipeline
@@ -5508,6 +7407,669 @@ fn exited_runtime_instances_without_active_operation_are_pruned_immediately() {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     assert!(!state.runtime_instances.contains_key(&deployed_key));
+}
+
+/// Scenario: a pipeline launch is reserved immediately before its OS thread is
+/// created and has not yet published a control sender.
+/// Guarantees: liveness includes the launching thread and spawn failure can
+/// roll the reservation back exactly once.
+#[test]
+fn launch_reservation_counts_liveness_before_activation() {
+    let runtime = test_runtime(&empty_engine_config());
+    let deployed_key = deployed_key("g1", "p1", 0, 7);
+
+    runtime
+        .reserve_instance_launch(&deployed_key)
+        .expect("launch reservation should succeed");
+    {
+        let state = runtime
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(state.active_instances, 1);
+        assert!(state.launching_instances.contains(&deployed_key));
+        assert!(!state.runtime_instances.contains_key(&deployed_key));
+    }
+
+    runtime.abort_instance_launch(&deployed_key);
+    runtime.abort_instance_launch(&deployed_key);
+    let state = runtime
+        .state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert_eq!(state.active_instances, 0);
+    assert!(!state.launching_instances.contains(&deployed_key));
+}
+
+/// Scenario: shutdown-when-done observes a producer whose launch is reserved
+/// but whose runtime record is not active yet.
+/// Guarantees: producer drain waits for the launching thread instead of
+/// advancing to observability shutdown early.
+#[test]
+fn producer_wait_includes_launch_reservations() {
+    let runtime = test_runtime(&empty_engine_config());
+    let deployed_key = deployed_key("g1", "p1", 0, 7);
+    runtime
+        .reserve_instance_launch(&deployed_key)
+        .expect("launch reservation should succeed");
+
+    let waiter = {
+        let runtime = Arc::clone(&runtime);
+        thread::spawn(move || runtime.wait_until_all_producer_instances_exit())
+    };
+    thread::sleep(Duration::from_millis(100));
+    assert!(
+        !waiter.is_finished(),
+        "producer wait must include in-flight launches"
+    );
+
+    runtime.note_instance_exit(deployed_key, RuntimeInstanceExit::Success);
+    waiter.join().expect("producer wait should finish");
+}
+
+/// Scenario: a fatal extension scope failure releases shutdown-when-done while a
+/// producer launch remains reserved.
+/// Guarantees: the producer wait reaches bounded extension scope teardown instead of
+/// blocking forever on the stalled launch.
+#[test]
+fn producer_wait_honors_fatal_release_latch() {
+    let runtime = test_runtime(&empty_engine_config());
+    let deployed_key = deployed_key("g1", "p1", 0, 7);
+    runtime
+        .reserve_instance_launch(&deployed_key)
+        .expect("launch reservation should succeed");
+
+    let waiter = {
+        let runtime = Arc::clone(&runtime);
+        thread::spawn(move || runtime.wait_until_all_producer_instances_exit())
+    };
+    thread::sleep(Duration::from_millis(100));
+    assert!(!waiter.is_finished());
+
+    runtime.release_instance_wait();
+    waiter
+        .join()
+        .expect("fatal release should unblock producer wait");
+    runtime.abort_instance_launch(&deployed_key);
+}
+
+/// Scenario: an extension scope failure closes launch admission during bootstrap.
+/// Guarantees: the rejected launch reports the recorded extension scope failure
+/// rather than replacing it with only a generic admission error.
+#[test]
+fn closed_launch_admission_preserves_fatal_runtime_error() {
+    let runtime = test_runtime(&empty_engine_config());
+    runtime.record_fatal_runtime_error("engine extension `auth` failed".to_owned());
+    runtime.close_pipeline_launches();
+
+    let error = runtime
+        .reserve_instance_launch(&deployed_key("g1", "p1", 0, 8))
+        .expect_err("launch admission should be closed");
+    assert!(error.to_string().contains("engine extension `auth` failed"));
+}
+
+/// Scenario: a pipeline thread exits after launch reservation but before the
+/// spawning thread can activate its runtime record.
+/// Guarantees: the exit consumes the reservation, decrements liveness once,
+/// and a late activation cannot resurrect the exited instance.
+#[test]
+fn exit_before_activation_consumes_launch_reservation_once() {
+    let runtime = test_runtime(&empty_engine_config());
+    let deployed_key = deployed_key("g1", "p1", 0, 8);
+    let (sender, _calls) = recording_admin_sender(None);
+
+    runtime
+        .reserve_instance_launch(&deployed_key)
+        .expect("launch reservation should succeed");
+    runtime.note_instance_exit(deployed_key.clone(), RuntimeInstanceExit::Success);
+    assert!(
+        runtime
+            .activate_instance_launch(deployed_key.clone(), sender)
+            .is_none()
+    );
+
+    let state = runtime
+        .state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert_eq!(state.active_instances, 0);
+    assert!(!state.launching_instances.contains(&deployed_key));
+    assert!(!state.runtime_instances.contains_key(&deployed_key));
+}
+
+/// Scenario: global shutdown begins after a launch reservation but before its
+/// pipeline thread publishes a control sender.
+/// Guarantees: launch admission closes atomically, the in-flight activation
+/// inherits shutdown, and later launches are rejected.
+#[test]
+fn global_shutdown_catches_inflight_launch_activation() {
+    let runtime = test_runtime(&empty_engine_config());
+    let in_flight_key = deployed_key("g1", "p1", 0, 9);
+    let observability_key = deployed_key(
+        SYSTEM_PIPELINE_GROUP_ID,
+        SYSTEM_OBSERVABILITY_PIPELINE_ID,
+        0,
+        0,
+    );
+    let (observability_sender, observability_shutdown) = deadline_notifying_admin_sender();
+    register_runtime_instance_with_sender(
+        &runtime,
+        observability_key.clone(),
+        observability_sender,
+        RuntimeInstanceLifecycle::Active,
+    );
+    runtime
+        .reserve_instance_launch(&in_flight_key)
+        .expect("in-flight launch should reserve");
+
+    runtime
+        .request_shutdown_all(2)
+        .expect("shutdown dispatch should succeed");
+    assert!(
+        observability_shutdown
+            .recv_timeout(Duration::from_millis(100))
+            .is_err(),
+        "observability must wait for the in-flight producer"
+    );
+
+    let (sender, calls) = recording_admin_sender(None);
+    runtime.complete_instance_launch(in_flight_key.clone(), sender);
+    assert_eq!(
+        calls
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_slice(),
+        ["global shutdown"]
+    );
+    assert!(
+        runtime
+            .reserve_instance_launch(&deployed_key("g1", "p1", 1, 9))
+            .is_err()
+    );
+
+    runtime.note_instance_exit(in_flight_key, RuntimeInstanceExit::Success);
+    assert!(runtime.wait_for_global_shutdown_completion());
+    runtime.mark_extension_scope_hosts_stopped();
+    runtime
+        .request_shutdown_all(2)
+        .expect("observability shutdown dispatch should succeed");
+    let (reason, _) = observability_shutdown
+        .recv_timeout(Duration::from_secs(1))
+        .expect("observability should stop after the producer exits");
+    assert_eq!(reason, "global shutdown");
+    runtime.note_instance_exit(observability_key, RuntimeInstanceExit::Success);
+    assert!(runtime.wait_for_global_shutdown_completion());
+    assert!(runtime.all_instances_exited());
+}
+
+/// Scenario: a shutdown-racing launch exits cleanly while its immediate
+/// shutdown send observes the already-closed control channel.
+/// Guarantees: activation uses the retained terminal result and does not turn
+/// the clean exit into a fatal extension-scope shutdown error.
+#[test]
+fn global_shutdown_activation_recognizes_clean_exit_before_send_failure() {
+    let runtime = test_runtime(&empty_engine_config());
+    let in_flight_key = deployed_key("g1", "p1", 0, 10);
+    runtime
+        .reserve_instance_launch(&in_flight_key)
+        .expect("in-flight launch should reserve");
+    runtime
+        .request_shutdown_all(1)
+        .expect("shutdown dispatch should succeed");
+
+    let sender: Arc<dyn PipelineAdminSender> = Arc::new(ExitThenFailPipelineAdminSender {
+        runtime: Arc::downgrade(&runtime),
+        deployed_key: in_flight_key.clone(),
+    });
+    runtime.complete_instance_launch(in_flight_key.clone(), sender);
+
+    assert!(runtime.wait_for_global_shutdown_completion_for(Duration::from_secs(1)));
+    assert!(
+        matches!(
+            runtime.instance_exit(&in_flight_key),
+            Some(RuntimeInstanceExit::Success)
+        ),
+        "the launch-racing clean exit should remain available"
+    );
+    assert!(!runtime.has_fatal_runtime_error());
+}
+
+/// Scenario: an early controller error drops the extension scope supervisor
+/// guard while a reserved pipeline thread is still alive.
+/// Guarantees: the guard closes launch admission and waits for the descendant
+/// exit before cancelling the extension scope supervisor task.
+#[test]
+fn extension_scope_supervisor_guard_keeps_hosts_alive_until_reserved_pipeline_exits() {
+    let runtime = test_runtime(&empty_engine_config());
+    let in_flight_key = deployed_key("g1", "p1", 0, 10);
+    runtime
+        .reserve_instance_launch(&in_flight_key)
+        .expect("launch reservation should succeed");
+
+    let (started_tx, started_rx) = std::sync::mpsc::channel();
+    let (stopped_tx, stopped_rx) = std::sync::mpsc::channel();
+    let handle = spawn_thread_local_task(
+        "test-extension-scope-guard",
+        TracingSetup::new(ProviderSetup::Noop, LogLevel::default(), engine_context),
+        move |cancellation_token| async move {
+            _ = started_tx.send(());
+            cancellation_token.cancelled().await;
+            _ = stopped_tx.send(());
+            Ok::<(), Error>(())
+        },
+    )
+    .expect("test extension scope supervisor should spawn");
+    started_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("test extension scope supervisor should start");
+
+    let guard = ExtensionScopeSupervisorGuard::new(handle, Arc::clone(&runtime));
+    let drop_thread = thread::spawn(move || drop(guard));
+    thread::sleep(Duration::from_millis(100));
+    assert!(
+        stopped_rx.try_recv().is_err(),
+        "extension scope supervisor must remain alive while a descendant is reserved"
+    );
+
+    runtime.note_instance_exit(in_flight_key, RuntimeInstanceExit::Success);
+    drop_thread
+        .join()
+        .expect("extension scope supervisor guard cleanup should finish");
+    stopped_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("extension scope supervisor should stop after descendants exit");
+}
+
+/// Scenario: teardown begins while a recovery worker owns its fencing token
+/// but no producer pipeline remains active.
+/// Guarantees: the extension scope supervisor guard initiates global shutdown,
+/// requests recovery cancellation, and waits for the worker before stopping providers.
+#[test]
+fn extension_scope_supervisor_guard_cancels_recovery_without_live_producer() {
+    let runtime = test_runtime(&empty_engine_config());
+    let pipeline_key = PipelineKey::new("g1".into(), "p1".into());
+    {
+        let mut state = runtime
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        _ = state.runtime_recoveries.insert(
+            (pipeline_key.clone(), 0),
+            RuntimeRecoveryState {
+                serving_generation: 0,
+                restart_count: 0,
+                ready_since: None,
+                worker_id: Some(43),
+                candidate_generation: None,
+                cancel_requested: false,
+            },
+        );
+    }
+
+    let recovery_runtime = Arc::clone(&runtime);
+    let recovery_thread = thread::spawn(move || {
+        for _ in 0..100 {
+            let mut state = recovery_runtime
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let recovery = state
+                .runtime_recoveries
+                .get_mut(&(pipeline_key.clone(), 0))
+                .expect("synthetic recovery should remain present");
+            if recovery.cancel_requested {
+                recovery.worker_id = None;
+                recovery_runtime.state_changed.notify_all();
+                return;
+            }
+            drop(state);
+            thread::sleep(Duration::from_millis(5));
+        }
+        panic!("extension scope supervisor guard did not cancel the synthetic recovery worker");
+    });
+
+    let (stopped_tx, stopped_rx) = std::sync::mpsc::channel();
+    let handle = spawn_thread_local_task(
+        "test-extension-scope-recovery-drain",
+        TracingSetup::new(ProviderSetup::Noop, LogLevel::default(), engine_context),
+        move |cancellation_token| async move {
+            cancellation_token.cancelled().await;
+            _ = stopped_tx.send(());
+            Ok::<(), Error>(())
+        },
+    )
+    .expect("test extension scope supervisor should spawn");
+    let guard = ExtensionScopeSupervisorGuard::new_with_timeouts(
+        handle,
+        Arc::clone(&runtime),
+        Duration::from_secs(1),
+        Duration::from_secs(1),
+    );
+
+    drop(guard);
+    recovery_thread
+        .join()
+        .expect("synthetic recovery worker should stop");
+    stopped_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("extension scope supervisor should stop after recovery worker release");
+    assert!(runtime.wait_for_runtime_recoveries_for(Duration::ZERO));
+}
+
+/// Scenario: a descendant pipeline remains live beyond the extension scope
+/// supervisor guard's finite cleanup budget.
+/// Guarantees: scope-host teardown returns a timeout error and cancels the
+/// supervisor instead of waiting forever.
+#[test]
+fn extension_scope_supervisor_guard_returns_after_descendant_timeout() {
+    let runtime = test_runtime(&empty_engine_config());
+    let stalled_key = deployed_key("g1", "p1", 0, 11);
+    runtime
+        .reserve_instance_launch(&stalled_key)
+        .expect("launch reservation should succeed");
+
+    let (stopped_tx, stopped_rx) = std::sync::mpsc::channel();
+    let handle = spawn_thread_local_task(
+        "test-extension-scope-timeout",
+        TracingSetup::new(ProviderSetup::Noop, LogLevel::default(), engine_context),
+        move |cancellation_token| async move {
+            cancellation_token.cancelled().await;
+            _ = stopped_tx.send(());
+            Ok::<(), Error>(())
+        },
+    )
+    .expect("test extension scope supervisor should spawn");
+    let mut guard = ExtensionScopeSupervisorGuard::new_with_timeouts(
+        handle,
+        Arc::clone(&runtime),
+        Duration::from_millis(150),
+        Duration::from_millis(150),
+    );
+
+    let started = Instant::now();
+    let error = guard
+        .shutdown_after_descendants()
+        .expect("stalled descendant should produce a timeout");
+    assert!(
+        error
+            .to_string()
+            .contains("global shutdown deadline elapsed")
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "descendant and supervisor cleanup must each remain bounded"
+    );
+    stopped_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("extension scope supervisor should be cancelled after timeout");
+
+    runtime.abort_instance_launch(&stalled_key);
+    assert!(runtime.wait_for_global_shutdown_completion_for(Duration::from_secs(2)));
+}
+
+/// Scenario: producer draining has finished but its deadline is already past when scope shutdown begins.
+/// Guarantees: the supervisor gets its own finite window without changing the producer deadline.
+#[test]
+fn extension_scope_supervisor_guard_starts_new_budget_after_producer_deadline() {
+    let runtime = test_runtime(&empty_engine_config());
+    let producer_deadline = Instant::now() - Duration::from_secs(1);
+    runtime
+        .request_shutdown_all_until(producer_deadline)
+        .expect("completed producer phase should establish its deadline");
+    let handle = spawn_thread_local_task(
+        "test-scope-independent-shutdown-budget",
+        TracingSetup::new(ProviderSetup::Noop, LogLevel::default(), engine_context),
+        move |cancellation_token| async move {
+            cancellation_token.cancelled().await;
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            Ok::<(), Error>(())
+        },
+    )
+    .expect("scope supervisor should start");
+    let mut guard = ExtensionScopeSupervisorGuard::new(handle, Arc::clone(&runtime));
+    let error = guard.shutdown_after_descendants();
+    assert!(
+        error.is_none(),
+        "expired producer grace must not truncate the next phase: {error:?}"
+    );
+    assert_eq!(
+        runtime.global_shutdown_deadline_or_insert(Duration::from_secs(60)),
+        producer_deadline
+    );
+}
+
+/// Scenario: a scope thread outlives its join budget and reports metrics after controller teardown returns.
+/// Guarantees: timeout detaches without stopping collection; observability gets fresh grace and owns final draining.
+#[tokio::test(flavor = "current_thread")]
+async fn extension_scope_supervisor_guard_bounds_scope_host_thread_join() {
+    let runtime = test_runtime(&empty_engine_config());
+    let observability_key = deployed_key(
+        SYSTEM_PIPELINE_GROUP_ID,
+        SYSTEM_OBSERVABILITY_PIPELINE_ID,
+        0,
+        0,
+    );
+    let (observability_sender, observability_shutdown) = deadline_notifying_admin_sender();
+    register_runtime_instance_with_sender(
+        &runtime,
+        observability_key.clone(),
+        observability_sender,
+        RuntimeInstanceLifecycle::Active,
+    );
+
+    struct ExitObservabilityOnDrop(Arc<ControllerRuntime<()>>, DeployedPipelineKey);
+    impl Drop for ExitObservabilityOnDrop {
+        fn drop(&mut self) {
+            self.0
+                .note_instance_exit(self.1.clone(), RuntimeInstanceExit::Success);
+        }
+    }
+    let observability_exit = ExitObservabilityOnDrop(Arc::clone(&runtime), observability_key);
+
+    let telemetry = InternalTelemetrySystem::default();
+    let collector = telemetry.collector();
+    let (collector_ready_tx, collector_ready_rx) = std_mpsc::channel();
+    let (collector_stopped_tx, collector_stopped_rx) = std_mpsc::channel();
+    // As in controller teardown, only lifetime ownership crosses these threads.
+    let collector_handle = Arc::new(
+        spawn_thread_local_task(
+            "test-deferred-scope-collector",
+            TracingSetup::new(ProviderSetup::Noop, LogLevel::default(), engine_context),
+            move |cancellation_token| {
+                let task = collector.run(cancellation_token);
+                _ = collector_ready_tx.send(());
+                async move {
+                    let result = task.await;
+                    _ = collector_stopped_tx.send(());
+                    result
+                }
+            },
+        )
+        .expect("collector should start"),
+    );
+    collector_ready_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("collector should be running");
+    let collector_lease = Arc::clone(&collector_handle);
+    let context = ControllerContext::new(telemetry.registry());
+    let mut metrics = telemetry
+        .registry()
+        .register_metric_set_for_entity::<OuterScopeLiveReconfigMetrics>(
+            context.register_engine_entity(),
+        );
+    let mut reporter = telemetry.reporter();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let (stopped_tx, stopped_rx) = std::sync::mpsc::channel();
+    let (cleanup_tx, cleanup_rx) = std_mpsc::channel();
+    let completion_runtime = Arc::clone(&runtime);
+    let handle = spawn_thread_local_task_with_cleanup(
+        "test-slow-extension-scope-shutdown",
+        TracingSetup::new(ProviderSetup::Noop, LogLevel::default(), engine_context),
+        move |cancellation_token| async move {
+            cancellation_token.cancelled().await;
+            release_rx
+                .await
+                .map_err(|error| Error::PipelineRuntimeError {
+                    source: Box::new(error),
+                })?;
+            metrics.reported.add(37);
+            reporter.report(&mut metrics)?;
+            reporter.flush().await?;
+            _ = stopped_tx.send(Instant::now());
+            Ok::<(), Error>(())
+        },
+        move |cancellation_token| {
+            completion_runtime.finish_shutdown_after_extension_scopes(&cancellation_token);
+            drop(collector_lease);
+            _ = cleanup_tx.send(());
+        },
+    )
+    .expect("test extension scope supervisor should spawn");
+    let mut guard = ExtensionScopeSupervisorGuard::new_with_timeouts(
+        handle,
+        Arc::clone(&runtime),
+        Duration::from_millis(100),
+        Duration::from_millis(100),
+    );
+
+    let started = Instant::now();
+    let error = guard
+        .shutdown_after_descendants()
+        .expect("slow extension scope shutdown should time out");
+    assert!(matches!(error, Error::ThreadJoinTimeout { .. }));
+    assert!(
+        started.elapsed() < Duration::from_millis(300),
+        "extension scope supervisor thread join must honor its own deadline"
+    );
+    assert!(
+        observability_shutdown.try_recv().is_err(),
+        "join timeout must not open observability shutdown"
+    );
+    let telemetry_error =
+        shutdown_telemetry_task("test-deferred-scope-collector", collector_handle)
+            .expect_err("controller must defer collector teardown while the scope thread is alive");
+    assert!(telemetry_error.to_string().contains("shutdown deferred"));
+    telemetry
+        .reporter()
+        .flush()
+        .await
+        .expect("collector must remain responsive after the join timeout");
+    runtime.release_instance_wait();
+    release_tx
+        .send(())
+        .expect("detached scope thread should still accept its completion barrier");
+    let scope_finished = stopped_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("detached scope thread should report its final metrics");
+    let (reason, deadline) = observability_shutdown
+        .recv_timeout(Duration::from_secs(1))
+        .expect("observability should stop after the extension scope hosts");
+    assert_eq!(reason, "global shutdown");
+    assert!(deadline >= scope_finished + ControllerRuntime::<()>::OBSERVABILITY_SHUTDOWN_TIMEOUT);
+    let batch = telemetry.registry().drain_metric_export_batch();
+    let values = batch
+        .metric_sets
+        .into_iter()
+        .filter(|set| set.descriptor.name == "test.extension.outer_scope_live_reconfig")
+        .map(|set| set.values)
+        .collect::<Vec<_>>();
+    assert_eq!(values, vec![vec![MetricValue::from(37_u64)]]);
+    assert!(
+        collector_stopped_rx.try_recv().is_err(),
+        "fatal wait release must not stop collection while observability is still alive"
+    );
+    drop(observability_exit);
+    collector_stopped_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("collector should stop after observability actually exits");
+    cleanup_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("detached supervisor should release all deferred resources");
+    assert!(runtime.wait_for_global_shutdown_completion_for(Duration::from_secs(1)));
+}
+
+/// Scenario: global shutdown begins while system observability and the
+/// extension scope supervisor are both active.
+/// Guarantees: extension scope hosts stop before observability receives its
+/// shutdown signal, preserving terminal scope-host telemetry.
+#[test]
+fn extension_scope_supervisor_guard_stops_observability_after_scope_hosts() {
+    let runtime = test_runtime(&empty_engine_config());
+    let observability_key = deployed_key(
+        SYSTEM_PIPELINE_GROUP_ID,
+        SYSTEM_OBSERVABILITY_PIPELINE_ID,
+        0,
+        0,
+    );
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let observability_sender: Arc<dyn PipelineAdminSender> =
+        Arc::new(RecordingPipelineAdminSender {
+            calls: Arc::clone(&events),
+            failure: None,
+        });
+    register_runtime_instance_with_sender(
+        &runtime,
+        observability_key.clone(),
+        observability_sender,
+        RuntimeInstanceLifecycle::Active,
+    );
+    runtime
+        .request_shutdown_all(1)
+        .expect("initial producer shutdown phase should succeed");
+    assert!(
+        events
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_empty(),
+        "observability must remain active before extension scope shutdown"
+    );
+
+    let extension_scope_events = Arc::clone(&events);
+    let handle = spawn_thread_local_task(
+        "test-extension-scope-observability-order",
+        TracingSetup::new(ProviderSetup::Noop, LogLevel::default(), engine_context),
+        move |cancellation_token| async move {
+            cancellation_token.cancelled().await;
+            extension_scope_events
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push("extension scope hosts stopped".to_owned());
+            Ok::<(), Error>(())
+        },
+    )
+    .expect("test extension scope supervisor should spawn");
+    let guard = ExtensionScopeSupervisorGuard::new_with_timeouts(
+        handle,
+        Arc::clone(&runtime),
+        Duration::from_secs(2),
+        Duration::from_secs(2),
+    );
+    let drop_thread = thread::spawn(move || drop(guard));
+
+    let deadline = Instant::now() + Duration::from_secs(1);
+    loop {
+        let observed = events
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        if observed.len() >= 2 {
+            assert_eq!(
+                observed,
+                ["extension scope hosts stopped", "global shutdown"]
+            );
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for ordered extension scope and observability shutdown"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    runtime.note_instance_exit(observability_key, RuntimeInstanceExit::Success);
+    drop_thread
+        .join()
+        .expect("extension scope supervisor guard cleanup should finish");
 }
 
 /// Scenario: a runtime thread reports exit before the controller finishes

--- a/rust/otap-dataflow/crates/controller/src/startup.rs
+++ b/rust/otap-dataflow/crates/controller/src/startup.rs
@@ -22,8 +22,9 @@
 
 use crate::{CONTROLLER_EXTENSION_FACTORIES, ControllerExtensionRegistry};
 use otel_arrow_dfe_config::engine::{HttpAdminSettings, OtelDataflowSpec};
+use otel_arrow_dfe_config::extension::ExtensionDeclarationScope;
 use otel_arrow_dfe_config::node::NodeKind;
-use otel_arrow_dfe_config::pipeline::PipelineConfig;
+use otel_arrow_dfe_config::pipeline::{PipelineConfig, PipelineExtensions};
 use otel_arrow_dfe_config::policy::{CoreAllocation, ResolvedPolicies, ResourcesPolicy};
 use otel_arrow_dfe_config::{PipelineGroupId, PipelineId};
 use otel_arrow_dfe_engine::PipelineFactory;
@@ -228,6 +229,41 @@ fn validate_rate_limiter_bindings(
     Ok(())
 }
 
+fn validate_extension_scope_declarations<PData: 'static + Clone + Debug>(
+    declaration_scope: &ExtensionDeclarationScope,
+    extensions: &PipelineExtensions,
+    factory: &PipelineFactory<PData>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    for (extension_id, extension) in extensions.iter() {
+        let urn = extension.r#type.as_str();
+        let Some(extension_factory) = factory.get_extension_factory_map().get(urn) else {
+            return Err(std::io::Error::other(format!(
+                "Unknown extension component `{urn}` at {declaration_scope} extension={}",
+                extension_id.as_ref()
+            ))
+            .into());
+        };
+        if extension_factory
+            .capabilities
+            .as_ref()
+            .is_some_and(|capabilities| capabilities.shared.is_empty())
+        {
+            return Err(std::io::Error::other(format!(
+                "Extension `{}` cannot be declared at {declaration_scope} because it does not provide a shared variant",
+                extension_id.as_ref()
+            ))
+            .into());
+        }
+        (extension_factory.validate_config)(&extension.config).map_err(|error| {
+            std::io::Error::other(format!(
+                "Invalid config for extension `{urn}` at {declaration_scope} extension={}: {error}",
+                extension_id.as_ref()
+            ))
+        })?;
+    }
+    Ok(())
+}
+
 /// Validates that every node in every pipeline (including the engine
 /// observability pipeline) references a component URN registered in the
 /// given [`PipelineFactory`].
@@ -239,6 +275,19 @@ pub fn validate_engine_components<PData: 'static + Clone + Debug>(
     engine_cfg: &OtelDataflowSpec,
     factory: &PipelineFactory<PData>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    validate_extension_scope_declarations(
+        &ExtensionDeclarationScope::Engine,
+        &engine_cfg.extensions,
+        factory,
+    )?;
+    for (pipeline_group_id, group) in &engine_cfg.groups {
+        validate_extension_scope_declarations(
+            &ExtensionDeclarationScope::PipelineGroup(pipeline_group_id.clone()),
+            &group.extensions,
+            factory,
+        )?;
+    }
+
     for resolved in engine_cfg.resolve().pipelines {
         validate_pipeline_components(
             &resolved.pipeline_group_id,

--- a/rust/otap-dataflow/crates/controller/src/thread_task.rs
+++ b/rust/otap-dataflow/crates/controller/src/thread_task.rs
@@ -6,10 +6,21 @@
 
 use std::future::Future;
 use std::thread;
+use std::time::{Duration, Instant};
 use tokio::{runtime::Builder as RtBuilder, task::LocalSet};
 use tokio_util::sync::CancellationToken;
 
 use otel_arrow_dfe_telemetry::TracingSetup;
+
+struct ThreadCleanup<F: FnOnce()>(Option<F>);
+
+impl<F: FnOnce()> Drop for ThreadCleanup<F> {
+    fn drop(&mut self) {
+        if let Some(cleanup) = self.0.take() {
+            cleanup();
+        }
+    }
+}
 
 /// Handle to a task running on a dedicated thread.  This represents
 /// OS thread and single-threaded async runtime, without thread
@@ -33,6 +44,34 @@ impl<T, E> ThreadLocalTaskHandle<T, E> {
         E: Into<crate::error::Error>,
     {
         self.shutdown_and_join_internal()
+    }
+
+    /// Request shutdown and join only until `deadline`.
+    ///
+    /// If the thread does not stop in time, its join handle is detached and a
+    /// timeout error is returned so controller teardown remains bounded.
+    pub fn shutdown_and_join_until(mut self, deadline: Instant) -> Result<T, crate::error::Error>
+    where
+        E: Into<crate::error::Error>,
+    {
+        self.shutdown();
+        let join_handle = self.join_handle.take().expect("join handle missing");
+        while !join_handle.is_finished() {
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                return Err(crate::error::Error::ThreadJoinTimeout {
+                    thread_name: self.name.clone(),
+                });
+            };
+            thread::sleep(remaining.min(Duration::from_millis(10)));
+        }
+        match join_handle.join() {
+            Ok(Ok(value)) => Ok(value),
+            Ok(Err(error)) => Err(error.into()),
+            Err(panic) => Err(crate::error::Error::ThreadJoinPanic {
+                thread_name: self.name.clone(),
+                panic_message: format!("{panic:?}"),
+            }),
+        }
     }
 
     fn shutdown_and_join_internal(mut self) -> Result<T, crate::error::Error>
@@ -111,15 +150,38 @@ where
     Fut: 'static + Future<Output = Result<T, E>>,
     F: 'static + Send + FnOnce(CancellationToken) -> Fut,
 {
+    spawn_thread_local_task_with_cleanup(thread_name, tracing_setup, task_factory, |_| {})
+}
+
+/// Runs cleanup on the same OS thread after its LocalSet and runtime are dropped,
+/// including on unwind. Cleanup may wait for other threads without blocking any
+/// local async work. Its captured resources survive a timed-out, detached join.
+/// The callback receives the same cancellation signal as the task.
+pub(crate) fn spawn_thread_local_task_with_cleanup<T, E, Fut, F, C>(
+    thread_name: impl Into<String>,
+    tracing_setup: TracingSetup,
+    task_factory: F,
+    cleanup: C,
+) -> Result<ThreadLocalTaskHandle<T, E>, crate::error::Error>
+where
+    T: Send + 'static,
+    E: Send + 'static,
+    Fut: 'static + Future<Output = Result<T, E>>,
+    F: 'static + Send + FnOnce(CancellationToken) -> Fut,
+    // The callback, like the factory, moves once onto its dedicated OS thread.
+    C: 'static + Send + FnOnce(CancellationToken),
+{
     let name = thread_name.into();
     let name_for_thread = name.clone();
     let token = CancellationToken::new();
     let token_for_task = token.clone();
+    let token_for_cleanup = token.clone();
 
     let join_handle = thread::Builder::new()
         .name(name_for_thread)
         .spawn(move || {
             tracing_setup.with_subscriber(|| {
+                let _cleanup = ThreadCleanup(Some(move || cleanup(token_for_cleanup)));
                 let rt = RtBuilder::new_current_thread()
                     .enable_all()
                     .build()
@@ -142,4 +204,58 @@ where
         join_handle: Some(join_handle),
         name,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Error;
+    use otel_arrow_dfe_config::settings::telemetry::logs::LogLevel;
+    use otel_arrow_dfe_telemetry::tracing_init::ProviderSetup;
+
+    struct LocalTaskDrop(std::sync::mpsc::Sender<&'static str>);
+
+    impl Drop for LocalTaskDrop {
+        fn drop(&mut self) {
+            _ = self.0.send("local task dropped");
+        }
+    }
+
+    /// Scenario: a scope thread panics with an unfinished task on its LocalSet.
+    /// Guarantees: shutdown cleanup runs after local task destruction, while the join still reports the panic.
+    #[test]
+    fn shutdown_cleanup_runs_after_local_tasks_drop_on_panic() {
+        let (events_tx, events_rx) = std::sync::mpsc::channel();
+        let cleanup_tx = events_tx.clone();
+        let handle: ThreadLocalTaskHandle<(), Error> = spawn_thread_local_task_with_cleanup(
+            "test-thread-shutdown-cleanup",
+            TracingSetup::new(
+                ProviderSetup::Noop,
+                LogLevel::default(),
+                crate::engine_context,
+            ),
+            move |_| async move {
+                let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+                let _task = tokio::task::spawn_local(async move {
+                    let _drop = LocalTaskDrop(events_tx);
+                    _ = ready_tx.send(());
+                    std::future::pending::<()>().await;
+                });
+                ready_rx.await.expect("local task should start");
+                panic!("synthetic scope thread panic");
+            },
+            move |_| {
+                _ = cleanup_tx.send("shutdown cleanup");
+            },
+        )
+        .expect("test thread should start");
+        assert!(matches!(
+            handle.shutdown_and_join(),
+            Err(Error::ThreadJoinPanic { .. })
+        ));
+        assert_eq!(
+            events_rx.try_iter().collect::<Vec<_>>(),
+            ["local task dropped", "shutdown cleanup"]
+        );
+    }
 }

--- a/rust/otap-dataflow/crates/ctl/src/pipeline_config_io.rs
+++ b/rust/otap-dataflow/crates/ctl/src/pipeline_config_io.rs
@@ -43,13 +43,13 @@ pub(crate) fn parse_pipeline_config_content(
     pipeline_id: &str,
 ) -> Result<PipelineConfig, CliError> {
     let parse_result = if looks_like_json(content) {
-        PipelineConfig::from_json(
+        PipelineConfig::from_json_allowing_inherited_extensions(
             pipeline_group_id.to_string().into(),
             pipeline_id.to_string().into(),
             content,
         )
     } else {
-        PipelineConfig::from_yaml(
+        PipelineConfig::from_yaml_allowing_inherited_extensions(
             pipeline_group_id.to_string().into(),
             pipeline_id.to_string().into(),
             content,
@@ -117,5 +117,28 @@ mod tests {
         let parsed = parse_pipeline_config_content(&rendered, "tenant-a", "ingest")
             .expect("json pipeline config should parse");
         assert!(parsed.eq_ignoring_policies(&pipeline_config()));
+    }
+
+    /// Scenario: a CLI or TUI pipeline document binds a capability declared at
+    /// engine or pipeline-group scope and therefore omits the declaration.
+    /// Guarantees: local parsing preserves the inherited binding so the server
+    /// can validate it against the full live configuration.
+    #[test]
+    fn parse_pipeline_config_content_accepts_inherited_extension_binding() {
+        let content = r#"
+nodes:
+  ingress:
+    type: "receiver:otlp"
+  egress:
+    type: "exporter:debug"
+    capabilities:
+      bearer_token_provider: ancestor_auth
+connections:
+  - from: ingress
+    to: egress
+"#;
+
+        _ = parse_pipeline_config_content(content, "tenant-a", "ingest")
+            .expect("inherited extension binding should be deferred to server validation");
     }
 }

--- a/rust/otap-dataflow/crates/engine/src/attributes.rs
+++ b/rust/otap-dataflow/crates/engine/src/attributes.rs
@@ -107,10 +107,9 @@ pub struct PipelineAttributeSet {
 /// `scope.kind` discriminator -- there is no way to build a "kind-less" or
 /// inconsistent scope set in the public API.
 ///
-/// When new scope kinds are introduced (e.g. `"engine"`, `"group"`),
-/// add a corresponding `#[compose]` payload field below and a matching
-/// constructor; existing constructors keep new payloads at `Default` so the
-/// descriptor stays stable across scope kinds.
+/// The single pipeline payload supplies the complete descendant identity.
+/// Engine scope leaves it at `Default`; group scope populates only its group
+/// ID; pipeline scope supplies the full runtime pipeline identity.
 #[attribute_set(scope, name = "extension.scope.attrs")]
 #[derive(Debug, Clone, Hash)]
 pub struct ExtensionScopeAttributeSet {
@@ -119,8 +118,8 @@ pub struct ExtensionScopeAttributeSet {
     #[attribute_key = "scope.kind"]
     pub(crate) kind: Cow<'static, str>,
 
-    /// Pipeline-scope payload. Populated when `kind == "pipeline"`; left at
-    /// `Default::default()` for other scope kinds.
+    /// Descendant identity payload. Group scope populates only
+    /// `pipeline_group_id`; pipeline scope populates the full set.
     #[compose]
     pub(crate) pipeline: PipelineAttributeSet,
 }
@@ -140,6 +139,27 @@ impl Default for ExtensionScopeAttributeSet {
 }
 
 impl ExtensionScopeAttributeSet {
+    /// Engine-host scope.
+    #[must_use]
+    pub fn engine() -> Self {
+        Self {
+            kind: Cow::Borrowed("engine"),
+            pipeline: PipelineAttributeSet::default(),
+        }
+    }
+
+    /// Pipeline-group-host scope.
+    #[must_use]
+    pub fn group(pipeline_group_id: Cow<'static, str>) -> Self {
+        Self {
+            kind: Cow::Borrowed("group"),
+            pipeline: PipelineAttributeSet {
+                pipeline_group_id,
+                ..PipelineAttributeSet::default()
+            },
+        }
+    }
+
     /// Pipeline-host scope. The full pipeline attribute set (group id,
     /// pipeline id, engine id, generation, resource attrs, ...) is composed
     /// into the resulting scope so two distinct `(group, pipeline)` pairs

--- a/rust/otap-dataflow/crates/engine/src/context.rs
+++ b/rust/otap-dataflow/crates/engine/src/context.rs
@@ -290,6 +290,24 @@ impl ControllerContext {
         self.telemetry_registry_handle.clone()
     }
 
+    /// Returns an extension context hosted once for the engine.
+    #[must_use]
+    pub fn engine_extension_context(&self) -> ExtensionContext {
+        ExtensionContext::new(self.clone(), ExtensionScopeAttributeSet::engine())
+    }
+
+    /// Returns an extension context hosted once for a pipeline group.
+    #[must_use]
+    pub fn pipeline_group_extension_context(
+        &self,
+        pipeline_group_id: PipelineGroupId,
+    ) -> ExtensionContext {
+        ExtensionContext::new(
+            self.clone(),
+            ExtensionScopeAttributeSet::group(pipeline_group_id),
+        )
+    }
+
     /// Returns the shared process-wide memory pressure state.
     #[must_use]
     pub fn memory_pressure_state(&self) -> MemoryPressureState {

--- a/rust/otap-dataflow/crates/engine/src/error.rs
+++ b/rust/otap-dataflow/crates/engine/src/error.rs
@@ -8,6 +8,7 @@
 
 use crate::node::{NodeId, NodeName};
 use otel_arrow_dfe_channel::error::SendError;
+use otel_arrow_dfe_config::extension::ExtensionDeclarationScope;
 use otel_arrow_dfe_config::node::NodeKind;
 use otel_arrow_dfe_config::{NodeUrn, PortName, TopicName};
 use otel_arrow_dfe_telemetry::event::ErrorSummary;
@@ -345,6 +346,17 @@ pub enum Error {
         plugin_urn: String,
     },
 
+    /// An extension declaration requires a shared variant at its scope.
+    #[error(
+        "Extension `{extension}` cannot be declared at {declaration_scope} because it does not provide a shared variant"
+    )]
+    ExtensionDeclarationRequiresSharedVariant {
+        /// The configured extension identifier.
+        extension: ExtensionId,
+        /// Scope containing the extension declaration.
+        declaration_scope: ExtensionDeclarationScope,
+    },
+
     /// Capability registration failed for an extension.
     #[error("Failed to register capabilities for extension `{extension}`: {message}")]
     CapabilityRegistrationFailed {
@@ -633,6 +645,9 @@ impl Error {
             Error::UnknownExporter { .. } => "UnknownExporter",
             Error::ExtensionAlreadyExists { .. } => "ExtensionAlreadyExists",
             Error::UnknownExtension { .. } => "UnknownExtension",
+            Error::ExtensionDeclarationRequiresSharedVariant { .. } => {
+                "ExtensionDeclarationRequiresSharedVariant"
+            }
             Error::CapabilityRegistrationFailed { .. } => "CapabilityRegistrationFailed",
             Error::CapabilityResolutionFailed { .. } => "CapabilityResolutionFailed",
             Error::UnknownNode { .. } => "UnknownNode",

--- a/rust/otap-dataflow/crates/engine/src/extension/mod.rs
+++ b/rust/otap-dataflow/crates/engine/src/extension/mod.rs
@@ -11,6 +11,7 @@
 //! | [`wrapper`]   | [`ControlChannel`], [`EffectHandler`], [`ExtensionLifecycle`], [`ExtensionWrapper`], [`ExtensionBundle`] |
 //! | [`builder`]   | Typestate chain: [`ExtensionBundleBuilder`] plus per-axis stages (see module docs) and [`SharedDecomposed`] / [`LocalDecomposed`] |
 //! | [`readiness`] | [`ReadinessSignaller`] / [`ReadinessProbe`] primitive for extension startup gating |
+//! | [`scope`]     | Declaration-scope hosts, supervision, and inherited provider lookup |
 //!
 //! For the local (!Send) and shared (Send) Extension traits, see
 //! [`local::extension`](crate::local::extension) and
@@ -18,6 +19,7 @@
 
 pub mod builder;
 pub mod readiness;
+pub mod scope;
 pub mod wrapper;
 
 #[cfg(test)]

--- a/rust/otap-dataflow/crates/engine/src/extension/scope/host.rs
+++ b/rust/otap-dataflow/crates/engine/src/extension/scope/host.rs
@@ -1,0 +1,391 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Runtime hosting for extensions declared at one configuration scope.
+
+use crate::channel_metrics::ChannelMetricsHandle;
+use crate::context::ExtensionContext;
+use crate::error::Error;
+use crate::extension::ExtensionWrapper;
+use crate::extension_lifecycle::{EXTENSION_SHUTDOWN_GRACE, ExtensionLifecycle, LifecycleEvent};
+use crate::extension_monitor::ExtensionMetricsMonitor;
+use crate::terminal_state::TerminalMetricsDeadline;
+use otel_arrow_dfe_config::MetricLevel;
+use otel_arrow_dfe_config::extension::ExtensionDeclarationScope;
+use otel_arrow_dfe_config::policy::ResolvedPolicies;
+use otel_arrow_dfe_telemetry::otel_warn;
+use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
+use std::time::{Duration, Instant};
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::{Interval, MissedTickBehavior, interval_at};
+
+const EXTENSION_MONITOR_TICK_INTERVAL: Duration = Duration::from_secs(1);
+const EXTENSION_MONITOR_COLLECT_TELEMETRY_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Effective runtime policy consumed by an extension scope host.
+///
+/// This projection is shared with live-control validation so policy reloads are
+/// rejected only when they would change an already-running scope host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExtensionHostRuntimePolicy {
+    control_node_capacity: usize,
+    pipeline_metrics: bool,
+    channel_metrics_enabled: bool,
+}
+
+impl ExtensionHostRuntimePolicy {
+    /// Projects the policy values used when constructing and monitoring an
+    /// extension scope host.
+    #[must_use]
+    pub fn from_resolved(policies: &ResolvedPolicies) -> Self {
+        Self {
+            control_node_capacity: policies.channel_capacity.control.node,
+            pipeline_metrics: policies.telemetry.pipeline_metrics,
+            channel_metrics_enabled: policies.telemetry.runtime_metrics >= MetricLevel::Basic,
+        }
+    }
+
+    #[must_use]
+    pub(super) fn control_node_capacity(self) -> usize {
+        self.control_node_capacity
+    }
+
+    #[must_use]
+    fn pipeline_metrics(self) -> bool {
+        self.pipeline_metrics
+    }
+
+    #[must_use]
+    pub(super) fn channel_metrics_enabled(self) -> bool {
+        self.channel_metrics_enabled
+    }
+
+    fn needs_independent_channel_metrics_tick(self) -> bool {
+        self.channel_metrics_enabled && !self.pipeline_metrics
+    }
+}
+
+pub(super) struct PreparedExtensionScopeHost {
+    pub(super) context: ExtensionContext,
+    pub(super) extensions: Vec<(
+        ExtensionWrapper,
+        otel_arrow_dfe_telemetry::registry::EntityKey,
+    )>,
+    pub(super) channel_metrics: Vec<ChannelMetricsHandle>,
+    pub(super) runtime_policy: ExtensionHostRuntimePolicy,
+}
+
+impl PreparedExtensionScopeHost {
+    pub(super) fn start(self, metrics_reporter: &MetricsReporter) -> RunningExtensionScopeHost {
+        let terminal_metrics_deadline = TerminalMetricsDeadline::host_owned();
+        let monitor = if self.runtime_policy.pipeline_metrics() {
+            ExtensionMetricsMonitor::new(
+                self.context.clone(),
+                EXTENSION_MONITOR_TICK_INTERVAL,
+                EXTENSION_MONITOR_COLLECT_TELEMETRY_INTERVAL,
+            )
+        } else {
+            ExtensionMetricsMonitor::disabled(self.context.clone())
+        };
+        let lifecycle = ExtensionLifecycle::spawn_current(
+            self.extensions,
+            metrics_reporter.clone(),
+            terminal_metrics_deadline.clone(),
+            &self.context,
+            monitor,
+        );
+        let channel_metrics_interval = self
+            .runtime_policy
+            .needs_independent_channel_metrics_tick()
+            .then(|| {
+                let start = tokio::time::Instant::now() + EXTENSION_MONITOR_TICK_INTERVAL;
+                let mut interval = interval_at(start, EXTENSION_MONITOR_TICK_INTERVAL);
+                interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                interval
+            });
+        RunningExtensionScopeHost {
+            lifecycle,
+            channel_metrics: self.channel_metrics,
+            channel_metrics_interval,
+            metrics_reporter: metrics_reporter.clone(),
+            terminal_metrics_deadline,
+        }
+    }
+}
+
+pub(super) struct RunningExtensionScopeHost {
+    lifecycle: ExtensionLifecycle,
+    channel_metrics: Vec<ChannelMetricsHandle>,
+    channel_metrics_interval: Option<Interval>,
+    metrics_reporter: MetricsReporter,
+    terminal_metrics_deadline: TerminalMetricsDeadline,
+}
+
+async fn next_optional_interval_tick(interval: &mut Option<Interval>) {
+    match interval {
+        Some(interval) => {
+            _ = interval.tick().await;
+        }
+        None => std::future::pending().await,
+    }
+}
+
+pub(super) enum ScopeEvent {
+    Ready(ExtensionDeclarationScope),
+    Failed {
+        scope: ExtensionDeclarationScope,
+        error: Error,
+    },
+}
+
+impl RunningExtensionScopeHost {
+    async fn wait_ready(&mut self) -> Result<(), Error> {
+        self.lifecycle.wait_all_spawned().await?;
+        self.lifecycle.wait_all_ready().await
+    }
+
+    fn report_channel_metrics(&self, metrics_reporter: &mut MetricsReporter) {
+        for metrics in &self.channel_metrics {
+            if let Err(error) = metrics.report(metrics_reporter) {
+                otel_warn!(
+                    "extension_scope.channel_metrics.reporting_failed",
+                    error = error.to_string()
+                );
+            }
+        }
+    }
+
+    async fn shutdown(&mut self, scope: &ExtensionDeclarationScope) -> Result<(), Error> {
+        self.shutdown_until(scope, Instant::now() + EXTENSION_SHUTDOWN_GRACE)
+            .await
+    }
+
+    async fn shutdown_until(
+        &mut self,
+        scope: &ExtensionDeclarationScope,
+        deadline: Instant,
+    ) -> Result<(), Error> {
+        self.terminal_metrics_deadline.record(deadline);
+        self.lifecycle
+            .initiate_shutdown_until(Some("extension scope host shutdown"), deadline);
+        let timed_out = self.lifecycle.drain_until_deadline().await;
+
+        let mut reporter = self.metrics_reporter.clone();
+        self.report_channel_metrics(&mut reporter);
+        let deadline = self.terminal_metrics_deadline.clone().get();
+        if let Err(error) = self
+            .lifecycle
+            .finish_metrics_reporting_until(&reporter, deadline)
+            .await
+        {
+            otel_warn!(
+                "extension_scope.metrics.final_reporting_failed",
+                error = error.to_string()
+            );
+        }
+        if timed_out > 0 {
+            return Err(Error::InternalError {
+                message: format!(
+                    "{scope} extension shutdown timed out; forcibly aborted {timed_out} task(s)"
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    pub(super) async fn run(
+        mut self,
+        scope: ExtensionDeclarationScope,
+        events: mpsc::UnboundedSender<ScopeEvent>,
+        mut shutdown_rx: oneshot::Receiver<Instant>,
+    ) -> Result<(), Error> {
+        let readiness = tokio::select! {
+            deadline = &mut shutdown_rx => {
+                return match deadline {
+                    Ok(deadline) => self.shutdown_until(&scope, deadline).await,
+                    Err(_) => self.shutdown(&scope).await,
+                };
+            }
+            readiness = self.wait_ready() => readiness,
+        };
+        let mut failure_reported = false;
+        match readiness {
+            Ok(()) => {
+                if events.send(ScopeEvent::Ready(scope.clone())).is_err() {
+                    return self.shutdown(&scope).await;
+                }
+            }
+            Err(error) => {
+                failure_reported = true;
+                if let Err(send_error) = events.send(ScopeEvent::Failed {
+                    scope: scope.clone(),
+                    error,
+                }) {
+                    let _ = self.shutdown(&scope).await;
+                    let ScopeEvent::Failed { error, .. } = send_error.0 else {
+                        unreachable!("failed readiness notification must contain an error");
+                    };
+                    return Err(error);
+                }
+            }
+        }
+
+        loop {
+            tokio::select! {
+                deadline = &mut shutdown_rx => {
+                    return match deadline {
+                        Ok(deadline) => self.shutdown_until(&scope, deadline).await,
+                        Err(_) => self.shutdown(&scope).await,
+                    };
+                }
+                event = self.lifecycle.next_event() => {
+                    match event {
+                        LifecycleEvent::MonitorTick(now) => {
+                            let mut reporter = self.metrics_reporter.clone();
+                            self.lifecycle.monitor_tick(now, &mut reporter);
+                            self.report_channel_metrics(&mut reporter);
+                        }
+                        LifecycleEvent::Completion(Ok(Ok(()))) => {
+                            unreachable!(
+                                "an extension completion before host shutdown must be upgraded to an error"
+                            );
+                        }
+                        LifecycleEvent::Completion(Ok(Err(error))) => {
+                            if !failure_reported {
+                                failure_reported = true;
+                                if let Err(send_error) = events.send(ScopeEvent::Failed {
+                                    scope: scope.clone(),
+                                    error,
+                                }) {
+                                    let _ = self.shutdown(&scope).await;
+                                    let ScopeEvent::Failed { error, .. } = send_error.0 else {
+                                        unreachable!(
+                                            "failed lifecycle notification must contain an error"
+                                        );
+                                    };
+                                    return Err(error);
+                                }
+                            } else {
+                                otel_warn!(
+                                    "extension_scope.host.additional_failure",
+                                    scope = scope.to_string(),
+                                    error = error.to_string()
+                                );
+                            }
+                        }
+                        LifecycleEvent::Completion(Err(error)) => {
+                            let error = Error::JoinTaskError {
+                                is_canceled: error.is_cancelled(),
+                                is_panic: error.is_panic(),
+                                error: error.to_string(),
+                            };
+                            if !failure_reported {
+                                failure_reported = true;
+                                if let Err(send_error) = events.send(ScopeEvent::Failed {
+                                    scope: scope.clone(),
+                                    error,
+                                }) {
+                                    let _ = self.shutdown(&scope).await;
+                                    let ScopeEvent::Failed { error, .. } = send_error.0 else {
+                                        unreachable!(
+                                            "failed join notification must contain an error"
+                                        );
+                                    };
+                                    return Err(error);
+                                }
+                            } else {
+                                otel_warn!(
+                                    "extension_scope.host.additional_failure",
+                                    scope = scope.to_string(),
+                                    error = error.to_string()
+                                );
+                            }
+                        }
+                    }
+                }
+                _ = next_optional_interval_tick(&mut self.channel_metrics_interval) => {
+                    let mut reporter = self.metrics_reporter.clone();
+                    self.report_channel_metrics(&mut reporter);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::ControllerContext;
+    use otel_arrow_dfe_telemetry::InternalTelemetrySystem;
+
+    /// Scenario: an early provider failure uses a metrics fallback before its host begins shutdown.
+    /// Guarantees: that local fallback does not constrain the host's later phase deadline.
+    #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_phase_does_not_inherit_pre_shutdown_metrics_fallback() {
+        let telemetry = InternalTelemetrySystem::default();
+        let prepared = PreparedExtensionScopeHost {
+            context: ControllerContext::new(telemetry.registry()).engine_extension_context(),
+            extensions: Vec::new(),
+            channel_metrics: Vec::new(),
+            runtime_policy: ExtensionHostRuntimePolicy {
+                control_node_capacity: 1,
+                pipeline_metrics: false,
+                channel_metrics_enabled: false,
+            },
+        };
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let collector =
+                    tokio::task::spawn_local(telemetry.collector().run_collection_loop());
+                let mut host = prepared.start(&telemetry.reporter());
+                let reporter_deadline = host.terminal_metrics_deadline.clone();
+                let early_failure_deadline = reporter_deadline.get();
+                let shutdown_deadline = early_failure_deadline + EXTENSION_SHUTDOWN_GRACE;
+                host.shutdown_until(&ExtensionDeclarationScope::Engine, shutdown_deadline)
+                    .await
+                    .expect("host shutdown should complete");
+                assert_eq!(
+                    reporter_deadline.get(),
+                    shutdown_deadline,
+                    "remaining providers must not inherit a pre-shutdown failure's cutoff"
+                );
+                reporter_deadline.record(shutdown_deadline + Duration::from_secs(1));
+                assert_eq!(reporter_deadline.get(), shutdown_deadline);
+                collector.abort();
+                assert!(
+                    collector
+                        .await
+                        .expect_err("collector should run until stopped")
+                        .is_cancelled()
+                );
+            })
+            .await;
+    }
+
+    /// Scenario: lifecycle metrics are disabled while runtime channel metrics
+    /// remain enabled for an extension scope host.
+    /// Guarantees: channel metrics receive an independent periodic reporting
+    /// tick instead of being silently disabled with lifecycle metrics.
+    #[test]
+    fn channel_metrics_tick_is_independent_from_pipeline_metrics() {
+        let runtime_only = ExtensionHostRuntimePolicy {
+            control_node_capacity: 1,
+            pipeline_metrics: false,
+            channel_metrics_enabled: true,
+        };
+        let all_metrics = ExtensionHostRuntimePolicy {
+            control_node_capacity: 1,
+            pipeline_metrics: true,
+            channel_metrics_enabled: true,
+        };
+        let no_metrics = ExtensionHostRuntimePolicy {
+            control_node_capacity: 1,
+            pipeline_metrics: false,
+            channel_metrics_enabled: false,
+        };
+
+        assert!(runtime_only.needs_independent_channel_metrics_tick());
+        assert!(!all_metrics.needs_independent_channel_metrics_tick());
+        assert!(!no_metrics.needs_independent_channel_metrics_tick());
+    }
+}

--- a/rust/otap-dataflow/crates/engine/src/extension/scope/mod.rs
+++ b/rust/otap-dataflow/crates/engine/src/extension/scope/mod.rs
@@ -1,0 +1,16 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Extension declaration scopes, controller-owned hosts, and inherited providers.
+//!
+//! Extensions declared at engine or pipeline-group scope are hosted once by the
+//! controller. Pipelines receive immutable registrations for the shared
+//! providers visible from their declaration scope.
+
+mod host;
+mod registry;
+mod supervisor;
+
+pub use host::ExtensionHostRuntimePolicy;
+pub use registry::{ExtensionScopeRegistry, InheritedExtensionRegistrations};
+pub use supervisor::{PreparedExtensionScopeSupervisor, RunningExtensionScopeSupervisor};

--- a/rust/otap-dataflow/crates/engine/src/extension/scope/registry.rs
+++ b/rust/otap-dataflow/crates/engine/src/extension/scope/registry.rs
@@ -1,0 +1,183 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Extension provider lookup across declaration scopes.
+
+use crate::capability::registry::CapabilityRegistry;
+use crate::capability::{ExtensionCapabilities, SharedInstanceFactory};
+use crate::error::Error;
+use otel_arrow_dfe_config::pipeline::PipelineExtensions;
+use otel_arrow_dfe_config::{ExtensionId, PipelineGroupId};
+use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
+
+/// A pipeline-owned snapshot of shared capability providers inherited from
+/// engine and pipeline-group scopes.
+#[derive(Clone, Default)]
+pub struct InheritedExtensionRegistrations {
+    known_extensions: HashSet<ExtensionId>,
+    registrations: Vec<SharedExtensionRegistration>,
+}
+
+impl Debug for InheritedExtensionRegistrations {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("InheritedExtensionRegistrations")
+            .field("known_extensions", &self.known_extensions)
+            .field(
+                "registered_extensions",
+                &self
+                    .registrations
+                    .iter()
+                    .map(|registration| &registration.extension_id)
+                    .collect::<Vec<_>>(),
+            )
+            .finish()
+    }
+}
+
+impl InheritedExtensionRegistrations {
+    /// Returns whether the snapshot contains no inherited extension entries.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.known_extensions.is_empty() && self.registrations.is_empty()
+    }
+
+    pub(crate) fn remove_shadowed_by(&mut self, pipeline_extensions: &PipelineExtensions) {
+        self.known_extensions
+            .retain(|extension_id| !pipeline_extensions.contains_key(extension_id));
+        self.registrations
+            .retain(|registration| !pipeline_extensions.contains_key(&registration.extension_id));
+    }
+
+    pub(crate) fn extend_known_extensions(&self, known_extensions: &mut HashSet<ExtensionId>) {
+        known_extensions.extend(self.known_extensions.iter().cloned());
+    }
+
+    pub(crate) fn register_into(&self, registry: &mut CapabilityRegistry) -> Result<(), Error> {
+        for registration in &self.registrations {
+            (registration.capabilities.register_shared)(
+                registration.extension_id.clone(),
+                registration.instance_factory.clone(),
+                registry,
+            )
+            .map_err(|error| Error::CapabilityRegistrationFailed {
+                extension: registration.extension_id.clone(),
+                message: error.to_string(),
+            })?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct SharedExtensionRegistration {
+    pub(super) extension_id: ExtensionId,
+    pub(super) capabilities: ExtensionCapabilities,
+    pub(super) instance_factory: SharedInstanceFactory,
+}
+
+#[derive(Default)]
+pub(super) struct ScopeCatalog {
+    pub(super) known_extensions: HashSet<ExtensionId>,
+    pub(super) registrations: Vec<SharedExtensionRegistration>,
+}
+
+#[derive(Default)]
+pub(super) struct ExtensionScopeCatalog {
+    pub(super) engine: ScopeCatalog,
+    pub(super) groups: HashMap<PipelineGroupId, ScopeCatalog>,
+}
+
+#[derive(Default)]
+struct ExtensionScopeRegistryState {
+    installed: bool,
+    catalog: ExtensionScopeCatalog,
+}
+
+/// Immutable capability catalogs for engine and pipeline-group declarations.
+///
+/// The mutex is used only to publish the catalog once and clone build-time
+/// snapshots across controller threads. Pipeline data paths never access it.
+#[derive(Clone, Default)]
+pub struct ExtensionScopeRegistry {
+    state: Arc<Mutex<ExtensionScopeRegistryState>>,
+}
+
+impl ExtensionScopeRegistry {
+    pub(super) fn install(&self, catalog: ExtensionScopeCatalog) -> Result<(), Error> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.installed {
+            return Err(Error::InternalError {
+                message: "extension scope catalog was installed more than once".into(),
+            });
+        }
+        state.catalog = catalog;
+        state.installed = true;
+        Ok(())
+    }
+
+    /// Returns the inherited registrations visible from a pipeline.
+    ///
+    /// Pipeline declarations shadow pipeline-group and engine declarations.
+    /// Pipeline-group declarations shadow engine declarations with the same
+    /// extension ID.
+    #[must_use]
+    pub fn registrations_for_pipeline(
+        &self,
+        pipeline_group_id: &PipelineGroupId,
+        pipeline_extensions: &PipelineExtensions,
+    ) -> InheritedExtensionRegistrations {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut inherited = InheritedExtensionRegistrations::default();
+        let group = state.catalog.groups.get(pipeline_group_id);
+
+        if let Some(group) = group {
+            for extension_id in &group.known_extensions {
+                if !pipeline_extensions.contains_key(extension_id) {
+                    let _ = inherited.known_extensions.insert(extension_id.clone());
+                }
+            }
+            inherited.registrations.extend(
+                group
+                    .registrations
+                    .iter()
+                    .filter(|registration| {
+                        !pipeline_extensions.contains_key(&registration.extension_id)
+                    })
+                    .cloned(),
+            );
+        }
+
+        for extension_id in &state.catalog.engine.known_extensions {
+            let shadowed_by_group =
+                group.is_some_and(|group| group.known_extensions.contains(extension_id));
+            if !pipeline_extensions.contains_key(extension_id) && !shadowed_by_group {
+                let _ = inherited.known_extensions.insert(extension_id.clone());
+            }
+        }
+        inherited.registrations.extend(
+            state
+                .catalog
+                .engine
+                .registrations
+                .iter()
+                .filter(|registration| {
+                    !pipeline_extensions.contains_key(&registration.extension_id)
+                        && !group.is_some_and(|group| {
+                            group.known_extensions.contains(&registration.extension_id)
+                        })
+                })
+                .cloned(),
+        );
+
+        inherited
+    }
+}

--- a/rust/otap-dataflow/crates/engine/src/extension/scope/supervisor.rs
+++ b/rust/otap-dataflow/crates/engine/src/extension/scope/supervisor.rs
@@ -1,0 +1,621 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Startup, supervision, and ordered shutdown for extension scope hosts.
+//!
+//! Extensions declared at engine or pipeline-group scope are instantiated once on a
+//! controller-owned `LocalSet`. Only their shared variant is retained because
+//! every inherited capability handle may cross pipeline-thread boundaries.
+
+use super::host::{
+    ExtensionHostRuntimePolicy, PreparedExtensionScopeHost, RunningExtensionScopeHost, ScopeEvent,
+};
+use super::registry::{
+    ExtensionScopeCatalog, ExtensionScopeRegistry, ScopeCatalog, SharedExtensionRegistration,
+};
+use crate::PipelineFactory;
+use crate::channel_metrics::ChannelMetricsRegistry;
+use crate::config::ExtensionConfig;
+use crate::context::{ControllerContext, ExtensionContext};
+use crate::entity_context::{EntityTelemetryGuard, EntityTelemetryHandle};
+use crate::error::Error;
+use crate::extension_lifecycle::{EXTENSION_SHUTDOWN_DRAIN_SLACK, EXTENSION_SHUTDOWN_GRACE};
+use futures::stream::{FuturesUnordered, StreamExt};
+use otel_arrow_dfe_config::PipelineGroupId;
+use otel_arrow_dfe_config::engine::OtelDataflowSpec;
+use otel_arrow_dfe_config::extension::ExtensionDeclarationScope;
+use otel_arrow_dfe_config::pipeline::PipelineExtensions;
+use otel_arrow_dfe_config::policy::{Policies, ResolvedPolicies};
+use otel_arrow_dfe_telemetry::otel_warn;
+use otel_arrow_dfe_telemetry::reporter::MetricsReporter;
+use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
+use std::future::Future;
+use std::time::{Duration, Instant};
+use tokio::sync::{mpsc, oneshot};
+use tokio::task;
+
+/// Prepared controller-owned extension scopes.
+///
+/// Construction is synchronous and does not spawn tasks. Call [`start`](Self::start)
+/// from inside the host thread's `LocalSet`.
+pub struct PreparedExtensionScopeSupervisor {
+    engine_scope: Option<PreparedExtensionScopeHost>,
+    group_scopes: Vec<(PipelineGroupId, PreparedExtensionScopeHost)>,
+    catalog: ExtensionScopeCatalog,
+    registry: ExtensionScopeRegistry,
+    metrics_reporter: MetricsReporter,
+}
+
+impl PreparedExtensionScopeSupervisor {
+    /// Starts the extension scope hosts without a startup cancellation signal.
+    pub async fn start(self) -> Result<RunningExtensionScopeSupervisor, Error> {
+        self.start_with_shutdown(std::future::pending())
+            .await?
+            .ok_or_else(|| Error::InternalError {
+                message: "uncancelled extension scope startup was cancelled".to_owned(),
+            })
+    }
+
+    /// Starts every engine and group extension, waits for spawn and readiness
+    /// barriers, and publishes the immutable capability catalog.
+    pub async fn start_with_shutdown<F>(
+        self,
+        shutdown: F,
+    ) -> Result<Option<RunningExtensionScopeSupervisor>, Error>
+    where
+        F: Future<Output = ()>,
+    {
+        let Self {
+            engine_scope,
+            group_scopes,
+            catalog,
+            registry,
+            metrics_reporter,
+        } = self;
+        let (events_tx, events_rx) = mpsc::unbounded_channel();
+        let mut supervisor = ScopeTaskSupervisor::new(events_rx);
+        let mut shutdown = Box::pin(shutdown);
+
+        if let Some(engine_scope) = engine_scope {
+            let scope = ExtensionDeclarationScope::Engine;
+            supervisor.spawn(
+                scope.clone(),
+                engine_scope.start(&metrics_reporter),
+                events_tx.clone(),
+            );
+            let mut pending = HashSet::from([scope]);
+            match supervisor
+                .wait_until_ready(&mut pending, shutdown.as_mut())
+                .await
+            {
+                Ok(StartupWaitOutcome::Ready) => {}
+                Ok(StartupWaitOutcome::Cancelled) => {
+                    let mut first_error = None;
+                    supervisor.shutdown_ordered(&mut first_error).await;
+                    return first_error.map_or(Ok(None), Err);
+                }
+                Err(error) => {
+                    let mut first_error = Some(error);
+                    supervisor.shutdown_ordered(&mut first_error).await;
+                    return Err(first_error.expect("startup failure must be preserved"));
+                }
+            }
+        }
+
+        // Every group starts only after the engine-level barrier succeeds.
+        // Groups are peers, so they start concurrently.
+        let mut pending_groups = HashSet::new();
+        for (pipeline_group_id, group_scope) in group_scopes {
+            let scope = ExtensionDeclarationScope::PipelineGroup(pipeline_group_id);
+            let _ = pending_groups.insert(scope.clone());
+            supervisor.spawn(
+                scope,
+                group_scope.start(&metrics_reporter),
+                events_tx.clone(),
+            );
+        }
+        drop(events_tx);
+        match supervisor
+            .wait_until_ready(&mut pending_groups, shutdown.as_mut())
+            .await
+        {
+            Ok(StartupWaitOutcome::Ready) => {}
+            Ok(StartupWaitOutcome::Cancelled) => {
+                let mut first_error = None;
+                supervisor.shutdown_ordered(&mut first_error).await;
+                return first_error.map_or(Ok(None), Err);
+            }
+            Err(error) => {
+                let mut first_error = Some(error);
+                supervisor.shutdown_ordered(&mut first_error).await;
+                return Err(first_error.expect("startup failure must be preserved"));
+            }
+        }
+
+        if let Err(error) = registry.install(catalog) {
+            let mut first_error = Some(error);
+            supervisor.shutdown_ordered(&mut first_error).await;
+            return Err(first_error.expect("catalog installation failure must be preserved"));
+        }
+
+        Ok(Some(RunningExtensionScopeSupervisor { supervisor }))
+    }
+}
+
+/// Running controller-owned engine and pipeline-group extension scopes.
+pub struct RunningExtensionScopeSupervisor {
+    supervisor: ScopeTaskSupervisor,
+}
+
+impl RunningExtensionScopeSupervisor {
+    /// Combined grace for the parallel group phase followed by the engine phase.
+    ///
+    /// The controller must budget this separately from descendant pipeline
+    /// draining, and allow additional time for thread coordination and observability.
+    pub const SHUTDOWN_TIMEOUT: Duration = EXTENSION_SHUTDOWN_GRACE
+        .saturating_add(EXTENSION_SHUTDOWN_DRAIN_SLACK)
+        .saturating_mul(2);
+
+    /// Drives all scopes until cancellation or the first extension failure.
+    ///
+    /// On failure, `notify_failure` runs before any surviving scope is stopped.
+    /// Providers remain alive until `shutdown` completes so the controller can
+    /// drain descendant pipelines first.
+    pub async fn run<F, N>(mut self, shutdown: F, notify_failure: N) -> Result<(), Error>
+    where
+        F: Future<Output = ()> + 'static,
+        N: FnOnce(String),
+    {
+        if self.supervisor.tasks.is_empty() {
+            shutdown.await;
+            return Ok(());
+        }
+
+        let mut first_error = None;
+        let mut notify_failure = Some(notify_failure);
+        let mut events_open = true;
+        let mut shutdown = Box::pin(shutdown);
+        loop {
+            tokio::select! {
+                biased;
+                event = self.supervisor.events_rx.recv(), if events_open => {
+                    match event {
+                        Some(ScopeEvent::Failed { scope, error }) => {
+                            Self::observe_failure(
+                                scope,
+                                error,
+                                &mut first_error,
+                                &mut notify_failure,
+                            );
+                        }
+                        Some(ScopeEvent::Ready(scope)) => {
+                            Self::observe_failure(
+                                scope.clone(),
+                                Error::InternalError {
+                                    message: format!(
+                                        "{scope} reported readiness after extension scope startup"
+                                    ),
+                                },
+                                &mut first_error,
+                                &mut notify_failure,
+                            );
+                        }
+                        None => {
+                            events_open = false;
+                            if !self.supervisor.tasks.is_empty() {
+                                Self::observe_failure(
+                                    ExtensionDeclarationScope::Engine,
+                                    Error::InternalError {
+                                        message: "extension scope event channel closed while scope hosts were still running".to_owned(),
+                                    },
+                                    &mut first_error,
+                                    &mut notify_failure,
+                                );
+                            }
+                        }
+                    }
+                }
+                Some(joined) = self.supervisor.tasks.next(), if !self.supervisor.tasks.is_empty() => {
+                    let (scope, error) = self.supervisor.route_completion(joined);
+                    if let Some(error) = error {
+                        Self::observe_failure(
+                            scope.unwrap_or(ExtensionDeclarationScope::Engine),
+                            error,
+                            &mut first_error,
+                            &mut notify_failure,
+                        );
+                    }
+                }
+                _ = shutdown.as_mut() => break,
+            }
+        }
+
+        self.supervisor.shutdown_ordered(&mut first_error).await;
+        first_error.map_or(Ok(()), Err)
+    }
+
+    /// Stops all scope hosts in declaration order without reporting a runtime failure.
+    pub async fn shutdown(mut self) -> Result<(), Error> {
+        let mut first_error = None;
+        self.supervisor.shutdown_ordered(&mut first_error).await;
+        first_error.map_or(Ok(()), Err)
+    }
+
+    fn observe_failure<N>(
+        scope: ExtensionDeclarationScope,
+        error: Error,
+        first_error: &mut Option<Error>,
+        notify_failure: &mut Option<N>,
+    ) where
+        N: FnOnce(String),
+    {
+        if first_error.is_none() {
+            if let Some(notify_failure) = notify_failure.take() {
+                notify_failure(error.to_string());
+            }
+            *first_error = Some(error);
+        } else {
+            otel_warn!(
+                "extension_scope.host.secondary_failure",
+                scope = scope.to_string(),
+                error = error.to_string()
+            );
+        }
+    }
+}
+
+enum StartupWaitOutcome {
+    Ready,
+    Cancelled,
+}
+
+struct ScopeTaskSupervisor {
+    events_rx: mpsc::UnboundedReceiver<ScopeEvent>,
+    tasks: FuturesUnordered<task::JoinHandle<(ExtensionDeclarationScope, Result<(), Error>)>>,
+    task_ids: HashMap<task::Id, ExtensionDeclarationScope>,
+    shutdown_senders: HashMap<ExtensionDeclarationScope, oneshot::Sender<Instant>>,
+    shutdown_requested: HashSet<ExtensionDeclarationScope>,
+    completed: HashSet<ExtensionDeclarationScope>,
+    engine_scope: Option<ExtensionDeclarationScope>,
+    group_scopes: Vec<ExtensionDeclarationScope>,
+}
+
+impl ScopeTaskSupervisor {
+    fn new(events_rx: mpsc::UnboundedReceiver<ScopeEvent>) -> Self {
+        Self {
+            events_rx,
+            tasks: FuturesUnordered::new(),
+            task_ids: HashMap::new(),
+            shutdown_senders: HashMap::new(),
+            shutdown_requested: HashSet::new(),
+            completed: HashSet::new(),
+            engine_scope: None,
+            group_scopes: Vec::new(),
+        }
+    }
+
+    fn spawn(
+        &mut self,
+        scope: ExtensionDeclarationScope,
+        running_scope: RunningExtensionScopeHost,
+        events: mpsc::UnboundedSender<ScopeEvent>,
+    ) {
+        match &scope {
+            ExtensionDeclarationScope::Engine => self.engine_scope = Some(scope.clone()),
+            ExtensionDeclarationScope::PipelineGroup(_) => self.group_scopes.push(scope.clone()),
+            ExtensionDeclarationScope::Pipeline(_, _) => {
+                unreachable!("pipeline-scoped extensions are hosted by runtime pipelines")
+            }
+        }
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let task_scope = scope.clone();
+        let handle = task::spawn_local(async move {
+            let result = running_scope
+                .run(task_scope.clone(), events, shutdown_rx)
+                .await;
+            (task_scope, result)
+        });
+        let _ = self.task_ids.insert(handle.id(), scope.clone());
+        self.tasks.push(handle);
+        let _ = self.shutdown_senders.insert(scope, shutdown_tx);
+    }
+
+    async fn wait_until_ready<F>(
+        &mut self,
+        pending: &mut HashSet<ExtensionDeclarationScope>,
+        mut shutdown: std::pin::Pin<&mut F>,
+    ) -> Result<StartupWaitOutcome, Error>
+    where
+        F: Future<Output = ()>,
+    {
+        while !pending.is_empty() {
+            tokio::select! {
+                biased;
+                event = self.events_rx.recv() => {
+                    match event {
+                        Some(ScopeEvent::Ready(scope)) => {
+                            if !pending.remove(&scope) {
+                                return Err(Error::InternalError {
+                                    message: format!(
+                                        "received unexpected or duplicate readiness from {scope}"
+                                    ),
+                                });
+                            }
+                        }
+                        Some(ScopeEvent::Failed { error, .. }) => return Err(error),
+                        None => {
+                            return Err(Error::InternalError {
+                                message: "extension scope event channel closed during startup".to_owned(),
+                            });
+                        }
+                    }
+                }
+                Some(joined) = self.tasks.next(), if !self.tasks.is_empty() => {
+                    let (scope, error) = self.route_completion(joined);
+                    return Err(error.unwrap_or_else(|| Error::InternalError {
+                        message: scope.map_or_else(
+                            || "unknown extension scope host exited during startup".to_owned(),
+                            |scope| format!("{scope} exited during startup"),
+                        ),
+                    }));
+                }
+                _ = shutdown.as_mut() => return Ok(StartupWaitOutcome::Cancelled),
+            }
+        }
+        Ok(StartupWaitOutcome::Ready)
+    }
+
+    fn request_shutdown(&mut self, scope: &ExtensionDeclarationScope, deadline: Instant) {
+        if self.completed.contains(scope) || !self.shutdown_requested.insert(scope.clone()) {
+            return;
+        }
+        if let Some(shutdown_tx) = self.shutdown_senders.remove(scope) {
+            let _ = shutdown_tx.send(deadline);
+        }
+    }
+
+    async fn shutdown_ordered(&mut self, first_error: &mut Option<Error>) {
+        let group_scopes = self.group_scopes.clone();
+        let group_deadline = Instant::now() + EXTENSION_SHUTDOWN_GRACE;
+        for scope in &group_scopes {
+            self.request_shutdown(scope, group_deadline);
+        }
+        self.drain_scopes(&group_scopes, first_error).await;
+
+        if let Some(engine_scope) = self.engine_scope.clone() {
+            self.request_shutdown(&engine_scope, Instant::now() + EXTENSION_SHUTDOWN_GRACE);
+            self.drain_scopes(&[engine_scope], first_error).await;
+        }
+
+        while let Ok(event) = self.events_rx.try_recv() {
+            if let ScopeEvent::Failed { error, .. } = event
+                && first_error.is_none()
+            {
+                *first_error = Some(error);
+            }
+        }
+    }
+
+    async fn drain_scopes(
+        &mut self,
+        scopes: &[ExtensionDeclarationScope],
+        first_error: &mut Option<Error>,
+    ) {
+        let mut events_open = true;
+        while scopes.iter().any(|scope| !self.completed.contains(scope)) {
+            tokio::select! {
+                biased;
+                event = self.events_rx.recv(), if events_open => {
+                    match event {
+                        Some(ScopeEvent::Failed { error, .. }) if first_error.is_none() => {
+                            *first_error = Some(error);
+                        }
+                        Some(_) => {}
+                        None => events_open = false,
+                    }
+                }
+                joined = self.tasks.next(), if !self.tasks.is_empty() => {
+                    let Some(joined) = joined else {
+                        break;
+                    };
+                    let (_, error) = self.route_completion(joined);
+                    if first_error.is_none() {
+                        *first_error = error;
+                    }
+                }
+                else => break,
+            }
+        }
+        if first_error.is_none() && scopes.iter().any(|scope| !self.completed.contains(scope)) {
+            *first_error = Some(Error::InternalError {
+                message: "extension scope host tasks disappeared during shutdown".to_owned(),
+            });
+        }
+    }
+
+    fn route_completion(
+        &mut self,
+        joined: Result<(ExtensionDeclarationScope, Result<(), Error>), task::JoinError>,
+    ) -> (Option<ExtensionDeclarationScope>, Option<Error>) {
+        match joined {
+            Ok((scope, result)) => {
+                self.task_ids
+                    .retain(|_, mapped_scope| mapped_scope != &scope);
+                let _ = self.completed.insert(scope.clone());
+                let _ = self.shutdown_senders.remove(&scope);
+                let shutdown_was_requested = self.shutdown_requested.contains(&scope);
+                let error = match result {
+                    Ok(()) if shutdown_was_requested => None,
+                    Ok(()) => Some(Error::InternalError {
+                        message: format!("{scope} exited before host shutdown"),
+                    }),
+                    Err(error) => Some(error),
+                };
+                (Some(scope), error)
+            }
+            Err(error) => {
+                let scope = self.task_ids.remove(&error.id());
+                if let Some(scope) = scope.as_ref() {
+                    let _ = self.completed.insert(scope.clone());
+                    let _ = self.shutdown_senders.remove(scope);
+                }
+                (
+                    scope,
+                    Some(Error::JoinTaskError {
+                        is_canceled: error.is_cancelled(),
+                        is_panic: error.is_panic(),
+                        error: error.to_string(),
+                    }),
+                )
+            }
+        }
+    }
+}
+
+impl<PData: 'static + Clone + Debug> PipelineFactory<PData> {
+    /// Prepares all engine and group extension declarations for the dedicated
+    /// extension-scope supervisor thread.
+    pub fn prepare_extension_scope_hosts(
+        &'static self,
+        config: &OtelDataflowSpec,
+        controller_context: &ControllerContext,
+        metrics_reporter: MetricsReporter,
+        registry: ExtensionScopeRegistry,
+    ) -> Result<PreparedExtensionScopeSupervisor, Error> {
+        let engine_declaration_scope = ExtensionDeclarationScope::Engine;
+        let engine_policies = Policies::resolve([&config.policies]);
+        let (engine_scope, engine_catalog) = self.prepare_extension_scope(
+            &engine_declaration_scope,
+            &config.extensions,
+            controller_context.engine_extension_context(),
+            &engine_policies,
+        )?;
+
+        let mut group_scopes = Vec::new();
+        let mut catalog = ExtensionScopeCatalog {
+            engine: engine_catalog,
+            groups: HashMap::new(),
+        };
+
+        let mut groups: Vec<_> = config.groups.iter().collect();
+        groups.sort_by(|(left, _), (right, _)| left.as_ref().cmp(right.as_ref()));
+        for (pipeline_group_id, pipeline_group) in groups {
+            let policies = pipeline_group.policies.as_ref().map_or_else(
+                || Policies::resolve([&config.policies]),
+                |group_policies| Policies::resolve([group_policies, &config.policies]),
+            );
+            let declaration_scope =
+                ExtensionDeclarationScope::PipelineGroup(pipeline_group_id.clone());
+            let (scope, group_catalog) = self.prepare_extension_scope(
+                &declaration_scope,
+                &pipeline_group.extensions,
+                controller_context.pipeline_group_extension_context(pipeline_group_id.clone()),
+                &policies,
+            )?;
+            if let Some(scope) = scope {
+                group_scopes.push((pipeline_group_id.clone(), scope));
+            }
+            if !group_catalog.known_extensions.is_empty() {
+                let _ = catalog
+                    .groups
+                    .insert(pipeline_group_id.clone(), group_catalog);
+            }
+        }
+
+        Ok(PreparedExtensionScopeSupervisor {
+            engine_scope,
+            group_scopes,
+            catalog,
+            registry,
+            metrics_reporter,
+        })
+    }
+
+    fn prepare_extension_scope(
+        &self,
+        declaration_scope: &ExtensionDeclarationScope,
+        extensions: &PipelineExtensions,
+        context: ExtensionContext,
+        policies: &ResolvedPolicies,
+    ) -> Result<(Option<PreparedExtensionScopeHost>, ScopeCatalog), Error> {
+        let runtime_policy = ExtensionHostRuntimePolicy::from_resolved(policies);
+        let mut configured_extensions: Vec<_> = extensions.iter().collect();
+        configured_extensions.sort_by(|(left, _), (right, _)| left.as_ref().cmp(right.as_ref()));
+
+        let mut wrappers = Vec::with_capacity(configured_extensions.len());
+        let mut channel_metrics = ChannelMetricsRegistry::default();
+        let mut catalog = ScopeCatalog::default();
+        for (extension_id, user_config) in configured_extensions {
+            let _ = catalog.known_extensions.insert(extension_id.clone());
+            let raw_urn = user_config.r#type.as_str();
+            let factory = self
+                .get_extension_factory_map()
+                .get(raw_urn)
+                .ok_or_else(|| Error::UnknownExtension {
+                    plugin_urn: raw_urn.to_string(),
+                })?;
+
+            if factory
+                .capabilities
+                .as_ref()
+                .is_some_and(|capabilities| capabilities.shared.is_empty())
+            {
+                return Err(Error::ExtensionDeclarationRequiresSharedVariant {
+                    extension: extension_id.clone(),
+                    declaration_scope: declaration_scope.clone(),
+                });
+            }
+
+            let runtime_config = ExtensionConfig::with_control_channel_capacity(
+                extension_id.clone(),
+                runtime_policy.control_node_capacity(),
+            );
+            let mut bundle = (factory.create)(
+                &context,
+                extension_id.clone(),
+                user_config.clone(),
+                &runtime_config,
+            )
+            .map_err(|error| Error::ConfigError(Box::new(error)))?;
+            let Some(mut shared) = bundle.take_shared() else {
+                return Err(Error::ExtensionDeclarationRequiresSharedVariant {
+                    extension: extension_id.clone(),
+                    declaration_scope: declaration_scope.clone(),
+                });
+            };
+
+            if let Some(capabilities) = factory.capabilities.as_ref() {
+                let instance_factory = shared
+                    .shared_instance_factory()
+                    .expect("a shared wrapper always has a shared instance factory")
+                    .clone();
+                catalog.registrations.push(SharedExtensionRegistration {
+                    extension_id: extension_id.clone(),
+                    capabilities: capabilities.clone(),
+                    instance_factory,
+                });
+            }
+
+            let entity_key =
+                context.register_extension_entity(extension_id.clone(), shared.variant());
+            let entity_handle = EntityTelemetryHandle::new(context.metrics_registry(), entity_key);
+            shared = shared.with_control_channel_metrics(
+                &entity_handle,
+                &context,
+                &mut channel_metrics,
+                runtime_policy.channel_metrics_enabled(),
+            );
+            shared = shared.with_entity_telemetry_guard(EntityTelemetryGuard::new(entity_handle));
+            wrappers.push((shared, entity_key));
+        }
+
+        let scope = (!wrappers.is_empty()).then(|| PreparedExtensionScopeHost {
+            context,
+            extensions: wrappers,
+            channel_metrics: channel_metrics.into_handles(),
+            runtime_policy,
+        });
+        Ok((scope, catalog))
+    }
+}

--- a/rust/otap-dataflow/crates/engine/src/extension/wrapper.rs
+++ b/rust/otap-dataflow/crates/engine/src/extension/wrapper.rs
@@ -185,10 +185,9 @@ pub enum ExtensionVariant {
     /// `!Send` variant scheduled onto the host `LocalSet`.
     Local,
     /// `Send` variant runnable on multi-threaded executors.
-    /// Whether an extension is shared between pipelines or not
-    /// is a separate concern that will be handled by the scope
-    /// that the extension is declared in. Currently only pipeline
-    /// scope is supported.
+    /// Whether an extension is shared between pipelines is determined by
+    /// its declaration scope: engine and group variants are distributed to
+    /// descendants, while pipeline variants remain per pipeline instance.
     Shared,
 }
 

--- a/rust/otap-dataflow/crates/engine/src/extension_lifecycle.rs
+++ b/rust/otap-dataflow/crates/engine/src/extension_lifecycle.rs
@@ -22,6 +22,7 @@ use crate::extension_monitor::{
 };
 use crate::terminal_state::TerminalMetricsDeadline;
 use futures::FutureExt;
+use futures::future::LocalBoxFuture;
 use futures::stream::{FuturesUnordered, StreamExt};
 use otel_arrow_dfe_telemetry::otel_warn;
 use otel_arrow_dfe_telemetry::registry::EntityKey;
@@ -75,7 +76,45 @@ impl ExtensionLifecycle {
         metrics_reporter: MetricsReporter,
         terminal_metrics_deadline: TerminalMetricsDeadline,
         ext_ctx: &ExtensionContext,
+        monitor: ExtensionMetricsMonitor,
+    ) -> Self {
+        Self::spawn_with(
+            extensions,
+            metrics_reporter,
+            terminal_metrics_deadline,
+            ext_ctx,
+            monitor,
+            |future| local_tasks.spawn_local(future),
+        )
+    }
+
+    /// Spawns extensions on the [`LocalSet`] currently driving this task.
+    pub(crate) fn spawn_current(
+        extensions: Vec<(ExtensionWrapper, EntityKey)>,
+        metrics_reporter: MetricsReporter,
+        terminal_metrics_deadline: TerminalMetricsDeadline,
+        ext_ctx: &ExtensionContext,
+        monitor: ExtensionMetricsMonitor,
+    ) -> Self {
+        Self::spawn_with(
+            extensions,
+            metrics_reporter,
+            terminal_metrics_deadline,
+            ext_ctx,
+            monitor,
+            task::spawn_local,
+        )
+    }
+
+    fn spawn_with(
+        extensions: Vec<(ExtensionWrapper, EntityKey)>,
+        metrics_reporter: MetricsReporter,
+        terminal_metrics_deadline: TerminalMetricsDeadline,
+        ext_ctx: &ExtensionContext,
         mut monitor: ExtensionMetricsMonitor,
+        mut spawn_task: impl FnMut(
+            LocalBoxFuture<'static, (ExtensionKey, Result<(), Error>)>,
+        ) -> JoinHandle<(ExtensionKey, Result<(), Error>)>,
     ) -> Self {
         let futures: FuturesUnordered<JoinHandle<(ExtensionKey, Result<(), Error>)>> =
             FuturesUnordered::new();
@@ -144,7 +183,7 @@ impl ExtensionLifecycle {
                 drop(control_sender);
                 (task_key, res)
             };
-            let handle = local_tasks.spawn_local(fut);
+            let handle = spawn_task(fut.boxed_local());
             let _ = task_id_to_key.insert(handle.id(), key.clone());
             futures.push(handle);
             let _ = pending_starts.insert(key);
@@ -451,6 +490,11 @@ impl ExtensionLifecycle {
     /// Broadcasts `Shutdown` to every active+background extension via its
     /// priority oneshot channel. Single-shot: subsequent calls are no-ops.
     pub fn initiate_shutdown(&mut self, reason: Option<&str>) {
+        self.initiate_shutdown_until(reason, Instant::now() + EXTENSION_SHUTDOWN_GRACE);
+    }
+
+    /// Uses the host's phase deadline for both extension shutdown and draining.
+    pub(crate) fn initiate_shutdown_until(&mut self, reason: Option<&str>, deadline: Instant) {
         if matches!(self.phase, LifecyclePhase::ShuttingDown { .. }) {
             return;
         }
@@ -458,7 +502,6 @@ impl ExtensionLifecycle {
             return;
         }
 
-        let deadline = Instant::now() + EXTENSION_SHUTDOWN_GRACE;
         self.phase = LifecyclePhase::ShuttingDown { deadline };
 
         let reason = reason.unwrap_or(DEFAULT_SHUTDOWN_REASON).to_string();
@@ -482,10 +525,12 @@ impl ExtensionLifecycle {
         }
     }
 
-    /// Drains remaining extension tasks, bounded by the shutdown deadline.
-    pub async fn drain_until_deadline(&mut self) {
+    /// Drains remaining extension tasks, aborting stragglers at the deadline.
+    ///
+    /// Returns the number of tasks that required forced cancellation.
+    pub async fn drain_until_deadline(&mut self) -> usize {
         if self.futures.is_empty() {
-            return;
+            return 0;
         }
         let deadline = match self.phase {
             LifecyclePhase::ShuttingDown { deadline } => deadline,
@@ -544,17 +589,36 @@ impl ExtensionLifecycle {
             }
         };
 
-        if tokio::time::timeout_at(drain_deadline, drain)
-            .await
-            .is_err()
-        {
+        if tokio::time::timeout_at(drain_deadline, drain).await.is_ok() {
+            return 0;
+        }
+
+        let timed_out = self.futures.len();
+        if timed_out > 0 {
             otel_warn!(
                 "extension.shutdown.timeout",
                 grace_secs = EXTENSION_SHUTDOWN_GRACE.as_secs(),
-                remaining = self.futures.len()
+                remaining = timed_out
             );
             self.monitor.mark_stragglers_as_timeout();
+            for handle in self.futures.iter() {
+                handle.abort();
+            }
+            while let Some(result) = self.futures.next().await {
+                if let Err(error) = result
+                    && !error.is_cancelled()
+                {
+                    otel_warn!(
+                        "extension.shutdown.forced_abort_join_error",
+                        is_panic = error.is_panic(),
+                        error = error.to_string()
+                    );
+                }
+            }
+            self.task_id_to_key.clear();
+            self.shutdown_channels.clear();
         }
+        timed_out
     }
 }
 
@@ -583,6 +647,8 @@ mod tests {
         (key, channel, rx)
     }
 
+    /// Scenario: An extension ignores shutdown past its bounded drain deadline.
+    /// Guarantees: The task is aborted and fully joined before the lifecycle returns.
     #[test]
     fn drain_until_deadline_is_bounded_for_stuck_extension() {
         let (rt, local_tasks) = crate::testing::setup_test_runtime();
@@ -619,7 +685,7 @@ mod tests {
             };
 
             let start = Instant::now();
-            lifecycle.drain_until_deadline().await;
+            let timed_out = lifecycle.drain_until_deadline().await;
             let elapsed = start.elapsed();
 
             let upper_bound = Duration::from_millis(100)
@@ -631,10 +697,8 @@ mod tests {
                 elapsed,
                 upper_bound,
             );
-            assert!(
-                !lifecycle.futures.is_empty(),
-                "stuck extension should still be present after the bounded drain timed out",
-            );
+            assert_eq!(timed_out, 1);
+            assert!(lifecycle.futures.is_empty());
         }));
     }
 
@@ -1340,7 +1404,7 @@ mod tests {
             );
 
             lifecycle.initiate_shutdown(Some("test"));
-            lifecycle.drain_until_deadline().await;
+            _ = lifecycle.drain_until_deadline().await;
 
             assert!(
                 observed_shutdown.get(),
@@ -1422,7 +1486,7 @@ mod tests {
             );
 
             lifecycle.initiate_shutdown(Some("test"));
-            lifecycle.drain_until_deadline().await;
+            _ = lifecycle.drain_until_deadline().await;
 
             assert!(observed_shutdown.get(), "extension must have observed Shutdown");
             assert!(!observed_close.get(), "extension control channel must not have closed early");

--- a/rust/otap-dataflow/crates/engine/src/lib.rs
+++ b/rust/otap-dataflow/crates/engine/src/lib.rs
@@ -760,6 +760,36 @@ impl<PData: 'static + Clone + Debug> PipelineFactory<PData> {
     /// from the Internal Telemetry System.
     pub fn build(
         self: &PipelineFactory<PData>,
+        pipeline_ctx: PipelineContext,
+        config: PipelineConfig,
+        channel_capacity_policy: ChannelCapacityPolicy,
+        telemetry_policy: TelemetryPolicy,
+        transport_headers_policy: Option<TransportHeadersPolicy>,
+        rate_limiter_policies: BTreeMap<String, RateLimiterPolicy>,
+        rate_limiter_scope: Option<RateLimiterDeclarationScope>,
+        internal_telemetry: Option<InternalTelemetrySettings>,
+    ) -> Result<RuntimePipeline<PData>, Error>
+    where
+        PData: Unwindable,
+    {
+        self.build_with_inherited_extensions(
+            pipeline_ctx,
+            config,
+            channel_capacity_policy,
+            telemetry_policy,
+            transport_headers_policy,
+            rate_limiter_policies,
+            rate_limiter_scope,
+            internal_telemetry,
+            extension::scope::InheritedExtensionRegistrations::default(),
+        )
+    }
+
+    /// Builds a runtime pipeline with shared capability providers inherited
+    /// from engine and pipeline-group extension scopes.
+    #[allow(clippy::too_many_arguments)]
+    pub fn build_with_inherited_extensions(
+        self: &PipelineFactory<PData>,
         mut pipeline_ctx: PipelineContext,
         mut config: PipelineConfig,
         channel_capacity_policy: ChannelCapacityPolicy,
@@ -768,6 +798,7 @@ impl<PData: 'static + Clone + Debug> PipelineFactory<PData> {
         rate_limiter_policies: BTreeMap<String, RateLimiterPolicy>,
         rate_limiter_scope: Option<RateLimiterDeclarationScope>,
         internal_telemetry: Option<InternalTelemetrySettings>,
+        mut inherited_extensions: extension::scope::InheritedExtensionRegistrations,
     ) -> Result<RuntimePipeline<PData>, Error>
     where
         PData: Unwindable,
@@ -871,9 +902,12 @@ impl<PData: 'static + Clone + Debug> PipelineFactory<PData> {
         // bodies run inside this same `build` call, so extension `start()`
         // side effects (which happen later, in `run_forever`) cannot be
         // observed by capability construction.
-        let known_extensions: HashSet<otel_arrow_dfe_config::ExtensionId> =
+        inherited_extensions.remove_shadowed_by(config.extensions());
+        let mut known_extensions: HashSet<otel_arrow_dfe_config::ExtensionId> =
             config.extensions().keys().cloned().collect();
+        inherited_extensions.extend_known_extensions(&mut known_extensions);
         let mut capability_registry = capability::registry::CapabilityRegistry::new();
+        inherited_extensions.register_into(&mut capability_registry)?;
         // Each entry tracks (extension id, bundle, is_background). The
         // `is_background` flag is captured here while we still have the
         // factory in hand -- Background extensions register zero

--- a/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
+++ b/rust/otap-dataflow/crates/engine/src/runtime_pipeline.rs
@@ -263,13 +263,12 @@ pub(crate) async fn report_terminal_metrics(
     terminal_state: TerminalState,
     terminal_metrics_deadline: &TerminalMetricsDeadline,
 ) {
-    let deadline = terminal_state.deadline();
-    terminal_metrics_deadline.record(deadline);
+    let deadline = terminal_metrics_deadline.for_report(terminal_state.deadline());
     report_metric_snapshots(
         metrics_reporter,
         terminal_state.into_metrics(),
         "terminal",
-        terminal_metrics_deadline.get(),
+        deadline,
     )
     .await;
 }
@@ -521,7 +520,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
             rt.block_on(local_tasks.run_until(extension_lifecycle.wait_all_spawned()))
         {
             extension_lifecycle.initiate_shutdown(Some("spawn barrier failed"));
-            rt.block_on(local_tasks.run_until(extension_lifecycle.drain_until_deadline()));
+            _ = rt.block_on(local_tasks.run_until(extension_lifecycle.drain_until_deadline()));
             return Err(barrier_err);
         }
 
@@ -536,7 +535,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
             rt.block_on(local_tasks.run_until(extension_lifecycle.wait_all_ready()))
         {
             extension_lifecycle.initiate_shutdown(Some("extension readiness gate failed"));
-            rt.block_on(local_tasks.run_until(extension_lifecycle.drain_until_deadline()));
+            _ = rt.block_on(local_tasks.run_until(extension_lifecycle.drain_until_deadline()));
             return Err(readiness_err);
         }
 
@@ -1009,7 +1008,7 @@ impl<PData: 'static + Debug + Clone + ReceivedAtNode + Unwindable + FlowMetricHo
                     // idempotent (no-op on the happy path).
                     extension_lifecycle
                         .initiate_shutdown(Some("pipeline data-path drained"));
-                    extension_lifecycle.drain_until_deadline().await;
+                    _ = extension_lifecycle.drain_until_deadline().await;
                     // Final monitor flush so per-extension counters reflect
                     // any terminal `ShutdownTimeout` entries on the way out.
                     let mut final_monitor_reporter = metrics_reporter.clone();
@@ -1179,6 +1178,20 @@ mod tests {
     use otel_arrow_dfe_telemetry::common_attributes::{Outcome, SignalOutcomeAttributes};
     use otel_arrow_dfe_telemetry::registry::TelemetryRegistryHandle;
     use otel_arrow_dfe_telemetry::{InternalTelemetrySystem, LogContext};
+    use std::time::Instant;
+
+    fn test_metrics_system(config: TelemetryConfig) -> InternalTelemetrySystem {
+        InternalTelemetrySystem::new(
+            &config,
+            config.reporting_interval,
+            TelemetryRegistryHandle::new(),
+            None,
+            SendPolicy::default(),
+            LogContext::new,
+            None,
+        )
+        .expect("ITS telemetry system should initialize")
+    }
 
     /// Scenario: optional node measurement interests are present without the normal-level message interests.
     /// Guarantees: no consumed or produced message, item, or size metric sets are registered below normal.
@@ -1229,18 +1242,8 @@ mod tests {
     /// Guarantees: the final snapshot reaches the registry before entity handles are released.
     #[tokio::test(flavor = "current_thread")]
     async fn terminal_snapshot_is_aggregated_before_telemetry_cleanup() {
-        let registry = TelemetryRegistryHandle::new();
-        let config = TelemetryConfig::default();
-        let metrics_system = InternalTelemetrySystem::new(
-            &config,
-            config.reporting_interval,
-            registry.clone(),
-            None,
-            SendPolicy::default(),
-            LogContext::new,
-            None,
-        )
-        .expect("ITS telemetry system should initialize");
+        let metrics_system = test_metrics_system(TelemetryConfig::default());
+        let registry = metrics_system.registry();
         let reporter = metrics_system.reporter();
         let collector_task = tokio::spawn(metrics_system.collector().run_collection_loop());
 
@@ -1260,7 +1263,7 @@ mod tests {
 
         report_terminal_metrics(
             &reporter,
-            TerminalState::new(std::time::Instant::now(), metric_set.terminal_snapshots()),
+            TerminalState::new(Instant::now(), metric_set.terminal_snapshots()),
             &TerminalMetricsDeadline::default(),
         )
         .await;
@@ -1303,5 +1306,40 @@ mod tests {
                 .expect_err("collector task should be cancelled")
                 .is_cancelled()
         );
+    }
+
+    /// Scenario: a provider's terminal deadline is expired while its host still has grace and the collector is blocked.
+    /// Guarantees: only that report stops waiting; the shared host phase deadline remains unchanged.
+    #[tokio::test(flavor = "current_thread")]
+    async fn host_terminal_reporting_honors_the_individual_deadline() {
+        let metrics_system = test_metrics_system(TelemetryConfig {
+            reporting_channel_size: 1,
+            ..TelemetryConfig::default()
+        });
+        let reporter = metrics_system.reporter();
+        let collection_loop = metrics_system.collector().run_collection_loop();
+        let deadline = TerminalMetricsDeadline::host_owned();
+        let phase_deadline = Instant::now() + Duration::from_secs(5);
+        deadline.record(phase_deadline);
+
+        let mut blocked_flush = Box::pin(reporter.flush_until(phase_deadline));
+        assert!(futures::poll!(blocked_flush.as_mut()).is_pending());
+        let report = report_terminal_metrics(
+            &reporter,
+            TerminalState::new(
+                Instant::now() - Duration::from_secs(1),
+                std::iter::empty::<MetricSetSnapshot>(),
+            ),
+            &deadline,
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), report)
+                .await
+                .is_ok(),
+            "an expired individual deadline must not wait for the host's longer deadline"
+        );
+        assert_eq!(deadline.get(), phase_deadline);
+        drop(blocked_flush);
+        drop(collection_loop);
     }
 }

--- a/rust/otap-dataflow/crates/engine/src/terminal_state.rs
+++ b/rust/otap-dataflow/crates/engine/src/terminal_state.rs
@@ -10,36 +10,78 @@ use std::ops::Add;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-/// Pipeline-wide deadline shared by every terminal metrics handoff.
+#[derive(Clone, Copy, Debug, Default)]
+enum DeadlineMode {
+    #[default]
+    Earliest,
+    HostOwned,
+}
+
+/// Shutdown deadline policy shared by terminal metrics reporters.
 ///
-/// The runtime control manager records the real shutdown deadline as soon as
-/// it accepts shutdown. Error paths that terminate without a shutdown message
-/// lazily establish one finite fallback. Every final reporter then uses the
-/// same absolute deadline instead of receiving a fresh timeout.
+/// Pipelines retain the earliest recorded deadline and share one error fallback.
+/// Scope hosts own their phase deadline; individual terminal deadlines and
+/// pre-shutdown error fallbacks never change that shared phase budget.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct TerminalMetricsDeadline {
     deadline: Arc<Mutex<Option<Instant>>>,
+    mode: DeadlineMode,
 }
 
 impl TerminalMetricsDeadline {
     const FALLBACK: Duration = Duration::from_secs(5);
 
-    /// Records a shutdown deadline, preserving the earliest deadline observed.
+    /// Creates a deadline that only explicit host shutdown can establish.
+    pub(crate) fn host_owned() -> Self {
+        Self {
+            mode: DeadlineMode::HostOwned,
+            ..Self::default()
+        }
+    }
+
+    /// Records an explicit shutdown deadline.
+    ///
+    /// Pipelines preserve the earliest value; hosts fix the first phase deadline.
     pub(crate) fn record(&self, deadline: Instant) {
         let mut current = self
             .deadline
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        *current = Some(current.map_or(deadline, |current| current.min(deadline)));
+        *current = Some(match self.mode {
+            DeadlineMode::Earliest => current.map_or(deadline, |current| current.min(deadline)),
+            DeadlineMode::HostOwned => current.unwrap_or(deadline),
+        });
     }
 
-    /// Returns the shared deadline, installing a finite fallback if necessary.
+    /// Resolves one terminal state's reporting deadline.
+    ///
+    /// A host-owned deadline is only read here: a peer may limit its own reporting,
+    /// but cannot change the budget for other peers or the host's final flush.
+    pub(crate) fn for_report(&self, terminal_deadline: Instant) -> Instant {
+        match self.mode {
+            DeadlineMode::Earliest => {
+                self.record(terminal_deadline);
+                self.get()
+            }
+            DeadlineMode::HostOwned => self.get().min(terminal_deadline),
+        }
+    }
+
+    /// Returns the phase deadline or a finite error-reporting fallback.
+    ///
+    /// Host fallbacks stay local to the reporting operation: early failures
+    /// must not start the shutdown clock for still-running peer providers.
     pub(crate) fn get(&self) -> Instant {
         let mut deadline = self
             .deadline
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        *deadline.get_or_insert_with(|| Instant::now() + Self::FALLBACK)
+        match self.mode {
+            DeadlineMode::Earliest => {
+                *deadline.get_or_insert_with(|| Instant::now() + Self::FALLBACK)
+            }
+            DeadlineMode::HostOwned => deadline.unwrap_or_else(|| Instant::now() + Self::FALLBACK),
+        }
     }
 }
 
@@ -100,6 +142,8 @@ impl Default for TerminalState {
 mod tests {
     use super::*;
 
+    /// Scenario: a pipeline receives several explicit shutdown deadlines.
+    /// Guarantees: every clone retains the earliest deadline rather than extending cleanup.
     #[test]
     fn terminal_metrics_deadline_preserves_the_earliest_recorded_deadline() {
         let deadline = TerminalMetricsDeadline::default();
@@ -112,6 +156,8 @@ mod tests {
         assert_eq!(deadline.clone().get(), now + Duration::from_secs(1));
     }
 
+    /// Scenario: pipeline error reporting starts without an explicit shutdown deadline.
+    /// Guarantees: all pipeline reporters share a single finite fallback.
     #[test]
     fn terminal_metrics_deadline_installs_only_one_fallback() {
         let deadline = TerminalMetricsDeadline::default();
@@ -119,5 +165,62 @@ mod tests {
 
         assert_eq!(deadline.get(), fallback);
         assert_eq!(deadline.clone().get(), fallback);
+    }
+
+    /// Scenario: pipeline terminal states return different deadlines after shutdown starts.
+    /// Guarantees: terminal reports retain the existing pipeline-wide earliest-deadline behavior.
+    #[test]
+    fn pipeline_terminal_reports_preserve_the_earliest_deadline() {
+        let deadline = TerminalMetricsDeadline::default();
+        let now = Instant::now();
+        deadline.record(now + Duration::from_secs(5));
+        let earlier = now + Duration::from_secs(1);
+        assert_eq!(deadline.for_report(earlier), earlier);
+        assert_eq!(deadline.get(), earlier);
+        assert_eq!(deadline.for_report(now + Duration::from_secs(10)), earlier);
+    }
+
+    /// Scenario: hosted extensions return earlier and later terminal deadlines within one phase.
+    /// Guarantees: each report is bounded locally while peers and repeated signals preserve the host deadline.
+    #[test]
+    fn host_terminal_reports_cannot_change_the_phase_deadline() {
+        let deadline = TerminalMetricsDeadline::host_owned();
+        let now = Instant::now();
+        let phase_deadline = now + Duration::from_secs(5);
+        deadline.record(phase_deadline);
+        let earlier = now + Duration::from_secs(1);
+        assert_eq!(deadline.for_report(earlier), earlier);
+        assert_eq!(deadline.get(), phase_deadline);
+        assert_eq!(deadline.clone().for_report(phase_deadline), phase_deadline);
+        assert_eq!(
+            deadline.for_report(phase_deadline + Duration::from_secs(5)),
+            phase_deadline
+        );
+        deadline.record(earlier);
+        deadline.record(phase_deadline + Duration::from_secs(5));
+        assert_eq!(deadline.get(), phase_deadline);
+    }
+
+    /// Scenario: a hosted provider fails before the host has entered its shutdown phase.
+    /// Guarantees: error reporting stays bounded without installing a deadline for peers or later shutdown.
+    #[test]
+    fn host_error_fallback_does_not_establish_the_phase_deadline() {
+        let deadline = TerminalMetricsDeadline::host_owned();
+        let now = Instant::now();
+        let expired = now - Duration::from_secs(1);
+        assert_eq!(deadline.for_report(expired), expired);
+        let fallback = deadline.get();
+        assert!(fallback >= now + TerminalMetricsDeadline::FALLBACK);
+        assert!(fallback <= Instant::now() + TerminalMetricsDeadline::FALLBACK);
+        assert!(
+            deadline
+                .deadline
+                .lock()
+                .expect("deadline mutex should not be poisoned")
+                .is_none()
+        );
+        let phase_deadline = fallback + Duration::from_secs(5);
+        deadline.record(phase_deadline);
+        assert_eq!(deadline.get(), phase_deadline);
     }
 }

--- a/rust/otap-dataflow/crates/engine/tests/extension_e2e.rs
+++ b/rust/otap-dataflow/crates/engine/tests/extension_e2e.rs
@@ -28,8 +28,10 @@
 //!    drained.
 
 use async_trait::async_trait;
+use otel_arrow_dfe_config::engine::OtelDataflowSpec;
 use otel_arrow_dfe_config::observed_state::{ObservedStateSettings, SendPolicy};
 use otel_arrow_dfe_config::pipeline::PipelineConfig;
+use otel_arrow_dfe_config::pipeline::telemetry::TelemetryConfig;
 use otel_arrow_dfe_config::policy::{
     ChannelCapacityPolicy, RateLimitAggregation, RateLimitEnforcement, RateLimitPressure,
     RateLimitUnit, RateLimiterPolicy, TelemetryPolicy, TokenBucketPolicy,
@@ -47,6 +49,8 @@ use otel_arrow_dfe_engine::control::{
 };
 use otel_arrow_dfe_engine::error::Error as EngineError;
 use otel_arrow_dfe_engine::exporter::ExporterWrapper;
+use otel_arrow_dfe_engine::extension::scope::ExtensionScopeRegistry;
+use otel_arrow_dfe_engine::extension::wrapper::ExtensionVariant;
 use otel_arrow_dfe_engine::extension::{EffectHandler, ExtensionBundle, ExtensionWrapper};
 use otel_arrow_dfe_engine::local::exporter as local_exp;
 use otel_arrow_dfe_engine::local::processor as local_proc;
@@ -63,7 +67,10 @@ use otel_arrow_dfe_engine::testing::capability::no_op_stateless::NoOpStateless;
 use otel_arrow_dfe_engine::testing::capability::no_op_stateless::SharedNoOpStateless;
 use otel_arrow_dfe_engine::{PipelineFactory, extension_capabilities};
 use otel_arrow_dfe_state::store::ObservedStateStore;
-use otel_arrow_dfe_telemetry::InternalTelemetrySystem;
+use otel_arrow_dfe_telemetry::attributes::AttributeSetHandler;
+use otel_arrow_dfe_telemetry::metrics::{MetricSet, MetricValue};
+use otel_arrow_dfe_telemetry::registry::TelemetryRegistryHandle;
+use otel_arrow_dfe_telemetry::{InternalTelemetrySystem, LogContext};
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
@@ -322,8 +329,9 @@ fn probe_receiver_create(
             }
         }
         CallSequence::Shared => {
-            if capabilities.require_shared::<NoOpStateless>().is_ok() {
+            if let Ok(handle) = capabilities.require_shared::<NoOpStateless>() {
                 let _ = probe.first_call_succeeded.fetch_add(1, Ordering::SeqCst);
+                *probe.captured_name.lock() = Some(handle.name().to_owned());
             }
         }
         CallSequence::RequireLocalTwice => {
@@ -1285,6 +1293,205 @@ const BACKGROUND_EXTENSION_FACTORY: ExtensionFactory = ExtensionFactory {
 };
 
 // ---------------------------------------------------------------------
+// Outer-scope telemetry extension -- reports a custom metric whenever
+// the host sends CollectTelemetry.
+// ---------------------------------------------------------------------
+
+#[otel_arrow_dfe_telemetry_macros::metric_set(name = "test.extension.outer_scope")]
+#[derive(Debug, Default, Clone)]
+struct OuterScopeExtensionMetrics {
+    #[metric(name = "reported", unit = "{item}")]
+    reported: otel_arrow_dfe_telemetry::instrument::Counter<u64>,
+}
+
+#[derive(Clone)]
+struct OuterScopeMetricsExtension {
+    metrics: MetricSet<OuterScopeExtensionMetrics>,
+    report_value: u64,
+    // Shared only as a completion barrier between both scope-host tasks and the test driver.
+    collected: Arc<AtomicUsize>,
+    shutdown_probe: Option<OuterScopeShutdownProbe>,
+}
+
+#[derive(Debug)]
+enum OuterScopeShutdownEvent {
+    Started {
+        value: u64,
+        deadline: Instant,
+    },
+    Completed {
+        value: u64,
+        at: Instant,
+        terminal_deadline: Instant,
+    },
+}
+
+#[derive(Clone)]
+struct OuterScopeShutdownProbe {
+    events: tokio::sync::mpsc::UnboundedSender<OuterScopeShutdownEvent>,
+    delay: Duration,
+    empty_terminal_state: bool,
+    // Shared only to pass a completion gate through the static test factory.
+    release: Option<Arc<tokio::sync::Notify>>,
+}
+
+async fn wait_outer_scope_shutdown_completion(
+    events: &mut tokio::sync::mpsc::UnboundedReceiver<OuterScopeShutdownEvent>,
+    expected_value: u64,
+) -> Instant {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if let OuterScopeShutdownEvent::Completed {
+                value,
+                terminal_deadline,
+                ..
+            } = events
+                .recv()
+                .await
+                .expect("scope event channel should stay open")
+                && value == expected_value
+            {
+                return terminal_deadline;
+            }
+        }
+    })
+    .await
+    .expect("extension should return its terminal state")
+}
+
+#[async_trait]
+impl otel_arrow_dfe_engine::shared::extension::Extension for OuterScopeMetricsExtension {
+    async fn start(
+        mut self: Box<Self>,
+        mut ctrl: otel_arrow_dfe_engine::shared::extension::ControlChannel,
+        _eh: EffectHandler,
+    ) -> Result<TerminalState, EngineError> {
+        loop {
+            match ctrl.recv().await {
+                Ok(ExtensionControlMsg::CollectTelemetry {
+                    mut metrics_reporter,
+                }) => {
+                    self.metrics.reported.add(self.report_value);
+                    metrics_reporter
+                        .report(&mut self.metrics)
+                        .map_err(|error| EngineError::InternalError {
+                            message: format!(
+                                "outer-scope extension metric reporting failed: {error}"
+                            ),
+                        })?;
+                    let _ = self.collected.fetch_add(1, Ordering::SeqCst);
+                }
+                Ok(ExtensionControlMsg::Shutdown { deadline, .. }) => {
+                    if let Some(probe) = &self.shutdown_probe {
+                        let _ = probe.events.send(OuterScopeShutdownEvent::Started {
+                            value: self.report_value,
+                            deadline,
+                        });
+                        tokio::time::sleep(probe.delay).await;
+                        if let Some(release) = &probe.release {
+                            release.notified().await;
+                        }
+                        let terminal_state = if probe.empty_terminal_state {
+                            TerminalState::default()
+                        } else {
+                            self.metrics.reported.add(self.report_value);
+                            TerminalState::new(deadline, [self.metrics.snapshot()])
+                        };
+                        let _ = probe.events.send(OuterScopeShutdownEvent::Completed {
+                            value: self.report_value,
+                            at: Instant::now(),
+                            terminal_deadline: terminal_state.deadline(),
+                        });
+                        return Ok(terminal_state);
+                    }
+                    return Ok(TerminalState::new(deadline, [self.metrics]));
+                }
+                Err(_) => break,
+                Ok(ExtensionControlMsg::Config { .. }) => {}
+            }
+        }
+        Ok(TerminalState::default())
+    }
+}
+
+#[derive(Clone, Default)]
+struct OuterScopeMetricsProbe {
+    collected: Arc<AtomicUsize>,
+    shutdown: Option<OuterScopeShutdownProbe>,
+}
+
+static OUTER_SCOPE_METRICS_PROBES: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashMap<String, OuterScopeMetricsProbe>>,
+> = std::sync::OnceLock::new();
+
+fn outer_scope_metrics_probes()
+-> &'static std::sync::Mutex<std::collections::HashMap<String, OuterScopeMetricsProbe>> {
+    OUTER_SCOPE_METRICS_PROBES
+        .get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+fn register_outer_scope_metrics_probe(key: &str, probe: OuterScopeMetricsProbe) {
+    let _ = outer_scope_metrics_probes()
+        .lock()
+        .expect("outer-scope metrics probes mutex poisoned")
+        .insert(key.to_owned(), probe);
+}
+
+fn lookup_outer_scope_metrics_probe(key: &str) -> OuterScopeMetricsProbe {
+    outer_scope_metrics_probes()
+        .lock()
+        .expect("outer-scope metrics probes mutex poisoned")
+        .get(key)
+        .cloned()
+        .unwrap_or_else(|| panic!("no OuterScopeMetricsProbe registered for key '{key}'"))
+}
+
+const OUTER_SCOPE_METRICS_EXTENSION_URN: &str = "urn:test:extension:outer_scope_metrics_extension";
+
+fn outer_scope_metrics_extension_create(
+    ctx: &ExtensionContext,
+    name: otel_arrow_dfe_config::ExtensionId,
+    user_config: Arc<otel_arrow_dfe_config::extension::ExtensionUserConfig>,
+    extension_config: &ExtensionConfig,
+) -> Result<ExtensionBundle, otel_arrow_dfe_config::error::Error> {
+    let probe_key = user_config
+        .config
+        .get("probe_key")
+        .and_then(|value| value.as_str())
+        .expect("probe_key present in outer-scope metrics extension config");
+    let report_value = user_config
+        .config
+        .get("report_value")
+        .and_then(serde_json::Value::as_u64)
+        .expect("report_value present in outer-scope metrics extension config");
+    let probe = lookup_outer_scope_metrics_probe(probe_key);
+
+    let entity_key = ctx.register_extension_entity(name.clone(), ExtensionVariant::Shared);
+    let metrics = ctx.register_metric_set_for_entity::<OuterScopeExtensionMetrics>(entity_key);
+    let extension = OuterScopeMetricsExtension {
+        metrics,
+        report_value,
+        collected: probe.collected,
+        shutdown_probe: probe.shutdown,
+    };
+    let bundle = ExtensionWrapper::builder(name, user_config, extension_config)
+        .background()
+        .shared::<OuterScopeMetricsExtension>(extension)
+        .build()
+        .expect("outer-scope metrics extension bundle builds");
+    Ok(bundle)
+}
+
+const OUTER_SCOPE_METRICS_EXTENSION_FACTORY: ExtensionFactory = ExtensionFactory {
+    name: OUTER_SCOPE_METRICS_EXTENSION_URN,
+    description: "background extension reporting a custom metric from an outer scope",
+    documentation_url: "",
+    capabilities: None,
+    create: outer_scope_metrics_extension_create,
+    validate_config: otel_arrow_dfe_config::validation::no_config,
+};
+
+// ---------------------------------------------------------------------
 // Shared-counter extension -- provides NoOpStateful via passive Cloned;
 // holds an `Arc<AtomicU64>` counter so cloned consumers share state.
 // ---------------------------------------------------------------------
@@ -1846,6 +2053,7 @@ const EXTENSION_FACTORIES: &[ExtensionFactory] = &[
     SHUTDOWN_RECORDING_EXTENSION_FACTORY,
     DUAL_ACTIVE_EXTENSION_FACTORY,
     BACKGROUND_EXTENSION_FACTORY,
+    OUTER_SCOPE_METRICS_EXTENSION_FACTORY,
     SHARED_COUNTER_EXTENSION_FACTORY,
     SHARED_COUNTER_SHARED_EXTENSION_FACTORY,
     CONSTRUCTED_EXTENSION_FACTORY,
@@ -2181,6 +2389,729 @@ connections:
         Some("passive-noop"),
         "name from passive-cloned extension is observable to the consumer"
     );
+}
+
+// ---------------------------------------------------------------------
+// Extension declaration scope inheritance
+// ---------------------------------------------------------------------
+
+/// Scenario: An engine extension is shadowed by a group extension with the same ID.
+/// Guarantees: A descendant resolves the nearest declaration and captures its shared capability.
+#[test]
+fn test_pipeline_group_extension_shadows_engine_extension() {
+    let probe_key = "scope-shadow";
+    let probe = make_probe(probe_key, CallSequence::Shared);
+    let yaml = format!(
+        r#"
+version: otel_dataflow/v1
+engine: {{}}
+extensions:
+  shared-ext:
+    type: "{PASSIVE_EXTENSION_URN}"
+groups:
+  test-group:
+    extensions:
+      shared-ext:
+        type: "{DUAL_EXTENSION_URN}"
+    pipelines:
+      test-pipeline:
+        nodes:
+          receiver:
+            type: "{PROBE_RECEIVER_URN}"
+            config:
+              probe_key: "{probe_key}"
+            capabilities:
+              no_op_stateless: shared-ext
+          exporter:
+            type: "{NOOP_EXPORTER_URN}"
+        connections:
+          - from: receiver
+            to: exporter
+"#
+    );
+    let spec = OtelDataflowSpec::from_yaml(&yaml).expect("valid extension scope config");
+    let telemetry_system = InternalTelemetrySystem::default();
+    let controller_ctx = ControllerContext::new(telemetry_system.registry());
+    let registry = ExtensionScopeRegistry::default();
+
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime")
+        .block_on(async {
+            let local_set = tokio::task::LocalSet::new();
+            local_set
+                .run_until(async {
+                    let prepared = TEST_PIPELINE_FACTORY
+                        .prepare_extension_scope_hosts(
+                            &spec,
+                            &controller_ctx,
+                            telemetry_system.reporter(),
+                            registry.clone(),
+                        )
+                        .expect("extension scope hosts prepare");
+                    let running = prepared.start().await.expect("extension scope hosts start");
+
+                    let group_id = PipelineGroupId::from("test-group");
+                    let pipeline_id = PipelineId::from("test-pipeline");
+                    let pipeline_config = spec
+                        .groups
+                        .get(&group_id)
+                        .expect("group")
+                        .pipelines
+                        .get(&pipeline_id)
+                        .expect("pipeline")
+                        .clone();
+                    let inherited = registry
+                        .registrations_for_pipeline(&group_id, pipeline_config.extensions());
+                    let pipeline_ctx =
+                        controller_ctx.pipeline_context_with(group_id, pipeline_id, 0, 1, 0);
+                    let _entity_key = pipeline_ctx.register_pipeline_entity();
+                    let runtime_pipeline = TEST_PIPELINE_FACTORY
+                        .build_with_inherited_extensions(
+                            pipeline_ctx,
+                            pipeline_config,
+                            ChannelCapacityPolicy::default(),
+                            TelemetryPolicy::default(),
+                            None,
+                            std::collections::BTreeMap::new(),
+                            None,
+                            None,
+                            inherited,
+                        )
+                        .expect("pipeline builds");
+                    drop(runtime_pipeline);
+
+                    running
+                        .run(async {}, |_| {})
+                        .await
+                        .expect("extension scope hosts stop");
+                })
+                .await;
+        });
+
+    assert_eq!(
+        probe.captured_name.lock().as_deref(),
+        Some("dual-noop"),
+        "the nearest group declaration must shadow the engine declaration"
+    );
+}
+
+/// Scenario: Two runtime instances of one logical pipeline inherit one engine-scoped extension.
+/// Guarantees: Both builds observe the same shared state instead of constructing per-core state.
+#[test]
+fn test_engine_extension_state_is_shared_across_pipeline_instances() {
+    let receiver_probe_key = "scope-shared-state";
+    let receiver_probe = make_probe(receiver_probe_key, CallSequence::SharedStatefulIncrement);
+    let extension_probe_key = "scope-engine";
+    let counter = Arc::new(AtomicU64::new(0));
+    register_shared_counter_probe(
+        extension_probe_key,
+        SharedCounterProbe {
+            counter: Arc::clone(&counter),
+        },
+    );
+    let yaml = format!(
+        r#"
+version: otel_dataflow/v1
+engine: {{}}
+extensions:
+  shared-state:
+    type: "{SHARED_COUNTER_SHARED_EXTENSION_URN}"
+    config:
+      probe_key: "{extension_probe_key}"
+groups:
+  test-group:
+    pipelines:
+      test-pipeline:
+        nodes:
+          receiver:
+            type: "{PROBE_RECEIVER_URN}"
+            config:
+              probe_key: "{receiver_probe_key}"
+            capabilities:
+              no_op_stateful: shared-state
+          exporter:
+            type: "{NOOP_EXPORTER_URN}"
+        connections:
+          - from: receiver
+            to: exporter
+"#
+    );
+    let spec = OtelDataflowSpec::from_yaml(&yaml).expect("valid extension scope config");
+    let telemetry_system = InternalTelemetrySystem::default();
+    let controller_ctx = ControllerContext::new(telemetry_system.registry());
+    let registry = ExtensionScopeRegistry::default();
+
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime")
+        .block_on(async {
+            let local_set = tokio::task::LocalSet::new();
+            local_set
+                .run_until(async {
+                    let prepared = TEST_PIPELINE_FACTORY
+                        .prepare_extension_scope_hosts(
+                            &spec,
+                            &controller_ctx,
+                            telemetry_system.reporter(),
+                            registry.clone(),
+                        )
+                        .expect("extension scope hosts prepare");
+                    let running = prepared.start().await.expect("extension scope hosts start");
+
+                    let group_id = PipelineGroupId::from("test-group");
+                    let pipeline_id = PipelineId::from("test-pipeline");
+                    let pipeline_config = spec
+                        .groups
+                        .get(&group_id)
+                        .expect("group")
+                        .pipelines
+                        .get(&pipeline_id)
+                        .expect("pipeline")
+                        .clone();
+                    let inherited = registry
+                        .registrations_for_pipeline(&group_id, pipeline_config.extensions());
+
+                    for core_id in 0..2 {
+                        let pipeline_ctx = controller_ctx.pipeline_context_with(
+                            group_id.clone(),
+                            pipeline_id.clone(),
+                            core_id,
+                            2,
+                            core_id,
+                        );
+                        let _entity_key = pipeline_ctx.register_pipeline_entity();
+                        let runtime_pipeline = TEST_PIPELINE_FACTORY
+                            .build_with_inherited_extensions(
+                                pipeline_ctx,
+                                pipeline_config.clone(),
+                                ChannelCapacityPolicy::default(),
+                                TelemetryPolicy::default(),
+                                None,
+                                std::collections::BTreeMap::new(),
+                                None,
+                                None,
+                                inherited.clone(),
+                            )
+                            .expect("pipeline instance builds");
+                        drop(runtime_pipeline);
+                    }
+
+                    running
+                        .run(async {}, |_| {})
+                        .await
+                        .expect("extension scope hosts stop");
+                })
+                .await;
+        });
+
+    assert_eq!(
+        receiver_probe.create_calls.load(Ordering::SeqCst),
+        2,
+        "both pipeline instances must consume the inherited capability"
+    );
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        2,
+        "both pipeline instances must mutate the same engine-scoped state"
+    );
+    assert_eq!(
+        receiver_probe
+            .stateful_increment_return
+            .lock()
+            .as_ref()
+            .copied(),
+        Some(2),
+        "the second pipeline instance must observe the first instance's mutation"
+    );
+}
+
+/// Scenario: Engine- and group-scoped shared background extensions receive scheduled telemetry.
+/// Guarantees: Both custom snapshots reach the collector with their provider host scope identity.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_outer_scope_extensions_report_custom_metrics_to_collector() {
+    let probe_key = "outer-scope-metric-collection";
+    let collected = Arc::new(AtomicUsize::new(0));
+    register_outer_scope_metrics_probe(
+        probe_key,
+        OuterScopeMetricsProbe {
+            collected: Arc::clone(&collected),
+            ..Default::default()
+        },
+    );
+    let yaml = format!(
+        r#"
+version: otel_dataflow/v1
+engine: {{}}
+extensions:
+  engine-metrics:
+    type: "{OUTER_SCOPE_METRICS_EXTENSION_URN}"
+    config:
+      probe_key: "{probe_key}"
+      report_value: 11
+groups:
+  test-group:
+    extensions:
+      group-metrics:
+        type: "{OUTER_SCOPE_METRICS_EXTENSION_URN}"
+        config:
+          probe_key: "{probe_key}"
+          report_value: 29
+    pipelines:
+      test-pipeline:
+        nodes:
+          receiver:
+            type: "{PROBE_RECEIVER_URN}"
+            config:
+              optional_only: true
+          exporter:
+            type: "{NOOP_EXPORTER_URN}"
+        connections:
+          - from: receiver
+            to: exporter
+"#
+    );
+    let spec = OtelDataflowSpec::from_yaml(&yaml).expect("valid extension scope config");
+    let telemetry_system = InternalTelemetrySystem::default();
+    let controller_ctx = ControllerContext::new(telemetry_system.registry());
+    let scope_registry = ExtensionScopeRegistry::default();
+    let local_set = tokio::task::LocalSet::new();
+
+    let batch = local_set
+        .run_until(async {
+            let collector_task =
+                tokio::task::spawn_local(telemetry_system.collector().run_collection_loop());
+            let prepared = TEST_PIPELINE_FACTORY
+                .prepare_extension_scope_hosts(
+                    &spec,
+                    &controller_ctx,
+                    telemetry_system.reporter(),
+                    scope_registry,
+                )
+                .expect("extension scope hosts prepare");
+            let running = prepared.start().await.expect("extension scope hosts start");
+
+            tokio::time::advance(Duration::from_secs(1)).await;
+            for _ in 0..32 {
+                if collected.load(Ordering::SeqCst) == 2 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+            assert_eq!(
+                collected.load(Ordering::SeqCst),
+                2,
+                "the first monitor tick must collect both outer-scope extensions"
+            );
+
+            telemetry_system
+                .reporter()
+                .flush()
+                .await
+                .expect("collector must aggregate outer-scope extension snapshots");
+            let batch = telemetry_system.registry().drain_metric_export_batch();
+
+            running
+                .run(async {}, |_| {})
+                .await
+                .expect("extension scope hosts stop");
+            collector_task.abort();
+            let abort = collector_task
+                .await
+                .expect_err("collector task must remain active until explicitly stopped");
+            assert!(abort.is_cancelled(), "collector task must be cancelled");
+            batch
+        })
+        .await;
+
+    let mut metrics_by_extension = std::collections::BTreeMap::new();
+    for metric_set in batch
+        .metric_sets
+        .into_iter()
+        .filter(|metric_set| metric_set.descriptor.name == "test.extension.outer_scope")
+    {
+        let attributes = metric_set
+            .attributes
+            .iter_attributes()
+            .map(|(key, value)| (key.to_owned(), value.to_string_value()))
+            .collect::<std::collections::BTreeMap<_, _>>();
+        let extension_id = attributes
+            .get("extension.id")
+            .cloned()
+            .expect("outer-scope metric must carry extension.id");
+        assert!(
+            metrics_by_extension
+                .insert(extension_id, (attributes, metric_set.values))
+                .is_none(),
+            "each outer-scope extension must produce exactly one custom metric set"
+        );
+    }
+
+    assert_eq!(
+        metrics_by_extension.len(),
+        2,
+        "engine and group scope must each export one custom metric set"
+    );
+    let (engine_attributes, engine_values) = metrics_by_extension
+        .get("engine-metrics")
+        .expect("engine-scoped custom metrics");
+    assert_eq!(
+        engine_attributes.get("scope.kind").map(String::as_str),
+        Some("engine")
+    );
+    assert_eq!(
+        engine_attributes
+            .get("extension.variant")
+            .map(String::as_str),
+        Some("shared")
+    );
+    assert_eq!(engine_values, &[MetricValue::from(11_u64)]);
+
+    let (group_attributes, group_values) = metrics_by_extension
+        .get("group-metrics")
+        .expect("group-scoped custom metrics");
+    assert_eq!(
+        group_attributes.get("scope.kind").map(String::as_str),
+        Some("group")
+    );
+    assert_eq!(
+        group_attributes
+            .get("pipeline.group.id")
+            .map(String::as_str),
+        Some("test-group")
+    );
+    assert_eq!(
+        group_attributes
+            .get("extension.variant")
+            .map(String::as_str),
+        Some("shared")
+    );
+    assert_eq!(group_values, &[MetricValue::from(29_u64)]);
+}
+
+/// Scenario: two group providers drain concurrently before their engine provider.
+/// Guarantees: peers share a deadline, the engine gets fresh grace, and all terminal snapshots are collected.
+#[tokio::test(flavor = "current_thread")]
+async fn test_outer_scope_shutdown_preserves_phase_budgets_and_terminal_metrics() {
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::unbounded_channel();
+    let probe_keys = [
+        ("shutdown-engine", Duration::from_millis(20)),
+        ("shutdown-fast-group", Duration::from_millis(20)),
+        ("shutdown-slow-group", Duration::from_millis(60)),
+    ];
+    for (key, delay) in probe_keys {
+        register_outer_scope_metrics_probe(
+            key,
+            OuterScopeMetricsProbe {
+                shutdown: Some(OuterScopeShutdownProbe {
+                    events: events_tx.clone(),
+                    delay,
+                    empty_terminal_state: false,
+                    release: None,
+                }),
+                ..Default::default()
+            },
+        );
+    }
+    let spec = OtelDataflowSpec::from_yaml(&format!(
+        r#"
+version: otel_dataflow/v1
+engine: {{}}
+extensions:
+  engine-final:
+    type: "{OUTER_SCOPE_METRICS_EXTENSION_URN}"
+    config:
+      probe_key: shutdown-engine
+      report_value: 11
+groups:
+  fast:
+    extensions:
+      fast-group-final:
+        type: "{OUTER_SCOPE_METRICS_EXTENSION_URN}"
+        config:
+          probe_key: shutdown-fast-group
+          report_value: 29
+    pipelines: {{}}
+  slow:
+    extensions:
+      slow-group-final:
+        type: "{OUTER_SCOPE_METRICS_EXTENSION_URN}"
+        config:
+          probe_key: shutdown-slow-group
+          report_value: 37
+    pipelines: {{}}
+"#
+    ))
+    .expect("scope shutdown config should parse");
+    let telemetry_system = InternalTelemetrySystem::default();
+    let controller_ctx = ControllerContext::new(telemetry_system.registry());
+    let local_set = tokio::task::LocalSet::new();
+    let (shutdown_started, batch) = local_set
+        .run_until(async {
+            let collector =
+                tokio::task::spawn_local(telemetry_system.collector().run_collection_loop());
+            let running = TEST_PIPELINE_FACTORY
+                .prepare_extension_scope_hosts(
+                    &spec,
+                    &controller_ctx,
+                    telemetry_system.reporter(),
+                    ExtensionScopeRegistry::default(),
+                )
+                .expect("scope hosts should prepare")
+                .start()
+                .await
+                .expect("scope hosts should start");
+            let shutdown_started = Instant::now();
+            running.shutdown().await.expect("scope hosts should drain");
+            telemetry_system
+                .reporter()
+                .flush()
+                .await
+                .expect("collector must remain available after terminal host reporting");
+            let batch = telemetry_system.registry().drain_metric_export_batch();
+            collector.abort();
+            let error = collector
+                .await
+                .expect_err("collector should run until explicitly stopped");
+            assert!(error.is_cancelled());
+            (shutdown_started, batch)
+        })
+        .await;
+
+    let mut started = std::collections::BTreeMap::new();
+    let mut completed = std::collections::BTreeMap::new();
+    let mut sequence = Vec::new();
+    while let Ok(event) = events_rx.try_recv() {
+        match event {
+            OuterScopeShutdownEvent::Started { value, deadline } => {
+                assert!(started.insert(value, deadline).is_none());
+                sequence.push((value, "started"));
+            }
+            OuterScopeShutdownEvent::Completed { value, at, .. } => {
+                assert!(completed.insert(value, at).is_none());
+                sequence.push((value, "completed"));
+            }
+        }
+    }
+    assert_eq!(started.len(), 3);
+    assert_eq!(completed.len(), 3);
+    assert_eq!(
+        started[&29], started[&37],
+        "peer groups must share the same phase deadline"
+    );
+    assert!(started[&29] >= shutdown_started + Duration::from_secs(5));
+    for group in [29, 37] {
+        assert!(
+            started[&11] >= completed[&group] + Duration::from_secs(5),
+            "engine grace must begin only after every group finishes"
+        );
+    }
+    assert_eq!(
+        &sequence[4..],
+        &[(11, "started"), (11, "completed")],
+        "both group shutdowns must finish before engine shutdown starts"
+    );
+
+    let metrics = batch
+        .metric_sets
+        .into_iter()
+        .filter(|set| set.descriptor.name == "test.extension.outer_scope")
+        .map(|set| {
+            let extension_id = set
+                .attributes
+                .iter_attributes()
+                .find(|(key, _)| *key == "extension.id")
+                .expect("terminal snapshot should retain its extension identity")
+                .1
+                .to_string_value();
+            (extension_id, set.values)
+        })
+        .collect::<std::collections::BTreeMap<_, _>>();
+    assert_eq!(
+        metrics,
+        std::collections::BTreeMap::from([
+            ("engine-final".to_owned(), vec![MetricValue::from(11_u64)]),
+            (
+                "fast-group-final".to_owned(),
+                vec![MetricValue::from(29_u64)]
+            ),
+            (
+                "slow-group-final".to_owned(),
+                vec![MetricValue::from(37_u64)]
+            ),
+        ]),
+        "the running collector must preserve all final custom snapshots"
+    );
+    let mut probes = outer_scope_metrics_probes()
+        .lock()
+        .expect("scope metric probes mutex should not be poisoned");
+    for (key, _) in probe_keys {
+        let _ = probes.remove(key);
+    }
+}
+
+/// Scenario: a fast scope peer returns an empty default state before a slower peer reports to a full collector.
+/// Guarantees: engine and group hosts preserve the slow peer's reporting grace and collect its terminal snapshot.
+#[tokio::test(flavor = "current_thread")]
+async fn test_outer_scope_peers_keep_independent_terminal_reporting_deadlines() {
+    for group_scoped in [false, true] {
+        let scope = if group_scoped { "group" } else { "engine" };
+        let fast_key = format!("peer-deadline-{scope}-fast");
+        let slow_key = format!("peer-deadline-{scope}-slow");
+        let (events_tx, mut events_rx) = tokio::sync::mpsc::unbounded_channel();
+        let release_slow = Arc::new(tokio::sync::Notify::new());
+        for (key, empty_terminal_state, release) in [
+            (&fast_key, true, None),
+            (&slow_key, false, Some(Arc::clone(&release_slow))),
+        ] {
+            register_outer_scope_metrics_probe(
+                key,
+                OuterScopeMetricsProbe {
+                    shutdown: Some(OuterScopeShutdownProbe {
+                        events: events_tx.clone(),
+                        delay: Duration::ZERO,
+                        empty_terminal_state,
+                        release,
+                    }),
+                    ..Default::default()
+                },
+            );
+        }
+        let mut spec = OtelDataflowSpec::from_yaml(&format!(
+            r#"
+version: otel_dataflow/v1
+engine: {{}}
+policies:
+  telemetry:
+    pipeline_metrics: false
+    runtime_metrics: none
+extensions:
+  fast-peer:
+    type: "{OUTER_SCOPE_METRICS_EXTENSION_URN}"
+    config:
+      probe_key: "{fast_key}"
+      report_value: 11
+  slow-peer:
+    type: "{OUTER_SCOPE_METRICS_EXTENSION_URN}"
+    config:
+      probe_key: "{slow_key}"
+      report_value: 29
+groups:
+  test-group:
+    pipelines: {{}}
+"#
+        ))
+        .expect("peer deadline config should parse");
+        if group_scoped {
+            spec.groups
+                .get_mut(&PipelineGroupId::from("test-group"))
+                .expect("test group should exist")
+                .extensions = std::mem::take(&mut spec.extensions);
+        }
+        let config = TelemetryConfig {
+            reporting_channel_size: 1,
+            ..TelemetryConfig::default()
+        };
+        let registry = TelemetryRegistryHandle::new();
+        let telemetry = InternalTelemetrySystem::new(
+            &config,
+            config.reporting_interval,
+            registry.clone(),
+            None,
+            SendPolicy::default(),
+            LogContext::new,
+            None,
+        )
+        .expect("telemetry should initialize");
+        let context = ControllerContext::new(registry.clone());
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                // Claim the production collector, but do not poll it until both
+                // peers have returned. Its one-slot queue must stay backpressured.
+                let collection_loop = telemetry.collector().run_collection_loop();
+                let mut reporter = telemetry.reporter();
+                let mut filler = registry
+                    .register_metric_set_for_entity::<OuterScopeExtensionMetrics>(
+                        context.register_engine_entity(),
+                    );
+                filler.reported.add(1);
+                reporter
+                    .report(&mut filler)
+                    .expect("filler must occupy the collector's only queue slot");
+                let running = TEST_PIPELINE_FACTORY
+                    .prepare_extension_scope_hosts(
+                        &spec,
+                        &context,
+                        reporter.clone(),
+                        ExtensionScopeRegistry::default(),
+                    )
+                    .expect("peer hosts should prepare")
+                    .start()
+                    .await
+                    .expect("peer hosts should start");
+                let mut shutdown = tokio::task::spawn_local(running.shutdown());
+                let fast_deadline = wait_outer_scope_shutdown_completion(&mut events_rx, 11).await;
+                tokio::time::sleep_until(tokio::time::Instant::from_std(
+                    fast_deadline + Duration::from_millis(20),
+                ))
+                .await;
+                release_slow.notify_one();
+                let slow_deadline = wait_outer_scope_shutdown_completion(&mut events_rx, 29).await;
+                assert!(slow_deadline > Instant::now());
+
+                let early_shutdown =
+                    tokio::time::timeout(Duration::from_millis(100), &mut shutdown).await;
+                let waited_for_collector = early_shutdown.is_err();
+                let collector = tokio::task::spawn_local(collection_loop);
+                let shutdown_result = match early_shutdown {
+                    Ok(result) => result,
+                    Err(_) => shutdown.await,
+                };
+                shutdown_result
+                    .expect("scope shutdown task should join")
+                    .expect("scope hosts should stop cleanly");
+                reporter
+                    .flush()
+                    .await
+                    .expect("collector should aggregate the terminal snapshot");
+                let batch = registry.drain_metric_export_batch();
+                collector.abort();
+                assert!(
+                    collector
+                        .await
+                        .expect_err("collector should run until stopped")
+                        .is_cancelled()
+                );
+                let slow_values = batch
+                    .metric_sets
+                    .into_iter()
+                    .filter(|set| {
+                        set.descriptor.name == "test.extension.outer_scope"
+                            && set.attributes.iter_attributes().any(|(key, value)| {
+                                key == "extension.id" && value.to_string_value() == "slow-peer"
+                            })
+                    })
+                    .map(|set| set.values)
+                    .collect::<Vec<_>>();
+                assert_eq!(
+                    slow_values,
+                    vec![vec![MetricValue::from(29_u64)]],
+                    "{scope} peer must not lose metrics to an earlier peer's deadline"
+                );
+                assert!(
+                    waited_for_collector,
+                    "{scope} host must wait within its own grace while the collector is blocked"
+                );
+            })
+            .await;
+        let mut probes = outer_scope_metrics_probes()
+            .lock()
+            .expect("scope metric probes mutex should not be poisoned");
+        _ = probes.remove(&fast_key);
+        _ = probes.remove(&slow_key);
+    }
 }
 
 // ---------------------------------------------------------------------
@@ -4346,6 +5277,7 @@ fn build_runtime_pipeline_with_ready_gate(
         SHUTDOWN_RECORDING_EXTENSION_FACTORY,
         DUAL_ACTIVE_EXTENSION_FACTORY,
         BACKGROUND_EXTENSION_FACTORY,
+        OUTER_SCOPE_METRICS_EXTENSION_FACTORY,
         SHARED_COUNTER_EXTENSION_FACTORY,
         SHARED_COUNTER_SHARED_EXTENSION_FACTORY,
         CONSTRUCTED_EXTENSION_FACTORY,

--- a/rust/otap-dataflow/docs/admin/live-reconfiguration.md
+++ b/rust/otap-dataflow/docs/admin/live-reconfiguration.md
@@ -109,6 +109,13 @@ traffic flip across the whole pipeline.
 - Per-pipeline reconfiguration does not mutate group-level or engine-level
   policy. Full-engine reconciliation can update those fields after all
   requested pipeline rollouts and deletions succeed.
+- Engine- and group-scoped extension declarations are hosted for the process
+  lifetime and cannot be added, removed, or changed through live
+  reconciliation. Creating or deleting a group that has hosted extensions also
+  requires an engine restart.
+- Full-engine reconciliation rejects changes to channel capacity or telemetry
+  values consumed by a running engine or pipeline-group extension scope host.
+  Unrelated policy values remain live-reloadable.
 - There is no dedicated scale endpoint. Scale-only changes use the same `PUT`
   endpoint as topology changes.
 
@@ -131,6 +138,11 @@ engine validation on that candidate snapshot. That validation does not make the
 operation a whole-config transaction: another logical pipeline can commit before
 this rollout commits, and commit applies only the accepted pipeline back into
 the latest live config.
+
+Each pipeline generation also captures the exact engine/group extension
+registrations visible when that generation is planned. Create, resize,
+replacement, rollback, and runtime recovery reuse those immutable snapshots;
+they do not re-resolve broader-scope providers from ambient live configuration.
 
 The API intentionally leaves room to adjust the consistency scope later. If
 group-level invariants become mutable outside full-engine reconciliation, the
@@ -296,7 +308,17 @@ growth.
 - Global shutdown dispatch: `POST /groups/shutdown` snapshots active instances
   and attempts shutdown delivery to all of them. One failed send does not
   prevent later instances from receiving shutdown. Dispatch is idempotent for
-  instances that already accepted shutdown.
+  instances that already accepted shutdown. Regular pipeline instances drain
+  first, followed by group- and engine-scoped extension hosts. The system
+  observability pipeline stops last so it can export terminal telemetry from
+  every preceding phase. The first accepted request fixes the regular-pipeline
+  deadline, not the duration of the full sequence. Group hosts share a fresh
+  five-second grace period, then engine hosts receive another five seconds;
+  each host phase has an additional 500 ms of forced-drain slack.
+  Observability receives a separate five-second final drain window.
+  Repeated requests cannot reset an active phase's deadline. A timed-out scope
+  thread is detached with an error, but retains metrics aggregation and
+  observed-state processing until the remaining telemetry producers actually exit.
 - Observed-state compaction: after active controller work no longer needs old
   generations, the controller compacts retained instance status to the selected
   serving view. During active rollout overlap, status still exposes both old and
@@ -456,6 +478,8 @@ Behavior:
 - When `deleteMissing=true`, live pipelines and groups omitted from the desired
   config are gracefully deleted.
 - When `deleteMissing=false`, omitted live pipelines and groups are preserved.
+- With `deleteMissing=false`, omitted engine/group extension declarations are
+  retained because their running hosts are immutable.
 - Engine-level and group-level metadata is committed only after the
   reconciliation succeeds.
 - Reconciliation is not atomic across pipelines. Pipeline rollouts that
@@ -463,6 +487,9 @@ Behavior:
   the committed live config.
 - Runtime topic profile mutation is rejected with `422 Unprocessable Entity`.
 - Runtime memory limiter mutation is rejected with `422 Unprocessable Entity`.
+- Engine/group extension declaration changes and hosted-extension runtime
+  policy changes are rejected with `422 Unprocessable Entity`; restart the
+  engine to apply them.
 
 Response body is an `EngineConfigReconcileStatus` with:
 
@@ -846,6 +873,8 @@ original state.
 - Full-config reconciliation, group creation, group deletion, and pipeline
   deletion use an engine-scoped lifecycle guard and return `409 Conflict` when
   another guarded operation is active.
+- Engine/group extension hosts remain alive while descendant pipelines drain
+  and stop in reverse scope order: pipelines, groups, then engine.
 - `GET /groups/{group}/pipelines/{id}` always returns the committed
   live config, not an uncommitted candidate.
 - `GET /groups/{group}/pipelines/{id}/status` is the best endpoint

--- a/rust/otap-dataflow/docs/configuration-model.md
+++ b/rust/otap-dataflow/docs/configuration-model.md
@@ -72,9 +72,10 @@ This section records the intentional choices behind the v1 model.
 
 ### Root Config, Groups, and Pipelines
 
-The engine accepts a single root spec with `version`, optional defaults, and
-`groups`. A group scopes related pipelines and group-level policies. A pipeline
-is an executable graph identified by `(group_id, pipeline_id)`.
+The engine accepts a single root spec with `version`, optional defaults,
+engine-scoped extensions, and `groups`. A group scopes related pipelines,
+group-level policies, and group-scoped extensions. A pipeline is an executable
+graph identified by `(group_id, pipeline_id)`.
 
 This hierarchy gives the controller a stable unit for deployment,
 observability, resource assignment, and live reconfiguration. It also keeps room
@@ -161,6 +162,7 @@ At startup, the engine runtime accepts a single root configuration file format
 - `version`: required schema version (`otel_dataflow/v1`)
 - `policies`: optional top-level defaults
 - `topics`: optional top-level topic declarations
+- `extensions`: optional engine-scoped capability providers
 - `engine`: optional engine-wide settings
 - `groups`: pipeline groups map
 
@@ -193,10 +195,17 @@ Live reconfiguration is intentionally narrower than root-file loading:
 - The target pipeline group must already exist.
 - Pipeline topology, node configuration, and pipeline-level policy changes are
   supported for the target pipeline.
+- Pipeline-scoped extension changes are supported as part of pipeline
+  replacement.
 - Scale-only changes use the same pipeline update path when the effective
   runtime change is `policies.resources.core_allocation`.
-- Group-level, engine-level, and topic-broker mutation are out of scope for the
-  current live reconfiguration API.
+- Engine- and group-scoped extension declarations are immutable after startup.
+  Full-config reconciliation also rejects changes to channel or telemetry
+  policy values consumed by a running extension scope host.
+- Group-level and engine-level metadata that does not affect a hosted extension,
+  plus unrelated telemetry policy values, can still be reconciled.
+- Topic-broker mutation remains out of scope for the current live
+  reconfiguration API.
 
 For the API flow, rollout behavior, rollback handling, and current limits, see
 [admin/live-reconfiguration.md](admin/live-reconfiguration.md).
@@ -242,8 +251,10 @@ The runtime model is hierarchical:
 
 - top-level configuration (root)
 - top-level `topics` (optional global topic declarations)
+- top-level `extensions` (optional engine-scoped providers)
 - `groups` (map of pipeline groups)
 - group-local `topics` (optional topic declarations inside a group)
+- group-local `extensions` (optional group-scoped providers)
 - `pipelines` (map of pipelines inside each group)
 
 A **pipeline group** is a logical container for related pipelines.
@@ -252,6 +263,8 @@ A **pipeline group** is a logical container for related pipelines.
 - It can define group-level `policies` applied to pipelines in that group.
 - It can define group-local `topics` that override top-level topics with the
   same local name for pipelines in that group.
+- It can define group-scoped extensions shared by regular pipelines in that
+  group.
 - It is the intermediate level between root defaults and
   pipeline-specific overrides.
 
@@ -300,6 +313,18 @@ Topic declaration precedence for a pipeline in a given group:
 - `groups.<group>.topics.<topic>`
 - `topics.<topic>`
 
+Extension declaration precedence for a regular pipeline:
+
+- `groups.<group>.pipelines.<pipeline>.extensions.<extension>`
+- `groups.<group>.extensions.<extension>`
+- `extensions.<extension>`
+
+The nearest declaration shadows the entire extension id. A pipeline extension
+is instantiated once per runtime pipeline core. Group and engine declarations
+are controller-hosted once per declaration scope and require a shared execution
+variant. The internal observability pipeline does not inherit user-declared
+engine or group extensions.
+
 ## Pipeline Structure
 
 At pipeline level:
@@ -316,7 +341,8 @@ At node level:
 - `config`: node-specific payload
 - `outputs` (optional): named output ports for multi-output nodes
 - `default_output` (optional): explicit default output port for implicit sends
-- `capabilities` (optional): capability bindings to pipeline extensions
+- `capabilities` (optional): capability bindings to lexically visible
+  pipeline, group, or engine extensions
 - `entity` (optional): node entity enrichment metadata
 - `header_capture` (optional): receiver-only transport header capture override
 - `header_propagation` (optional): exporter-only transport header propagation

--- a/rust/otap-dataflow/docs/configuration.md
+++ b/rust/otap-dataflow/docs/configuration.md
@@ -81,11 +81,13 @@ Every runtime file is a single root document that describes the engine process:
 version: otel_dataflow/v1
 policies: {}
 topics: {}
+extensions: {}
 engine: {}
 groups:
     default:
         topics: {}
         policies: {}
+        extensions: {}
         pipelines:
             main:
                 type: otap
@@ -105,6 +107,7 @@ Optional root fields:
 
 - `policies`: top-level policy defaults.
 - `topics`: global topic declarations.
+- `extensions`: engine-scoped capability providers shared by regular pipelines.
 - `engine`: engine-wide settings.
 
 Most simple configurations only need `version` and `groups`.
@@ -182,7 +185,7 @@ Common node fields:
   processors.
 - `default_output`: optional default output port used by nodes that emit without
   selecting a port.
-- `capabilities`: optional bindings from capability name to pipeline extension.
+- `capabilities`: optional bindings from capability name to a visible extension.
 - `entity`: optional node entity enrichment metadata.
 - `header_capture`: receiver-only transport header capture override.
 - `header_propagation`: exporter-only transport header propagation override.
@@ -208,6 +211,7 @@ groups:
     ingest:
         policies: {}
         topics: {}
+        extensions: {}
         pipelines:
             traces:
                 nodes: {}
@@ -218,9 +222,53 @@ A pipeline is an executable graph:
 
 - `type`: pipeline data type. Defaults to `otap`.
 - `nodes`: receivers, processors, and exporters in the data path.
-- `extensions`: long-lived components available to nodes through capabilities.
+- `extensions`: pipeline-scoped components available through capabilities.
 - `connections`: explicit graph wiring.
 - `policies`: optional pipeline-level policy overrides.
+
+Extensions can also be declared at root or group scope. Declaration scope
+determines sharing:
+
+- root `extensions`: one engine-scoped host shared by all regular pipelines;
+- `groups.<group>.extensions`: one host shared by regular pipelines in that
+  group;
+- pipeline `extensions`: one independent instance per runtime pipeline core.
+
+A node resolves extension ids lexically: pipeline, then group, then engine.
+Declaring the same extension id at a nearer scope shadows the entire broader
+scope declaration. Sibling groups are isolated. Engine- and group-scoped providers
+must support the shared execution model; local-only providers remain
+pipeline-scoped. The internal observability pipeline does not inherit
+user-declared engine or group extensions.
+
+```yaml
+version: otel_dataflow/v1
+
+extensions:
+    shared_auth:
+        type: extension:oauth2_client_auth
+        config: {}
+
+groups:
+    ingest:
+        extensions:
+            tenant_auth:
+                type: extension:oauth2_client_auth
+                config: {}
+        pipelines:
+            traces:
+                nodes:
+                    receiver:
+                        type: receiver:otlp
+                        capabilities:
+                            bearer_token_provider: tenant_auth
+                        config: {}
+                    exporter:
+                        type: exporter:noop
+                connections:
+                    - from: receiver
+                      to: exporter
+```
 
 An `otap` pipeline is multi-signal by default. Logs, metrics, and traces can
 move through the same pipeline graph, unlike the Collector model where

--- a/rust/otap-dataflow/docs/extension-requirements.md
+++ b/rust/otap-dataflow/docs/extension-requirements.md
@@ -31,7 +31,7 @@ The extension system should:
   * thread-per-core execution
   * minimal synchronization
   * local hot-path access
-* support **future hierarchical scopes** (global, group, pipeline)
+* support extension **declaration scopes** (engine, group, pipeline)
 * allow extensions to run **background tasks**
 
 ## Non-Goals
@@ -105,10 +105,10 @@ Multiple instances may exist using different configurations or implementations.
 
 The execution model of an extension (for example **local per core** or
 **shared**) is defined by the **extension provider implementation**, not by the
-configuration. The placement of the extension declaration in the configuration
-hierarchy remains an orthogonal concern handled by the runtime, and ultimately
-determines the *sharing boundary* of an instance (see
-[Extension Scopes](#extension-scopes)).
+configuration. The placement of the extension declaration remains an
+orthogonal concern handled by the runtime, and ultimately determines the
+*sharing boundary* of an instance (see
+[Extension Declaration Scopes](#extension-declaration-scopes)).
 
 ### Capability Binding
 
@@ -142,36 +142,42 @@ This approach improves:
 
 ## Configuration Integration
 
-The extension system integrates directly into the engine's configuration
-hierarchy.
+The extension system integrates directly into the engine configuration.
+Extensions can be declared at engine, group, or pipeline scope.
+The declaration scope determines the physical instance boundary:
 
-For phase 1, extensions are declared at the **pipeline level** and consumed by
-nodes within that pipeline.
+* engine scope: one host shared by all regular pipelines in the process
+* group scope: one host shared by regular pipelines in that group
+* pipeline scope: one instance per runtime pipeline instance (per core)
 
 Example:
 
 ```yaml
 version: otel_dataflow/v1
 
+extensions:
+  oidc_auth_main:
+    type: extension:oidc_auth
+    config:
+      issuer: https://accounts.example.com
+
 groups:
   continuous_benchmark:
+    extensions:
+      local_auth:
+        type: extension:basic_auth
+        config:
+          file: /etc/auth/tokens.yaml
+
     pipelines:
       sut:
-
         extensions:
-
-          oidc_auth_main:
-            type: extension:oidc_auth
+          pipeline_auth:
+            type: extension:static_auth
             config:
-              issuer: https://accounts.example.com
-
-          local_auth:
-            type: extension:basic_auth
-            config:
-              file: /etc/auth/tokens.yaml
+              token: example
 
         nodes:
-
           otlp_recv1:
             type: receiver:otlp
             capabilities:
@@ -191,8 +197,15 @@ groups:
                   listening_addr: "127.0.0.1:4337"
 ```
 
-This model keeps extension usage explicit and consistent with the existing
-`groups -> pipelines -> nodes` structure.
+Bindings resolve lexically. A pipeline declaration shadows a group or engine
+declaration with the same extension id, and a group declaration shadows the
+engine declaration. Shadowing applies to the entire extension id, sibling
+groups are isolated, and the internal observability pipeline does not inherit
+user-declared engine or group extensions.
+
+Engine- and group-scoped declarations require a provider with a shared
+execution variant because their capability handles cross pipeline-thread
+boundaries. Local-only providers remain valid at pipeline scope.
 
 ## User Experience
 
@@ -322,43 +335,38 @@ The execution model of an extension (`local` or `shared`) is determined by the
 model defines the *type constraints* on the implementation (`!Send` for
 `local`, `Send + Clone` for `shared`); the *sharing boundary* of an instance is
 determined by the configuration scope at which the extension is declared (see
-[Extension Scopes](#extension-scopes)).
+[Extension Declaration Scopes](#extension-declaration-scopes)).
 
 These extension implementation bounds are distinct from capability trait
 bounds. The generated local capability trait adds no `Send` or `Sync`
 requirement, while the generated shared capability trait requires
 `Send + Sync`. This allows a shared capability handle to be retained behind
-shared references by concurrent consumers without changing the Phase 1
-per-pipeline extension instance boundary.
+shared references by concurrent consumers without changing the pipeline-scoped
+per-core instance boundary.
 
-## Extension Scopes
+## Extension Declaration Scopes
 
-### Phase 1 - Pipeline Scope
+The execution model and declaration scope are separate choices. The provider's
+execution model defines its type constraints. The declaration scope defines
+how many physical extension hosts exist and which pipelines can bind to them.
 
-In phase 1, extensions are declared at the **pipeline level** and consumed by
-nodes within that pipeline.
+| Declaration scope | Physical host boundary                  | Visible to                      | Required execution variant |
+| ----------------- | --------------------------------------- | ------------------------------- | -------------------------- |
+| engine            | one per engine process                  | all regular pipelines           | shared                     |
+| group             | one per pipeline group                  | regular pipelines in that group | shared                     |
+| pipeline          | one per runtime pipeline instance/core  | nodes in that pipeline          | local, shared, or both     |
 
-Two execution models are supported by extension providers. The execution model
-expresses the *type constraints* the implementation accepts; the actual
-*sharing boundary* of an instance is determined by the scope at which it is
-declared (pipeline scope in Phase 1).
+Pipeline-scoped behavior is unchanged from phase 1: even a provider's shared
+variant is constructed independently in every runtime pipeline instance.
+Cross-core sharing occurs only when the declaration is moved to group or
+engine scope. A dual provider uses its shared variant at engine or group scope;
+a local-only or local-background provider is rejected there.
 
-| Execution Model | Type Constraints  | Phase 1 Sharing Boundary (pipeline scope)                     |
-|-----------------|-------------------|---------------------------------------------------------------|
-| `local`         | `!Send`           | One instance per pipeline instance (per core)                 |
-| `shared`        | `Send + Clone`    | One instance per pipeline instance (per core); cloned on bind |
-
-The supported model is declared by the extension provider implementation.
-
-> **Phase 1 note on `shared`.** Because Phase 1 only supports pipeline scope,
-> a `shared` extension is still instantiated *per pipeline instance* (i.e., per
-> core) -- it is not yet shared across cores. The `Send + Clone` bounds are
-> what makes true cross-core sharing possible *later*, when extensions can be
-> declared at higher scopes (group, engine). At those scopes, a single
-> `shared` instance will be cloned to each pipeline instance, giving genuine
-> cross-core sharing of state behind `Arc`. Until then, treat `shared` as
-> "per-pipeline-instance, ready to be hoisted to a broader scope without code
-> changes" rather than "one instance for the whole engine".
+Engine- and group-scoped providers are hosted by the controller. The controller
+waits for their spawn and opt-in readiness barriers before constructing
+pipelines. Pipelines receive immutable registration snapshots, resolve typed
+capability handles during construction, and perform no scope-registry lookup on
+the data path.
 
 ### Local Execution Model Advantages
 
@@ -392,14 +400,17 @@ Features:
 * capability binding in nodes
 * background tasks supported
 
-### Phase 2 - Hierarchical Extensions
+### Phase 2 - Extension Declaration Scopes (implemented)
 
-Adds:
+Includes:
 
 * extension declarations at
 
   * top/engine-level
   * group-level
+* lexical visibility and whole-id shadowing
+* controller-owned engine/group scope hosts and readiness
+* immutable inherited capability snapshots for pipeline generations
 
 Possible future distributed scope.
 
@@ -539,8 +550,8 @@ A typical pattern is:
 
 ### 6. Shared scopes should avoid making every call cross-core
 
-For non-local `pipeline` scope and future broader scopes, implementations should
-avoid designs where every capability call requires cross-core communication.
+For group and engine scopes, implementations should avoid designs where every
+capability call requires cross-core communication.
 
 A better pattern is usually:
 
@@ -565,8 +576,10 @@ it should remain up to date and include at least:
 
 * description
 * supported capabilities
-* supported scopes
+* supported execution models
 * documentation URL
 
-Note: We probably want to enforce this with a macro to register extensions,
-which would require metadata fields to be provided at compile time.
+Engine/group-scope eligibility is currently inferred from shared capability
+metadata and verified against the extension bundle produced at startup. An
+explicit supported-scope metadata field can be added later if it provides
+enough value to justify the factory API change.

--- a/rust/otap-dataflow/docs/extension-system-architecture.md
+++ b/rust/otap-dataflow/docs/extension-system-architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document describes the proposed Phase 1 architecture
+This document describes the current Phase 1 and Phase 2 architecture
 for the extension system in the OTAP dataflow engine,
 building on the [extension system proposal](
 extension-requirements.md) which establishes the vision, goals, and
@@ -22,30 +22,25 @@ is addressed in the Phase 1 implementation:
 | Capability-based access | `#[capability]` proc macro generates typed traits; consumers resolve via `require_local()` / `require_shared()` |
 | Multiple implementations of same capability | `CapabilityRegistry` keyed by `(extension_name, TypeId)` -- different extensions can provide the same capability |
 | Multiple configured instances | `extensions:` section in YAML, each with a unique name; nodes bind by name in `capabilities:` |
-| Existing config model integration | Extensions are siblings to `nodes` in the pipeline config hierarchy |
-| Preserve performance model (thread-per-core) | Local extensions use `Rc<RefCell<T>>` for shared state (no locks); shared extensions use `Clone + Send` with `Arc`-wrapped state. Both are still instantiated per pipeline instance (per core) at pipeline scope -- see *Pipeline-scoped extensions are per-core* below. |
+| Existing config model integration | Extensions can be declared at engine, group, or pipeline scope |
+| Preserve performance model (thread-per-core) | Pipeline declarations remain per-core; engine and group declarations publish immutable shared factories resolved during pipeline construction |
 | Background tasks | Active extensions get their own event loop via `Extension::start()` |
 | Explicit capability binding | Nodes declare `capabilities: { name: extension_instance }` -- no implicit discovery |
 | No hot-path registry lookup | Capabilities resolved once at factory time; nodes hold typed handles for their lifetime |
-| Future hierarchical scopes | `CapabilityRegistry` and `resolve_bindings()` are scope-agnostic by design |
+| Declaration scopes | Lexical visibility is pipeline > group > engine with whole-extension-id shadowing |
 
 Beyond the proposal's requirements, the design rests on
 four additional principles:
 
-- **Pipeline-scoped extensions are per-core.** Both local
-  and shared pipeline-scoped extensions are instantiated
-  **per pipeline instance** (i.e., per core). The
-  local/shared distinction at pipeline scope is about type
-  constraints (`!Send` vs `Send + Clone`), not about
-  cross-core sharing. This follows a consistent principle:
-  **an extension's sharing boundary is determined by the
-  scope it is declared in**, not by its execution model.
-  Pipeline is the only scope in Phase 1; broader scopes
-  (group, engine) and narrower scopes (node-set, node) are
-  future work and will each define their own sharing
-  boundary. The execution model (local vs shared)
-  determines only the type constraints imposed on the
-  implementation.
+- **Declaration scope determines sharing.** Pipeline-scoped
+  local and shared extensions are instantiated **per
+  pipeline instance** (per core), preserving Phase 1
+  behavior. A group declaration creates one controller-owned
+  scope host for that group, and an engine declaration creates one
+  scope host for the process. Engine and group declarations require a
+  shared variant; the local/shared execution model still
+  determines implementation type constraints rather than
+  configuration cardinality.
 - **Active/Passive lifecycle distinction.** Not every
   extension needs a background task. Extensions that only
   provide capabilities are marked *Passive* -- no task is
@@ -122,55 +117,69 @@ struct MyExtension {
 
 ## What Are Extensions?
 
-Extensions are standalone pipeline components that provide
+Extensions are standalone runtime components that provide
 **shared, cross-cutting capabilities** -- such as
 authentication, storage etc. -- to
 data-path nodes (receivers, processors, exporters). They
-are configured as siblings to `nodes`, not as nodes
-themselves, and they never touch pipeline data directly.
+are configured at engine or group scope, or as siblings to
+`nodes` at pipeline scope. They are not data-path nodes and
+never touch pipeline data directly.
 
 ## Architecture Overview
 
 ```text
-+----------------------------------------------------------+
-|                     Pipeline Engine                      |
-|                                                          |
-|  +-------------------+  +-------------------+            |
-|  | Extension A       |  | Extension B       |  ...       |
-|  | Active(auth)      |  | Passive(kv store) |            |
-|  | local + shared    |  | shared only       |            |
-|  | lifecycle         |  | no task spawned   |            |
-|  +---------+---------+  +---------+---------+            |
-|            | #[capability] proc macro                    |
-|            | + extension_capabilities!() macro           |
-|            v                                             |
-|  +----------------------------+                          |
-|  |    CapabilityRegistry      |  (built once per         |
-|  |  local_handles HashMap     |   pipeline)              |
-|  |  shared_handles HashMap    |                          |
-|  +----+-----------------+-----+                          |
-|       | resolve_bindings|                                |
-|       v                 v                                |
-|  +-----------+  +-----------+                            |
-|  | Receiver  |  | Exporter  |                            |
-|  | require   |  | require   |                            |
-|  | _local()  |  | _shared() |                            |
-|  | -> Box<T> |  | -> Box<T> |                            |
-|  +-----------+  +-----------+                            |
-|                                                          |
-|  Local consumers get Box<dyn local::Trait>               |
-|  Shared consumers get Box<dyn shared::Trait>             |
-|  Shared capability trait objects are Send + Sync         |
-+----------------------------------------------------------+
++----------------------------------------------------------------+
+| Controller-owned extension scope supervisor                    |
+|                                                                |
+| Engine scope host (one/process)                                |
+|   `- Pipeline-group scope hosts (one/group)                    |
+|                                                                |
+| Publishes immutable shared registration snapshots              |
++-------------------------------+--------------------------------+
+                                |
+                                v
++----------------------------------------------------------------+
+| Runtime pipeline instance (one/core)                           |
+|                                                                |
+| Pipeline-local extensions + inherited shared registrations     |
+|                 |                                              |
+|                 v                                              |
+|          CapabilityRegistry (build time only)                  |
+|                 | resolve_bindings                             |
+|                 v                                              |
+|          Receiver / Processor / Exporter typed handles         |
+|                                                                |
+| No scope-registry lookup occurs on the data path.              |
++----------------------------------------------------------------+
 ```
 
 ## Key Design Decisions
 
-1. **Extensions start first, shut down last.** Active
-   extensions are spawned before data-path nodes. At
-   shutdown, extensions terminate only after all data-path
-   nodes have drained. Passive extensions (no lifecycle)
-   skip spawning entirely.
+1. **Extensions start first, shut down last.** Pipeline
+   extensions are spawned before their data-path nodes and
+   terminate after those nodes drain. Engine and group
+   extensions start before any descendant regular pipeline.
+   Shutdown follows reverse declaration-scope order: descendant
+   pipelines drain first, then group scope hosts, then the engine
+   scope host. The
+   system observability pipeline remains active through those
+   phases so terminal scope-host telemetry can be exported, and
+   stops only after the scope hosts finish. Passive extensions skip
+   lifecycle task spawning. The first shutdown request fixes the
+   producer-pipeline deadline. After producers drain, group hosts
+   share a five-second grace period, followed by a separate
+   five-second engine-host grace period. Each host phase allows
+   another 500 ms to abort and join stragglers. Observability then
+   receives its own five-second drain window. Repeated requests
+   do not reset an active phase's deadline. Each host owns its phase
+   deadline: an extension can limit its own terminal reporting, but
+   cannot shorten a peer's reporting window or the host's final flush.
+   Pre-shutdown failures use bounded local deadlines without starting
+   the host's shutdown clock. The controller's bounded
+   supervisor join covers the provider and observability windows,
+   plus thread-coordination slack. If it times out, teardown reports
+   an error, but the detached thread retains telemetry support until
+   all remaining producers and observability actually exit.
 
    *Scope of the guarantee.* This orders **lifecycle
    calls**, not init completion. `start()` is async, so
@@ -188,30 +197,22 @@ themselves, and they never touch pipeline data directly.
    surface a not-ready error/default until init has
    progressed.
 
-   *Future consideration.* If an extension genuinely
-   needs an init-complete guarantee before the data path
-   runs, the framework can later add an opt-in readiness
-   probe so participating extensions can block data-path
-   spawn until they signal ready, while non-participating
-   extensions keep today's behavior unchanged.
+   *Readiness.* Active extensions can opt into a readiness
+   probe. Pipeline startup waits for opted-in pipeline
+   extensions. Scope-host startup waits for every engine and
+   group declaration before publishing its capability catalog or
+   constructing regular pipelines. Extensions without a
+   readiness probe preserve the zero-cost spawn-only
+   behavior.
 
-   *Runtime cost.* `start()` runs on the same per-core
-   async runtime as the data path -- the runtime that
-   drives every node, channel, and extension on this
-   core. Blocking calls (synchronous I/O, lock
-   contention, file reads without `tokio::fs`) and
-   CPU-heavy work (compression, large
-   serialization/deserialization, cryptographic
-   operations) inside `start()` -- or inside any
-   capability method dispatched on that runtime --
-   stall every other future on the core, including the
-   data path itself. Extensions that need such work
-   must move it off the per-core runtime: a bounded
-   `tokio::task::spawn_blocking` for blocking I/O, a
-   dedicated worker thread for sustained CPU work, or
-   a Rayon pool for parallel compute. The same
-   guidance applies to background extensions, whose
-   `start()` body shares the same runtime.
+   *Runtime cost.* Pipeline-scoped `start()` runs on the
+   same per-core async runtime as the data path. Engine- and
+   group-scoped `start()` runs on a controller-owned `LocalSet`,
+   shared by all extension scope hosts. Blocking I/O, lock contention,
+   or sustained CPU work can therefore stall either a
+   pipeline core or all controller-hosted extension scopes. Such work
+   must move to bounded blocking tasks or dedicated worker
+   resources.
 
 2. **PData-free.** Extensions are completely decoupled from
    the pipeline data type. They use `ExtensionControlMsg`
@@ -238,7 +239,9 @@ themselves, and they never touch pipeline data directly.
    second is unrepresentable in the typestate. The choice
    of `.shared(...)` vs `.local(...)` only governs how the
    engine hosts the instance (`Send + Clone` vs
-   `Clone` but not `Send`, per-pipeline). Background extensions
+   `Clone` but not `Send`, per-pipeline). Local background
+   extensions are therefore pipeline-only; engine and group scopes
+   require the shared form. Background extensions
    never appear as the right-hand side of a capability
    binding; their factory's `capabilities` field is
    `Option<_>::None`, and that `None` is the engine's
@@ -341,13 +344,19 @@ themselves, and they never touch pipeline data directly.
 ```text
 engine/src/
   lib.rs                    -> ExtensionFactory, engine build logic
+  extension_lifecycle.rs    -> shared lifecycle, readiness,
+                              failure, and shutdown orchestration
 
   extension/
     mod.rs                  -> module root, ExtensionBundle,
-                              ExtensionLifecycle, ExtensionWrapper
+                              ExtensionWrapper
     builder.rs              -> Typestate builder: ActiveStage,
                               PassiveStage, PassiveClonedStage,
                               PassiveConstructedStage
+    scope/
+      host.rs               -> one engine/group declaration-scope host
+      registry.rs           -> visibility and inherited registrations
+      supervisor.rs         -> startup, failure, and ordered shutdown
     wrapper.rs              -> ExtensionWrapper variants,
                               ControlChannel, EffectHandler
     tests.rs                -> extension-level tests


### PR DESCRIPTION
# Change summary

Adds extension declarations at the engine (`extensions`) and pipeline-group
(`groups.<id>.extensions`) scopes. Pipelines can bind capabilities from these
providers without changing the capability consumer API.

- Resolution is pipeline > group > engine. A nearer declaration shadows the
  whole extension ID; sibling groups do not inherit each other's providers.
- Engine/group hosts run shared extension variants. Pipeline-scoped extensions
  retain their per-runtime-instance construction and variant pruning.
- Pipeline reload, rollback, and recovery carry inherited registrations.
  Healthy engine/group providers remain running across pipeline rebuilds.
- Adds readiness handling, reverse-scope shutdown ordering, and outer-scope
  telemetry collection. Supervisor shutdown includes observability's completion
  grace.

## Related issue

Related to open-telemetry/otel-arrow#1966.

## Validation

- Passed `RUST_TEST_THREADS=4 cargo xtask check` in `rust/otap-dataflow`
  after merging upstream `main`.
- `make chlog-validate`, `python3 tools/sanitycheck.py`, and Markdown lint.
- Regression coverage includes shared state, shadowing, retained hosts and
  metrics across pipeline replacement, variant pruning, and shutdown budgets.

Validation was local on macOS. Hierarchy-specific integration coverage uses test
providers, not a live authentication service. No cross-platform or performance
validation is claimed.

## User-facing changes

Existing pipeline-only configurations retain their current scope semantics.
Engine/group declarations allow providers to outlive individual pipeline
generations. Changelog entries and scope documentation are included.

Current limits:

- Engine/group declaration changes, and changes to runtime policies used by
  those hosts, require an engine restart. Ordinary pipeline reload remains
  supported.
- An ancestor-host failure initiates engine-wide shutdown. Scoped failure
  containment, ancestor recovery, and live ancestor reconfiguration are deferred.
- System observability can use its own pipeline-local extensions but does not
  inherit engine/group providers. Controller-bootstrap extensions remain
  separate from this hierarchy.
